### PR TITLE
chore: add Lean code style skill

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -22,6 +22,7 @@ agents/
     ├── ci-fix/                 # Diagnose & fix a red CI run
     ├── pr-resolve-review/      # Address PR review comments
     ├── haskell-code-style/     # Opinionated Haskell review (+ references/)
+    ├── lean-code-style/        # Strict Lean 4 proof review (+ references/)
     ├── doc-review/             # Docs review (+ references/)
     └── doc-review-and-fix/     # Review and edit docs in one pass
 ```
@@ -104,6 +105,6 @@ Portman keeps its own fuller `agents/` tree.
 ## Adding a skill
 
 1. Create `agents/skills/<name>/SKILL.md` with YAML frontmatter
-   (`name`, `description`, optional `date`/`status`).
+   (`name`, `description`).
 2. Supporting references go under `agents/skills/<name>/references/`.
 3. Run the provider link command for the runtime that should expose it.

--- a/agents/skills/lean-code-style/SKILL.md
+++ b/agents/skills/lean-code-style/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: lean-code-style
+description: >
+  Strict Lean 4 review and authoring guide for Cortex theory work. Use
+  when asked to review Lean, check proof style, write or edit .lean files,
+  mechanize axioms, refactor proofs, evaluate mathlib/tactic usage, or
+  assess theory/lake/Nix changes for correctness, maintainability, and
+  proof robustness.
+---
+
+# IRONCLAD Lean Code Style
+
+Review or write Lean 4 code as a proof artifact, not as executable
+notation that happens to compile. The standard is intentionally stricter
+than generic Lean style: Cortex proofs must be stable, explicit,
+well-named, and easy to audit months later.
+
+## Usage
+
+```
+/lean-code-style [target...]
+```
+
+Arguments:
+
+- No arguments: review changed Lean/theory files in the current branch
+  against `main`.
+- `--base <branch>`: review the branch diff against another base.
+- File paths: review those files.
+- Directory paths: review `.lean` and theory build files under them.
+
+Examples:
+
+```bash
+/lean-code-style
+/lean-code-style --base main theory/Cortex/Graph
+/lean-code-style theory/Cortex/Pulse/Frontier.lean
+```
+
+In authoring mode, apply the same rules while editing Lean code. Do not
+wait for review to enforce them.
+
+## IRONCLAD Standard
+
+- No untracked trusted-base expansion.
+- No proof debt hidden behind automation, wildcard cases, or linter
+  suppression.
+- No local reinvention of mature `Std` or `Mathlib` theory when a robust
+  external library supplies the right abstraction.
+- No theorem statement that proves an artifact of the encoding instead
+  of the intended model.
+- No public proof API that compiles today but is hard to reuse tomorrow.
+
+## Workflow
+
+### 1. Determine Scope
+
+If explicit files or directories are given, expand directories to:
+
+```bash
+rg --files "$DIR" | rg '(^theory/.*\.lean$|^theory/lakefile\.lean$|^theory/lean-toolchain$|^theory/lake-manifest\.json$|^nix/lean\.nix$)'
+```
+
+If no files are given, use branch-diff mode:
+
+```bash
+BASE="${BASE:-main}"
+git diff --name-only "$BASE"...HEAD -- \
+  'theory/**/*.lean' \
+  'theory/lakefile.lean' \
+  'theory/lean-toolchain' \
+  'theory/lake-manifest.json' \
+  'nix/lean.nix'
+```
+
+If no theory files are found, report that there is no Lean/theory scope
+to review and exit.
+
+### 2. Run Mechanical Checks
+
+Run these before manual review:
+
+```bash
+rg -n '\b(sorry|admit|axiom|constant|unsafe|partial)\b|set_option\s+linter\.[A-Za-z0-9_.]+\s+false|set_option\s+autoImplicit\s+true' $FILES
+rg -n '\bsimp_all\b|\baesop\b|\bomega\b|\blinarith\b|\bring_nf\b|\bnorm_num\b|\btauto\b' $FILES
+rg -n '\|[[:space:]]*_[[:space:]]*=>' $FILES
+```
+
+Interpret results manually:
+
+- New `sorry`, `admit`, `axiom`, `constant`, `unsafe`, or `partial` is
+  **[P1]** unless the file is explicitly a tracked scaffold and the debt
+  is documented in `theory/README.md`.
+- New linter suppression is **[P1]** if broad or unexplained, **[P2]** if
+  local but avoidable. Prefer fixing the code or using local `omit`,
+  namespaces, or proof restructuring.
+- Heavy automation and wildcard patterns are review triggers, not
+  automatic failures. They must have a small, stable proof surface.
+
+### 3. Load References
+
+Read these reference files before giving a substantive review:
+
+- `references/review-rubric.md`: scoring and priority levels.
+- `references/writing-guide.md`: declarations, names, imports,
+  docstrings, theorem statements, and proof style.
+- `references/proof-patterns.md`: tactics, simp discipline,
+  automation, theorem API shape, and axiom policy.
+- `references/theory-architecture.md`: Cortex-specific Lean track
+  boundaries, validation commands, and build-file expectations.
+
+### 4. Read the Code
+
+In branch-diff mode, read the diff first:
+
+```bash
+git diff "$BASE"...HEAD -- "$FILE"
+```
+
+Then read the full current file. Lean review cannot be done from a
+small hunk alone because variable scopes, namespace shape, imports,
+attributes, and local notation alter proof meaning.
+
+In explicit-target mode, review the whole target file or directory.
+
+### 5. Review
+
+Apply the rubric and make findings concrete. Prioritize:
+
+- Logical soundness and trusted-kernel hygiene.
+- Explicit theorem statements and stable proof scripts.
+- Minimal imports and correct dependency management.
+- Namespace/API shape suitable for later theorem reuse.
+- `simp`/attribute discipline.
+- Elimination of scaffold debt rather than normalization of new debt.
+- Validation through both Lake and Nix where relevant.
+
+Treat "compiles" as the floor. A proof can compile and still be too
+fragile, too implicit, or too opaque for Cortex.
+
+### 6. Report
+
+Use this shape:
+
+```markdown
+## Lean Style Review: <branch> vs <base>
+
+**Files reviewed:** N
+**Overall:** one-sentence assessment
+
+### <filename>
+
+**Score:** X/10
+
+**Findings:**
+- [P1] <correctness/soundness issue> - line N
+- [P2] <robustness/API/architecture issue> - line N
+- [style] <local cleanup> - line N
+
+**Good:**
+- <specific strong choice>
+
+### Summary
+
+| File | Score | Key Issue |
+|---|---:|---|
+| ... | X/10 | ... |
+
+**Top priorities:**
+1. <most important fix>
+2. <second>
+3. <third>
+```
+
+If there are no findings, say so directly and state any residual risk
+or test gap.
+
+### 7. Offer Fixes
+
+After review, ask whether to apply findings. When the user asks for
+fixes, edit narrowly and rerun validation. Prefer proving a smaller
+lemma or improving theorem shape over adding automation until the error
+goes away.

--- a/agents/skills/lean-code-style/agents/openai.yaml
+++ b/agents/skills/lean-code-style/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Lean Code Style"
+  short_description: "Strict Lean 4 proof style review"
+  default_prompt: "Use $lean-code-style to review the Lean 4 changes on this branch."

--- a/agents/skills/lean-code-style/references/proof-patterns.md
+++ b/agents/skills/lean-code-style/references/proof-patterns.md
@@ -1,0 +1,123 @@
+# Lean Proof Patterns
+
+This file defines Cortex's standard for robust Lean proofs.
+
+## Axiom And Sorry Policy
+
+- New mechanization work should reduce the axiom surface.
+- A new `axiom` is allowed only in an explicit scaffold file and only
+  when the corresponding proof obligation is listed in `theory/README.md`.
+- Never replace a hard proof with `sorry`, `admit`, `axiom`, or
+  `constant` to make CI pass.
+- If a theorem is intentionally postponed, name the obligation precisely
+  and document the semantic gap.
+
+## Tactic Discipline
+
+Use tactics as transparent proof construction, not as an opaque search
+button.
+
+Prefer:
+
+- `rfl`, `exact`, `refine`, `constructor`, `cases`, `induction`,
+  `simp only`, `simpa only`, and short `calc` blocks.
+- Small helper lemmas with reusable names.
+- Explicit `rw` lists when the rewrite sequence is the point of the
+  proof.
+- `simp [local_def]` for definitional closure over local definitions.
+
+Use cautiously:
+
+- `simp_all`: acceptable in throwaway local proof cleanup, suspicious in
+  exported theorems because it rewrites from the entire context.
+- `aesop`, `omega`, `linarith`, `ring_nf`, `norm_num`, `tauto`: useful
+  when the theorem is exactly in their domain and the surrounding proof
+  isolates their job.
+- Repeated `<;>` chains: fine for tiny symmetric goals, but split goals
+  explicitly when each side has semantic content.
+
+Avoid:
+
+- Broad `simp` relying on a large imported simp set when `simp only`
+  would be stable.
+- `first | ...` tactic search ladders in public proofs.
+- Proofs that succeed only because a transient hypothesis has a lucky
+  generated name.
+
+## External Library Use
+
+Prefer robust maintained theory over bespoke local proof infrastructure.
+
+- Look first in `Std` and `Mathlib` for algebraic structures, orders,
+  finite sets/maps, relations, quotients, graph-adjacent abstractions,
+  well-founded recursion, arithmetic, and rewrite support.
+- Import the narrowest module that provides the needed theorem or
+  structure. Do not import broad namespaces to make search tactics
+  succeed.
+- Use library theorem names directly when they express the proof idea.
+  Wrap them only when Cortex needs a domain-specific statement,
+  orientation, or namespace.
+- Do not build a local abstraction merely to avoid learning an existing
+  one. A smaller proof today is not a win if it isolates Cortex from
+  the maintained Lean ecosystem.
+- Add new Lake dependencies only when they materially reduce proof risk
+  or replace a fragile local development path. Pin them through the same
+  toolchain path as the rest of `theory/`.
+
+## Simp Rules
+
+Before adding `@[simp]`, answer:
+
+1. Does this rewrite reduce to a canonical form?
+2. Can it loop with existing simp rules?
+3. Does it erase information a downstream proof may need?
+4. Is the theorem name and orientation obvious from the statement?
+
+If any answer is unclear, do not add `@[simp]`. Use the theorem
+explicitly with `rw` or `simp [theorem_name]`.
+
+## Attributes And Instances
+
+- Keep attributes near declarations.
+- Avoid global attributes for local proof convenience.
+- Named instances should follow local Lean conventions and expose the
+  class being implemented in the name when ambiguity is possible.
+- Do not add an instance merely to make a single proof shorter if it
+  changes global typeclass search for downstream modules.
+
+## Pattern Matching
+
+- Pattern-match owned inductives explicitly when the constructor set is
+  semantically meaningful.
+- A wildcard branch is allowed only when all remaining constructors have
+  the same meaning and that meaning is obvious from the function name.
+- In proofs, avoid `_` branches that hide which cases were discharged.
+
+## Definitional Equality
+
+- Use `rfl` when the definition truly computes to the target.
+- Do not contort definitions solely to make one proof `rfl` if it harms
+  the model's semantic shape.
+- Prefer theorem-level simplification over changing a domain definition
+  to satisfy a local proof.
+
+## Classical And Decidability
+
+- Prefer constructive definitions and explicit decidability assumptions.
+- Use local `classical` for proofs that need choice or decidable
+  propositions.
+- If a data structure such as `Finset` requires `[DecidableEq α]`, keep
+  that assumption explicit in declarations that need it and out of
+  declarations that do not.
+
+## Proof Factoring
+
+Factor when:
+
+- a tactic block is longer than roughly 15 lines,
+- the same rewrite pattern appears twice,
+- a local `have` names a reusable concept,
+- a proof mixes domain reasoning and algebraic cleanup.
+
+Do not factor into names like `aux`, `helper`, or `foo'` unless the
+result is private and adjacent. Good helper names describe the fact.

