### PR TITLE
refactor: introduce canonical Cortex module taxonomy

### DIFF
--- a/agents/context.md
+++ b/agents/context.md
@@ -6,14 +6,17 @@ file instead.
 
 Cortex is a standalone substrate: a durable runtime plus a
 structured-reasoning library above it (see ADR 0015). The runtime is the
-canonical public surface. `Cortex.Logos` is a library on top of the
+canonical public surface. `Cortex.Logoi` is a library on top of the
 substrate and depends on it, not the other way round.
 
 ## Repository Shape
 
-- `src/Cortex/` - main Haskell library. `Cortex.Graph`,
-  `Cortex.Circuit`, `Cortex.Wire`, `Cortex.Pulse`, `Cortex.Memory`,
-  `Cortex.Capability`, `Cortex.Task`, `Cortex.Provider`, etc.
+- `src/Cortex/` - main Haskell library. Canonical substrate roots are
+  `Cortex.Graph`, `Cortex.Circuit`, `Cortex.Wire`, `Cortex.Pulse`,
+  `Cortex.Memory`, `Cortex.Capability`, `Cortex.Document`, and
+  `Cortex.Event`. Implementation-era roots such as `Cortex.Task`,
+  `Cortex.Provider`, `Cortex.Research`, and `Cortex.Run` remain only as
+  migration surfaces until the Logoi follow-up lands.
 - `src-platform/Platform/` - runtime substrate library Cortex depends
   on: `Platform.Observability`, `Platform.DurableTask`,
   `Platform.Database`, `Platform.HTTP.Retry`, `Platform.Text`, etc.
@@ -126,7 +129,7 @@ Cortex docs are the source of truth for substrate design. When editing
 docs:
 
 - Architecture chapters describe the substrate. Keep reasoning-layer
-  content explicitly attributed to `Cortex.Logos`.
+  content explicitly attributed to `Cortex.Logoi`.
 - ADRs are numbered and append-only. New decisions get new ADR files.
 - `docs/Consumers/<consumer>/` documents downstream consumer bindings
   and integration contracts, not the frame for Cortex itself.

--- a/agents/skills/doc-review/SKILL.md
+++ b/agents/skills/doc-review/SKILL.md
@@ -195,9 +195,15 @@ Mermaid standard:
   sentences belong in the surrounding prose, not in the diagram
 - sequence diagrams stay at 4 actors or fewer because the docs prose
   width is roughly 720px
-- use `classDef` only for *semantically* coloured nodes such as error
-  or danger states; cosmetic `classDef` and per-node `style` overrides
-  defeat the cycling palette and should be a finding
+- **prefer the default theme colours.** No `style X fill:…`, no
+  `classDef` cosmetic colour, no inline hex on nodes or edges. Mermaid
+  bakes inline fills into the SVG, so any pinned colour overrides the
+  per-theme palette and the diagram stops responding to the
+  light/slate toggle. This is the single most common diagram-review
+  finding in this repo
+- the only legitimate use of `classDef` is *semantic* colour — an
+  error or danger state that must read as such regardless of theme.
+  Treat any other use as a finding and strip it
 - diagrams should also flip cleanly between the light theme and slate;
   edge labels and subgraph titles are the usual under-contrast
   failures

--- a/agents/skills/haskell-code-style/SKILL.md
+++ b/agents/skills/haskell-code-style/SKILL.md
@@ -329,7 +329,7 @@ outcomeLogLevel = \case
 ### 7. Respect the Cortex layer boundary
 
 Per ADR 0015, Cortex is a runtime substrate with a structured-reasoning
-library (`Cortex.Logos`, future) on top. The runtime **never** imports
+library (`Cortex.Logoi`, future) on top. The runtime **never** imports
 the reasoning layer, and neither the runtime nor the reasoning layer
 ever imports a consumer-specific module, product binding, or host-edge
 module. A cross-layer import is a **[P1]** finding.

--- a/agents/skills/impl/SKILL.md
+++ b/agents/skills/impl/SKILL.md
@@ -62,14 +62,14 @@ your plan:
 - `Cortex.Wire` / `Cortex.Wire.V1` — source language + rewrite algebra
 - `Cortex.Pulse.*` — durable execution runtime
 - `Cortex.Memory.*` — memory substrate
-- `Cortex.Capability.*` / `Cortex.Provider.*` — model + tool abstractions
-- `Cortex.Task.*` — task orchestration primitives
+- `Cortex.Capability.*` — model + tool abstractions
+- `Cortex.Document.*` — structured artifacts and reports
 - `Platform.*` — generic runtime substrate (observability, durable task,
   database, crypto, HTTP retry). Lives in `src-platform/`.
 
 If the work would introduce reasoning-layer concerns (role taxonomies,
 reasoning templates, memory presets), it probably belongs in a future
-`Cortex.Logos` module set — not in the runtime substrate. Flag this and
+`Cortex.Logoi` module set — not in the runtime substrate. Flag this and
 stop to discuss before coding.
 
 ### 3. Prerequisites

