### PR TITLE
fix: enforce Wire record terminators

### DIFF
--- a/docs/Reference/Wire/grammar-v1.md
+++ b/docs/Reference/Wire/grammar-v1.md
@@ -69,7 +69,7 @@ contract   node   let   import   from   select   true   false
 
 **Lists.** `[a, b, c]`. Trailing comma permitted. Empty list: `[]`.
 
-**Records.** `{ k1 = v1; k2 = v2; }`. Fields separated by `;` or `,`. Trailing separator permitted. Empty record: `{}`.
+**Records.** `{ k1 = v1; k2 = v2; }`. Fields are terminated by `;`; every field needs its terminating `;`. Empty record: `{}`.
 
 **Numbers.** Decimal integers and floats: `42`, `3.14`, `-7`. Leading `-` is part of the numeric literal, not an operator — Wire has no arithmetic in v1. No hex, octal, or scientific notation.
 
@@ -498,7 +498,7 @@ selector select(
 { title = "Report"; maxTokens = 16384; tools = [webSearch, getDate]; }
 ```
 
-Fields are separated by `;` or `,`. A trailing separator is permitted. Field names are unqualified identifiers; values are arbitrary expressions.
+Fields are terminated by `;`. Field names are unqualified identifiers; values are arbitrary expressions. Commas are graph overlay shorthand in file-return position and separators in list/tuple/select syntax; they are not record field delimiters.
 
 ### 8.2 `//` — right-biased shallow merge
 
@@ -914,9 +914,7 @@ partial_expr      ::= "@" qualified_ident record_expr
 
 constructor_expr  ::= qualified_ident record_expr   # config-value constructor, no @
 
-record_expr       ::= "{" [ field { record_sep field } [ record_sep ] ] "}"
-
-record_sep        ::= ";" | ","
+record_expr       ::= "{" { field ";" } "}"
 
 field             ::= path "=" expr
 

--- a/src/Cortex/Wire/V1/Parser.hs
+++ b/src/Cortex/Wire/V1/Parser.hs
@@ -318,12 +318,12 @@ constructorExpr = do
 recordExpr :: Parser Record
 recordExpr = do
   _ <- symbol "{"
-  fields <- field `sepEndBy` recordFieldSeparator
+  fields <- many terminatedField
   _ <- symbol "}"
   pure (Record fields)
 
-recordFieldSeparator :: Parser Text
-recordFieldSeparator = symbol ";" <|> symbol ","
+terminatedField :: Parser Field
+terminatedField = field <* symbol ";"
 
 field :: Parser Field
 field = do

--- a/test/Cortex/Wire/V1/ParserSpec.hs
+++ b/test/Cortex/Wire/V1/ParserSpec.hs
@@ -181,13 +181,17 @@ spec = describe "Cortex.Wire.V1.Parser" $ do
           length fields `shouldBe` 2
         other -> expectationFailure ("unexpected: " <> show other)
 
-    it "parses comma-separated executor config fields" $ do
-      case parseWireExpr
+    it "rejects comma-separated executor config fields" $
+      parseWireExpr
         "test"
-        "@llm.analyst { prompt = \"Find current evidence.\", tools = [webSearch], }" of
-        Right (ExprApply (QName ("llm" :| ["analyst"])) (Record fields)) ->
-          length fields `shouldBe` 2
-        other -> expectationFailure ("unexpected: " <> show other)
+        "@llm.analyst { prompt = \"Find current evidence.\", tools = [webSearch], }"
+        `shouldSatisfy` isParseFailure
+
+    it "rejects unterminated executor config fields" $
+      parseWireExpr
+        "test"
+        "@llm.analyst {\n  prompt = \"Find current evidence.\"\n  ; tools = [webSearch]\n}"
+        `shouldSatisfy` isParseFailure
 
     it "parses a bare @llm executor reference as a single-segment qname" $ do
       case parseWireExpr "test" "@llm {}" of


### PR DESCRIPTION
## Summary
- require every Wire v1 record field to be terminated by `;`
- reject comma-separated record fields so comma remains graph overlay shorthand, not record syntax
- update grammar reference and parser regression coverage

## Verification
- nix run .#cortex-tests -- --match "/Cortex.Wire.V1.Parser"
- just test

Note: opened for review only; not merged per request.