### PR TITLE
docs: define Wire executor and pure node boundaries

### DIFF
--- a/docs/ADRs/0018-wire-executor-and-port-catalog-boundary.md
+++ b/docs/ADRs/0018-wire-executor-and-port-catalog-boundary.md
@@ -1,0 +1,369 @@
+---
+title: "ADR 0018 — Wire Executor and Port Catalog Boundary"
+description: "Wire separates value-level contracts, id-referencing port profiles, compile-time projections, runtime payload validation, Pulse framing, and host codecs."
+sidebar:
+  label: "0018. Executor and ports"
+  order: 18
+status: proposed
+date: 2026-04-27
+superseded_by: null
+related:
+  - docs/Architecture/05-wire-language.md
+  - docs/Architecture/09-nous-reasoning-library.md
+  - docs/Reference/Wire/contracts-ports-and-matching.md
+  - docs/ADRs/0010-wire-closed-authority-and-three-layer-stack.md
+  - docs/ADRs/0014-executor-taxonomy-model-vs-external-call.md
+  - docs/ADRs/0017-cortex-roots-and-nous-pattern-extraction.md
+  - docs/ADRs/0019-wire-pure-nodes.md
+  - "GitHub #55"
+---
+
+# ADR 0018 — Wire Executor and Port Catalog Boundary
+
+## Status
+
+Proposed - names the central seam exposed by the first DeepReport contract
+extraction: `WireCompileEnv` currently conflates executor authority projection,
+executor-port projection, and contract catalog projection. The target
+architecture splits those responsibilities before extracting more DeepReport
+structure from Portman.
+
+## Context
+
+PR #54 moved the generic DeepReport contract catalog from Portman into
+`Cortex.Nous.Patterns.DeepReport.Contracts`. That removed duplicated contract
+meaning, but it also exposed the next conflation. Portman still declares generic
+DeepReport port maps in `Portman.Workflow.WireEnv`, binds executor ids to
+runnable Haskell actions in `Portman.Task.DeepReportWorkflow`, and owns concrete
+payload records, codecs, prompts, persistence, and product semantics.
+
+The problem is vocabulary drift. In Wire discussions, "contract" and "port" are
+often used for three different things:
+
+- value-level payload meaning
+- structural boundary slots on nodes
+- host/runtime code that marshals Haskell values and grants executor authority
+
+Those are different architecture artifacts. Folding them together makes it hard
+to extract reusable Nous pattern structure without accidentally moving product
+authority into `Cortex.Nous`.
+
+The current Haskell staging surface also blurs the seam. `WireCompileEnv` carries
+at least three distinct projections in one record:
+
+- the set of known executor ids, which is an authority projection from the host
+- the port shape each executor exposes, which is a catalog projection
+- the contract registry, which is the value-level catalog
+
+Wire does not need all host authority metadata to compile. It needs a projection:
+known contract ids and port shapes for the executor ids that source mentions.
+
+## Decision
+
+Cortex separates value-level contracts, id-referencing port profiles,
+compile-time projections, runtime payload validation, Pulse framing, and host
+application codecs.
+
+### Contracts are values, not Haskell types
+
+A Wire contract is a value-level descriptor of what a payload means at a Wire
+boundary. It is pure data: enumerable, serializable, shippable as JSON,
+comparable by id, and usable across process and language boundaries. It is not a
+Haskell type, and it is not parameterized over one.
+
+Current Haskell shape:
+
+```haskell
+data WireContractSpec = WireContractSpec
+  { wcsId :: ContractId
+  , wcsPayloadKind :: WirePayloadKind
+  , wcsSchema :: Maybe Aeson.Value
+  , wcsDescription :: Text
+  , wcsExamples :: [Aeson.Value]
+  }
+
+data WirePayloadKind
+  = WirePayloadJson
+  | WirePayloadMarkdown
+  | WirePayloadText
+  | WirePayloadTable
+  | WirePayloadArtifactRef
+
+data WireValue = WireValue
+  { wireValueContract :: ContractId
+  , wireValuePayloadKind :: WirePayloadKind
+  , wireValueValue :: Aeson.Value
+  }
+```
+
+`WirePayloadKind` is a closed Wire enum. Adding a payload kind is a Wire change,
+not a downstream extension point. The current runtime is JSON-value centered:
+markdown and text payloads are JSON strings, table payloads are JSON objects or
+arrays, and artifact refs are JSON objects. A contract catalog must survive
+documentation generation, JSON export, Pulse replay logs, and future
+cross-language clients. Making contracts phantom-typed Haskell values would make
+that catalog property depend on every consumer sharing the same Haskell type
+definitions.
+
+Haskell payload types are a binding-layer concern. A downstream binder may decide
+that `ResearchPlan` corresponds to contract
+`cortex.deepreport.research-plan/v1`, but the contract catalog does not know the
+`ResearchPlan` type exists.
+
+### Ports reference contracts by id
+
+A port is the structural shape of one boundary slot on a node. It references a
+contract by id and adds positional metadata: local label, cardinality,
+requiredness, and exclusive-output grouping. A port never carries the full
+contract spec inline.
+
+Illustrative target shape:
+
+```haskell
+data Cardinality = One | ZeroOrOne | Many
+
+data WireInputPort = WireInputPort
+  { wipLabel :: PortLabel
+  , wipContractId :: ContractId
+  , wipCardinality :: Cardinality
+  , wipRequired :: Bool
+  }
+
+data WireOutputPort = WireOutputPort
+  { wopLabel :: PortLabel
+  , wopContractId :: ContractId
+  , wopCardinality :: Cardinality
+  , wopGroup :: Maybe ExclusiveGroup
+  }
+
+data WirePorts = WirePorts
+  { wpInputs :: [WireInputPort]
+  , wpOutputs :: [WireOutputPort]
+  }
+```
+
+A port profile is a named `WirePorts` value published in a catalog. The name is
+what makes it shareable. Many executors can declare that they conform to a
+profile such as `deepreport.gatherer/v1`, and Wire can check that the executor's
+projected ports match the profile structurally. Port profiles carry no runnable
+authority.
+
+Labels are not the reason to extract DeepReport ports. The current DeepReport
+shape can be expressed with contract-only routing: each node input has a distinct
+contract, so no node needs two same-contract slots. Extracting
+`Cortex.Nous.Patterns.DeepReport.Ports` is therefore a module-boundary cleanup,
+not a new expressiveness requirement.
+
+Labels become mandatory when a node needs distinct roles for the same contract,
+for example a comparative rewriter with `previous: ReportSection` and
+`reference: ReportSection`, an analysis diff with `baseline: Analysis` and
+`candidate: Analysis`, or a pure scoring node with several `Float` inputs. Those
+cases motivate pure nodes and structural primitives, not the first DeepReport
+port extraction. ADR 0019 owns that sequencing.
+
+### Executors grant authority through bindings
+
+An executor definition is not a contract and not merely a port shape. It names a
+runnable authority and should eventually include executor id, production kind from
+ADR 0014, config schema or decoder, port profile reference or explicit port
+constraints, replay and side-effect metadata, tool-scope requirements, provider
+policy when model-mediated, and the host binder or interpreter.
+
+The binder is where Haskell type identity matters. Executors are implemented over
+real application types such as `ResearchPlan` or `EvidenceBundle`. The binder
+bridges those values into `WirePayload` and binds the Haskell type to a contract
+id under host authority.
+
+Illustrative downstream shape:
+
+```haskell
+class HasContract a where
+  contractId :: ContractId
+
+class HasContract a => WireCodec a where
+  encodeWire :: a -> WirePayload
+  decodeWire :: WirePayload -> Either DecodeError a
+```
+
+These instances live with the application type or downstream pattern binding, not
+inside the value-level contract catalog. The catalog remains serializable and
+language-neutral.
+
+## Layer Split
+
+The architecture has two distinct serialization layers.
+
+**Layer 1: Pulse wire framing.** Pulse owns deterministic framing from
+`WireValue` to bytes. The framing table is closed and indexed by
+`WirePayloadKind`, but the current representation is JSON-centered: JSON payloads
+are framed as canonical JSON, markdown and text payloads are JSON strings, table
+payloads are JSON objects or arrays, and artifact refs are JSON objects.
+Downstream consumers must not plug arbitrary codecs into this layer because
+durable replay depends on stable framing.
+
+**Layer 2: application codecs.** The host binder owns mappings between Haskell
+types and `WireValue`. This is where an executor returning `ResearchPlan` is
+encoded into a JSON-valued payload carrying the research-plan contract id. Replay
+decodes the persisted `WireValue` through the same host codec when a runnable
+stage needs the application type again.
+
+The enforcement responsibilities are also separate.
+
+**Compile time.** Wire checks only structural facts: known contract ids, port
+shapes per mentioned executor id, labels, cardinality, exclusive output groups,
+and graph topology. It does not need schemas, codecs, or Haskell payload types.
+
+**Wire runtime.** Wire runtime currently validates that emitted `WireValue`
+values match the declared output contract's payload kind and coarse shape. Future
+schema and content validation belongs in this layer after payload-kind checks. It
+still does not know Haskell application types.
+
+**Pulse persistence.** Pulse persists framed `WireValue` bytes according to the
+closed `WirePayloadKind` table. Contract schemas do not affect framing.
+
+**Host binding.** The binder admits executor ids, config, tools, provider policy,
+artifact destinations, product permissions, and application codecs. It is the
+place where authority and Haskell type identity enter.
+
+**Executor.** The executor is ordinary host code over host types. It is downstream
+of the binding decision and does not define Wire contract semantics.
+
+The dependency rule is: lower substrate layers know less. Contract catalogs do
+not know Haskell types. Wire knows contract ids, port profiles, payload kinds,
+and schemas, but not application codecs. Pulse knows payload kinds and framing,
+but not schemas or Haskell types. Host codecs know Haskell types and contract ids,
+but do not define Pulse framing.
+
+## `WireCompileEnv` Target Shape
+
+`WireCompileEnv` should become an explicit compile-time projection rather than a
+mixed authority and catalog record. This is the central seam: executor admission
+is a host decision, while executor port shape is the structural projection Wire
+uses for checking.
+
+Current staging shape:
+
+- known executor ids are present because maps are keyed by executor id
+- executor port shapes are present as `WirePorts`
+- contract registry is present as catalog data
+
+Target shape:
+
+- richer `ExecutorSpec` or host registration records live outside Wire compile
+- each executor spec references a port profile or declares explicit port
+  constraints
+- Wire receives only the projection it needs: `Map ExecutorId WirePorts` plus the
+  contract registry, in strict or explicitly permissive mode
+- host authority metadata no longer leaks into the compile-time API
+
+Port extraction should be designed around this projection. It can publish inert
+profile values now while leaving executor authority downstream. Pure nodes and
+structural primitives should wait until same-contract labeled slots are tested as
+part of their implementation, because those features actually require labels for
+expressiveness.
+
+## DeepReport Migration Implications
+
+For DeepReport, `Cortex.Nous.Patterns.DeepReport.Ports` should publish named port
+profiles such as planner, gatherer, required-evidence gate, analyst, section
+compiler, reviewer, rewriter, publish gate, workflow audit, and artifact emitter
+profiles. Portman may import those profiles, override or extend them for
+product-specific executors, and keep the runtime binder and payload records
+downstream.
+
+This extraction should preserve today's DeepReport graph language. It should not
+introduce new port-label semantics, pure-node syntax, or structural primitive
+syntax. Current DeepReport gains cleaner module boundaries and less duplicated
+catalog data, not new expressiveness.
+
+Portman can remove duplicate generic contract definitions after PR #54 by
+importing `deepReportWireContractRegistry`. The next removal target is duplicate
+generic DeepReport port profiles, not executor dispatch or payload types.
+
+Portman should keep ownership of:
+
+- executor dispatch and Haskell stage implementations
+- product prompts until finance-specific instructions are separated
+- runtime payload records and host codecs until generic schemas/codecs are
+  deliberately designed
+- product tools, tool authorization, provider keys, and model defaults
+- DB-backed workflow loading and bundled-template sync
+- workspace artifact destinations and report UX policy
+
+The clean next sequence is:
+
+1. Add `Cortex.Nous.Patterns.DeepReport.Ports` with generic port profiles.
+2. Update Portman to compose those port profiles with product-specific additions.
+3. Introduce explicit executor-definition types after the port profile shape is
+   stable enough to avoid encoding Portman assumptions into Cortex.
+4. Decide the final home for generic artifact contracts such as
+   `ReportArtifactRef` before making artifact-emitter profiles canonical.
+
+## Alternatives considered
+
+- **Make contracts phantom-typed Haskell values.** Rejected because contracts must
+  be serializable catalog values usable by docs, logs, cross-process replay, and
+  non-Haskell clients.
+- **Let ports carry contract specs inline.** Rejected because ports are endpoint
+  structure. Inlining specs would duplicate catalog data and make contract
+  identity harder to compare.
+- **Let executors own contracts.** Rejected because contracts are shared across
+  planners, gatherers, analysts, reviewers, emitters, and future patterns.
+- **Let downstream code plug Pulse framing codecs.** Rejected because durable
+  replay requires a closed, deterministic, kind-indexed framing table.
+- **Move Portman's runtime binder into Cortex.Nous.** Rejected because the binder
+  grants tool, provider, artifact, DB, and product authority. Nous patterns may
+  publish inert catalogs and templates, not host authority.
+- **Delay port extraction until a full `ExecutorSpec` exists.** Rejected because
+  the current duplicate `WirePorts` maps are already extractable as inert catalog
+  values. A full executor-definition API can follow once the profile boundary is
+  proven.
+
+## Consequences
+
+### Positive
+
+- Contract catalogs remain portable data rather than Haskell-only type witnesses.
+- DeepReport ports can move to Cortex without moving Portman runtime authority.
+- Executors can share contract vocabulary and port profiles explicitly.
+- Pulse replay has a closed framing story independent of application codecs.
+- Future executor-definition work has a target shape rather than being inferred
+  from `WireCompileEnv` maps.
+
+### Negative
+
+- The transition keeps a staged API where `WireCompileEnv` still mixes compile
+  projection and temporary executor-port maps.
+- Port catalogs introduce another named artifact that must be documented and kept
+  in sync with templates.
+- Broad object schemas in the current contract catalog still defer real content
+  validation.
+- Application codec ownership must be documented for each downstream binding.
+
+### Obligations
+
+- Add tests when extracting `Cortex.Nous.Patterns.DeepReport.Ports` to prove the
+  profile names, accepted contracts, output contracts, labels, and cardinalities.
+- Keep generated or materialized build metadata with source changes that expose
+  new Haskell modules.
+- Document downstream override rules when Portman composes generic profiles with
+  product-specific executors.
+- Keep Pulse framing closed and deterministic; do not make it a user codec hook.
+- Add schema/content validation after the current payload-kind and coarse-shape
+  runtime checks before relying on schemas as enforced contracts.
+- Keep application `WireCodec` instances out of contract catalogs unless a future
+  ADR deliberately introduces a language-specific binding package.
+- Do not let a Nous pattern module import Portman or grant product authority.
+- Replace `Maybe WireContractRegistry` with an explicit strict/permissive mode
+  before claiming closed authority for imported Nous templates.
+
+## Related
+
+- [ADR 0010 — Wire as Closed-Authority Language](./0010-wire-closed-authority-and-three-layer-stack.md)
+- [ADR 0014 — Model vs External Call](./0014-executor-taxonomy-model-vs-external-call.md)
+- [ADR 0017 — Cortex Roots and Nous Pattern Extraction](./0017-cortex-roots-and-nous-pattern-extraction.md)
+- [ADR 0019 — Wire Pure Nodes](./0019-wire-pure-nodes.md)
+- [Chapter 05 — Wire Language](../Architecture/05-wire-language.md)
+- [Chapter 09 — Nous Reasoning Library](../Architecture/09-nous-reasoning-library.md)
+- [Wire Reference — Contracts, Ports, and Matching](../Reference/Wire/contracts-ports-and-matching.md)
+- GitHub #55