--- a/agents/skills/pr-resolve-review/SKILL.md
+++ b/agents/skills/pr-resolve-review/SKILL.md
@@ -151,7 +151,7 @@ Formulate the answer, post the reply. Link the authoritative source
 when one exists — ADRs, architecture chapters, or other docs:
 
 ```bash
-reply_body=$'Short answer: <n>.\n\nSee [ADR 0015](docs/ADRs/0015-cortex-logos-reasoning-layer.md) for the full reasoning.'
+reply_body=$'Short answer: <n>.\n\nSee [ADR 0015](docs/ADRs/0015-cortex-logoi-reasoning-layer.md) for the full reasoning.'
 jq -n --arg body "$reply_body" '{body: $body}' \
   | gh api "repos/Digimuoto/cortex/pulls/$PR/comments/<comment-id>/replies" \
       --method POST --input -

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -6,7 +6,7 @@ description:
     Cortex is a durable runtime substrate for typed-dataflow programs:
     Graph algebra, Circuit validation, Wire source language, Pulse
     executor, memory substrate, and capability abstractions. A structured
-    reasoning library (Cortex.Logos) sits on top of the substrate and
+    reasoning library (Cortex.Logoi) sits on top of the substrate and
     depends on it, not the other way round (ADR 0015).
 
 license:            Apache-2.0
@@ -96,7 +96,8 @@ common runtime-library-deps
         resource-pool >=0.4,
 
         -- HTTP client + WAI middleware
-        -- (Platform.HTTP.Retry, Cortex.Provider.OpenRouter, Platform.Observability.Wai)
+        -- (Platform.HTTP.Retry, Cortex.Capability.Provider.OpenRouter,
+        -- Platform.Observability.Wai)
         servant-server >=0.20,
         servant-client-core >=0.20,
         openapi3 >=3.2,
@@ -133,7 +134,7 @@ common runtime-library-deps
         monad-logger >=0.3,
         configurator >=0.3,
 
-        -- Markdown rendering (Cortex.Text)
+        -- Markdown rendering
         cmark-gfm >=0.2.5
 
 -- Public sub-library: the Platform runtime substrate.
@@ -163,6 +164,11 @@ library platform-runtime
         Platform.DurableTask.Types
         Platform.DurableTask.Schedule
         Platform.DurableTask.Workflow
+        Platform.Serde
+        Platform.Serde.Json
+        Platform.Serde.Json.Object
+        Platform.Serde.Json.Preview
+        Platform.Serde.Json.Text
         Platform.Text
         Platform.Config
         Platform.Crypto
@@ -197,20 +203,37 @@ library
         Cortex.Wire.V1.Compiler
         Cortex.Wire.V1.Parser
     exposed-modules:
-        Cortex.Agent.Definition
         Cortex.Agent.Config
+        Cortex.Agent.Definition
         Cortex.Agent.Policy
-        Cortex.Document.IR
-        Cortex.Document.Metadata
+        Cortex.Capability
+        Cortex.Capability.Model
         Cortex.Capability.Model.Client
         Cortex.Capability.Model.Message
         Cortex.Capability.Model.Output
         Cortex.Capability.Model.Types
+        Cortex.Capability.Provider
+        Cortex.Capability.Provider.OpenRouter
+        Cortex.Capability.Provider.OpenRouter.Client
+        Cortex.Capability.Provider.OpenRouter.Embedding
+        Cortex.Capability.Provider.OpenRouter.Wire
+        Cortex.Capability.StructuredOutput
+        Cortex.Capability.Tool
         Cortex.Capability.Tool.Definition
+        Cortex.Capability.Tool.Host
+        Cortex.Capability.Tool.Loop
         Cortex.Capability.Tool.Record
+        Cortex.Document
         Cortex.Document.Host
+        Cortex.Document.IR
+        Cortex.Document.Metadata
+        Cortex.Document.Report
+        Cortex.Document.Section
+        Cortex.Event
         Cortex.Events
         Cortex.Graph
+        Cortex.Graph.Algebra
+        Cortex.Graph.Mokhov
         Cortex.Json.Object
         Cortex.Json.Preview
         Cortex.Json.Text
@@ -218,7 +241,10 @@ library
         Cortex.Provider.OpenRouter.Client
         Cortex.Provider.OpenRouter.Embeddings
         Cortex.Provider.OpenRouter.Wire
+        Cortex.Memory
+        Cortex.Memory.Candidate
         Cortex.Memory.Candidates
+        Cortex.Memory.Compact
         Cortex.Memory.Conflict
         Cortex.Memory.Document
         Cortex.Memory.Host
@@ -243,6 +269,8 @@ library
         Cortex.Task.ToolLoop
         Cortex.Text
         Cortex.Pulse
+        Cortex.Pulse.Attempt
+        Cortex.Pulse.Event
         Cortex.Pulse.Executor
         Cortex.Pulse.Executor.Attempt
         Cortex.Pulse.Executor.Events
@@ -253,8 +281,22 @@ library
         Cortex.Pulse.Executor.ReplayPolicy
         Cortex.Pulse.Executor.Resume
         Cortex.Pulse.Executor.Types
+        Cortex.Pulse.Frontier
+        Cortex.Pulse.Hydrate
+        Cortex.Pulse.Materialize
+        Cortex.Pulse.Outcome
+        Cortex.Pulse.Persistence
+        Cortex.Pulse.Replay
+        Cortex.Pulse.Resume
+        Cortex.Pulse.Runtime
         Cortex.Circuit
+        Cortex.Circuit.Artifact
+        Cortex.Circuit.Compile
         Cortex.Wire
+        Cortex.Wire.Compile
+        Cortex.Wire.Contract
+        Cortex.Wire.Parser
+        Cortex.Wire.Syntax
         Cortex.Wire.V1
         Cortex.Circuit.Compiled
         Cortex.Circuit.Compiler
@@ -277,7 +319,9 @@ library
         Cortex.Pulse.Scheduler
         Cortex.Pulse.Types
         Cortex.Circuit.IR
+        Cortex.Circuit.Lower
         Cortex.Circuit.Lowering
+        Cortex.Circuit.Node
         Cortex.Circuit.NodeKind
 
 -- Pulse executor binary: substrate shell.

--- a/docs/ADRs/0015-cortex-logoi-reasoning-layer.md
+++ b/docs/ADRs/0015-cortex-logoi-reasoning-layer.md
@@ -1,6 +1,6 @@
 ---
 title: "ADR 0015 — Structured Reasoning Above the Cortex Substrate"
-description: "Cortex is a durable runtime substrate with a structured reasoning library above it. Cortex.Logos is a namespace and library on top of the substrate, not a peer layer."
+description: "Cortex is a durable runtime substrate with a structured reasoning library above it. Cortex.Logoi is a namespace and library on top of the substrate, not a peer layer."
 sidebar:
   label: "0015. Structured reasoning"
   order: 15
@@ -29,7 +29,7 @@ Cortex conflates two concerns in its public narrative: a generic durable runtime
 
 The current architecture book reinforces the conflation. Chapters 03–08 are runtime-centric, but reasoning-facing concepts — role taxonomies, memory presets, template programs — sit awkwardly inside those chapters.
 
-A first sketch proposed a new "Cortex.Logos" layer as a peer of Graph / Circuit / Wire / Pulse. That proposal duplicated ownership of executors, contracts, and memory — the substrate already owns those mechanisms under ADR 0010 and the chapter 08 contract registry. The useful residue is not a new substrate layer; it is an opinionated library of reasoning patterns built on top of the closed authority the substrate already defines.
+A first sketch proposed a new "Cortex.Logoi" layer as a peer of Graph / Circuit / Wire / Pulse. That proposal duplicated ownership of executors, contracts, and memory — the substrate already owns those mechanisms under ADR 0010 and the chapter 08 contract registry. The useful residue is not a new substrate layer; it is an opinionated library of reasoning patterns built on top of the closed authority the substrate already defines.
 
 ## Decision
 
@@ -38,11 +38,11 @@ Cortex is explicitly two things:
 - a **durable runtime substrate** — Graph algebra, Circuit validation, Wire grammar and compiler, Pulse execution, rewrite admission and materialization, memory query substrate, envelope mechanics, contract registry infrastructure;
 - a **structured reasoning library** built on that substrate — executor families, contract entries and their meanings, role taxonomy, reasoning templates, memory strategy presets, reasoning policy.
 
-The split is **vertical, not horizontal**. `Cortex.Logos` is a namespace and library on top of the substrate, not a peer of Graph / Circuit / Wire / Pulse. Dependency direction is strict: runtime never imports Logos; Logos depends on runtime.
+The split is **vertical, not horizontal**. `Cortex.Logoi` is a namespace and library on top of the substrate, not a peer of Graph / Circuit / Wire / Pulse. Dependency direction is strict: runtime never imports Logoi; Logoi depends on runtime.
 
-**Logos introduces no new runtime registries.** The runtime has two: executors (per ADR 0014) and contracts (per chapter 08). Logos does not add a third. What Logos libraries ship instead are **library-owned catalogs** — code, data, and source artifacts exported by stable names and imported by consumer programs:
+**Logoi introduces no new runtime registries.** The runtime has two: executors (per ADR 0014) and contracts (per chapter 08). Logoi does not add a third. What Logoi libraries ship instead are **library-owned catalogs** — code, data, and source artifacts exported by stable names and imported by consumer programs:
 
-| Logos artifact       | Shape                                    | Discovery                                            |
+| Logoi artifact       | Shape                                    | Discovery                                            |
 |----------------------|------------------------------------------|------------------------------------------------------|
 | Template programs    | `.wire` source modules                   | Imported by consumer `.wire` programs by module path. |
 | Memory-strategy presets | Library-exposed `WalkSpec` / `MemoryStrategy` values | Referenced in `.wire` by stable name (e.g. `preset = "reviewer"`). |
@@ -50,9 +50,9 @@ The split is **vertical, not horizontal**. `Cortex.Logos` is a namespace and lib
 
 Templates are not registered — they are authored source shipped by libraries. Presets are not registered — they are Haskell values exposed by libraries. Role tags extend the *existing* executor-registration metadata with an optional field; they do not create a parallel registration surface.
 
-Three concepts straddle the Runtime/Logos line and must be consciously partitioned:
+Three concepts straddle the Runtime/Logoi line and must be consciously partitioned:
 
-| Concept        | Runtime                                   | Logos                                                                       |
+| Concept        | Runtime                                   | Logoi                                                                       |
 |----------------|-------------------------------------------|-----------------------------------------------------------------------------|
 | Wire           | Grammar, compiler, port-matching algebra  | Concrete `.wire` programs; vocabulary of registered names                    |
 | Contracts      | Registry mechanics, schemas, codecs, lint | Entries and their meanings (`thesis_claim`, `verdict`)                       |
@@ -62,24 +62,24 @@ This ADR fixes the split and the naming. Decisions that follow from the split �
 
 ## Alternatives considered
 
-- **Logos as a peer substrate layer beside Graph / Circuit / Wire / Pulse.** Rejected because the sketch duplicated ownership of executors, contracts, and memory mechanics that the substrate already owns. The useful residue is not a new layer but a library of opinionated patterns on top of the closed authority already defined.
+- **Logoi as a peer substrate layer beside Graph / Circuit / Wire / Pulse.** Rejected because the sketch duplicated ownership of executors, contracts, and memory mechanics that the substrate already owns. The useful residue is not a new layer but a library of opinionated patterns on top of the closed authority already defined.
 - **No separation — keep the reasoning stack unnamed inside the substrate narrative.** Rejected because the runtime story (extraction, non-reasoning workflow reuse, third-party integration) becomes incoherent when reasoning-specific taxonomy sits inside substrate chapters.
-- **Multiple peer reasoning namespaces** (for example `Cortex.Assistant`, `Cortex.Logos`, `Cortex.Reasoning.Domain` at the same level). Rejected because reasoning is one layer with product bindings below it. Horizontal fragmentation at the reasoning level hides the single registration model integrators need.
-- **Introduce a new Logos-specific registry** for templates, presets, and role tags. Rejected because it duplicates the runtime registration surface without adding semantics; library-owned catalogs referenced by stable name are simpler and sufficient.
+- **Multiple peer reasoning namespaces** (for example `Cortex.Assistant`, `Cortex.Logoi`, `Cortex.Reasoning.Domain` at the same level). Rejected because reasoning is one layer with product bindings below it. Horizontal fragmentation at the reasoning level hides the single registration model integrators need.
+- **Introduce a new Logoi-specific registry** for templates, presets, and role tags. Rejected because it duplicates the runtime registration surface without adding semantics; library-owned catalogs referenced by stable name are simpler and sufficient.
 
 ## Consequences
 
 ### Positive
 
 - Runtime stays extractable for non-reasoning durable workflows; the chapter 02 extraction story remains coherent.
-- Public framing crystallizes: *Cortex is a durable runtime substrate; Cortex.Logos is its structured reasoning library.*
+- Public framing crystallizes: *Cortex is a durable runtime substrate; Cortex.Logoi is its structured reasoning library.*
 - The library-owned-catalog model explains how third parties extend reasoning without opening a new registration surface: ship Haskell values and `.wire` modules; consumers import by name.
-- Downstream assistants split cleanly in follow-up work: generic conversational patterns live in Logos; domain persona, domain tools, and product policy stay in the product binding.
+- Downstream assistants split cleanly in follow-up work: generic conversational patterns live in Logoi; domain persona, domain tools, and product policy stay in the product binding.
 
 ### Negative
 
 - Three existing concepts (Wire, contracts, memory) acquire dual identity and must be consciously partitioned in docs and code. Ambiguity here will leak responsibilities back across the line.
-- The name "Logos" carries connotations (λόγος = structured speech / reasoning) that must be actively defended against drift into vague "intelligence layer" framing.
+- The name "Logoi" carries connotations (λόγοι = structured speech / reasoning forms) that must be actively defended against drift into vague "intelligence layer" framing.
 - Several consequential decisions — role semantics, canonical program set, integration model, admission policy, doc IA — are explicitly out of scope here and must land as separate ADRs or plans before the split becomes operational.
 
 ### Obligations
@@ -87,15 +87,15 @@ This ADR fixes the split and the naming. Decisions that follow from the split �
 - Partition the three straddlers with explicit statements in chapter 05 (Wire), chapter 08 (contracts), and chapter 06 (memory).
 - Write follow-up ADRs before the split can be shipped operationally:
   - **Role authority guardrail** — establish that roles are node metadata, not authority bearers.
-  - **Canonical Logos program set** — fix the reference programs (conversational suspended wire, batch, planner-driven) that libraries build against.
+  - **Canonical Logoi program set** — fix the reference programs (conversational suspended wire, batch, planner-driven) that libraries build against.
   - **Library integration and per-run admission policy** — how libraries register, how `.wire` composes registered authority, and how per-run admission bounds what a single assistant run can do.
-- Treat any proposal to introduce a new Logos-specific runtime registry as a supersession of this ADR; default is to extend existing executor and contract registries with reasoning metadata.
+- Treat any proposal to introduce a new Logoi-specific runtime registry as a supersession of this ADR; default is to extend existing executor and contract registries with reasoning metadata.
 - Defer the reasoning-facing documentation layout (`docs/reasoning/` or equivalent) to a plan, not an ADR — structure is execution, not decision.
 
 ## Related
 
-- [0010-wire-closed-authority-and-three-layer-stack.md](./0010-wire-closed-authority-and-three-layer-stack.md) — Logos inherits closed authority; this ADR extends the principle upward.
-- [0014-executor-taxonomy-model-vs-external-call.md](./0014-executor-taxonomy-model-vs-external-call.md) — Logos uses this taxonomy; it does not introduce new executor kinds.
-- [../Architecture/01-overview.md](../Architecture/01-overview.md), [../Architecture/02-ownership-and-boundaries.md](../Architecture/02-ownership-and-boundaries.md) — ownership model; Logos extends it upward without changing the runtime extraction story.
+- [0010-wire-closed-authority-and-three-layer-stack.md](./0010-wire-closed-authority-and-three-layer-stack.md) — Logoi inherits closed authority; this ADR extends the principle upward.
+- [0014-executor-taxonomy-model-vs-external-call.md](./0014-executor-taxonomy-model-vs-external-call.md) — Logoi uses this taxonomy; it does not introduce new executor kinds.
+- [../Architecture/01-overview.md](../Architecture/01-overview.md), [../Architecture/02-ownership-and-boundaries.md](../Architecture/02-ownership-and-boundaries.md) — ownership model; Logoi extends it upward without changing the runtime extraction story.
 - [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md) — site of the Wire straddle.
 - [../Architecture/08-artifacts-and-provenance.md](../Architecture/08-artifacts-and-provenance.md) — site of the contract-registry straddle.

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -28,7 +28,7 @@ Each ADR captures one committed design decision. Files use `NNNN-kebab-slug.md` 
 | [0012](0012-topological-memory-as-deterministic-graph-query.md) | Topological Memory as Deterministic Graph Query | accepted |
 | [0013](0013-report-provenance-artifact-contract.md) | Artifact Provenance Contract | accepted |
 | [0014](0014-executor-taxonomy-model-vs-external-call.md) | Model vs External Call | proposed |
-| [0015](0015-cortex-logos-reasoning-layer.md) | Structured Reasoning Above the Cortex Substrate | proposed |
+| [0015](0015-cortex-logoi-reasoning-layer.md) | Structured Reasoning Above the Cortex Substrate | proposed |
 
 ## Writing a new ADR
 

--- a/docs/Architecture/01-overview.md
+++ b/docs/Architecture/01-overview.md
@@ -67,12 +67,6 @@ flowchart LR
 
     B --> D[Downstream domain logic<br/>product-specific semantics]
     T --> P[Downstream persistence and delivery<br/>storage, streaming, notifications]
-
-    style T fill:#e0f2fe,stroke:#0284c7,color:#0f172a
-    style B fill:#fef3c7,stroke:#d97706,color:#0f172a
-    style X fill:#dcfce7,stroke:#16a34a,color:#0f172a
-    style D fill:#ede9fe,stroke:#7c3aed,color:#0f172a
-    style P fill:#fce7f3,stroke:#db2777,color:#0f172a
 ```
 
 Ownership rules:

