### PR TITLE
ci: enforce canonical commit integration

### DIFF
--- a/.github/allowed_signers
+++ b/.github/allowed_signers
@@ -1,0 +1,1 @@
+julius.koskela@digimuoto.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMxHeXUEdMoA6NQOcYQJAVf0mdOw5P1PdcRtRlfrWsJ8

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,3 +17,9 @@
 ## Status
 
 <!-- ready / partial / experimental. Note deferred work or follow-ups. -->
+
+## Integration
+
+<!-- Cortex main is fast-forward-only. Do not use GitHub squash/merge/rebase buttons. -->
+
+- [ ] Commits are signed, signed off, and pass `just check-commit-provenance origin/main..HEAD`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,49 @@ jobs:
               - 'flake.nix'
               - 'nix/**'
 
+  commit-provenance:
+    name: Commit Provenance
+    runs-on: [self-hosted, nix, mercury, cortex]
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Check commit provenance
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            git fetch --no-tags origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+            RANGE="origin/${GITHUB_BASE_REF}..HEAD"
+          else
+            if [[ "${BEFORE:-}" =~ ^0+$ || -z "${BEFORE:-}" ]]; then
+              RANGE="$GITHUB_SHA"
+            else
+              RANGE="${BEFORE}..${GITHUB_SHA}"
+            fi
+          fi
+
+          scripts/check-commit-provenance "$RANGE"
+
+  repository-merge-policy:
+    name: Repository Merge Policy
+    runs-on: [self-hosted, nix, mercury, cortex]
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check GitHub merge policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: nix develop -c scripts/check-github-merge-policy
+
   conventional-commits:
     name: Conventional commits
     if: github.event_name == 'pull_request'
@@ -283,6 +326,8 @@ jobs:
     if: always()
     needs:
       - changes
+      - commit-provenance
+      - repository-merge-policy
       - conventional-commits
       - conventional-pr-title
       - format-check