--- a/docs/ADRs/0019-wire-pure-nodes.md
+++ b/docs/ADRs/0019-wire-pure-nodes.md
@@ -1,0 +1,216 @@
+---
+title: "ADR 0019 — Wire Pure Nodes"
+description: "Pure nodes are deterministic Wire-authored computations interpreted by registered pure executors; they require labeled same-contract slots but do not add a third executor kind."
+sidebar:
+  label: "0019. Pure nodes"
+  order: 19
+status: proposed
+date: 2026-04-27
+superseded_by: null
+related:
+  - docs/Architecture/05-wire-language.md
+  - docs/Reference/Wire/grammar-v1.md
+  - docs/Reference/Wire/contracts-ports-and-matching.md
+  - docs/ADRs/0014-executor-taxonomy-model-vs-external-call.md
+  - docs/ADRs/0018-wire-executor-and-port-catalog-boundary.md
+  - "GitHub #55"
+---
+
+# ADR 0019 — Wire Pure Nodes
+
+## Status
+
+Proposed - records the target semantics for pure nodes before implementation.
+Pure nodes are the first planned feature family that makes same-contract labeled
+inputs unavoidable; they are not needed for the current DeepReport port-profile
+extraction.
+
+## Context
+
+Wire already has the vocabulary for registered executors, explicit ports, labels,
+and contract-polymorphic utility executors in the reference grammar. The current
+DeepReport shape does not force that machinery very hard: each node input uses a
+distinct contract, so contract-only routing is enough.
+
+Pure computations change the pressure. A simple weighted score needs several
+inputs with the same primitive contract but different roles:
+
+```wire
+node weighted_score :
+  <- evidence_score: Float
+  <- recency_score: Float
+  <- authority_score: Float
+  -> Float
+= @pure { expr = "0.5 * evidence_score + 0.3 * recency_score + 0.2 * authority_score"; };
+```
+
+Without labels, the structural roles would have to be encoded as distinct
+contracts such as `EvidenceScore`, `RecencyScore`, and `AuthorityScore`. That
+would put graph-local slot identity into the contract catalog, which is exactly
+the conflation ADR 0018 rejects.
+
+The same pressure appears in structural primitives:
+
+```wire
+node analysis_diff :
+  <- baseline: Analysis
+  <- candidate: Analysis
+  -> AnalysisDelta
+= @pure { expr = "diff(baseline, candidate)"; };
+
+node merge_evidence :
+  <- primary: EvidenceBundle
+  <- secondary: EvidenceBundle
+  -> EvidenceBundle
+= @pure { expr = "merge(primary, secondary)"; };
+```
+
+These examples are not blockers for extracting current DeepReport ports. They are
+the reason pure nodes and structural primitives should land with tested label
+semantics.
+
+## Decision
+
+Wire pure nodes are deterministic, side-effect-free computations authored in Wire
+and interpreted by registered pure executors. They do not create a third
+node-level executor kind. Under ADR 0014, a pure evaluator is a registered
+`ExternalCallExecutor` variant with purity, replay-safety, and side-effect
+metadata set to the pure/no-effect class.
+
+The expression body is executor config or sugar for executor config, not executor
+definition. Wire still does not let source files define new executor authority.
+For example, this surface:
+
+```wire
+node weighted_score :
+  <- evidence_score: Float
+  <- recency_score: Float
+  <- authority_score: Float
+  -> Float
+= @pure { expr = "0.5 * evidence_score + 0.3 * recency_score + 0.2 * authority_score"; };
+```
+
+means: use the host-registered `@pure` evaluator with explicit ports and an
+expression config. The host decides whether `@pure` is registered, which pure
+functions are available, which contracts are admitted, and how expression errors
+are reported.
+
+Initial pure-node implementation should obey these constraints:
+
+- Ports are explicit. The compiler should not infer ports from expression
+  variables in the first slice.
+- Same-contract sibling inputs require explicit labels. Expression variable names
+  bind to labels. A single unlabeled input may be exposed as `in`; otherwise
+  pure-node inputs should be labeled to bind expression variables explicitly.
+- The pure evaluator operates on `WirePayload`-level values, not downstream
+  Haskell application types.
+- The expression language is closed and deterministic: no IO, time, randomness,
+  model calls, tool calls, memory queries, durable-state reads, or host callbacks
+  other than registered pure functions.
+- Pulse persistence still uses the closed `PayloadKind` framing table from ADR
+  0018. Pure nodes do not install Pulse codecs.
+- Runtime output is wrapped and validated through the declared output contract in
+  the normal Wire runtime path.
+
+## Boundary With Contracts And Codecs
+
+Pure nodes make the ADR 0018 split concrete.
+
+- Contract catalogs define value meaning such as `Float`, `Analysis`, or
+  `Evidence`.
+- Port labels define graph-local roles such as `baseline`, `candidate`,
+  `primary`, or `secondary`.
+- The pure evaluator sees decoded `WirePayload` values according to payload kind
+  and schema, not Haskell types such as `ResearchPlan`.
+- Host application codecs remain for host executors that work over Haskell types.
+  They are not used to make pure expressions type-check.
+
+This keeps pure nodes portable. A future cross-language executor can evaluate the
+same pure expression over the same contract and schema catalog without importing
+Portman Haskell types.
+
+## Relationship To Structural Primitives
+
+Pure nodes and structural primitives should share the same label discipline, but
+they do not have to ship in one implementation PR.
+
+- `@pure` evaluates deterministic expressions.
+- `@identity`, `@const`, `@pack`, `@unpack`, `@merge`, and `@compare` are
+  registered pure utility executors or sugar over the same pure-evaluator family.
+- Contract-polymorphic utilities must still compile through explicit port
+  declarations and known contract ids.
+- Utilities that combine several values of the same contract must use labels to
+  distinguish roles.
+
+This is why label testing belongs with pure/structural utility work, not with the
+current DeepReport port extraction.
+
+## Implementation Sequence
+
+1. Keep current DeepReport port extraction simple: move existing generic
+   `WirePorts` values into `Cortex.Nous.Patterns.DeepReport.Ports` without new
+   syntax or label semantics.
+2. Add pure-node reference tests for same-contract labeled inputs, expression
+   variable binding, deterministic evaluation, output wrapping, and schema/kind
+   validation.
+3. Register the first `@pure` evaluator through the normal executor-registration
+   path as a pure `ExternalCallExecutor` variant.
+4. Add structural primitives only after the pure evaluator and same-contract label
+   tests are stable.
+
+## Alternatives considered
+
+- **Make pure nodes a third executor kind.** Rejected because ADR 0014 already
+  splits node executors by production mode. A pure evaluator is non-model host
+  execution with stronger replay and side-effect metadata.
+- **Infer contracts and ports from expression variables.** Rejected for the first
+  slice because it hides boundary shape. Explicit ports keep Wire's structural
+  type-checking visible.
+- **Invent role-specific contracts for every primitive input.** Rejected because
+  `EvidenceScore`, `RecencyScore`, and `AuthorityScore` are graph-local roles over
+  the same value shape. Labels, not contracts, should distinguish them.
+- **Evaluate pure expressions over downstream Haskell types.** Rejected because it
+  makes pure Wire programs language-specific and collapses the catalog/binder
+  split from ADR 0018.
+- **Allow host callbacks inside pure expressions.** Rejected because it turns pure
+  nodes into hidden tool calls and breaks deterministic replay expectations.
+
+## Consequences
+
+### Positive
+
+- Pure scoring, comparison, thresholding, and structural plumbing can be authored
+  without introducing product host actions for every small computation.
+- Labels get a concrete motivating feature: same-contract slots with distinct
+  structural roles.
+- Pure nodes preserve ADR 0014 by staying inside the registered executor model.
+- Pure expressions remain portable because they operate over `WirePayload` and
+  contract/schema catalogs rather than Haskell application types.
+
+### Negative
+
+- The pure expression language needs its own syntax, static checks, evaluator,
+  and determinism tests.
+- Schema access for JSON contracts must be specified carefully, or pure nodes will
+  become ad hoc JSON-path scripts.
+- The feature can grow into a general programming language if the evaluator is
+  not kept small.
+
+### Obligations
+
+- Specify the pure expression grammar before implementation.
+- Add conformance tests for same-contract labeled inputs.
+- Add replay determinism tests for every built-in pure function.
+- Keep `@pure` registration outside `.wire` source; Wire source may configure the
+  registered evaluator but must not define new executor authority.
+- Keep pure-node runtime failures observable through the existing executor error
+  path rather than inventing a separate failure channel.
+
+## Related
+
+- [ADR 0014 — Model vs External Call](./0014-executor-taxonomy-model-vs-external-call.md)
+- [ADR 0018 — Wire Executor and Port Catalog Boundary](./0018-wire-executor-and-port-catalog-boundary.md)
+- [Chapter 05 — Wire Language](../Architecture/05-wire-language.md)
+- [Wire Grammar v1](../Reference/Wire/grammar-v1.md)
+- [Wire Reference — Contracts, Ports, and Matching](../Reference/Wire/contracts-ports-and-matching.md)
+- GitHub #55

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -31,6 +31,8 @@ Each ADR captures one committed design decision. Files use `NNNN-kebab-slug.md` 
 | [0015](0015-cortex-logoi-reasoning-layer.md) | Structured Reasoning Above the Cortex Substrate | superseded |
 | [0016](0016-canonical-cortex-epistemological-archetypes.md) | Canonical Cortex Nous Archetypes | proposed |
 | [0017](0017-cortex-roots-and-nous-pattern-extraction.md) | Cortex Roots and Nous Pattern Extraction | proposed |
