### PR TITLE
feat: add Cortex and Platform public preludes

### DIFF
--- a/cortex.cabal
+++ b/cortex.cabal
@@ -144,6 +144,7 @@ library platform-runtime
     visibility:       public
     hs-source-dirs:   src-platform
     exposed-modules:
+        Platform
         Platform.Database
         Platform.Database.Encode
         Platform.Database.Rel8TH
@@ -203,6 +204,7 @@ library
         Cortex.Wire.V1.Compiler
         Cortex.Wire.V1.Parser
     exposed-modules:
+        Cortex
         Cortex.Agent.Config
         Cortex.Agent.Definition
         Cortex.Agent.Policy
@@ -237,6 +239,7 @@ library
         Cortex.Json.Object
         Cortex.Json.Preview
         Cortex.Json.Text
+        Cortex.Logoi
         Cortex.Provider.OpenRouter
         Cortex.Provider.OpenRouter.Client
         Cortex.Provider.OpenRouter.Embeddings
@@ -350,6 +353,7 @@ test-suite cortex-test
     build-tool-depends:
         hspec-discover:hspec-discover >=2.10
     other-modules:
+        Cortex.PublicPreludeSpec
         Cortex.Agent.ConfigSpec
         Cortex.Circuit.CompilerSpec
         Cortex.Circuit.IRSpec

--- a/docs/Architecture/02-ownership-and-boundaries.md
+++ b/docs/Architecture/02-ownership-and-boundaries.md
@@ -48,6 +48,27 @@ flowchart LR
 
 The placement rule: if a module would be reusable outside the host as generic AI infrastructure, it belongs in the Cortex substrate, even when the product binding is currently the only caller. If it knows about host domain semantics, product-specific artifacts, truth policy, or host tool authority, it stays downstream.
 
+## Public import boundary
+
+Downstream products consume Cortex and Platform through two umbrella modules:
+
+```haskell
+import Cortex
+import Platform
+```
+
+Those modules are the supported public API boundary. They re-export the
+stable Cortex substrate surface, the public reasoning/workflow surface, and
+the generic Platform runtime utilities that downstream products are expected
+to use directly.
+
+Area modules such as `Cortex.Wire`, `Cortex.Pulse`, `Cortex.Memory`, or
+`Platform.Observability` remain available for advanced imports, examples, and
+focused tests. Implementation-era roots are not the downstream contract. A
+consumer that reaches past the umbrella modules should do so deliberately and
+expect that import to be reviewed when Cortex tightens its internal module
+layout.
+
 ## Ownership breakdown
 
 ### Cortex substrate

--- a/src-platform/Platform.hs
+++ b/src-platform/Platform.hs
@@ -1,0 +1,51 @@
+-- | Supported Platform import surface for downstream consumers.
+--
+-- Downstream products should prefer @import Platform@ for the stable runtime
+-- utility API. Area modules remain available for advanced use, but this module
+-- is the boundary that accumulates public compatibility promises.
+module Platform
+  ( module Platform.Config,
+    module Platform.Crypto,
+    module Platform.Database,
+    module Platform.Database.Encode,
+    module Platform.Database.Rel8TH,
+    module Platform.DurableTask.Checkpoint,
+    module Platform.DurableTask.Cron,
+    module Platform.DurableTask.Error,
+    module Platform.DurableTask.Polling,
+    module Platform.DurableTask.Pool,
+    module Platform.DurableTask.Schedule,
+    module Platform.DurableTask.Types,
+    module Platform.DurableTask.Workflow,
+    module Platform.Error,
+    module Platform.Error.Servant,
+    module Platform.HTTP.Retry,
+    module Platform.Observability,
+    module Platform.Patch,
+    module Platform.Require,
+    module Platform.Serde,
+    module Platform.Text,
+  )
+where
+
+import Platform.Config
+import Platform.Crypto
+import Platform.Database
+import Platform.Database.Encode
+import Platform.Database.Rel8TH
+import Platform.DurableTask.Checkpoint
+import Platform.DurableTask.Cron
+import Platform.DurableTask.Error
+import Platform.DurableTask.Polling
+import Platform.DurableTask.Pool
+import Platform.DurableTask.Schedule
+import Platform.DurableTask.Types
+import Platform.DurableTask.Workflow
+import Platform.Error
+import Platform.Error.Servant
+import Platform.HTTP.Retry
+import Platform.Observability
+import Platform.Patch
+import Platform.Require
+import Platform.Serde
+import Platform.Text