--- a/agents/skills/lean-code-style/references/review-rubric.md
+++ b/agents/skills/lean-code-style/references/review-rubric.md
@@ -1,0 +1,94 @@
+# Lean Review Rubric
+
+Use this rubric for Cortex Lean 4 code. The score is secondary; the
+priority findings are what matter.
+
+## Priority Levels
+
+**[P1] Block merge**
+
+- New `sorry`, `admit`, `axiom`, `constant`, `unsafe`, or `partial`
+  outside a deliberately tracked scaffold.
+- A proof that depends on an invalid theorem statement, over-generalized
+  precondition, missing side condition, or false simplification lemma.
+- A `simp` attribute or theorem orientation that can loop, erase
+  information, or make downstream proofs unstable.
+- A broad linter suppression, `autoImplicit`, or namespace/import change
+  that hides real proof debt.
+- A theorem whose trusted base grows unintentionally through new axioms,
+  global classical reasoning, or opaque dependencies.
+- A build-file change that makes local Lake, Nix, or CI disagree about
+  Lean/mathlib versions.
+
+**[P2] Must address or explicitly track**
+
+- Heavy automation where the proof boundary is opaque and likely to
+  break under harmless import or simp-set changes.
+- Missing explicit argument or result types on public definitions.
+- Public declarations without docstrings or unclear theorem names.
+- Unnecessary classical scope, global `open`, or broad variable scope.
+- Non-minimal imports, unpinned dependency changes, or generated
+  manifest drift without an intentional Lake change.
+- Local definitions or lemmas that duplicate mature `Std`/`Mathlib`
+  abstractions and make later proofs less compatible with the ecosystem.
+- Theorem APIs that are hard to rewrite with: wrong orientation,
+  avoidable anonymous binders, or hypotheses buried right of `:`.
+
+**[style] Local cleanup**
+
+- Indentation, line wrapping, naming, short comments, duplicate namespace
+  names, or cosmetic proof simplifications.
+- Small opportunities to use a clearer local lemma, `simp only`, or
+  `rfl`/`simpa` instead of a longer tactic block.
+
+## Scoring
+
+Start each file at 10 and subtract:
+
+- 5 for each P1.
+- 2 for each P2.
+- 0.5 for each repeated style issue.
+
+Do not let a file with any P1 score above 5. Do not let a file with new
+untracked proof debt score above 6.
+
+## Review Axes
+
+### Soundness
+
+The theorem states exactly the intended property. All side conditions
+are explicit. Definitions do not smuggle assumptions through typeclass
+search, `Classical`, impossible branches, or unreviewed attributes.
+
+Review exported theorems for trusted-base drift. When the change claims
+to discharge scaffold debt or reduce assumptions, inspect theorem
+dependencies with Lean's axiom reporting tools and make sure the result
+actually depends on less than before.
+
+### Proof Robustness
+
+Proof scripts should survive benign import ordering and simp-set changes.
+Prefer small lemmas, stable rewrites, and explicit local reasoning over
+large tactic blasts.
+
+### API Shape
+
+Names, namespaces, theorem direction, and attributes should make the
+next proof easier. A theorem that compiles but cannot be reused cleanly
+is not finished.
+
+### Readability
+
+Reviewers should be able to follow the proof state transitions from the
+source. Use comments only for proof strategy or non-obvious mathematical
+intent.
+
+### Build Integrity
+
+The Lean toolchain, Lake manifest, and Nix packaging must describe the
+same dependency story. CI must run the same proof surface the developer
+expects locally.
+
+External dependencies are welcome when they replace brittle local proof
+work with maintained theory, but every dependency must be pinned through
+Lake/Nix and have a clear proof-level reason to exist.