+| [0018](0018-wire-executor-and-port-catalog-boundary.md) | Wire Executor and Port Catalog Boundary | proposed |
+| [0019](0019-wire-pure-nodes.md) | Wire Pure Nodes | proposed |
 
 ## Writing a new ADR
 

--- a/docs/Architecture/05-wire-language.md
+++ b/docs/Architecture/05-wire-language.md
@@ -214,6 +214,10 @@ Cortex still owns the source language, composition rules, and substrate runtime.
   runtime admission and realized topology
 - [Chapter 08 — Artifacts and provenance](08-artifacts-and-provenance.md) —
   payload, artifact, and provenance surfaces
+- [ADR 0018 — Wire Executor and Port Catalog Boundary](../ADRs/0018-wire-executor-and-port-catalog-boundary.md) —
+  contract, port, executor, and binding separation
+- [ADR 0019 — Wire Pure Nodes](../ADRs/0019-wire-pure-nodes.md) —
+  deterministic expression nodes and same-contract labels
 - [Wire Grammar v1](../Reference/Wire/grammar-v1.md) — normative grammar
 - [Cortex Terminology](../Reference/terminology.md) — accepted vocabulary
 - [Consumer examples](../Consumers/) — downstream binding examples

--- a/docs/Architecture/09-nous-reasoning-library.md
+++ b/docs/Architecture/09-nous-reasoning-library.md
@@ -214,6 +214,8 @@ semantics, DB loading, and authorization.
 - [ADR 0015 — Structured Reasoning Above the Cortex Substrate](../ADRs/0015-cortex-logoi-reasoning-layer.md)
 - [ADR 0016 — Canonical Cortex Nous Archetypes](../ADRs/0016-canonical-cortex-epistemological-archetypes.md)
 - [ADR 0017 — Cortex Roots and Nous Pattern Extraction](../ADRs/0017-cortex-roots-and-nous-pattern-extraction.md)