--- a/src/Cortex.hs
+++ b/src/Cortex.hs
@@ -1,0 +1,37 @@
+-- | Supported Cortex import surface for downstream consumers.
+--
+-- Downstream products should prefer @import Cortex@ for the stable substrate
+-- API. Area modules remain available for advanced use, but this module is the
+-- boundary that accumulates public compatibility promises.
+module Cortex
+  ( module Cortex.Capability,
+    module Cortex.Circuit,
+    module Cortex.Document,
+    DocumentValidationError,
+    module Cortex.Event,
+    module Cortex.Graph,
+    GraphValidationError,
+    module Cortex.Logoi,
+    module Cortex.Memory,
+    module Cortex.Pulse,
+    module Cortex.Wire,
+  )
+where
+
+import Cortex.Capability
+import Cortex.Circuit
+import Cortex.Document hiding (ValidationError)
+import Cortex.Document qualified as Document
+import Cortex.Event
+import Cortex.Graph hiding (ValidationError)
+import Cortex.Graph qualified as Graph
+import Cortex.Logoi
+import Cortex.Memory
+import Cortex.Pulse
+import Cortex.Wire
+
+-- | Domain-shaped alias for document validation failures.
+type DocumentValidationError = Document.ValidationError
+
+-- | Domain-shaped alias for graph validation failures.
+type GraphValidationError = Graph.ValidationError

--- a/src/Cortex/Logoi.hs
+++ b/src/Cortex/Logoi.hs
@@ -1,0 +1,66 @@
+-- | Public reasoning/workflow surface.
+--
+-- Logoi collect the reusable reasoning-mode machinery that sits above the
+-- Wire/Circuit/Pulse substrate: model policy, task hosts, structured task
+-- loops, report sections, and event emission.
+module Cortex.Logoi
+  ( module Cortex.Agent.Config,
+    module Cortex.Research.Runtime,
+    module Cortex.Research.Section,
+    module Cortex.Run.Types,
+    module Cortex.Task.Gather,
+    module Cortex.Task.Host,
+    module Cortex.Task.Plan,
+    module Cortex.Task.Report,
+    module Cortex.Task.Runtime,
+    module Cortex.Task.StructuredOutput,
+    module Cortex.Task.ToolHost,
+    module Cortex.Task.ToolLoop,
+    emitRunAgentDone,
+    emitRunAgentStart,
+    emitRunError,
+    emitRunSummary,
+    emitRunThinking,
+  )
+where
+
+import Cortex.Agent.Config
+import Cortex.Events (CortexEventEmitter)
+import Cortex.Research.Runtime
+import Cortex.Research.Section
+import Cortex.Run.Engine qualified as RunEngine
+import Cortex.Run.Types
+import Cortex.Task.Gather
+import Cortex.Task.Host
+import Cortex.Task.Plan
+import Cortex.Task.Report
+import Cortex.Task.Runtime
+import Cortex.Task.StructuredOutput
+import Cortex.Task.ToolHost
+import Cortex.Task.ToolLoop
+import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+
+-- | Low-level run-event start emitter.
+--
+-- Task-level emitters remain exported from 'Cortex.Task.Runtime' under their
+-- existing names. The run-level emitters are prefixed here so the public Logoi
+-- facade can expose both surfaces without ambiguous names.
+emitRunAgentStart :: CortexEventEmitter -> CortexStageDescriptor -> Text -> Maybe Text -> IO ()
+emitRunAgentStart = RunEngine.emitAgentStart
+
+-- | Low-level run-event completion emitter.
+emitRunAgentDone :: CortexEventEmitter -> CortexStageDescriptor -> Text -> Maybe Text -> IO ()
+emitRunAgentDone = RunEngine.emitAgentDone
+
+-- | Low-level run-event thinking emitter.
+emitRunThinking :: CortexEventEmitter -> CortexStageDescriptor -> Text -> Maybe Text -> IO ()
+emitRunThinking = RunEngine.emitThinking
+
+-- | Low-level run-event summary emitter.
+emitRunSummary :: CortexEventEmitter -> CortexStageDescriptor -> Text -> Maybe Text -> Maybe Aeson.Value -> IO ()
+emitRunSummary = RunEngine.emitSummary
+
+-- | Low-level run-event error emitter.
+emitRunError :: CortexEventEmitter -> CortexStageDescriptor -> Text -> Maybe Text -> IO ()
+emitRunError = RunEngine.emitError