--- a/agents/skills/lean-code-style/references/theory-architecture.md
+++ b/agents/skills/lean-code-style/references/theory-architecture.md
@@ -1,0 +1,75 @@
+# Cortex Theory Architecture
+
+The Lean tree lives under `theory/` and mechanizes substrate guarantees.
+It is not a separate research playground.
+
+## Tracks
+
+- `Cortex.Graph.*`: Mokhov graph algebra and graph equivalence.
+- `Cortex.Pulse.*`: frontier safety, progress, and determinism modulo
+  external sparks.
+- `Cortex.Wire.*`: rewrite admission and soundness.
+- Future provider/spark and substrate/consumer boundary models should
+  stay under `Cortex.*` and mirror the documentation roadmap.
+
+## Boundaries
+
+- Lean should model the substrate, not Portman product behavior.
+- Portman examples may appear only as downstream examples, never as the
+  identity of Cortex.
+- Haskell executable modules are the implementation counterpart; Lean
+  modules are the proof counterpart. Cross-reference exact Haskell files
+  when a definition mirrors runtime behavior.
+
+## Build Files
+
+Review these as part of Lean changes:
+
+- `theory/lean-toolchain`
+- `theory/lakefile.lean`
+- `theory/lake-manifest.json`
+- `nix/lean.nix`
+
+Rules:
+
+- Lean, Lake, mathlib, and Nix package versions must agree.
+- Manifest changes must correspond to intentional `lakefile.lean`
+  changes.
+- Nix checks should build the proof surface used by CI.
+- Do not add dependencies unless they materially simplify proof work or
+  replace bespoke fragile reasoning.
+
+## Validation
+
+For Lean-only edits, run:
+
+```bash
+nix develop -c just lean-build
+just lean-check
+```
+
+Run this when executable, Lake target, dependency, or `Main.lean` wiring
+changes:
+
+```bash
+nix develop -c just lean-build-exe
+```
+
+Run formatting for any committed branch:
+
+```bash
+just fmt-check
+```
+
+If pre-commit hooks run during commit, record their result in the final
+summary.
+
+## Review Expectations
+
+- A proof module should say which obligations it discharges and which
+  remain.
+- A scaffold module should make proof debt explicit and finite.
+- A completed mechanization should replace assumptions, not add another
+  abstraction layer above them.
+- Any theorem expected to support later tracks should have a reusable
+  name and theorem statement, not merely prove the current file compiles.