+- [ADR 0018 — Wire Executor and Port Catalog Boundary](../ADRs/0018-wire-executor-and-port-catalog-boundary.md)
+- [ADR 0019 — Wire Pure Nodes](../ADRs/0019-wire-pure-nodes.md)
 - [Chapter 02 — Ownership and boundaries](02-ownership-and-boundaries.md)
 - [Chapter 05 — Wire language](05-wire-language.md)
 - [Chapter 08 — Artifacts and provenance](08-artifacts-and-provenance.md)


### PR DESCRIPTION
## Summary
- Add ADR 0018 for the boundary between value-level contracts, id-referencing port profiles, executor definitions, JSON-centered Pulse framing, and host application codecs.
- Name `WireCompileEnv` as the current central seam: it conflates executor authority projection, executor-port projection, and contract catalog projection.
- Clarify that current DeepReport port extraction is a module-boundary cleanup, not a new label-semantics or expressiveness change.
- Add ADR 0019 for Wire pure nodes as the feature family that actually forces same-contract labels and exposes pure evaluator authority in surface Wire.

## Design Questions Captured
- Why is a contract a value-level catalog entry rather than a Haskell type?
- How do ports reference contract ids without carrying contract specs inline?
- What does Wire check at compile time versus Wire runtime versus Pulse persistence?
- Where do application codecs and Haskell type identity belong?
- Can executors share contract ids and port profiles?
- Why do labels not block current DeepReport extraction, but do become mandatory for pure nodes and structural primitives?
- How should `@pure` fit under ADR 0014 without creating a third executor kind?

## Verification
- [x] `just fmt`
- [x] `just docs-check`
- [x] `just check-commit-provenance origin/main..HEAD`

## Checklist
- [x] ADR 0018 drafted
- [x] ADR 0019 drafted
- [x] Docs index updated
- [x] Review architecture language
- [ ] Ready for review

## Issue
Closes #55