### PR TITLE
fix: accept comma record separators in Wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/Digimuoto/cortex/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Digimuoto/cortex/actions/workflows/ci.yml/badge.svg" /></a>
-  <a href="https://github.com/Digimuoto/cortex/actions/workflows/docs.yml"><img alt="Docs" src="https://github.com/Digimuoto/cortex/actions/workflows/docs.yml/badge.svg" /></a>
+  <a href="https://digimuoto.github.io/cortex/"><img alt="Docs" src="https://github.com/Digimuoto/cortex/actions/workflows/docs.yml/badge.svg" /></a>
   <a href="LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue" /></a>
   <img alt="Build: Nix" src="https://img.shields.io/badge/build-Nix-5277C3" />
 </p>
@@ -47,17 +47,16 @@ plan => gather => write
 
 ## Documentation
 
-- [Docs landing](docs/index.md) - architecture, reference, ADRs, roadmap, and
-  consumer bindings.
-- [Architecture overview](docs/Architecture/01-overview.md) - system frame and
-  ownership boundary.
-- [Wire language](docs/Architecture/05-wire-language.md) - authoring model and
-  language architecture.
-- [Wire grammar v1](docs/Reference/Wire/grammar-v1.md) - normative grammar.
-- [Pulse runtime](docs/Architecture/06-pulse-runtime.md) - durable execution
-  model.
-- [Development workflow](docs/Reference/development.md) - build, test, docs,
-  formatting, and local validation commands.
+- [Docs landing](https://digimuoto.github.io/cortex/) - architecture,
+  reference, ADRs, roadmap, and consumer bindings.
+- [Stable canon](https://digimuoto.github.io/cortex/#stable-canon) -
+  architecture, reference, ADRs, and canonical docs.
+- [Working artifacts](https://digimuoto.github.io/cortex/#working-artifacts) -
+  roadmap, research notes, experiments, handoffs, and templates.
+- [Start here](https://digimuoto.github.io/cortex/#start-here) - the intended
+  first reading path through the published docs.
+- [Consumer examples](https://digimuoto.github.io/cortex/#consumer-examples) -
+  downstream bindings, including Portman.
 
 ## Repository
 

--- a/docs/Reference/Wire/grammar-v1.md
+++ b/docs/Reference/Wire/grammar-v1.md
@@ -69,7 +69,7 @@ contract   node   let   import   from   select   true   false
 
 **Lists.** `[a, b, c]`. Trailing comma permitted. Empty list: `[]`.
 
-**Records.** `{ k1 = v1; k2 = v2; }`. Fields separated by `;`. Trailing `;` permitted. Empty record: `{}`.
+**Records.** `{ k1 = v1; k2 = v2; }`. Fields separated by `;` or `,`. Trailing separator permitted. Empty record: `{}`.
 
 **Numbers.** Decimal integers and floats: `42`, `3.14`, `-7`. Leading `-` is part of the numeric literal, not an operator — Wire has no arithmetic in v1. No hex, octal, or scientific notation.
 
@@ -498,7 +498,7 @@ selector select(
 { title = "Report"; maxTokens = 16384; tools = [webSearch, getDate]; }
 ```
 
-Fields separated by `;`. Trailing `;` permitted. Field names are unqualified identifiers; values are arbitrary expressions.
+Fields are separated by `;` or `,`. A trailing separator is permitted. Field names are unqualified identifiers; values are arbitrary expressions.
 
 ### 8.2 `//` — right-biased shallow merge
 
@@ -914,7 +914,9 @@ partial_expr      ::= "@" qualified_ident record_expr
 
 constructor_expr  ::= qualified_ident record_expr   # config-value constructor, no @
 
-record_expr       ::= "{" [ field { ";" field } [ ";" ] ] "}"
+record_expr       ::= "{" [ field { record_sep field } [ record_sep ] ] "}"
+
+record_sep        ::= ";" | ","
 
 field             ::= path "=" expr
 

--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -21,7 +21,7 @@
           title = "Cortex";
           tagline = "Research wiki";
           description = "Cortex engineering specifications, ADRs, research notes, and publications";
-          publicBaseUrl = "https://crispy-barnacle-j1kepz8.pages.github.io";
+          publicBaseUrl = "https://digimuoto.github.io/cortex";
           routeBase = "/";
         };
 

--- a/src/Cortex/Wire/V1/Parser.hs
+++ b/src/Cortex/Wire/V1/Parser.hs
@@ -318,9 +318,12 @@ constructorExpr = do
 recordExpr :: Parser Record
 recordExpr = do
   _ <- symbol "{"
-  fields <- field `sepEndBy` symbol ";"
+  fields <- field `sepEndBy` recordFieldSeparator
   _ <- symbol "}"
   pure (Record fields)
+
+recordFieldSeparator :: Parser Text
+recordFieldSeparator = symbol ";" <|> symbol ","
 
 field :: Parser Field
 field = do

--- a/test/Cortex/Wire/V1/ParserSpec.hs
+++ b/test/Cortex/Wire/V1/ParserSpec.hs
@@ -181,6 +181,14 @@ spec = describe "Cortex.Wire.V1.Parser" $ do
           length fields `shouldBe` 2
         other -> expectationFailure ("unexpected: " <> show other)
 
+    it "parses comma-separated executor config fields" $ do
+      case parseWireExpr
+        "test"
+        "@llm.analyst { prompt = \"Find current evidence.\", tools = [webSearch], }" of
+        Right (ExprApply (QName ("llm" :| ["analyst"])) (Record fields)) ->
+          length fields `shouldBe` 2
+        other -> expectationFailure ("unexpected: " <> show other)
+
     it "parses a bare @llm executor reference as a single-segment qname" $ do
       case parseWireExpr "test" "@llm {}" of
         Right (ExprApply (QName ("llm" :| [])) (Record [])) ->


### PR DESCRIPTION
## Summary
- allow Wire v1 record fields to be separated by semicolons or commas
- add a regression for generated executor configs with trailing comma fields
- update the Wire v1 grammar reference to document both separators

## Verification
- just test