--- a/src/Cortex/Pulse.hs
+++ b/src/Cortex/Pulse.hs
@@ -1,10 +1,22 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Cortex Pulse: standalone durable execution runtime.
--- Entry point for the cortex-pulse daemon.
+-- | Cortex Pulse public facade and daemon entry point.
 module Cortex.Pulse
   ( runPulse,
+    module Cortex.Pulse.Executor,
+    module Cortex.Pulse.Hydrate,
+    module Cortex.Pulse.Materialize,
+    module Cortex.Pulse.Memory,
+    module Cortex.Pulse.Memory.Tool,
+    module Cortex.Pulse.Node,
+    module Cortex.Pulse.Persistence,
+    module Cortex.Pulse.Query,
+    module Cortex.Pulse.Rewrite,
+    module Cortex.Pulse.Runtime,
+    module Cortex.Pulse.Schema,
+    module Cortex.Pulse.Signal,
+    module Cortex.Pulse.Types,
   )
 where
 
@@ -14,9 +26,19 @@ import Control.Exception (SomeException, catch, displayException)
 import Cortex.Pulse.Executor (TaskContext (..), TaskRegistry)
 import Cortex.Pulse.Executor qualified as Executor
 import Cortex.Pulse.Health (PulseHealthState (..), initialHealthState, runHealthServer)
+import Cortex.Pulse.Hydrate
+import Cortex.Pulse.Materialize
+import Cortex.Pulse.Memory
+import Cortex.Pulse.Memory.Tool
+import Cortex.Pulse.Node
+import Cortex.Pulse.Persistence
+import Cortex.Pulse.Query hiding (recordRunEvent)
 import Cortex.Pulse.Query qualified as Q
-import Cortex.Pulse.Scheduler (finalizeTaskSchedule, recoverExpiredRuns, runSchedulerLoop, withLeaseRenewal)
-import Cortex.Pulse.Schema (PulseTaskDefinitionRow (..))
+import Cortex.Pulse.Rewrite
+import Cortex.Pulse.Runtime
+import Cortex.Pulse.Scheduler qualified as Scheduler
+import Cortex.Pulse.Schema
+import Cortex.Pulse.Signal
 import Cortex.Pulse.Types
 import Data.Aeson qualified as Aeson
 import Data.Int (Int32)
@@ -119,7 +141,7 @@ runPulse registry rawConfig = do
       pure ids
 
   -- 4b. Recover expired foreign-owner runs
-  expiredResult <- recoverExpiredRuns pool leaseOwner now
+  expiredResult <- Scheduler.recoverExpiredRuns pool leaseOwner now
   expiredCount <- case expiredResult of
     Left err -> do
       emitEvent (Just obsRuntime) $
@@ -165,7 +187,7 @@ runPulse registry rawConfig = do
           link healthAsync
           withAsync (resumeReclaimedRuns registry taskContext leaseDuration reclaimedRunIds) $ \reclaimAsync -> do
             link reclaimAsync
-            runSchedulerLoop registry taskContext healthState
+            Scheduler.runSchedulerLoop registry taskContext healthState
 
   -- The scheduler loop exits when shutdownFlag is set (by signal handler).
   -- Catch unexpected exceptions only.
@@ -294,10 +316,10 @@ resumeOneRun registry taskContext leaseDuration runId = do
               ]
             pure Nothing
       outcome <-
-        withLeaseRenewal pool runId leaseDuration $
+        Scheduler.withLeaseRenewal pool runId leaseDuration $
           Executor.resumeTask registry taskContext runId task
       endTime <- getCurrentTime