--- a/agents/skills/lean-code-style/references/writing-guide.md
+++ b/agents/skills/lean-code-style/references/writing-guide.md
@@ -1,0 +1,101 @@
+# Lean Writing Guide
+
+Use this guide when writing or reviewing Lean declarations in Cortex.
+It adapts good ideas from Lean/mathlib community style and CS teaching
+style, but Cortex is stricter about long-lived proof maintainability.
+
+## Module Shape
+
+- Keep imports minimal. Every import must justify itself by declarations
+  used in the file.
+- Keep imports grouped and sorted when there is more than one logical
+  group. Avoid importing all of Mathlib unless the file is intentionally
+  exploratory.
+- Preserve the repository's current module-header style unless the
+  change is explicitly about header policy. Do not churn headers merely
+  to imitate mathlib.
+- Each proof module needs a top-level description stating:
+  - what structure is modeled,
+  - which results are real theorems,
+  - which obligations remain,
+  - which executable modules or papers it mirrors.
+
+## Namespaces
+
+- Put declarations in the smallest meaningful namespace.
+- Avoid duplicated fully qualified names such as
+  `Cortex.Graph.Graph.foo` unless matching an existing local convention.
+  If a duplicate is intentional, keep any linter suppression local and
+  document why.
+- Avoid broad `open` commands. Use qualified names when they make proof
+  dependencies clearer.
+- Avoid global `open Classical`. Prefer explicit `[DecidableEq α]`,
+  local `classical`, or `noncomputable section` when needed.
+
+## Declarations
+
+- Public `def`, `abbrev`, `structure`, `inductive`, `class`,
+  `instance`, `theorem`, and `lemma` declarations need explicit result
+  types.
+- Public structures and fields need docstrings. Fields should describe
+  the invariant or semantic role, not restate the name.
+- Prefer named records and structures when adjacent arguments have the
+  same type or when a theorem statement becomes swap-prone.
+- Use `where` for structures and instances. Avoid large anonymous record
+  literals when field names carry meaning.
+- Use `theorem` for exported proof API. Use `lemma` for local support
+  facts if the file already follows that convention; otherwise match
+  local style.
+
+## Variable Scope
+
+- Keep `variable` blocks close to the declarations that need them.
+- Split variables so typeclass assumptions are not in scope for
+  declarations that do not use them.
+- Prefer `omit [Foo α] in theorem ...` over suppressing
+  `unusedSectionVars`.
+- Do not rely on `autoImplicit`. Declare every type, value, relation,
+  and hypothesis intentionally.
+
+## Naming
+
+- Use Lean-style lower snake case for theorem and definition names.
+- Names should encode the main head symbols and theorem direction:
+  `foo_empty_left`, `map_overlay`, `denote_connect_decomposition`.
+- Hypotheses start with `h` and should be mnemonic:
+  `hReady`, `hDeps`, `hij`, `hmem`, `hterminal`.
+- Induction hypotheses start with `ih`.
+- Avoid shadowing. If an infoview would show daggered variables, rename
+  the local binder.
+- Avoid names like `this` in long proofs except for a one-line local
+  bridge that is consumed immediately.
+
+## Statement Shape
+
+- Put hypotheses to the left of the colon when the proof starts by
+  introducing them.
+- Keep theorem parameters explicit, especially typeclass assumptions and
+  decidability requirements.
+- Orient equalities for rewriting from complex/source expression to
+  simpler/canonical expression.
+- If a theorem is intended as a simp rule, its statement must be a stable
+  normalization rule.
+
+## Formatting
+
+- Target 100 columns.
+- Put `:= by` at the end of the theorem statement line or final
+  continuation line; do not put `by` alone on its own line.
+- Indent theorem continuation lines by four spaces and proof bodies by
+  two spaces.
+- Use focused bullets `·` for generated goals. Do not leave goal changes
+  visually implicit.
+- Keep parentheses with their argument. Do not orphan closing syntax on
+  unrelated lines.
+
+## Comments
+
+- Use docstrings for public API.
+- Use ordinary comments only for proof strategy, model limitations, or
+  non-obvious correspondence to Haskell/docs.
+- Delete comments that narrate tactics or restate code.


### PR DESCRIPTION
## Summary

Adds the repo-local Lean 4 code style skill with a strict Cortex proof review rubric, writing guide, proof-pattern guidance, and theory-architecture guardrails.

## Context

This mirrors the existing Haskell code-style skill for the Lean mechanization track.

## Verification

- `git diff --check`
- `just fmt-check`
- `quick_validate.py agents/skills/lean-code-style`

## Risk

Low. Agent context and skill documentation only.

## Status

ready

## Integration

- [x] Commits are signed, signed off, and pass commit provenance expectations.