--- a/docs/Architecture/02-ownership-and-boundaries.md
+++ b/docs/Architecture/02-ownership-and-boundaries.md
@@ -44,12 +44,6 @@ flowchart LR
 
     C --> F[Domain core<br/>product semantics]
     S --> D[Persistence<br/>schemas + storage]
-
-    style S fill:#e0f2fe,stroke:#0284c7,color:#0f172a
-    style C fill:#fef3c7,stroke:#d97706,color:#0f172a
-    style X fill:#dcfce7,stroke:#16a34a,color:#0f172a
-    style F fill:#ede9fe,stroke:#7c3aed,color:#0f172a
-    style D fill:#fce7f3,stroke:#db2777,color:#0f172a
 ```
 
 The placement rule: if a module would be reusable outside the host as generic AI infrastructure, it belongs in the Cortex substrate, even when the product binding is currently the only caller. If it knows about host domain semantics, product-specific artifacts, truth policy, or host tool authority, it stays downstream.

--- a/docs/Architecture/05-wire-language.md
+++ b/docs/Architecture/05-wire-language.md
@@ -57,12 +57,6 @@ flowchart LR
     W --> C[Circuit<br/>validated executable topology]
     C --> P[Pulse<br/>durable execution]
     D[Downstream bindings<br/>domain policy and artifacts] --> R
-
-    style R fill:#dbeafe,stroke:#2563eb,color:#0f172a
-    style W fill:#fef3c7,stroke:#d97706,color:#0f172a
-    style C fill:#dcfce7,stroke:#16a34a,color:#0f172a
-    style P fill:#ede9fe,stroke:#7c3aed,color:#0f172a
-    style D fill:#fce7f3,stroke:#db2777,color:#0f172a
 ```
 
 ## Design rules

--- a/docs/Publications/Paper-4-wire-language/Figures/wire-layering-overview.mmd
+++ b/docs/Publications/Paper-4-wire-language/Figures/wire-layering-overview.mmd
@@ -3,9 +3,3 @@ flowchart LR
     W --> C[Circuit<br/>validated executable topology]
     C --> P[Pulse<br/>durable execution and materialization]
     D[Downstream bindings<br/>domain policy and artifacts] --> R
-
-    style R fill:#dbeafe,stroke:#2563eb,color:#0f172a
-    style W fill:#fef3c7,stroke:#d97706,color:#0f172a
-    style C fill:#dcfce7,stroke:#16a34a,color:#0f172a
-    style P fill:#ede9fe,stroke:#7c3aed,color:#0f172a
-    style D fill:#fce7f3,stroke:#db2777,color:#0f172a

--- a/docs/Publications/Paper-4-wire-language/manuscript.md
+++ b/docs/Publications/Paper-4-wire-language/manuscript.md
@@ -45,12 +45,6 @@ flowchart LR
     W --> C[Circuit<br/>validated executable topology]
     C --> P[Pulse<br/>durable execution and materialization]
     D[Downstream bindings<br/>domain policy and artifacts] --> R
-
-    style R fill:#dbeafe,stroke:#2563eb,color:#0f172a
-    style W fill:#fef3c7,stroke:#d97706,color:#0f172a
-    style C fill:#dcfce7,stroke:#16a34a,color:#0f172a
-    style P fill:#ede9fe,stroke:#7c3aed,color:#0f172a
-    style D fill:#fce7f3,stroke:#db2777,color:#0f172a
 ```
 
 *Figure 1.* Wire is an authoring layer above registered authority and below the compiled executable artifact.

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -22,10 +22,6 @@ flowchart TD
 
     W -->|compiles to| C
     C -->|runs on| P
-
-    style W fill:#fef3c7,stroke:#d97706,color:#0f172a
-    style C fill:#dcfce7,stroke:#16a34a,color:#0f172a
-    style P fill:#dbeafe,stroke:#2563eb,color:#0f172a
 ```
 
 Graph is the pure algebraic substrate that Wire authors over and Circuit validates.

