### PR TITLE
docs: enable Lean theory pages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -734,11 +734,11 @@
         "tree-sitter-json": "tree-sitter-json"
       },
       "locked": {
-        "lastModified": 1777233865,
-        "narHash": "sha256-CcS7lRe5dO9PIOBMzDQay7alVE7xANKG6NwnCtpsrJY=",
+        "lastModified": 1777302744,
+        "narHash": "sha256-bey8F/rm1aoorNie+mranO2cdxUp9WO+pmo2qMz9QjE=",
         "owner": "Digimuoto",
         "repo": "repo-docs",
-        "rev": "2084267c4c036c6cdd06c553b50a2f942ec368d0",
+        "rev": "1c83a1f7cf5906fae76c85e867d04a34c5a15950",
         "type": "github"
       },
       "original": {

--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -40,6 +40,8 @@
         languages.wire = {
           grammarSrc = ../editors/tree-sitter-wire;
         };
+
+        lean4.theoryDir = "theory";
       };
     };
 


### PR DESCRIPTION
## Summary
Validate the updated repo-docs flake input for `lean4.theoryDir` site config support and collect feedback for upstream.

## Plan
- [x] Inspect the updated flake input and current docs-site configuration.
- [x] Configure Cortex docs to declare `lean4.theoryDir = "theory"`.
- [x] Build or check the docs/Lean integration locally.
- [x] Capture findings and communicate upstream repo-docs follow-up.

## Validation
- [x] `just docs-check`
- [x] `just docs-build`
- [x] generated `default-site-config.json` contains `"lean4":{"theoryDir":"theory"}`
- [x] `just lean-build`
- [x] `just check`

## Checklist
- [x] Implementation complete
- [x] Tests added/updated where applicable
- [x] `just check` passes locally
- [ ] Ready for review

## Upstream
Reported validation to repo-docs: https://github.com/Digimuoto/repo-docs/issues/1

## Issue
No tracking issue.