### PR TITLE
chore(agents): add OpenCode to the provider-link script

### DIFF
--- a/agents/context.md
+++ b/agents/context.md
@@ -146,7 +146,8 @@ Repo-local agent context lives under `agents/`.
 - Source-tree context: `agents/<repo-path>/context.md`.
 - Skills: `agents/skills/<name>/SKILL.md`.
 - Provider symlinks are gitignored and regenerated with
-  `just agent-link-codex` or `just agent-link-claude`.
+  `just agent-link-codex`, `just agent-link-claude`, or
+  `just agent-link-opencode`.
 
 Do not edit generated provider files directly. Move reusable guidance
 back into provider-neutral context or skills.

--- a/agents/scripts/link-provider
+++ b/agents/scripts/link-provider
@@ -2,12 +2,15 @@
 set -eu
 
 usage() {
-  echo "usage: agents/scripts/link-provider codex|claude" >&2
+  echo "usage: agents/scripts/link-provider codex|claude|opencode" >&2
   exit 2
 }
 
 provider="${1:-}"
-[ "$provider" = "codex" ] || [ "$provider" = "claude" ] || usage
+case "$provider" in
+  codex|claude|opencode) ;;
+  *) usage ;;
+esac
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
@@ -77,7 +80,21 @@ link_claude() {
   done
 }
 
+link_opencode() {
+  link_contexts AGENTS.md
+
+  skill_dest="$repo_root/.opencode/skills"
+  mkdir -p "$skill_dest"
+
+  for skill_dir in "$repo_root"/agents/skills/*; do
+    [ -d "$skill_dir" ] || continue
+    skill_name="$(basename "$skill_dir")"
+    link_rel "$skill_dir" "$skill_dest/$skill_name"
+  done
+}
+
 case "$provider" in
   codex) link_codex ;;
   claude) link_claude ;;
+  opencode) link_opencode ;;
 esac

--- a/justfile
+++ b/justfile
@@ -158,6 +158,10 @@ agent-link-codex:
 agent-link-claude:
     agents/scripts/link-provider claude
 
+# Link repo-local agent context and skills for OpenCode
+agent-link-opencode:
+    agents/scripts/link-provider opencode
+
 # Start Nix REPL
 repl:
     nix repl -f flake:nixpkgs


### PR DESCRIPTION
## Summary

Add OpenCode support to the repo-local agent provider linking flow.

## Changes

- Add an `opencode` case to `agents/scripts/link-provider`.
- Add `just agent-link-opencode`.
- Document OpenCode alongside the existing Codex and Claude provider-link commands.

## Verification

- [x] `just check`