-      finalizeTaskSchedule pool (Just runId) task triggerSource endTime outcome
+      Scheduler.finalizeTaskSchedule pool (Just runId) task triggerSource endTime outcome
   where
     emitEvent' level op msg extra =
       emitGlobalEvent $

--- a/test/Cortex/PublicPreludeSpec.hs
+++ b/test/Cortex/PublicPreludeSpec.hs
@@ -1,0 +1,36 @@
+module Cortex.PublicPreludeSpec
+  ( spec,
+  )
+where
+
+import Cortex qualified
+import Platform qualified
+import Test.Hspec
+
+spec :: Spec
+spec =
+  describe "public preludes" $ do
+    it "exposes representative Cortex substrate and Logoi types" $ do
+      Cortex.unNodeId (Cortex.NodeId "root") `shouldBe` "root"
+      Cortex.researchChunkHasVisibleContent emptyChunk `shouldBe` False
+      Cortex.emptyCortexAgentBudget `shouldBe` Cortex.CortexAgentBudget Nothing Nothing
+
+    it "exposes representative Platform runtime helpers" $ do
+      Platform.runStatusToText Platform.Pending `shouldBe` "pending"
+      Platform.stripNonEmptyText "  cortex  " `shouldBe` Just "cortex"
+      Platform.toolValidationError "field" "missing" "value"
+        `shouldBe` "Error: missing: value"
+
+emptyChunk :: Cortex.ResearchChunk
+emptyChunk =
+  Cortex.ResearchChunk
+    { Cortex.researchChunkSectionId = "section",
+      Cortex.researchChunkTitle = "Section",
+      Cortex.researchChunkSummary = Nothing,
+      Cortex.researchChunkParagraphs = [],
+      Cortex.researchChunkFindings = [],
+      Cortex.researchChunkTables = [],
+      Cortex.researchChunkEvidenceRefs = [],
+      Cortex.researchChunkExternalRefs = [],
+      Cortex.researchChunkOpenGaps = []
+    }


### PR DESCRIPTION
## Summary

Add supported umbrella import modules for downstream consumers:

- `Cortex` is the canonical Cortex public import boundary.
- `Platform` is the canonical generic runtime public import boundary.
- `Cortex.Logoi` exposes the current reusable reasoning/workflow surface without adding new downstream product semantics.
- `Cortex.Pulse` now behaves as a public Pulse facade instead of only the daemon entry point.

This is the API-boundary follow-up to the module taxonomy refactor. Area modules remain available for advanced imports, examples, and focused tests, but downstream products should be able to target the umbrella modules first while Cortex keeps tightening internal layout.

## Boundary Notes

This PR does not migrate Portman imports or add Portman-specific compatibility modules. Portman3 was used as a downstream compile proof against this local Cortex branch, and no Portman3 files were edited.

The `Cortex.Logoi` module is intentionally a facade over the current reusable reasoning/task/report modules. It gives the canonical root a stable shape now, while deeper internal renames can happen behind that boundary later.

## Changes

- [x] Add `src/Cortex.hs` as the supported Cortex prelude.
- [x] Add `src-platform/Platform.hs` as the supported Platform prelude.
- [x] Add `src/Cortex/Logoi.hs` as the public reasoning/workflow facade.
- [x] Widen `Cortex.Pulse` into a Pulse public facade.
- [x] Expose the new modules in `cortex.cabal`.
- [x] Add a compile smoke test that imports only `Cortex` and `Platform`.
- [x] Document the public import boundary in `docs/Architecture/02-ownership-and-boundaries.md`.

## Verification

- [x] `just build`
- [x] `nix run .#cortex-tests`
- [x] `just check`
- [x] `nix build .#portman-server --override-input cortex path:/home/juliuskoskela/Repos/cortex --no-link --print-build-logs --builders ''`
- [x] `nix build .#portman-tests --override-input cortex path:/home/juliuskoskela/Repos/cortex --no-link --print-build-logs --builders ''`

`just test-match "public preludes"` is not usable in this local dev shell because `postgresql-libpq` cannot find `pg_config`; the Nix test target above is the working test path.

## Non-goals

- No Portman import migration.
- No internal sub-library split yet.
- No removal of per-area exposed modules.
- No new Logoi semantics beyond the public facade.

Closes #45