@@ -300,6 +345,8 @@ jobs:
 
           results=(
             "${{ needs.changes.result }}"
+            "${{ needs.commit-provenance.result }}"
+            "${{ needs.repository-merge-policy.result }}"
             "${{ needs.conventional-commits.result }}"
             "${{ needs.conventional-pr-title.result }}"
             "${{ needs.format-check.result }}"

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ editors/tree-sitter-wire/target
 !/.github/
 !/.github/**
 
+# Repo-local maintenance scripts
+!scripts/
+!scripts/**
+
 # === Root Files (anchored with /) ===
 !/.envrc
 !/.gitignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ verifiable.
 1. All commits must be signed and verifiable.
 2. LLMs and coding agents must not be listed as authors or co-authors.
 3. Human git identity must be real and stable.
-4. Builds and checks go through the repo's `just` and Nix surfaces.
+4. `main` advances only by fast-forwarding already signed commits.
+5. Builds and checks go through the repo's `just` and Nix surfaces.
 
 ## Authorship and Copyright
 
@@ -46,6 +47,7 @@ Recommended checks:
 ```bash
 git log --show-signature --max-count=5
 git verify-commit HEAD
+just check-commit-provenance origin/main..HEAD
 ```
 
 For SSH signing, configure an allowed signers file so Git can verify
@@ -67,16 +69,66 @@ Default policy:
 
 - Rebase ordinary feature branches before integration when that makes
   the commit sequence easier to review, bisect, or audit.
-- Keep `main` immutable. Never force-push trunk.
+- Keep `main` immutable. Never force-push trunk except for an explicit,
+  lease-protected history repair approved by the maintainer.
 - Use `git push --force-with-lease` after deliberate branch rewrites.
   Do not use raw `git push --force`.
 - CI must pass after the final rebase or rewrite.
-- Prefer fast-forward or squash integration into trunk.
+- Integrate PRs by fast-forwarding `main` to the exact signed branch tip.
+  Do not use GitHub's merge, squash, or rebase buttons as the Cortex
+  integration protocol.
 - Use merge commits deliberately for release branches, vendor branches,
   backports, long-running integration branches, large collaborative
   features, or audit cases where the parallel topology matters.
 
 Merge is not forbidden. Uncontrolled merge is the antipattern.
+
+## PR Integration
+
+GitHub's PR buttons manufacture commit objects for merge and squash
+flows. Rebase-and-merge also rewrites commits on GitHub's side. Those
+objects do not preserve the local author, committer, signature, and
+signoff that Cortex requires for `main`.
+
+The repository therefore keeps GitHub's merge settings in a deliberately
+constrained state:
+
+- merge commits disabled
+- squash merge disabled
+- rebase merge left enabled only because GitHub requires at least one
+  merge method for PRs
+- branch rules require signed commits, linear history, PR checks, and
+  rebase-only PR integration
+- branch rules grant an explicit maintainer/integration bypass so the
+  reviewed branch tip can be pushed by local fast-forward after checks
+
+With signed commits required, the remaining GitHub rebase button should
+not be used. Integration is local fast-forward:
+
+```bash
+just integrate-pr <branch-or-pr-number>
+```
+
+The helper verifies the commits introduced by the branch, checks that
+the branch is a fast-forward from `main`, merges with `--ff-only`, and
+pushes `main`.
+
+That bypass is only for this integration path or an explicit
+lease-protected history repair. It is not permission to bypass CI,
+signature checks, signoff checks, or review.
+
+Hard checks:
+
+```bash
+just check-commit-provenance origin/main..HEAD
+just check-github-merge-policy
+```
+
+`check-commit-provenance` rejects GitHub/web-flow identities,
+non-Digimuoto author or committer emails, missing matching
+`Signed-off-by` trailers, unverifiable signatures, and merge commits.
+`check-github-merge-policy` rejects repository settings or branch rules
+that would re-enable GitHub-manufactured merge or squash commits.
 
 ## Build and Check Workflow
 
@@ -130,4 +182,5 @@ Cortex is substrate code, not Portman product code.
 - relevant build/test commands pass
 - commits are signed
 - `git log --show-signature` verifies the commits you are pushing
+- `just check-commit-provenance origin/main..HEAD` passes
 - no AI authorship or co-authorship appears anywhere in commit metadata

--- a/agents/README.md
+++ b/agents/README.md
@@ -80,7 +80,10 @@ semantic sequence of changes.
 - Use `git push --force-with-lease` only when history was deliberately
   rewritten and the remote still points where you expect.
 - Make CI pass after the final rebase.
-- Prefer fast-forward or squash integration into trunk.
+- Integrate by fast-forwarding `main` to the exact signed branch tip.
+- Do not use GitHub's merge, squash, or rebase buttons for Cortex
+  `main`; use `just integrate-pr <branch-or-pr-number>` after PR
+  review and CI.
 - Use merge commits only when the existence of parallel development
   lines is itself meaningful.
 

--- a/agents/context.md
+++ b/agents/context.md
@@ -72,15 +72,18 @@ private staging areas for a coherent change.
 
 Follow this policy:
 
-- `main` is immutable. Never force-push the shared trunk.
+- `main` is immutable. Never force-push the shared trunk except for an
+  explicit, lease-protected history repair approved by the maintainer.
 - Feature branches are rewriteable by their owner. Rebase, squash,
   fixup, and reorder before integration when that makes the branch read
   as a semantic argument.
 - Shared feature branches require protocol. Use
   `git push --force-with-lease`, never raw `git push --force`.
 - CI must pass after the final rebase or rewrite.
-- Integration should be fast-forward or squash merge by default. Avoid
-  arbitrary merge commits into trunk.
+- Integration is fast-forward-only from an already signed branch tip.
+  Do not use GitHub's merge, squash, or rebase buttons for Cortex
+  `main`. The maintainer ruleset bypass exists only for
+  `just integrate-pr <branch-or-pr-number>` after PR review and CI.
 - Long-running collaborative, release, vendor, backport, or integration
   branches may use merge commits deliberately when the topology itself
   carries meaning.
@@ -93,6 +96,8 @@ Every commit in this repo must be signed and verifiable.
 - Do not create unsigned commits.
 - After rewriting or creating commits, verify them with
   `git log --show-signature` or `git verify-commit`.
+- Before publishing a branch for integration, run
+  `just check-commit-provenance origin/main..HEAD`.
 
 LLMs and coding agents are not authors for copyright purposes.
 

--- a/agents/skills/impl/SKILL.md
+++ b/agents/skills/impl/SKILL.md
@@ -204,8 +204,8 @@ their own repo.
 
 ## Principles
 
-1. **Small commits, one concern each.** Reviewers can follow a story;
-   squash-merge compresses it cleanly.
+1. **Small commits, one concern each.** Reviewers can follow a story,
+   and the exact signed branch tip may become `main`.
 2. **Plan before coding.** Plan mode surfaces the shape before you sink
    hours into the wrong one.
 3. **Respect the layer boundary.** Runtime never imports reasoning or

--- a/agents/skills/publish/SKILL.md
+++ b/agents/skills/publish/SKILL.md
@@ -80,6 +80,16 @@ history was intentionally rewritten (rebase, squash, fixup, amend after
 review) and a normal push is rejected. Never use raw `--force` against
 shared branches; never force-push `main`.
 
+Before pushing, verify the branch's commit provenance:
+
+```bash
+just check-commit-provenance origin/main..HEAD
+```
+
+Cortex `main` is integrated by fast-forwarding to exact signed branch
+commits after PR review and CI. Do not assume the branch will be merged
+with a GitHub squash, merge, or rebase button.
+
 ### 4. Verify
 
 ```bash
@@ -105,9 +115,9 @@ Expected end state:
 3. **Preserve user changes.** Don't auto-stage unrelated drift. When in
    doubt, ask.
 4. **Semantic history.** Prefer a small number of meaningful commits.
-   Rebase or fix up private branch history when it removes process noise.
-   The branch usually gets squash-merged; optimize for review clarity,
-   bisectability, and the final artifact.
+   Rebase or fix up private branch history when it removes process
+   noise. The branch tip may become `main` by fast-forward, so optimize
+   for review clarity, bisectability, and the final artifact.
 
 ## Output
 

--- a/justfile
+++ b/justfile
@@ -130,6 +130,18 @@ ci-check:
     @echo "🚀 Running CI-aligned checks..."
     nix run .#_ci-check
 
+# Check commit signatures, signoffs, and authorship for a revision range
+check-commit-provenance RANGE="origin/main..HEAD":
+    scripts/check-commit-provenance "{{ RANGE }}"
+
+# Check that GitHub merge settings cannot manufacture squash/merge commits
+check-github-merge-policy:
+    nix develop -c scripts/check-github-merge-policy
+
+# Fast-forward main to an already reviewed and signed branch or PR number
+integrate-pr TARGET:
+    scripts/integrate-pr "{{ TARGET }}"
+
 # Regenerate haskell.nix materialized plans (after editing cortex.cabal)
 update-materialized:
     nix run .#update-materialized

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -41,6 +41,7 @@
           # Dev tooling
           git
           jq
+          python3
           ripgrep
           fd
           just

--- a/scripts/check-commit-provenance
+++ b/scripts/check-commit-provenance
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check-commit-provenance [<rev-list-range>]
+
+Checks Cortex commit provenance for the selected commits.
+
+Default range:
+  origin/main..HEAD
+
+Policy:
+  - no merge commits
+  - no GitHub/web-flow authored or committed commits
+  - author and committer email must match CORTEX_ALLOWED_COMMIT_EMAIL_REGEX
+  - every commit must have a matching Signed-off-by trailer
+  - every commit must verify against CORTEX_ALLOWED_SIGNERS_FILE
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+range="${1:-origin/main..HEAD}"
+allowed_email_regex="${CORTEX_ALLOWED_COMMIT_EMAIL_REGEX:-^[^@]+@digimuoto\.com$}"
+allowed_signers_file="${CORTEX_ALLOWED_SIGNERS_FILE:-.github/allowed_signers}"
+
+if [[ ! -f "$allowed_signers_file" ]]; then
+  echo "Missing allowed signers file: $allowed_signers_file" >&2
+  exit 1
+fi
+
+if [[ "$range" == *..* || "$range" == *" "* || "$range" == ^* ]]; then
+  mapfile -t commits < <(git rev-list --reverse "$range")
+else
+  mapfile -t commits < <(git rev-parse --verify "${range}^{commit}")
+fi
+
+if [[ "${#commits[@]}" -eq 0 ]]; then
+  echo "No commits to check for range: $range"
+  exit 0
+fi
+
+failed=0
+
+fail_commit() {
+  local commit="$1"
+  local message="$2"
+  printf 'commit provenance violation: %s %s\n' "$commit" "$message" >&2
+  failed=1
+}
+
+for commit in "${commits[@]}"; do
+  short="$(git rev-parse --short "$commit")"
+  subject="$(git show -s --format=%s "$commit")"
+  author_name="$(git show -s --format=%an "$commit")"
+  author_email="$(git show -s --format=%ae "$commit")"
+  committer_name="$(git show -s --format=%cn "$commit")"
+  committer_email="$(git show -s --format=%ce "$commit")"
+  parent_count="$(git rev-list --parents -n 1 "$commit" | awk '{print NF - 1}')"
+  message="$(git show -s --format=%B "$commit")"
+
+  echo "Checking $short $subject"
+
+  if [[ "$parent_count" -gt 1 ]]; then
+    fail_commit "$short" "is a merge commit; main is fast-forward-only"
+  fi
+
+  if [[ "$author_email" =~ @users\.noreply\.github\.com$ ||
+        "$author_email" == "noreply@github.com" ||
+        "$committer_email" =~ @users\.noreply\.github\.com$ ||
+        "$committer_email" == "noreply@github.com" ||
+        "$committer_name" == "GitHub" ]]; then
+    fail_commit "$short" "uses GitHub/web-flow identity ($author_name <$author_email> / $committer_name <$committer_email>)"
+  fi
+
+  if ! [[ "$author_email" =~ $allowed_email_regex ]]; then
+    fail_commit "$short" "author email is not allowed: $author_email"
+  fi
+
+  if ! [[ "$committer_email" =~ $allowed_email_regex ]]; then
+    fail_commit "$short" "committer email is not allowed: $committer_email"
+  fi
+
+  signoff="Signed-off-by: $author_name <$author_email>"
+  if ! grep -Fqx "$signoff" <<<"$message"; then
+    fail_commit "$short" "is missing matching trailer: $signoff"
+  fi
+
+  if ! verify_output="$(git -c "gpg.ssh.allowedSignersFile=$allowed_signers_file" verify-commit "$commit" 2>&1)"; then
+    fail_commit "$short" "does not verify against $allowed_signers_file"
+    printf '%s\n' "$verify_output" >&2
+  fi
+done
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "Commit provenance OK for range: $range"

--- a/scripts/check-github-merge-policy
+++ b/scripts/check-github-merge-policy
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+
+API = "https://api.github.com"
+
+
+def get_token() -> str:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token
+    try:
+        return subprocess.check_output(
+            ["gh", "auth", "token"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    except Exception:
+        print(
+            "GH_TOKEN or GITHUB_TOKEN is required to check GitHub merge policy",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def api_get(path: str, token: str):
+    request = urllib.request.Request(
+        f"{API}{path}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        body = error.read().decode("utf-8", errors="replace")
+        print(f"GitHub API request failed: {path}: {error.code} {body}", file=sys.stderr)
+        sys.exit(1)
+
+
+def fail(message: str, failures: list[str]) -> None:
+    failures.append(message)
+    print(f"github merge policy violation: {message}", file=sys.stderr)
+
+
+def warn(message: str) -> None:
+    print(f"github merge policy warning: {message}", file=sys.stderr)
+
+
+def ruleset_matches_default_branch(ruleset, default_branch: str) -> bool:
+    ref_name = ruleset.get("conditions", {}).get("ref_name")
+    if not ref_name:
+        return True
+    included = set(ref_name.get("include", []))
+    return bool(
+        included
+        & {
+            "~DEFAULT_BRANCH",
+            default_branch,
+            f"refs/heads/{default_branch}",
+        }
+    )
+
+
+def main() -> int:
+    repository = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("GITHUB_REPOSITORY")
+    if not repository:
+        repository = "Digimuoto/cortex"
+
+    token = get_token()
+    failures: list[str] = []
+
+    repo = api_get(f"/repos/{repository}", token)
+    default_branch = repo["default_branch"]
+
+    expected_repo_flags = {
+        "allow_merge_commit": False,
+        "allow_squash_merge": False,
+        "allow_rebase_merge": True,
+    }
+    limited_repository_payload = False
+    for key, expected in expected_repo_flags.items():
+        if key not in repo:
+            limited_repository_payload = True
+            warn(f"repository setting {key} is not exposed by this token; skipping")
+            continue
+        actual = repo[key]
+        if actual is not expected:
+            fail(f"repository setting {key} is {actual}, expected {expected}", failures)
+
+    summaries = api_get(f"/repos/{repository}/rulesets", token)
+    matching_rulesets = []
+    for summary in summaries:
+        if summary.get("enforcement") != "active" or summary.get("target") != "branch":
+            continue
+        full = api_get(f"/repos/{repository}/rulesets/{summary['id']}", token)
+        if ruleset_matches_default_branch(full, default_branch):
+            matching_rulesets.append(full)
+
+    if not matching_rulesets:
+        fail(f"no active branch ruleset applies to {default_branch}", failures)
+
+    for ruleset in matching_rulesets:
+        name = ruleset.get("name", f"ruleset {ruleset.get('id')}")
+        rules = ruleset.get("rules", [])
+        rule_types = {rule.get("type") for rule in rules}
+        bypass_actors = ruleset.get("bypass_actors", [])
+
+        for required in {
+            "non_fast_forward",
+            "pull_request",
+            "required_linear_history",
+            "required_signatures",
+            "required_status_checks",
+        }:
+            if required not in rule_types:
+                fail(f"{name} is missing rule {required}", failures)
+
+        pull_request_rules = [rule for rule in rules if rule.get("type") == "pull_request"]
+        for rule in pull_request_rules:
+            methods = rule.get("parameters", {}).get("allowed_merge_methods")
+            if methods != ["rebase"]:
+                fail(
+                    f"{name} allows merge methods {methods}; expected ['rebase']",
+                    failures,
+                )
+
+        if limited_repository_payload and not bypass_actors:
+            warn(
+                f"{name} bypass actors are not exposed by this token; "
+                "skipping fast-forward bypass check"
+            )
+        else:
+            has_fast_forward_bypass = any(
+                actor.get("bypass_mode") == "always"
+                and actor.get("actor_type")
+                in {"Integration", "OrganizationAdmin", "RepositoryRole"}
+                for actor in bypass_actors
+            )
+            if not has_fast_forward_bypass:
+                fail(
+                    f"{name} has no maintainer or integration bypass for local fast-forward pushes",
+                    failures,
+                )
+
+    if failures:
+        return 1
+
+    if limited_repository_payload:
+        print(f"GitHub merge policy OK for {repository} (limited token)")
+    else:
+        print(f"GitHub merge policy OK for {repository}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/integrate-pr
+++ b/scripts/integrate-pr
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/integrate-pr <branch-or-pr-number>
+
+Fast-forward main to an already reviewed and signed branch tip.
+
+This command does not create merge, squash, or rebase commits. It preserves
+the exact commit objects that CI and reviewers saw on the PR branch.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+target="${1:?branch name or PR number required}"
+remote="${CORTEX_REMOTE:-origin}"
+base_branch="${CORTEX_BASE_BRANCH:-main}"
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Worktree has local changes; integrate from a clean tree" >&2
+  exit 1
+fi
+
+if [[ "$target" =~ ^[0-9]+$ ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "PR-number integration requires gh" >&2
+    exit 1
+  fi
+  target_branch="$(gh pr view "$target" --json headRefName --jq .headRefName)"
+else
+  target_branch="${target#refs/heads/}"
+  target_branch="${target_branch#${remote}/}"
+fi
+
+base_ref="refs/remotes/${remote}/${base_branch}"
+target_ref="refs/remotes/${remote}/${target_branch}"
+
+git fetch "$remote" \
+  "${base_branch}:${base_ref}" \
+  "${target_branch}:${target_ref}"
+
+scripts/check-commit-provenance "${base_ref}..${target_ref}"
+
+git switch "$base_branch"
+git pull --ff-only "$remote" "$base_branch"
+
+if ! git merge-base --is-ancestor HEAD "$target_ref"; then
+  echo "${target_branch} is not a fast-forward from ${base_branch}" >&2
+  echo "Rebase the branch onto ${base_branch}, verify CI, then retry." >&2
+  exit 1
+fi
+
+git merge --ff-only "$target_ref"
+git push "$remote" "$base_branch"
+
+echo "Integrated ${target_branch} into ${base_branch} by fast-forward."


### PR DESCRIPTION
## Summary

Codifies Cortex's canonical integration workflow: PRs are for review and CI, while `main` advances by fast-forwarding already signed branch commits.

## Context

GitHub squash/rebase/merge buttons manufacture or rewrite commit objects, which can lose the local Digimuoto author, committer, signature, and signoff identity. This PR adds local and CI guardrails for that policy.

## Verification

- `scripts/check-commit-provenance origin/main..HEAD`
- `scripts/check-github-merge-policy`
- known-good signed commit accepted
- known-bad GitHub/web-flow commit rejected
- `git diff --check`
- `just fmt-check`
- signed commit verification

## Risk

Medium. This changes repository workflow policy and CI requirements, but does not affect runtime code.

## Status

ready

## Integration

- [x] Commits are signed, signed off, and pass `just check-commit-provenance origin/main..HEAD`.