--- a/flake.lock
+++ b/flake.lock
@@ -734,11 +734,11 @@
         "tree-sitter-json": "tree-sitter-json"
       },
       "locked": {
-        "lastModified": 1777225625,
-        "narHash": "sha256-nHdwrowv/z/sESQJhEWsy9hAhf1uUYYPCec4/aQD7Ic=",
+        "lastModified": 1777233865,
+        "narHash": "sha256-CcS7lRe5dO9PIOBMzDQay7alVE7xANKG6NwnCtpsrJY=",
         "owner": "Digimuoto",
         "repo": "repo-docs",
-        "rev": "12112ed603eea8b392101cc774faf81e7d4c4c7f",
+        "rev": "2084267c4c036c6cdd06c553b50a2f942ec368d0",
         "type": "github"
       },
       "original": {

--- a/src-platform/Platform/Serde.hs
+++ b/src-platform/Platform/Serde.hs
@@ -1,0 +1,6 @@
+module Platform.Serde
+  ( module Platform.Serde.Json,
+  )
+where
+
+import Platform.Serde.Json

--- a/src-platform/Platform/Serde/Json.hs
+++ b/src-platform/Platform/Serde/Json.hs
@@ -1,0 +1,10 @@
+module Platform.Serde.Json
+  ( module Platform.Serde.Json.Object,
+    module Platform.Serde.Json.Preview,
+    module Platform.Serde.Json.Text,
+  )
+where
+
+import Platform.Serde.Json.Object
+import Platform.Serde.Json.Preview
+import Platform.Serde.Json.Text

--- a/src-platform/Platform/Serde/Json/Object.hs
+++ b/src-platform/Platform/Serde/Json/Object.hs
@@ -1,0 +1,30 @@
+module Platform.Serde.Json.Object
+  ( hasObjectBool,
+    lookupObjectArray,
+    lookupObjectText,
+  )
+where
+
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Text (Text)
+import Data.Vector qualified as V
+
+hasObjectBool :: Text -> KeyMap.KeyMap Aeson.Value -> Bool
+hasObjectBool fieldName obj =
+  case KeyMap.lookup (Key.fromText fieldName) obj of
+    Just (Aeson.Bool boolValue) -> boolValue
+    _ -> False
+
+lookupObjectText :: Text -> KeyMap.KeyMap Aeson.Value -> Maybe Text
+lookupObjectText fieldName obj =
+  case KeyMap.lookup (Key.fromText fieldName) obj of
+    Just (Aeson.String textValue) -> Just textValue
+    _ -> Nothing
+
+lookupObjectArray :: Text -> KeyMap.KeyMap Aeson.Value -> Maybe [Aeson.Value]
+lookupObjectArray fieldName obj =
+  case KeyMap.lookup (Key.fromText fieldName) obj of
+    Just (Aeson.Array values) -> Just (V.toList values)
+    _ -> Nothing

--- a/src-platform/Platform/Serde/Json/Preview.hs
+++ b/src-platform/Platform/Serde/Json/Preview.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Platform.Serde.Json.Preview
+  ( toolCallPayloadPreview,
+    truncateJsonValue,
+    truncateText,
+  )
+where
+
+import Data.Aeson ((.=))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Data.Vector qualified as V
+import Platform.Text (truncateText)
+
+toolCallPayloadPreview :: Int -> Int -> Int -> Text -> Maybe Aeson.Value
+toolCallPayloadPreview maxDepth maxArrayItems maxObjectFields rawResult =
+  case Aeson.decodeStrict' (TE.encodeUtf8 rawResult) of
+    Just jsonValue ->
+      Just (truncateJsonValue maxDepth maxArrayItems maxObjectFields jsonValue)
+    Nothing ->
+      let trimmed = T.strip rawResult
+          shortText = truncateText 600 trimmed
+       in if T.null shortText
+            then Nothing
+            else Just (Aeson.object ["text" .= shortText])
+
+truncateJsonValue :: Int -> Int -> Int -> Aeson.Value -> Aeson.Value
+truncateJsonValue maxDepth maxArrayItems maxObjectFields value
+  | maxDepth <= 0 = Aeson.String "..."
+  | otherwise =
+      case value of
+        Aeson.Array arr ->
+          Aeson.Array . V.fromList $
+            fmap
+              (truncateJsonValue (maxDepth - 1) maxArrayItems maxObjectFields)
+              (take maxArrayItems (V.toList arr))
+        Aeson.Object obj ->
+          Aeson.object
+            [ key .= truncateJsonValue (maxDepth - 1) maxArrayItems maxObjectFields fieldValue
+            | (key, fieldValue) <- take maxObjectFields (KeyMap.toList obj)
+            ]
+        Aeson.String txt ->
+          Aeson.String (truncateText 600 txt)
+        other -> other

--- a/src-platform/Platform/Serde/Json/Text.hs
+++ b/src-platform/Platform/Serde/Json/Text.hs
@@ -1,0 +1,27 @@
+module Platform.Serde.Json.Text
+  ( decodeLazyUtf8,
+    jsonValueText,
+    toolError,
+    toolValidationError,
+  )
+where
+
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as BSL
+import Data.Text (Text)
+import Data.Text.Encoding qualified as TE
+import Data.Text.Encoding.Error (lenientDecode)
+
+decodeLazyUtf8 :: BSL.ByteString -> Text
+decodeLazyUtf8 = TE.decodeUtf8With lenientDecode . BSL.toStrict
+
+jsonValueText :: Aeson.Value -> Text
+jsonValueText = decodeLazyUtf8 . Aeson.encode
+
+-- | Format a tool error as deterministic plain text.
+toolError :: Text -> Text
+toolError msg = "Error: " <> msg
+
+-- | Format a field-level validation error as deterministic plain text.
+toolValidationError :: Text -> Text -> Text -> Text
+toolValidationError _field msg value = "Error: " <> msg <> ": " <> value

--- a/src-platform/Platform/Text.hs
+++ b/src-platform/Platform/Text.hs
@@ -1,12 +1,29 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Platform.Text
-  ( truncateText,
+  ( showText,
+    stripNonEmptyMaybeText,
+    stripNonEmptyText,
+    truncateText,
   )
 where
 
 import Data.Text (Text)
 import Data.Text qualified as T
+
+showText :: (Show a) => a -> Text
+showText = T.pack . show
+
+stripNonEmptyText :: Text -> Maybe Text
+stripNonEmptyText rawText
+  | T.null stripped = Nothing
+  | otherwise = Just stripped
+  where
+    stripped = T.strip rawText
+
+stripNonEmptyMaybeText :: Maybe Text -> Maybe Text
+stripNonEmptyMaybeText =
+  (>>= stripNonEmptyText)
 
 truncateText :: Int -> Text -> Text
 truncateText maxLen txt

--- a/src/Cortex/Agent/Config.hs
+++ b/src/Cortex/Agent/Config.hs
@@ -23,13 +23,13 @@ module Cortex.Agent.Config
 where
 
 import Control.Applicative ((<|>))
-import Cortex.Text (stripNonEmptyMaybeText)
 import Data.Aeson qualified as Aeson
 import Data.Maybe (isNothing, maybeToList)
 import Data.OpenApi (ToSchema)
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
+import Platform.Text (stripNonEmptyMaybeText)
 
 data CortexAgentBudget = CortexAgentBudget
   { maxToolSteps :: Maybe Int,

--- a/src/Cortex/Capability.hs
+++ b/src/Cortex/Capability.hs
@@ -1,0 +1,12 @@
+module Cortex.Capability
+  ( module Cortex.Capability.Model,
+    module Cortex.Capability.Provider,
+    module Cortex.Capability.StructuredOutput,
+    module Cortex.Capability.Tool,
+  )
+where
+
+import Cortex.Capability.Model
+import Cortex.Capability.Provider
+import Cortex.Capability.StructuredOutput
+import Cortex.Capability.Tool

--- a/src/Cortex/Capability/Model.hs
+++ b/src/Cortex/Capability/Model.hs
@@ -1,0 +1,12 @@
+module Cortex.Capability.Model
+  ( module Cortex.Capability.Model.Client,
+    module Cortex.Capability.Model.Message,
+    module Cortex.Capability.Model.Output,
+    module Cortex.Capability.Model.Types,
+  )
+where
+
+import Cortex.Capability.Model.Client
+import Cortex.Capability.Model.Message
+import Cortex.Capability.Model.Output
+import Cortex.Capability.Model.Types

--- a/src/Cortex/Capability/Provider.hs
+++ b/src/Cortex/Capability/Provider.hs
@@ -1,0 +1,6 @@
+module Cortex.Capability.Provider
+  ( module Cortex.Capability.Provider.OpenRouter,
+  )
+where
+
+import Cortex.Capability.Provider.OpenRouter

--- a/src/Cortex/Capability/Provider/OpenRouter.hs
+++ b/src/Cortex/Capability/Provider/OpenRouter.hs
@@ -1,0 +1,6 @@
+module Cortex.Capability.Provider.OpenRouter
+  ( module Cortex.Provider.OpenRouter,
+  )
+where
+
+import Cortex.Provider.OpenRouter

--- a/src/Cortex/Capability/Provider/OpenRouter/Client.hs
+++ b/src/Cortex/Capability/Provider/OpenRouter/Client.hs
@@ -1,0 +1,6 @@
+module Cortex.Capability.Provider.OpenRouter.Client
+  ( module Cortex.Provider.OpenRouter.Client,
+  )
+where
+
+import Cortex.Provider.OpenRouter.Client

--- a/src/Cortex/Capability/Provider/OpenRouter/Embedding.hs
+++ b/src/Cortex/Capability/Provider/OpenRouter/Embedding.hs
@@ -1,0 +1,6 @@
+module Cortex.Capability.Provider.OpenRouter.Embedding
+  ( module Cortex.Provider.OpenRouter.Embeddings,
+  )
+where
+
+import Cortex.Provider.OpenRouter.Embeddings

--- a/src/Cortex/Capability/Provider/OpenRouter/Wire.hs
+++ b/src/Cortex/Capability/Provider/OpenRouter/Wire.hs
@@ -1,0 +1,6 @@
+module Cortex.Capability.Provider.OpenRouter.Wire
+  ( module Cortex.Provider.OpenRouter.Wire,
+  )
+where
+
+import Cortex.Provider.OpenRouter.Wire

--- a/src/Cortex/Capability/StructuredOutput.hs
+++ b/src/Cortex/Capability/StructuredOutput.hs
@@ -1,0 +1,6 @@
+module Cortex.Capability.StructuredOutput
+  ( module Cortex.Task.StructuredOutput,
+  )
+where
+
+import Cortex.Task.StructuredOutput

--- a/src/Cortex/Capability/Tool.hs
+++ b/src/Cortex/Capability/Tool.hs
@@ -1,0 +1,12 @@
+module Cortex.Capability.Tool
+  ( module Cortex.Capability.Tool.Definition,
+    module Cortex.Capability.Tool.Host,
+    module Cortex.Capability.Tool.Loop,
+    module Cortex.Capability.Tool.Record,
+  )
+where
+
+import Cortex.Capability.Tool.Definition
+import Cortex.Capability.Tool.Host
+import Cortex.Capability.Tool.Loop
+import Cortex.Capability.Tool.Record

--- a/src/Cortex/Capability/Tool/Host.hs
+++ b/src/Cortex/Capability/Tool/Host.hs
@@ -1,0 +1,6 @@
+module Cortex.Capability.Tool.Host
+  ( module Cortex.Task.ToolHost,
+  )
+where
+
+import Cortex.Task.ToolHost

--- a/src/Cortex/Capability/Tool/Loop.hs
+++ b/src/Cortex/Capability/Tool/Loop.hs
@@ -1,0 +1,6 @@
+module Cortex.Capability.Tool.Loop
+  ( module Cortex.Task.ToolLoop,
+  )
+where
+
+import Cortex.Task.ToolLoop

--- a/src/Cortex/Capability/Tool/Record.hs
+++ b/src/Cortex/Capability/Tool/Record.hs
@@ -6,11 +6,6 @@ module Cortex.Capability.Tool.Record
   )
 where
 
-import Cortex.Json.Preview
-  ( toolCallPayloadPreview,
-    truncateJsonValue,
-    truncateText,
-  )
 import Data.Aeson ((.=))
 import Data.Aeson qualified as Aeson
 import Data.Maybe (fromMaybe)
@@ -19,6 +14,11 @@ import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
 import Data.Time (UTCTime)
 import GHC.Generics (Generic)
+import Platform.Serde.Json.Preview
+  ( toolCallPayloadPreview,
+    truncateJsonValue,
+    truncateText,
+  )
 
 data CortexToolCallRecord = CortexToolCallRecord
   { cortexToolCallRecordId :: Text,

--- a/src/Cortex/Circuit.hs
+++ b/src/Cortex/Circuit.hs
@@ -1,14 +1,14 @@
 module Cortex.Circuit
-  ( module Cortex.Circuit.Compiled,
-    module Cortex.Circuit.Compiler,
+  ( module Cortex.Circuit.Artifact,
+    module Cortex.Circuit.Compile,
     module Cortex.Circuit.IR,
-    module Cortex.Circuit.Lowering,
-    module Cortex.Circuit.NodeKind,
+    module Cortex.Circuit.Lower,
+    module Cortex.Circuit.Node,
   )
 where
 
-import Cortex.Circuit.Compiled
-import Cortex.Circuit.Compiler
+import Cortex.Circuit.Artifact
+import Cortex.Circuit.Compile
 import Cortex.Circuit.IR
-import Cortex.Circuit.Lowering
-import Cortex.Circuit.NodeKind
+import Cortex.Circuit.Lower
+import Cortex.Circuit.Node

--- a/src/Cortex/Circuit/Artifact.hs
+++ b/src/Cortex/Circuit/Artifact.hs
@@ -1,0 +1,6 @@
+module Cortex.Circuit.Artifact
+  ( module Cortex.Circuit.Compiled,
+  )
+where
+
+import Cortex.Circuit.Compiled

--- a/src/Cortex/Circuit/Compile.hs
+++ b/src/Cortex/Circuit/Compile.hs
@@ -1,0 +1,6 @@
+module Cortex.Circuit.Compile
+  ( module Cortex.Circuit.Compiler,
+  )
+where
+
+import Cortex.Circuit.Compiler

--- a/src/Cortex/Circuit/Compiler.hs
+++ b/src/Cortex/Circuit/Compiler.hs
@@ -9,7 +9,7 @@ module Cortex.Circuit.Compiler
 where
 
 import Control.Monad ((>=>))
-import Cortex.Circuit.Compiled
+import Cortex.Circuit.Artifact
   ( CircuitCompatibilityWitness (..),
     CircuitConditionNode (..),
     CompiledCircuit (..),

--- a/src/Cortex/Circuit/IR.hs
+++ b/src/Cortex/Circuit/IR.hs
@@ -18,7 +18,7 @@ module Cortex.Circuit.IR
 where
 
 import Control.Lens ((&), (?~))
-import Cortex.Circuit.NodeKind (CircuitNodeKind)
+import Cortex.Circuit.Node (CircuitNodeKind)
 import Data.Aeson
   ( FromJSON,
     FromJSONKey,

--- a/src/Cortex/Circuit/Lower.hs
+++ b/src/Cortex/Circuit/Lower.hs
@@ -1,0 +1,6 @@
+module Cortex.Circuit.Lower
+  ( module Cortex.Circuit.Lowering,
+  )
+where
+
+import Cortex.Circuit.Lowering

--- a/src/Cortex/Circuit/Lowering.hs
+++ b/src/Cortex/Circuit/Lowering.hs
@@ -14,14 +14,14 @@ module Cortex.Circuit.Lowering
   )
 where
 
-import Cortex.Circuit.Compiled
+import Cortex.Circuit.Artifact
   ( CircuitConditionNode (..),
     CompiledCircuit (..),
     CompiledCircuitFragment (..),
     CompiledCircuitNode (..),
     compiledCircuitNodeRef,
   )
-import Cortex.Circuit.Compiler
+import Cortex.Circuit.Compile
   ( CircuitCompileError,
     compileCircuitIR,
   )

--- a/src/Cortex/Circuit/Node.hs
+++ b/src/Cortex/Circuit/Node.hs
@@ -1,0 +1,6 @@
+module Cortex.Circuit.Node
+  ( module Cortex.Circuit.NodeKind,
+  )
+where
+
+import Cortex.Circuit.NodeKind

--- a/src/Cortex/Document.hs
+++ b/src/Cortex/Document.hs
@@ -1,0 +1,14 @@
+module Cortex.Document
+  ( module Cortex.Document.Host,
+    module Cortex.Document.IR,
+    module Cortex.Document.Metadata,
+    module Cortex.Document.Report,
+    module Cortex.Document.Section,
+  )
+where
+
+import Cortex.Document.Host
+import Cortex.Document.IR
+import Cortex.Document.Metadata
+import Cortex.Document.Report
+import Cortex.Document.Section

--- a/src/Cortex/Document/Metadata.hs
+++ b/src/Cortex/Document/Metadata.hs
@@ -10,12 +10,12 @@ module Cortex.Document.Metadata
 where
 
 import Cortex.Document.IR qualified as IR
-import Cortex.Text (stripNonEmptyText)
 import Data.Aeson ((.=))
 import Data.Aeson qualified as Aeson
 import Data.Maybe (listToMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Platform.Text (stripNonEmptyText)
 
 documentTitleFromIr :: IR.ReportIR -> Maybe Text
 documentTitleFromIr ir =

--- a/src/Cortex/Document/Report.hs
+++ b/src/Cortex/Document/Report.hs
@@ -1,0 +1,6 @@
+module Cortex.Document.Report
+  ( module Cortex.Task.Report,
+  )
+where
+
+import Cortex.Task.Report

--- a/src/Cortex/Document/Section.hs
+++ b/src/Cortex/Document/Section.hs
@@ -1,0 +1,6 @@
+module Cortex.Document.Section
+  ( module Cortex.Research.Section,
+  )
+where
+
+import Cortex.Research.Section

--- a/src/Cortex/Event.hs
+++ b/src/Cortex/Event.hs
@@ -1,0 +1,6 @@
+module Cortex.Event
+  ( module Cortex.Events,
+  )
+where
+
+import Cortex.Events

--- a/src/Cortex/Graph.hs
+++ b/src/Cortex/Graph.hs
@@ -3,7 +3,7 @@
 -- Re-exports all submodules so downstream consumers import only
 -- @Cortex.Graph@.
 module Cortex.Graph
-  ( module Cortex.Graph.Core,
+  ( module Cortex.Graph.Algebra,
     module Cortex.Graph.Modify,
     module Cortex.Graph.Search,
     module Cortex.Graph.Decompose,
@@ -12,7 +12,7 @@ module Cortex.Graph
   )
 where
 
-import Cortex.Graph.Core
+import Cortex.Graph.Algebra
 import Cortex.Graph.Decompose
 import Cortex.Graph.Influence
 import Cortex.Graph.Modify

--- a/src/Cortex/Graph/Algebra.hs
+++ b/src/Cortex/Graph/Algebra.hs
@@ -1,0 +1,6 @@
+module Cortex.Graph.Algebra
+  ( module Cortex.Graph.Core,
+  )
+where
+
+import Cortex.Graph.Core

--- a/src/Cortex/Graph/Mokhov.hs
+++ b/src/Cortex/Graph/Mokhov.hs
@@ -1,0 +1,6 @@
+module Cortex.Graph.Mokhov
+  ( module Cortex.Graph.Core,
+  )
+where
+
+import Cortex.Graph.Core

--- a/src/Cortex/Json/Object.hs
+++ b/src/Cortex/Json/Object.hs
@@ -1,30 +1,8 @@
+-- | Compatibility facade for downstream consumers migrating to
+-- 'Platform.Serde.Json.Object'.
 module Cortex.Json.Object
-  ( hasObjectBool,
-    lookupObjectArray,
-    lookupObjectText,
+  ( module Platform.Serde.Json.Object,
   )
 where
 
-import Data.Aeson qualified as Aeson
-import Data.Aeson.Key qualified as Key
-import Data.Aeson.KeyMap qualified as KeyMap
-import Data.Text (Text)
-import Data.Vector qualified as V
-
-hasObjectBool :: Text -> KeyMap.KeyMap Aeson.Value -> Bool
-hasObjectBool fieldName obj =
-  case KeyMap.lookup (Key.fromText fieldName) obj of
-    Just (Aeson.Bool boolValue) -> boolValue
-    _ -> False
-
-lookupObjectText :: Text -> KeyMap.KeyMap Aeson.Value -> Maybe Text
-lookupObjectText fieldName obj =
-  case KeyMap.lookup (Key.fromText fieldName) obj of
-    Just (Aeson.String textValue) -> Just textValue
-    _ -> Nothing
-
-lookupObjectArray :: Text -> KeyMap.KeyMap Aeson.Value -> Maybe [Aeson.Value]
-lookupObjectArray fieldName obj =
-  case KeyMap.lookup (Key.fromText fieldName) obj of
-    Just (Aeson.Array values) -> Just (V.toList values)
-    _ -> Nothing
+import Platform.Serde.Json.Object

--- a/src/Cortex/Json/Preview.hs
+++ b/src/Cortex/Json/Preview.hs
@@ -1,48 +1,8 @@
-{-# LANGUAGE OverloadedStrings #-}
-
+-- | Compatibility facade for downstream consumers migrating to
+-- 'Platform.Serde.Json.Preview'.
 module Cortex.Json.Preview
-  ( toolCallPayloadPreview,
-    truncateJsonValue,
-    truncateText,
+  ( module Platform.Serde.Json.Preview,
   )
 where
 
-import Data.Aeson ((.=))
-import Data.Aeson qualified as Aeson
-import Data.Aeson.KeyMap qualified as KeyMap
-import Data.Text (Text)
-import Data.Text qualified as T
-import Data.Text.Encoding qualified as TE
-import Data.Vector qualified as V
-import Platform.Text (truncateText)
-
-toolCallPayloadPreview :: Int -> Int -> Int -> Text -> Maybe Aeson.Value
-toolCallPayloadPreview maxDepth maxArrayItems maxObjectFields rawResult =
-  case Aeson.decodeStrict' (TE.encodeUtf8 rawResult) of
-    Just jsonValue ->
-      Just (truncateJsonValue maxDepth maxArrayItems maxObjectFields jsonValue)
-    Nothing ->
-      let trimmed = T.strip rawResult
-          shortText = truncateText 600 trimmed
-       in if T.null shortText
-            then Nothing
-            else Just (Aeson.object ["text" .= shortText])
-
-truncateJsonValue :: Int -> Int -> Int -> Aeson.Value -> Aeson.Value
-truncateJsonValue maxDepth maxArrayItems maxObjectFields value
-  | maxDepth <= 0 = Aeson.String "..."
-  | otherwise =
-      case value of
-        Aeson.Array arr ->
-          Aeson.Array . V.fromList $
-            fmap
-              (truncateJsonValue (maxDepth - 1) maxArrayItems maxObjectFields)
-              (take maxArrayItems (V.toList arr))
-        Aeson.Object obj ->
-          Aeson.object
-            [ key .= truncateJsonValue (maxDepth - 1) maxArrayItems maxObjectFields fieldValue
-            | (key, fieldValue) <- take maxObjectFields (KeyMap.toList obj)
-            ]
-        Aeson.String txt ->
-          Aeson.String (truncateText 600 txt)
-        other -> other
+import Platform.Serde.Json.Preview

--- a/src/Cortex/Json/Text.hs
+++ b/src/Cortex/Json/Text.hs
@@ -1,29 +1,8 @@
+-- | Compatibility facade for downstream consumers migrating to
+-- 'Platform.Serde.Json.Text'.
 module Cortex.Json.Text
-  ( decodeLazyUtf8,
-    jsonValueText,
-    toolError,
-    toolValidationError,
+  ( module Platform.Serde.Json.Text,
   )
 where
 
-import Data.Aeson qualified as Aeson
-import Data.ByteString.Lazy qualified as BSL
-import Data.Text (Text)
-import Data.Text.Encoding qualified as TE
-import Data.Text.Encoding.Error (lenientDecode)
-
-decodeLazyUtf8 :: BSL.ByteString -> Text
-decodeLazyUtf8 = TE.decodeUtf8With lenientDecode . BSL.toStrict
-
-jsonValueText :: Aeson.Value -> Text
-jsonValueText = decodeLazyUtf8 . Aeson.encode
-
--- | Format a tool error as deterministic plain text.
--- This is the contract that assistant/tool tests and the LLM parser expect.
-toolError :: Text -> Text
-toolError msg = "Error: " <> msg
-
--- | Format a field-level validation error as deterministic plain text.
--- Includes the invalid value for debuggability.
-toolValidationError :: Text -> Text -> Text -> Text
-toolValidationError _field msg value = "Error: " <> msg <> ": " <> value
+import Platform.Serde.Json.Text

--- a/src/Cortex/Memory.hs
+++ b/src/Cortex/Memory.hs
@@ -1,0 +1,26 @@
+module Cortex.Memory
+  ( module Cortex.Memory.Candidate,
+    module Cortex.Memory.Compact,
+    module Cortex.Memory.Conflict,
+    module Cortex.Memory.Document,
+    module Cortex.Memory.Host,
+    module Cortex.Memory.Pack,
+    module Cortex.Memory.Query,
+    module Cortex.Memory.Rank,
+    module Cortex.Memory.Retrieve,
+    module Cortex.Memory.Source,
+    module Cortex.Memory.Types,
+  )
+where
+
+import Cortex.Memory.Candidate
+import Cortex.Memory.Compact
+import Cortex.Memory.Conflict
+import Cortex.Memory.Document
+import Cortex.Memory.Host
+import Cortex.Memory.Pack
+import Cortex.Memory.Query
+import Cortex.Memory.Rank
+import Cortex.Memory.Retrieve
+import Cortex.Memory.Source
+import Cortex.Memory.Types

--- a/src/Cortex/Memory/Candidate.hs
+++ b/src/Cortex/Memory/Candidate.hs
@@ -1,0 +1,6 @@
+module Cortex.Memory.Candidate
+  ( module Cortex.Memory.Candidates,
+  )
+where
+
+import Cortex.Memory.Candidates

--- a/src/Cortex/Memory/Compact.hs
+++ b/src/Cortex/Memory/Compact.hs
@@ -1,0 +1,6 @@
+module Cortex.Memory.Compact
+  ( module Cortex.MemoryCompaction,
+  )
+where
+
+import Cortex.MemoryCompaction

--- a/src/Cortex/Memory/Document.hs
+++ b/src/Cortex/Memory/Document.hs
@@ -11,8 +11,8 @@ module Cortex.Memory.Document
   )
 where
 
+import Cortex.Memory.Compact (estimateTextTokens)
 import Cortex.Memory.Types (CortexMemoryEntityConfig (..))
-import Cortex.MemoryCompaction (estimateTextTokens)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time (UTCTime)

--- a/src/Cortex/Provider/OpenRouter/Client.hs
+++ b/src/Cortex/Provider/OpenRouter/Client.hs
@@ -34,12 +34,6 @@ import Cortex.Capability.Model.Types
     CortexChoiceTimeoutClass (..),
     CortexUsage,
   )
-import Cortex.Json.Preview
-  ( truncateText,
-  )
-import Cortex.Json.Text
-  ( decodeLazyUtf8,
-  )
 import Cortex.Provider.OpenRouter qualified as OpenRouterProvider
 import Cortex.Provider.OpenRouter.Wire
   ( OpenRouterCompletion (..),
@@ -69,6 +63,12 @@ import Network.HTTP.Client
   )
 import Network.HTTP.Types.Status (status429, status500, status503, status504, statusCode)
 import Platform.HTTP.Retry (retryPolicy, shouldRetry)
+import Platform.Serde.Json.Preview
+  ( truncateText,
+  )
+import Platform.Serde.Json.Text
+  ( decodeLazyUtf8,
+  )
 import System.Timeout (timeout)
 
 openRouterChatUrl :: String

--- a/src/Cortex/Provider/OpenRouter/Embeddings.hs
+++ b/src/Cortex/Provider/OpenRouter/Embeddings.hs
@@ -13,9 +13,6 @@ import Control.Exception (throwIO, try)
 import Control.Monad (void, when)
 import Control.Monad.Catch qualified as MC
 import Control.Retry (recovering)
-import Cortex.Json.Text
-  ( decodeLazyUtf8,
-  )
 import Cortex.Provider.OpenRouter.Client
   ( OpenRouterHttpErrorDetails (httpErrorProviderMessage),
     decodeOpenRouterHttpErrorDetails,
@@ -45,6 +42,9 @@ import Network.HTTP.Types.Status (status429, status500, status503, status504, st
 import Platform.HTTP.Retry
   ( retryPolicy,
     shouldRetry,
+  )
+import Platform.Serde.Json.Text
+  ( decodeLazyUtf8,
   )
 
 openRouterEmbeddingsUrl :: String

--- a/src/Cortex/Provider/OpenRouter/Wire.hs
+++ b/src/Cortex/Provider/OpenRouter/Wire.hs
@@ -17,9 +17,6 @@ where
 
 import Control.Applicative ((<|>))
 import Control.Monad (join, unless, (>=>))
-import Cortex.Json.Text
-  ( jsonValueText,
-  )
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KeyMap
@@ -31,6 +28,9 @@ import Data.Scientific qualified as Scientific
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Vector qualified as V
+import Platform.Serde.Json.Text
+  ( jsonValueText,
+  )
 import Text.Read (readMaybe)
 
 data OpenRouterCompletion = OpenRouterCompletion

--- a/src/Cortex/Pulse/Attempt.hs
+++ b/src/Cortex/Pulse/Attempt.hs
@@ -1,0 +1,6 @@
+module Cortex.Pulse.Attempt
+  ( module Cortex.Pulse.Executor.Attempt,
+  )
+where
+
+import Cortex.Pulse.Executor.Attempt

--- a/src/Cortex/Pulse/Event.hs
+++ b/src/Cortex/Pulse/Event.hs
@@ -1,0 +1,6 @@
+module Cortex.Pulse.Event
+  ( module Cortex.Pulse.Executor.Events,
+  )
+where
+
+import Cortex.Pulse.Executor.Events

--- a/src/Cortex/Pulse/Frontier.hs
+++ b/src/Cortex/Pulse/Frontier.hs
@@ -1,0 +1,6 @@
+module Cortex.Pulse.Frontier
+  ( module Cortex.Pulse.Executor.Frontier,
+  )
+where
+
+import Cortex.Pulse.Executor.Frontier

--- a/src/Cortex/Pulse/Hydrate.hs
+++ b/src/Cortex/Pulse/Hydrate.hs
@@ -1,0 +1,6 @@
+module Cortex.Pulse.Hydrate
+  ( module Cortex.Pulse.PlanHydration,
+  )
+where
+
+import Cortex.Pulse.PlanHydration

--- a/src/Cortex/Pulse/Materialization.hs
+++ b/src/Cortex/Pulse/Materialization.hs
@@ -25,9 +25,12 @@ import Cortex.Graph
     relEdges,
     relVertices,
   )
-import Cortex.Pulse.GraphRuntime
-  ( GraphState (..),
-    NodeStatus (..),
+import Cortex.Pulse.Hydrate
+  ( RewriteError (..),
+    SerializableStageDefinition (..),
+    decodeSerializableRewrite,
+    hydrateRewrite,
+    planRewriteDelta,
   )
 import Cortex.Pulse.Memory.Types (defaultMemoryStrategy)
 import Cortex.Pulse.Node (NodeId (..))
@@ -36,13 +39,6 @@ import Cortex.Pulse.Plan
     StageAction,
     StageDefinition (..),
     StagePlan (..),
-  )
-import Cortex.Pulse.PlanHydration
-  ( RewriteError (..),
-    SerializableStageDefinition (..),
-    decodeSerializableRewrite,
-    hydrateRewrite,
-    planRewriteDelta,
   )
 import Cortex.Pulse.Rewrite
   ( GraphRewrite (..),
@@ -53,6 +49,10 @@ import Cortex.Pulse.Rewrite
     admitRewriteDelta,
     admittedDelta,
     admittedRemainingBudget,
+  )
+import Cortex.Pulse.Runtime
+  ( GraphState (..),
+    NodeStatus (..),
   )
 import Crypto.Hash (SHA256, hashlazy)
 import Data.Aeson (FromJSON, ToJSON)

--- a/src/Cortex/Pulse/Materialize.hs
+++ b/src/Cortex/Pulse/Materialize.hs
@@ -1,0 +1,6 @@
+module Cortex.Pulse.Materialize
+  ( module Cortex.Pulse.Materialization,
+  )
+where
+
+import Cortex.Pulse.Materialization

--- a/src/Cortex/Pulse/Memory.hs
+++ b/src/Cortex/Pulse/Memory.hs
@@ -46,11 +46,11 @@ where
 
 import Control.Concurrent.STM (TVar, atomically, readTVar)
 import Cortex.Graph (Relation)
-import Cortex.Pulse.GraphRuntime (GraphState (..))
-import Cortex.Pulse.Materialization (PersistedGraphState (..))
+import Cortex.Pulse.Materialize (PersistedGraphState (..))
 import Cortex.Pulse.Memory.Query (pureQueryMemory)
 import Cortex.Pulse.Memory.Types
 import Cortex.Pulse.Node (NodeId)
+import Cortex.Pulse.Runtime (GraphState (..))
 import Data.Map.Strict (Map)
 import Data.Time (UTCTime, getCurrentTime)
 

--- a/src/Cortex/Pulse/Memory/Query.hs
+++ b/src/Cortex/Pulse/Memory/Query.hs
@@ -17,7 +17,6 @@ module Cortex.Pulse.Memory.Query
 where
 
 import Cortex.Graph (Relation, dagRandomWalkInfluence)
-import Cortex.Pulse.GraphRuntime (NodeStatus (..))
 import Cortex.Pulse.Memory.Score (composeScore)
 import Cortex.Pulse.Memory.Types
   ( ExtractedFields (..),
@@ -30,6 +29,7 @@ import Cortex.Pulse.Memory.Types
   )
 import Cortex.Pulse.Memory.Walk (directionRelations, walkCandidates)
 import Cortex.Pulse.Node (NodeId)
+import Cortex.Pulse.Runtime (NodeStatus (..))
 import Data.List (sortOn)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map

--- a/src/Cortex/Pulse/Memory/Types.hs
+++ b/src/Cortex/Pulse/Memory/Types.hs
@@ -54,8 +54,8 @@ module Cortex.Pulse.Memory.Types
 where
 
 import Cortex.Graph (Relation)
-import Cortex.Pulse.GraphRuntime (NodeStatus)
 import Cortex.Pulse.Node (NodeId)
+import Cortex.Pulse.Runtime (NodeStatus)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types qualified as AesonT
 import Data.Map.Strict (Map)

--- a/src/Cortex/Pulse/Memory/Walk.hs
+++ b/src/Cortex/Pulse/Memory/Walk.hs
@@ -27,12 +27,12 @@ import Cortex.Graph
     successors,
     transposeRelation,
   )
-import Cortex.Pulse.GraphRuntime (NodeStatus (..))
 import Cortex.Pulse.Memory.Types
   ( WalkDirection (..),
     WalkScope (..),
   )
 import Cortex.Pulse.Node (NodeId)
+import Cortex.Pulse.Runtime (NodeStatus (..))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)

--- a/src/Cortex/Pulse/Outcome.hs
+++ b/src/Cortex/Pulse/Outcome.hs
@@ -1,0 +1,6 @@
+module Cortex.Pulse.Outcome
+  ( module Cortex.Pulse.Executor.Outcome,
+  )
+where
+
+import Cortex.Pulse.Executor.Outcome

--- a/src/Cortex/Pulse/Persistence.hs
+++ b/src/Cortex/Pulse/Persistence.hs
@@ -1,0 +1,6 @@
+module Cortex.Pulse.Persistence
+  ( module Cortex.Pulse.Executor.Persistence,
+  )
+where
+
+import Cortex.Pulse.Executor.Persistence

--- a/src/Cortex/Pulse/Replay.hs
+++ b/src/Cortex/Pulse/Replay.hs
@@ -1,0 +1,6 @@
+module Cortex.Pulse.Replay
+  ( module Cortex.Pulse.Executor.ReplayPolicy,
+  )
+where
+
+import Cortex.Pulse.Executor.ReplayPolicy

--- a/src/Cortex/Pulse/Resume.hs
+++ b/src/Cortex/Pulse/Resume.hs
@@ -1,0 +1,6 @@
+module Cortex.Pulse.Resume
+  ( module Cortex.Pulse.Executor.Resume,
+  )
+where
+
+import Cortex.Pulse.Executor.Resume

--- a/src/Cortex/Pulse/Runtime.hs
+++ b/src/Cortex/Pulse/Runtime.hs
@@ -1,0 +1,6 @@
+module Cortex.Pulse.Runtime
+  ( module Cortex.Pulse.GraphRuntime,
+  )
+where
+
+import Cortex.Pulse.GraphRuntime

--- a/src/Cortex/Task/Gather.hs
+++ b/src/Cortex/Task/Gather.hs
@@ -36,11 +36,11 @@ import Cortex.Task.ToolLoop
     CortexToolLoopResult (..),
     runToolLoop,
   )
-import Cortex.Text (showText)
 import Data.Aeson qualified as Aeson
 import Data.List (nub)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Platform.Text (showText)
 
 data CortexGatherTaskConfig = CortexGatherTaskConfig
   { cortexGatherTaskModelId :: Text,

--- a/src/Cortex/Task/Report.hs
+++ b/src/Cortex/Task/Report.hs
@@ -24,10 +24,6 @@ import Cortex.Capability.Model.Types
   )
 import Cortex.Capability.Tool.Definition (toolDefinitionName)
 import Cortex.Capability.Tool.Record (CortexToolCallRecord (..))
-import Cortex.Json.Object
-  ( hasObjectBool,
-    lookupObjectText,
-  )
 import Cortex.Run.Types (CortexStageDescriptor (..))
 import Cortex.Task.Gather
   ( CortexGatherRepairTaskConfig (..),
@@ -42,6 +38,10 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Text (Text)
 import Data.Text qualified as T
+import Platform.Serde.Json.Object
+  ( hasObjectBool,
+    lookupObjectText,
+  )
 
 data CortexToolCallResultStatus
   = CortexToolCallResultSuccess

--- a/src/Cortex/Task/ToolLoop.hs
+++ b/src/Cortex/Task/ToolLoop.hs
@@ -22,8 +22,6 @@ import Cortex.Capability.Model.Types
 import Cortex.Capability.Tool.Record
   ( CortexToolCallRecord (..),
   )
-import Cortex.Json.Preview (truncateText)
-import Cortex.Json.Text (decodeLazyUtf8)
 import Cortex.Run.Types
   ( CortexStageDescriptor (..),
   )
@@ -39,6 +37,8 @@ import Data.Aeson qualified as Aeson
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time (defaultTimeLocale, formatTime)
+import Platform.Serde.Json.Preview (truncateText)
+import Platform.Serde.Json.Text (decodeLazyUtf8)
 
 data CortexToolLoopConfig = CortexToolLoopConfig
   { cortexToolLoopDescriptor :: CortexStageDescriptor,

--- a/src/Cortex/Text.hs
+++ b/src/Cortex/Text.hs
@@ -1,23 +1,7 @@
+-- | Compatibility facade for downstream consumers migrating to 'Platform.Text'.
 module Cortex.Text
-  ( showText,
-    stripNonEmptyMaybeText,
-    stripNonEmptyText,
+  ( module Platform.Text,
   )
 where
 
-import Data.Text (Text)
-import Data.Text qualified as T
-
-showText :: (Show a) => a -> Text
-showText = T.pack . show
-
-stripNonEmptyText :: Text -> Maybe Text
-stripNonEmptyText rawText
-  | T.null stripped = Nothing
-  | otherwise = Just stripped
-  where
-    stripped = T.strip rawText
-
-stripNonEmptyMaybeText :: Maybe Text -> Maybe Text
-stripNonEmptyMaybeText =
-  (>>= stripNonEmptyText)
+import Platform.Text

--- a/src/Cortex/Wire.hs
+++ b/src/Cortex/Wire.hs
@@ -1,6 +1,5 @@
 module Cortex.Wire
-  ( module Cortex.Wire.AST,
-    module Cortex.Wire.V1.AST,
+  ( module Cortex.Wire.Syntax,
     WireCompileEnv (..),
     WireContractSpec (..),
     WireContractRegistry (..),
@@ -52,8 +51,17 @@ module Cortex.Wire
   )
 where
 
-import Cortex.Wire.AST
-import Cortex.Wire.Contracts
+import Cortex.Wire.Compile
+  ( compileWireFile,
+    compileWireFileWithEnv,
+    compileWireFragmentFile,
+    compileWireFragmentFileWithEnv,
+    compileWireFragmentText,
+    compileWireFragmentTextWithEnv,
+    compileWireText,
+    compileWireTextWithEnv,
+  )
+import Cortex.Wire.Contract
   ( WireCompileEnv (..),
     WireContractRegistry (..),
     WireContractSpec (..),
@@ -61,6 +69,12 @@ import Cortex.Wire.Contracts
     emptyWireContractRegistry,
     wireContractRegistryFromList,
     wirePortsFromMetadataValue,
+  )
+import Cortex.Wire.Parser
+  ( ParseError,
+    parseWireExpr,
+    parseWireFile,
+    renderParseError,
   )
 import Cortex.Wire.Proposal
   ( WireAppendHole (..),
@@ -85,23 +99,7 @@ import Cortex.Wire.Runtime
     wrapWireStageOutput,
     wrapWireStageResult,
   )
-import Cortex.Wire.V1.AST
-import Cortex.Wire.V1.Compiler
-  ( compileWireFile,
-    compileWireFileWithEnv,
-    compileWireFragmentFile,
-    compileWireFragmentFileWithEnv,
-    compileWireFragmentText,
-    compileWireFragmentTextWithEnv,
-    compileWireText,
-    compileWireTextWithEnv,
-  )
-import Cortex.Wire.V1.Parser
-  ( ParseError,
-    parseWireExpr,
-    parseWireFile,
-    renderParseError,
-  )
+import Cortex.Wire.Syntax
 import Cortex.Wire.Value
   ( WirePayloadKind (..),
     WireValue (..),

--- a/src/Cortex/Wire/Compile.hs
+++ b/src/Cortex/Wire/Compile.hs
@@ -1,0 +1,11 @@
+-- | Canonical Wire compiler facade.
+--
+-- The concrete grammar implementation currently lives under
+-- 'Cortex.Wire.V1'. Future grammar generations should switch this facade
+-- rather than making downstream code import a versioned implementation.
+module Cortex.Wire.Compile
+  ( module Cortex.Wire.V1.Compiler,
+  )
+where
+
+import Cortex.Wire.V1.Compiler

--- a/src/Cortex/Wire/Contract.hs
+++ b/src/Cortex/Wire/Contract.hs
@@ -1,0 +1,6 @@
+module Cortex.Wire.Contract
+  ( module Cortex.Wire.Contracts,
+  )
+where
+
+import Cortex.Wire.Contracts

--- a/src/Cortex/Wire/Contracts.hs
+++ b/src/Cortex/Wire/Contracts.hs
@@ -17,7 +17,7 @@ where
 
 import Control.Monad (void)
 import Cortex.Circuit.IR (CircuitNodeRef (..))
-import Cortex.Wire.AST
+import Cortex.Wire.Syntax
 import Cortex.Wire.Value (WirePayloadKind, renderWirePayloadKind)
 import Data.Aeson (ToJSON (..), (.:), (.=))
 import Data.Aeson qualified as Aeson

--- a/src/Cortex/Wire/Parser.hs
+++ b/src/Cortex/Wire/Parser.hs
@@ -1,0 +1,11 @@
+-- | Canonical Wire parser facade.
+--
+-- Versioned grammar implementations live below this module. Downstream code
+-- should import this facade unless it deliberately tests a specific grammar
+-- generation.
+module Cortex.Wire.Parser
+  ( module Cortex.Wire.V1.Parser,
+  )
+where
+
+import Cortex.Wire.V1.Parser

--- a/src/Cortex/Wire/Proposal.hs
+++ b/src/Cortex/Wire/Proposal.hs
@@ -19,7 +19,7 @@ where
 
 import Control.Applicative ((<|>))
 import Control.Monad (when)
-import Cortex.Circuit.Compiled (CircuitConditionNode (..), CompiledCircuit (..), CompiledCircuitNode (..))
+import Cortex.Circuit.Artifact (CircuitConditionNode (..), CompiledCircuit (..), CompiledCircuitNode (..))
 import Cortex.Circuit.IR
   ( CircuitArtifactBoundary (..),
     CircuitNodeRef (..),
@@ -27,8 +27,8 @@ import Cortex.Circuit.IR
     CircuitSignalBoundary (..),
     CircuitTaskNode (..),
   )
-import Cortex.Wire.AST
-import Cortex.Wire.Contracts (WireCompileEnv, wirePortsFromMetadataValue)
+import Cortex.Wire.Contract (WireCompileEnv, wirePortsFromMetadataValue)
+import Cortex.Wire.Syntax
 import Cortex.Wire.V1 qualified as WireV1
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key

--- a/src/Cortex/Wire/Runtime.hs
+++ b/src/Cortex/Wire/Runtime.hs
@@ -20,8 +20,8 @@ import Cortex.Pulse.Plan
     StageDefinition (..),
     StageResult (..),
   )
-import Cortex.Wire.AST (WireOutputPort (..), WirePorts (..))
-import Cortex.Wire.Contracts (WireContractRegistry (..), WireContractSpec (..))
+import Cortex.Wire.Contract (WireContractRegistry (..), WireContractSpec (..))
+import Cortex.Wire.Syntax (WireOutputPort (..), WirePorts (..))
 import Cortex.Wire.Value
   ( WirePayloadKind (..),
     WireValue (..),

--- a/src/Cortex/Wire/Syntax.hs
+++ b/src/Cortex/Wire/Syntax.hs
@@ -1,0 +1,13 @@
+-- | Canonical Wire syntax facade.
+--
+-- The current grammar implementation is backed by 'Cortex.Wire.V1.AST'. This
+-- module is the stable import surface for source-level syntax and shared Wire
+-- structural types.
+module Cortex.Wire.Syntax
+  ( module Cortex.Wire.AST,
+    module Cortex.Wire.V1.AST,
+  )
+where
+
+import Cortex.Wire.AST
+import Cortex.Wire.V1.AST

--- a/src/Cortex/Wire/V1.hs
+++ b/src/Cortex/Wire/V1.hs
@@ -1,9 +1,7 @@
--- | Wire v1 public surface.
+-- | Compatibility surface for the current Wire grammar implementation.
 --
--- Re-exports the parts of the v1 language implementation that consumers
--- and tests legitimately depend on. Internal helpers stay behind
--- 'Cortex.Wire.V1.AST' and 'Cortex.Wire.V1.Parser' (hidden under the
--- @cortex-runtime@ library).
+-- New code should prefer the unversioned canonical modules:
+-- 'Cortex.Wire.Syntax', 'Cortex.Wire.Parser', and 'Cortex.Wire.Compile'.
 module Cortex.Wire.V1
   ( -- * AST (re-exports)
     module Cortex.Wire.V1.AST,

--- a/src/Cortex/Wire/V1/Compiler.hs
+++ b/src/Cortex/Wire/V1/Compiler.hs
@@ -16,7 +16,7 @@ where
 
 import Control.Applicative ((<|>))
 import Control.Monad (unless, when)
-import Cortex.Circuit.Compiled
+import Cortex.Circuit.Artifact
   ( CircuitCompatibilityWitness (..),
     CircuitConditionNode (..),
     CompiledCircuit (..),
@@ -31,7 +31,7 @@ import Cortex.Circuit.IR
     CircuitSignalBoundary (..),
     CircuitTaskNode (..),
   )
-import Cortex.Circuit.NodeKind (CircuitNodeKind (Act))
+import Cortex.Circuit.Node (CircuitNodeKind (Act))
 import Cortex.Graph
   ( Relation,
     edges,
@@ -45,13 +45,13 @@ import Cortex.Graph
     vertices,
   )
 import Cortex.Pulse.Memory.Types (MemoryStrategy (..))
-import Cortex.Wire.AST qualified as WireCore
-import Cortex.Wire.Contracts
+import Cortex.Wire.Contract
   ( WireCompileEnv (..),
     WireContractRegistry (..),
     emptyWireCompileEnv,
     portsMetadataValue,
   )
+import Cortex.Wire.Syntax qualified as WireCore
 import Cortex.Wire.V1.AST
 import Cortex.Wire.V1.Parser (parseWireFile, renderParseError)
 import Crypto.Hash (Digest, SHA256, hashlazy)

--- a/test/Cortex/Circuit/CompilerSpec.hs
+++ b/test/Cortex/Circuit/CompilerSpec.hs
@@ -34,6 +34,7 @@ import Cortex.Graph
     successors,
     toRelation,
   )
+import Cortex.Pulse.Hydrate (planRewriteDelta)
 import Cortex.Pulse.Memory (defaultMemoryStrategy, discardMemoryHandle)
 import Cortex.Pulse.Node (NodeId (..))
 import Cortex.Pulse.Plan
@@ -53,7 +54,6 @@ import Cortex.Pulse.Plan
     stageActionId,
     stageTemplateId,
   )
-import Cortex.Pulse.PlanHydration (planRewriteDelta)
 import Cortex.Pulse.Rewrite (BudgetContext (..), PlannedRewriteDelta (..))
 import Cortex.Pulse.Types (defaultRewriteBudget)
 import Data.Aeson qualified as Aeson

--- a/test/Cortex/GraphSpec.hs
+++ b/test/Cortex/GraphSpec.hs
@@ -3,8 +3,8 @@
 module Cortex.GraphSpec (spec) where
 
 import Cortex.Graph
-import Cortex.Pulse.GraphRuntime
 import Cortex.Pulse.Node (NodeId (..))
+import Cortex.Pulse.Runtime
 import Data.Aeson qualified as Aeson
 import Data.List (sort, sortOn)
 import Data.Map.Strict qualified as Map

--- a/test/Cortex/Memory/DocumentSpec.hs
+++ b/test/Cortex/Memory/DocumentSpec.hs
@@ -2,6 +2,9 @@
 
 module Cortex.Memory.DocumentSpec (spec) where
 
+import Cortex.Memory.Compact
+  ( estimateTextTokens,
+  )
 import Cortex.Memory.Document
   ( CortexMemoryDocument (..),
     CortexMemoryPassageDraft (..),
@@ -14,9 +17,6 @@ import Cortex.Memory.Pack
   )
 import Cortex.Memory.Types
   ( defaultCortexMemoryEntityConfig,
-  )
-import Cortex.MemoryCompaction
-  ( estimateTextTokens,
   )
 import Data.Text qualified as T
 import Data.Time (UTCTime (..), fromGregorian, secondsToDiffTime)

--- a/test/Cortex/MemoryCompactionSpec.hs
+++ b/test/Cortex/MemoryCompactionSpec.hs
@@ -3,7 +3,7 @@
 
 module Cortex.MemoryCompactionSpec (spec) where
 
-import Cortex.MemoryCompaction
+import Cortex.Memory.Compact
   ( CheckpointSourceReference (..),
     CheckpointSummary (..),
     CompactionConfig (..),

--- a/test/Cortex/Provider/OpenRouterSpec.hs
+++ b/test/Cortex/Provider/OpenRouterSpec.hs
@@ -12,16 +12,16 @@ import Cortex.Capability.Model.Types
     CortexGroundingMode (..),
     CortexResponseFormat (..),
   )
-import Cortex.Provider.OpenRouter
+import Cortex.Capability.Provider.OpenRouter
   ( buildOpenRouterRequestPayload,
     defaultMaxOutputTokens,
     sourceLinksFromAnnotations,
   )
-import Cortex.Provider.OpenRouter.Client
+import Cortex.Capability.Provider.OpenRouter.Client
   ( openRouterRequestPayload,
     openRouterResolvedMaxOutputTokens,
   )
-import Cortex.Provider.OpenRouter.Wire
+import Cortex.Capability.Provider.OpenRouter.Wire
   ( OpenRouterChoice (..),
     OpenRouterCompletion (..),
     OpenRouterUsage (..),

--- a/test/Cortex/Pulse/Executor/EventsSpec.hs
+++ b/test/Cortex/Pulse/Executor/EventsSpec.hs
@@ -2,7 +2,7 @@
 
 module Cortex.Pulse.Executor.EventsSpec (spec) where
 
-import Cortex.Pulse.Executor.Events
+import Cortex.Pulse.Event
   ( ExecutorEvent (..),
     RewriteRejectionInfo (..),
   )

--- a/test/Cortex/Pulse/ExecutorSpec.hs
+++ b/test/Cortex/Pulse/ExecutorSpec.hs
@@ -14,12 +14,12 @@ import Control.Concurrent.MVar (newEmptyMVar, putMVar, readMVar, tryPutMVar)
 import Control.Concurrent.STM (TVar, atomically, newTVarIO, writeTVar)
 import Control.Exception (AsyncException (ThreadKilled), SomeException, displayException, finally, throwIO, try)
 import Control.Monad (void, when)
-import Cortex.Circuit.Compiled (CompiledCircuit (..))
+import Cortex.Circuit.Artifact (CompiledCircuit (..))
 import Cortex.Circuit.IR
   ( CircuitNodeRef (..),
     CircuitTaskNode (..),
   )
-import Cortex.Circuit.Lowering
+import Cortex.Circuit.Lower
   ( CircuitLoweringError (..),
     CircuitPulseBinder (..),
     CircuitPulseConfig (..),
@@ -66,15 +66,7 @@ import Cortex.Pulse.Executor
     stageTemplateId,
   )
 import Cortex.Pulse.Executor qualified as Executor
-import Cortex.Pulse.GraphRuntime
-  ( GraphState (..),
-    InterruptReason (..),
-    NodeStatus (..),
-    initialGraphState,
-    markCompleted,
-    markFailed,
-  )
-import Cortex.Pulse.Materialization (NodeProvenanceEntry (..))
+import Cortex.Pulse.Materialize (NodeProvenanceEntry (..))
 import Cortex.Pulse.Memory (defaultMemoryStrategy)
 import Cortex.Pulse.Node (NodeId (..))
 import Cortex.Pulse.Query (PulseRunEvent (..), PulseStageAttemptLogDetail (..), PulseStageLogDetail (..))
@@ -88,6 +80,14 @@ import Cortex.Pulse.Rewrite
     RewriteRejectionContext (..),
     SubgraphSpec (..),
     budgetFraction,
+  )
+import Cortex.Pulse.Runtime
+  ( GraphState (..),
+    InterruptReason (..),
+    NodeStatus (..),
+    initialGraphState,
+    markCompleted,
+    markFailed,
   )
 import Cortex.Pulse.Schema (PulseTaskDefinitionRow (..))
 import Cortex.Pulse.Signal (SignalName (..))

--- a/test/Cortex/Pulse/GraphRewriteSpec.hs
+++ b/test/Cortex/Pulse/GraphRewriteSpec.hs
@@ -27,7 +27,7 @@ import Cortex.Pulse.Executor
     stageActionId,
     stageTemplateId,
   )
-import Cortex.Pulse.Materialization (computeTopologyHash)
+import Cortex.Pulse.Materialize (computeTopologyHash)
 import Cortex.Pulse.Memory (defaultMemoryStrategy)
 import Cortex.Pulse.Node (NodeId (..))
 import Cortex.Pulse.Rewrite

--- a/test/Cortex/Pulse/MemoryIntegrationSpec.hs
+++ b/test/Cortex/Pulse/MemoryIntegrationSpec.hs
@@ -29,11 +29,11 @@ import Cortex.Graph
     edges,
     toRelation,
   )
-import Cortex.Pulse.GraphRuntime (GraphState (..), NodeStatus (..))
-import Cortex.Pulse.Materialization (PersistedGraphState (..))
+import Cortex.Pulse.Materialize (PersistedGraphState (..))
 import Cortex.Pulse.Memory
 import Cortex.Pulse.Node (NodeId (..))
 import Cortex.Pulse.Rewrite (RewriteBudget (..))
+import Cortex.Pulse.Runtime (GraphState (..), NodeStatus (..))
 import Cortex.Wire (unwrapWireStageValue)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KeyMap

--- a/test/Cortex/Pulse/MemorySpec.hs
+++ b/test/Cortex/Pulse/MemorySpec.hs
@@ -17,7 +17,6 @@ import Cortex.Graph
     toRelation,
     vertices,
   )
-import Cortex.Pulse.GraphRuntime (NodeStatus (..))
 import Cortex.Pulse.Memory
 import Cortex.Pulse.Memory.Score
   ( clamp01,
@@ -26,6 +25,7 @@ import Cortex.Pulse.Memory.Score
     tokenJaccard,
   )
 import Cortex.Pulse.Node (NodeId (..))
+import Cortex.Pulse.Runtime (NodeStatus (..))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Map.Strict (Map)

--- a/test/Cortex/Pulse/MemoryToolSpec.hs
+++ b/test/Cortex/Pulse/MemoryToolSpec.hs
@@ -21,10 +21,10 @@ import Cortex.Graph
     edges,
     toRelation,
   )
-import Cortex.Pulse.GraphRuntime (NodeStatus (..))
 import Cortex.Pulse.Memory
 import Cortex.Pulse.Memory.Tool
 import Cortex.Pulse.Node (NodeId (..))
+import Cortex.Pulse.Runtime (NodeStatus (..))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KeyMap

--- a/test/Cortex/Wire/V1/CompilerSpec.hs
+++ b/test/Cortex/Wire/V1/CompilerSpec.hs
@@ -4,7 +4,7 @@
 
 module Cortex.Wire.V1.CompilerSpec (spec) where
 
-import Cortex.Circuit.Compiled
+import Cortex.Circuit.Artifact
   ( CircuitConditionNode (..),
     CompiledCircuit (..),
     CompiledCircuitFragment (..),


### PR DESCRIPTION
## Summary
Introduce the first Cortex source taxonomy refactor as compatibility-oriented canonicalization.

This PR creates canonical import facades for the agreed Cortex roots without implementing Logoi behavior yet:

- `Cortex.Wire.Syntax`, `Cortex.Wire.Parser`, `Cortex.Wire.Compile`, `Cortex.Wire.Contract`
- `Cortex.Circuit.Artifact`, `Cortex.Circuit.Compile`, `Cortex.Circuit.Lower`, `Cortex.Circuit.Node`
- `Cortex.Pulse.Runtime`, `Attempt`, `Frontier`, `Outcome`, `Persistence`, `Replay`, `Resume`, `Hydrate`, `Materialize`, `Event`
- `Cortex.Graph.Algebra` and `Cortex.Graph.Mokhov`
- root facades for `Capability`, `Document`, `Memory`, and `Event`

It moves generic JSON/text implementations into Platform while preserving Portman-required Cortex import names as thin compatibility facades:

- implementation: `Platform.Serde.Json.*` and `Platform.Text`
- compatibility shims: `Cortex.Json.*` and `Cortex.Text`

It also scrubs stale `Cortex.Logos` naming to `Cortex.Logoi` in agent context and ADR 0015. Actual Logoi modules remain intentionally out of scope for the follow-up PR.

A second docs-only commit removes diagram-local Mermaid theme variables so diagrams inherit the docs site theme.

## Notes
- `Wire/V1` remains the current grammar implementation seam, not the canonical import surface. New code should use the unversioned Wire facades.
- Implementation-era roots remain exposed where current Portman imports require them; new Cortex code should prefer the canonical facades.
- `PORTMAN_CORTEX_REFACTOR_INTEGRATION.md` was written locally as an ignored handoff note and is intentionally not committed.

## Validation
- [x] `just build`
- [x] `just test`
- [x] `just fmt-check`
- [x] `just lint`
- [x] `just check`
- [x] `just docs-check`
- [x] `just check-commit-provenance origin/main..HEAD`
- [x] `git verify-commit HEAD && git verify-commit HEAD~1`
- [x] Portman downstream compile: `nix build .#portman-tests --override-input cortex path:/home/juliuskoskela/Repos/cortex --no-link --print-build-logs`
