### PR TITLE
feat: strengthen Pulse recovery theory

### DIFF
--- a/docs/Publications/Paper-1-staged-reduction/index.md
+++ b/docs/Publications/Paper-1-staged-reduction/index.md
@@ -15,7 +15,7 @@ Staged reduction for durable workflow execution over fixed DAG topology. The pap
 
 Draft manuscript. See [manuscript.md](manuscript.md) for the full text.
 
-The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`, including the structural recovery theorem (`persistence_safety`), frontier antichain, disjoint-key accumulation commutativity, and the extensiveness and idempotence closure laws. The paper stays `draft` until the remaining obligations in [lean-mechanization.md](lean-mechanization.md) land: closure monotonicity, permutation invariance of full frontier folds, classification exhaustiveness, and the artifact note describing the Lean ↔ Haskell boundary.
+The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`, including the structural recovery theorem (`persistence_safety`), frontier antichain, disjoint-key accumulation commutativity, fold permutation invariance, and the extensiveness, monotonicity, and idempotence closure laws. The paper stays `draft` until the remaining obligations in [lean-mechanization.md](lean-mechanization.md) land: classification exhaustiveness and the artifact note describing the Lean ↔ Haskell boundary.
 
 ## Abstract
 

--- a/docs/Publications/Paper-1-staged-reduction/lean-mechanization.md
+++ b/docs/Publications/Paper-1-staged-reduction/lean-mechanization.md
@@ -31,8 +31,8 @@ The target is structural safety, not end-to-end workflow correctness.
 Paper 1 should stay `draft` until all of the following exist in Lean 4:
 
 1. A machine-checked `wellFormedGraphState` predicate for normalized, closed recovered states. **Done** (`theory/Cortex/Pulse/Validity.lean`).
-2. Proofs of the three closure laws for `propagateFailure`: extensiveness, monotonicity, idempotence. **Partial** — extensiveness (`propagateFailure_extensive`) and idempotence (`propagateFailure_idempotent`) are discharged in `theory/Cortex/Pulse/Closure.lean`; monotonicity remains.
-3. A machine-checked structural recovery theorem matching Proposition 1 in the manuscript. **Done** (`persistence_safety` in `theory/Cortex/Pulse/Recovery.lean`), conditional on persisted topology-domain, output, and causal-history preconditions.
+2. Proofs of the three closure laws for `propagateFailure`: extensiveness, monotonicity, idempotence. **Done** — `propagateFailure_extensive`, `propagateFailure_monotone`, and `propagateFailure_idempotent` are discharged in `theory/Cortex/Pulse/Closure.lean`.
+3. A machine-checked structural recovery theorem matching Proposition 1 in the manuscript. **Done** (`persistence_safety` in `theory/Cortex/Pulse/Recovery.lean`), conditional on persisted topology-domain, output-ownership, output-completeness, and causal-history preconditions.
 4. A short artifact note explaining the modeling boundary between the Lean kernel and the live Haskell runtime. **Open**.
 
 ## What Must Be Proved
@@ -41,12 +41,12 @@ Load-bearing theorems for the paper, with their current Lean status:
 
 - `frontier_antichain` — done (`theory/Cortex/Pulse/Frontier.lean`)
 - `applyNodeFact_comm` — done (`theory/Cortex/Pulse/Fact.lean`)
-- permutation invariance of accumulation over frontier results — open (only pairwise commutativity is mechanized)
+- `NodeResult.applyNodeFacts_perm_invariant` — done (`theory/Cortex/Pulse/Fact.lean`)
 - `propagateFailure_extensive` — done (`theory/Cortex/Pulse/Closure.lean`)
-- `propagateFailure_monotone` — open
+- `propagateFailure_monotone` — done (`theory/Cortex/Pulse/Closure.lean`)
 - `propagateFailure_idempotent` — done (`theory/Cortex/Pulse/Closure.lean`)
 - normalization lemmas for `resetRunningToPending` — done (`theory/Cortex/Pulse/State.lean`, `Recovery.lean`)
-- `frontierExact` on normalized, closed states — done (`theory/Cortex/Pulse/Validity.lean`); the non-trivial bridge `readyNodes_eq_directReadyNodes` lives in the same file
+- `frontierBridge` on normalized, closed states — done (`theory/Cortex/Pulse/Validity.lean`); the non-trivial bridge `readyNodes_eq_directReadyNodes` lives in the same file
 - classification exhaustiveness on normalized, closed states — open (no `Classify.lean` yet)
 - structural persistence safety after persisted-prefix crashes — done (`persistence_safety` in `theory/Cortex/Pulse/Recovery.lean`)
 
@@ -85,7 +85,7 @@ theory/Cortex/Pulse/
   State.lean      -- NodeStatus, GraphState, resetRunningToPending
   Fact.lean       -- NodeOutcome, NodeResult, applyNodeFact, Admissible
   Frontier.lean   -- Ready / DirectReady, antichain
-  Closure.lean    -- propagateFailure, extensiveness, idempotence
+  Closure.lean    -- propagateFailure, extensiveness, monotonicity, idempotence
   Validity.lean   -- wellFormedGraphState, frontier-bridge theorems
   Recovery.lean   -- recoveredState, persistence_safety
   -- Classify.lean -- pending: classification exhaustiveness
@@ -106,8 +106,8 @@ Build order followed by the existing artifacts:
 | Manuscript section | Lean artifact |
 |---|---|
 | Lemma 1: frontier antichain | `frontier_antichain` in `theory/Cortex/Pulse/Frontier.lean` |
-| Lemma 2: disjoint-key accumulation commutativity | `NodeResult.applyNodeFact_comm` in `theory/Cortex/Pulse/Fact.lean` |
-| Phase 2 closure laws | `propagateFailure_extensive`, `propagateFailure_idempotent` in `theory/Cortex/Pulse/Closure.lean` (monotonicity pending) |
+| Lemma 2: disjoint-key accumulation commutativity | `NodeResult.applyNodeFact_comm` and `NodeResult.applyNodeFacts_perm_invariant` in `theory/Cortex/Pulse/Fact.lean` |
+| Phase 2 closure laws | `propagateFailure_extensive`, `propagateFailure_monotone`, `propagateFailure_idempotent` in `theory/Cortex/Pulse/Closure.lean` |
 | Definition 1: valid recovered graph state | `wellFormedGraphState` in `theory/Cortex/Pulse/Validity.lean` |
 | Proposition 1: structural persistence safety | `persistence_safety` in `theory/Cortex/Pulse/Recovery.lean` |
 | Phase 3 classification split | pending `Classify.lean` |
@@ -116,22 +116,18 @@ Build order followed by the existing artifacts:
 
 The mechanized obligations now have direct Lean references in the manuscript body. Remaining manuscript-side guidance:
 
-- keep Proposition 1's preconditions explicit — the Lean theorem is conditional on persisted topology-domain, output-ownership, and causal-history invariants that the runtime must establish
-- keep monotonicity described as an implementation lemma (QuickCheck plus code inspection) until `propagateFailure_monotone` is discharged
-- keep permutation invariance of frontier-result folds as a paper-level argument until the Lean fold-level theorem exists; the disjoint-key pairwise theorem is mechanized
+- keep Proposition 1's preconditions explicit — the Lean theorem is conditional on persisted topology-domain, output-ownership, output-completeness, and causal-history invariants that the runtime must establish
+- keep classification exhaustiveness as proof-sketch wording until `Classify.lean` exists
 
 When the remaining work lands:
 
-- promote `propagateFailure_monotone` and the fold-level permutation theorem to direct Lean references
 - once `Classify.lean` exists, retire the proof-sketch wording around classification exhaustiveness
 - write the artifact note explaining the Lean ↔ Haskell modeling boundary (status, output, payload, and persistence assumptions) and link it from the manuscript
 
 ## Immediate Next Steps
 
-1. Prove `propagateFailure_monotone` to close the third closure law.
-2. Lift `applyNodeFact_comm` to a fold-level permutation-invariance theorem under disjoint frontier keys.
-3. Add `Classify.lean` with the four-way classification and an exhaustiveness theorem on `wellFormedGraphState`.
-4. Draft the Lean ↔ Haskell artifact note and link it from the manuscript and landing page.
+1. Add `Classify.lean` with the four-way classification and an exhaustiveness theorem on `wellFormedGraphState`.
+2. Draft the Lean ↔ Haskell artifact note and link it from the manuscript and landing page.
 
 ## Related
 

--- a/docs/Publications/Paper-1-staged-reduction/manuscript.md
+++ b/docs/Publications/Paper-1-staged-reduction/manuscript.md
@@ -23,8 +23,6 @@ We present a durable workflow execution runtime organized as a staged pure reduc
 
 The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`; see [lean-mechanization.md](lean-mechanization.md) for the artifact mapping. The manuscript remains `draft` until the following obligations also land:
 
-- prove `propagateFailure_monotone` to round out the closure laws (extensiveness and idempotence are discharged)
-- prove permutation invariance of frontier-result folds (only pairwise disjoint-key commutativity is mechanized)
 - prove classification exhaustiveness on normalized, closed states
 - add a short artifact note describing the boundary between the Lean model and the live runtime
 
@@ -154,7 +152,7 @@ flowchart TB
 
 ### 3.1 Frontier Computation
 
-The execution frontier is the set of Pending nodes whose predecessors are all Completed or Skipped:
+The execution frontier is the set of Pending nodes whose predecessors are all Completed, Skipped, or Rewritten:
 
 ```haskell
 readyNodes :: Relation NodeId -> GraphState o -> [NodeId]
@@ -171,7 +169,7 @@ readyNodes rel state =
 $$
 B = v_0 \to v_1 \to \cdots \to v_k = A.
 $$
-For $A$ to be ready, $v_{k-1}$ must be `Completed` or `Skipped`. Inducting backward, each $v_i$ for $1 \le i < k$ must be `Completed` or `Skipped`; in particular, $B$ must be `Completed` or `Skipped`. But frontier membership requires $B$ to be `Pending`. Contradiction.
+For $A$ to be ready, $v_{k-1}$ must be `Completed`, `Skipped`, or `Rewritten`. Inducting backward, each $v_i$ for $1 \le i < k$ must be `Completed`, `Skipped`, or `Rewritten`; in particular, $B$ must have one of those statuses. But frontier membership requires $B$ to be `Pending`. Contradiction.
 
 **Consequence.** Frontier nodes update disjoint keys. Workers execute from the same predecessor-complete snapshot without sibling ordering dependence.
 
@@ -243,7 +241,7 @@ propagateFailure :: Relation NodeId -> GraphState o -> GraphState o
 - **extensive:** failures are only added, never removed
 - **idempotent:** applying closure twice yields the same result as once
 
-Extensiveness and idempotence are mechanized in Lean 4 as `propagateFailure_extensive` and `propagateFailure_idempotent` (see [lean-mechanization.md](lean-mechanization.md)). Monotonicity remains supported by QuickCheck and code inspection in this manuscript.
+Extensiveness, monotonicity, and idempotence are mechanized in Lean 4 as `propagateFailure_extensive`, `propagateFailure_monotone`, and `propagateFailure_idempotent` (see [lean-mechanization.md](lean-mechanization.md)).
 
 #### Definition 1 (Valid recovered graph state)
 
@@ -251,10 +249,10 @@ Let $G$ be a fixed DAG and $gs$ a graph state after recovery normalization and c
 
 1. $\operatorname{dom}(gsNodeStatuses) = V(G)$
 2. $\operatorname{dom}(gsNodeOutputs) \subseteq V(G)$
-3. if $nid \in \operatorname{dom}(gsNodeOutputs)$, then `gsNodeStatuses[nid] = NodeCompleted`
-4. no node is `NodeRunning`
+3. a node has an output iff its status is `NodeCompleted` or `NodeRewritten`
+4. no node is `NodeRunning` or `NodeInterrupted`
 5. every `Pending` or `Waiting` descendant of a `Failed` node is itself `Failed`
-6. $\texttt{readyNodes}(G, gs)$ is exactly the set of `Pending` nodes all of whose predecessors are `Completed` or `Skipped`
+6. $\texttt{readyNodes}(G, gs)$ is exactly the set of `Pending` nodes all of whose predecessors are `Completed`, `Skipped`, or `Rewritten`
 
 Items 5 and 6 are properties of the closed, normalized state used for classification and resume. Arbitrary mid-accumulation persisted snapshots need not satisfy them before normalization and closure.
 
@@ -272,14 +270,14 @@ Then `gsRecovered` is a valid recovered graph state. In particular, `readyNodes 
 *Proof sketch.* The proof obligation breaks into named parts:
 
 1. **Domain preservation.** `applyNodeFact` only updates keys already present in the topology-indexed status and output maps, so accumulation never introduces out-of-topology node ids.
-2. **Normalization.** `resetRunningToPending` preserves domains and outputs while removing the only transient status (`NodeRunning`) that may remain after a crash.
+2. **Normalization.** `resetRunningToPending` preserves domains and outputs while removing volatile `NodeRunning` and `NodeInterrupted` markers that may remain after a crash.
 3. **Closure completeness.** `propagateFailure` preserves domains and saturates all propagatable descendants of failed nodes, establishing item 5 of Definition 1.
 4. **Frontier correctness.** `readyNodes` is an extensional test of item 6: it selects exactly the Pending nodes whose predecessors are Completed or Skipped.
 5. **Resume safety under additional facts.** When unpersisted nodes re-execute, re-closing cannot invalidate already propagated failures because closure is idempotent and monotone.
 
 The proposition is therefore a structural statement: the recovered graph state is normalized, closed, and schedulable. It does not prove that replayed worker I/O yields the same business result as the pre-crash execution.
 
-Proposition 1 is mechanized in Lean 4 as `persistence_safety` in `theory/Cortex/Pulse/Recovery.lean` (see [lean-mechanization.md](lean-mechanization.md)). The Lean theorem is conditional on persisted topology-domain, output-ownership, and causal-history preconditions, which the runtime must establish at the persistence boundary.
+Proposition 1 is mechanized in Lean 4 as `persistence_safety` in `theory/Cortex/Pulse/Recovery.lean` (see [lean-mechanization.md](lean-mechanization.md)). The Lean theorem is conditional on persisted topology-domain, output-ownership, output-completeness, and causal-history preconditions, which the runtime must establish at the persistence boundary.
 
 ### 3.5 Phase 3: Classify
 
@@ -331,6 +329,8 @@ applyFrontierResults rel results gs =
 **Proposition 2 (Permutation invariance).** `applyFrontierResults` is invariant under permutation of `results`.
 
 *Proof.* By Lemma 2, the accumulation fold is permutation-invariant for distinct-key frontier results. `propagateFailure` and `classifyGraphState` are deterministic functions of the accumulated state. QED.
+
+The Lean theorem `NodeResult.applyNodeFacts_perm_invariant` mechanizes the fold-level accumulation claim for distinct node keys.
 
 ### 3.7 Crash Recovery
 
@@ -451,7 +451,7 @@ The implementation-level claims are backed by QuickCheck property tests on rando
 | Recovery normalization | §3.4, §3.7 | Partial frontier + `resetRunningToPending` + classify yields a valid closed state |
 | Sequential = batch | §3.6 | Fold of single-element `applyFrontierResults` matches batch application |
 
-Several of these properties are now mechanized in Lean 4 — frontier antichain, disjoint-key commutativity, closure extensiveness and idempotence, and recovery normalization — and the artifacts are listed in [lean-mechanization.md](lean-mechanization.md). The QuickCheck tests remain runtime evidence on the live Haskell implementation; for the still-open obligations (closure monotonicity, permutation invariance of full folds, classification exhaustiveness) they are not a substitute for proof.
+Several of these properties are now mechanized in Lean 4 — frontier antichain, disjoint-key commutativity and fold permutation, closure extensiveness, monotonicity, idempotence, and recovery normalization — and the artifacts are listed in [lean-mechanization.md](lean-mechanization.md). The QuickCheck tests remain runtime evidence on the live Haskell implementation; for the still-open classification exhaustiveness obligation, they are not a substitute for proof.
 
 ---
 

--- a/docs/Publications/Paper-2-algebraic-foundations/manuscript.md
+++ b/docs/Publications/Paper-2-algebraic-foundations/manuscript.md
@@ -46,11 +46,11 @@ The main validity predicate is defined only on normalized, closed states.
 
 1. $\operatorname{dom}(status) = V$
 2. $\operatorname{dom}(output) \subseteq V$
-3. outputs appear only on statuses that semantically carry outputs
-4. no node is $\text{Running}$
+3. outputs appear exactly on statuses that semantically carry outputs
+4. no node is $\text{Running}$ or $\text{Interrupted}$
 5. every $\text{Pending}$ or $\text{Waiting}$ descendant of a $\text{Failed}$ node is itself $\text{Failed}$
 6. $\operatorname{readyNodes}(G, s)$ is extensionally equal to the readiness predicate:
-   nodes that are $\text{Pending}$ and whose predecessors are all $\text{Completed}$ or $\text{Skipped}$
+   nodes that are $\text{Pending}$ and whose predecessors are all $\text{Completed}$, $\text{Skipped}$, or $\text{Rewritten}$
 
 This definition is intentionally relative to fixed topology. Once topology changes, the validity contract must be enriched with materialization and identity invariants.
 

--- a/docs/Roadmap/Plans/lean-mechanization.md
+++ b/docs/Roadmap/Plans/lean-mechanization.md
@@ -25,9 +25,10 @@ contract the runtime actually relies on: commutative accumulation of node-local
 facts, idempotent failure closure, deterministic classification, and recovery
 safety after persisted-prefix crashes.
 
-The central artifact is an explicit `wellFormedGraphState` predicate for
-normalized, closed states. Without that predicate, Paper 1's recovery claim and
-Paper 2's algebraic presentation remain too rhetorical.
+The central artifact is an explicit `WellFormedGraphState` structure, exposed
+under the published `wellFormedGraphState` predicate name, for normalized,
+closed states. Without that predicate, Paper 1's recovery claim and Paper 2's
+algebraic presentation remain too rhetorical.
 
 ## Core Definitions
 
@@ -45,17 +46,19 @@ Mechanization starts by fixing the objects the paper set depends on:
 The hub predicate should be:
 
 ```lean
-def wellFormedGraphState (G : DAG) (s : GraphState) : Prop :=
-  statusDomainExact G s
-  ∧ outputDomainWithinTopology G s
-  ∧ outputsRespectStatuses s
-  ∧ noRunningNodes s
-  ∧ failureClosureComplete G s
-  ∧ frontierExact G s
+structure WellFormedGraphState (G : DAG) (s : GraphState) : Prop where
+  topologyDomain : topologyDomain G s
+  outputsRespectStatuses : outputsRespectStatuses s
+  outputsCompleteForStatuses : outputsCompleteForStatuses s
+  noRunningNodes : noRunningNodes s
+  noInterruptedNodes : noInterruptedNodes s
+  failureClosureComplete : failureClosureComplete G s
+  causalHistoryClosed : CausalHistoryClosed G s
+  frontierBridge : frontierBridge G s
 ```
 
-Here `frontierExact` means `readyNodes G s` is sound and complete for the
-readiness predicate.
+Here `frontierBridge` means proof-level `readyNodes G s` coincides with the
+runtime-style direct-predecessor frontier `directReadyNodes G s`.
 
 ## Theorem Stack
 
@@ -74,7 +77,7 @@ theorem applyNodeFact_comm (r1 r2 : NodeResult) (s : GraphState)
 ```
 
 ```lean
-theorem fold_applyNodeFact_perm
+theorem NodeResult.applyNodeFacts_perm_invariant
   (results1 results2 : List NodeResult) (s : GraphState)
   (h_perm : results1 ~ results2)
   (h_distinct : results1.Pairwise (fun a b => a.nid ≠ b.nid)) :
@@ -90,9 +93,9 @@ theorem propagateFailure_extensive (G : DAG) (s : GraphState) :
 ```
 
 ```lean
-theorem propagateFailure_monotone (G : DAG) (s1 s2 : GraphState)
-  (h : s1 ≤ s2) :
-  propagateFailure G s1 ≤ propagateFailure G s2
+theorem propagateFailure_monotone (G : DAG) {s1 s2 : GraphState}
+  (h : GraphState.failureLe s1 s2) :
+  GraphState.failureLe (propagateFailure G s1) (propagateFailure G s2)
 ```
 
 ```lean
@@ -118,10 +121,10 @@ theorem closure_failure_complete (G : DAG) (s : GraphState) :
 ```
 
 ```lean
-theorem frontier_exact_closed (G : DAG) (s : GraphState)
-  (h_norm : noRunningNodes s)
-  (h_closed : failureClosureComplete G s) :
-  frontierExact G s
+theorem frontierBridge_of_closed_causal (G : DAG) (s : GraphState)
+  (h_closed : failureClosureComplete G s)
+  (h_causal : CausalHistoryClosed G s) :
+  frontierBridge G s
 ```
 
 ### Tier 4: Structural recovery safety
@@ -176,7 +179,7 @@ plan is to make valid graph state a first-class theorem object.
 - Finite DAG representation may need an adapter from the runtime's relation-style graph model.
 - Closure idempotence is the hardest proof burden in the current stack.
 - `Waiting(signal)` complicates any local status order because waiting carries data.
-- `outputsRespectStatuses` should be stated so later rewrite theory can extend it without contradiction.
+- Output ownership is two-sided in the fixed-topology kernel: outputs must appear only where statuses own them, and completed/rewritten statuses must carry outputs.
 
 ## Relationship to the Paper Set
 

--- a/theory/Cortex/Pulse/Closure.lean
+++ b/theory/Cortex/Pulse/Closure.lean
@@ -140,7 +140,22 @@ theorem hasFailedAncestor_of_failed_after_reaches
   · rcases hAncestor with ⟨root, hRootFailed, hRootReach⟩
     exact ⟨root, hRootFailed, G.reaches_trans hRootReach hReach⟩
 
-/-- `propagateFailure_extensive` proves propagation is extensive over failed nodes. -/
+/-- `hasFailedAncestor_monotone` lifts failed ancestors through failure-growth. -/
+theorem hasFailedAncestor_monotone
+    (G : DAG ν)
+    {left right : GraphState ν payload}
+    (hLe : GraphState.failureLe left right)
+    {node : ν}
+    (hAncestor : hasFailedAncestor G left node) :
+    hasFailedAncestor G right node := by
+  rcases hAncestor with ⟨failedNode, hFailed, hReach⟩
+  exact ⟨failedNode, GraphState.failureLe_preserves_failed hLe hFailed, hReach⟩
+
+/-- `propagateFailure_extensive` proves propagation is extensive over failed nodes.
+
+Use this closure-law theorem when a proof only needs preservation of the
+already-failed set. Use `propagateFailure_monotone` for whole-state
+failure-growth reasoning through `GraphState.failureLe`. -/
 theorem propagateFailure_extensive
     (G : DAG ν)
     (state : GraphState ν payload) :
@@ -149,6 +164,48 @@ theorem propagateFailure_extensive
         (propagateFailure G state).status node = NodeStatus.failed := by
   intro node hFailed
   exact propagateFailure_preserves_failed G state hFailed
+
+/-- `propagateStatus_monotone` proves node-local failure propagation is monotone. -/
+theorem propagateStatus_monotone
+    (G : DAG ν)
+    {left right : GraphState ν payload}
+    (hLe : GraphState.failureLe left right)
+    (node : ν) :
+    NodeStatus.failureLe (propagateStatus G left node) (propagateStatus G right node) := by
+  classical
+  by_cases hLeftClosed :
+    NodeStatus.propagatable (left.status node) ∧ hasFailedAncestor G left node
+  · have hRightFailed : propagateStatus G right node = NodeStatus.failed := by
+      rcases hLe node with hSame | hFailure
+      · have hRightClosed :
+          NodeStatus.propagatable (right.status node) ∧ hasFailedAncestor G right node := by
+          constructor
+          · simpa [hSame] using hLeftClosed.1
+          · exact hasFailedAncestor_monotone G hLe hLeftClosed.2
+        simp [propagateStatus, hRightClosed]
+      · rcases hFailure with ⟨_hLeftPropagatable, hRightStatus⟩
+        simp [propagateStatus, hRightStatus, NodeStatus.propagatable]
+    have hLeftFailed : propagateStatus G left node = NodeStatus.failed := by
+      simp [propagateStatus, hLeftClosed]
+    rw [hLeftFailed, hRightFailed]
+    exact NodeStatus.failureLe_refl NodeStatus.failed
+  · by_cases hRightClosed :
+      NodeStatus.propagatable (right.status node) ∧ hasFailedAncestor G right node
+    · have hLeftPropagatable :
+          NodeStatus.propagatable (left.status node) :=
+        NodeStatus.failureLe_reflects_propagatable (hLe node) hRightClosed.1
+      simpa [propagateStatus, hLeftClosed, hRightClosed] using
+        NodeStatus.failureLe_to_failed hLeftPropagatable
+    · simpa [propagateStatus, hLeftClosed, hRightClosed] using hLe node
+
+/-- `propagateFailure_monotone` proves failure closure is monotone over failure-growth. -/
+theorem propagateFailure_monotone
+    (G : DAG ν)
+    {left right : GraphState ν payload}
+    (hLe : GraphState.failureLe left right) :
+    GraphState.failureLe (propagateFailure G left) (propagateFailure G right) := by
+  intro node
+  exact propagateStatus_monotone G hLe node
 
 /-- `propagateFailure_failureClosureComplete` proves propagation reaches closure. -/
 theorem propagateFailure_failureClosureComplete
@@ -177,6 +234,20 @@ theorem propagateFailure_preserves_noRunning
   · intro hRunning
     simp [propagateFailure, propagateStatus, hClosed] at hRunning
   · simpa [propagateFailure, propagateStatus, hClosed] using hNoRunning node
+
+/-- `propagateFailure_preserves_noInterrupted` preserves the absence of interrupted nodes. -/
+theorem propagateFailure_preserves_noInterrupted
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hNoInterrupted : GraphState.noInterruptedNodes state) :
+    GraphState.noInterruptedNodes (propagateFailure G state) := by
+  classical
+  intro node
+  by_cases hClosed :
+    NodeStatus.propagatable (state.status node) ∧ hasFailedAncestor G state node
+  · intro hInterrupted
+    simp [propagateFailure, propagateStatus, hClosed] at hInterrupted
+  · simpa [propagateFailure, propagateStatus, hClosed] using hNoInterrupted node
 
 /-- `propagateFailure_preserves_topologyDomain` preserves off-topology absence. -/
 theorem propagateFailure_preserves_topologyDomain
@@ -215,6 +286,28 @@ theorem propagateFailure_preserves_outputsRespectStatuses
         , hStatus
         ] at hClosed hMayHaveOutput ⊢
   · simpa [propagateFailure, propagateStatus, hClosed] using hOutputs node value hOutput
+
+/-- `propagateFailure_preserves_outputsCompleteForStatuses` preserves required outputs. -/
+theorem propagateFailure_preserves_outputsCompleteForStatuses
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hOutputs : GraphState.outputsCompleteForStatuses state) :
+    GraphState.outputsCompleteForStatuses (propagateFailure G state) := by
+  classical
+  intro node hRequiresOutput
+  by_cases hClosed :
+    NodeStatus.propagatable (state.status node) ∧ hasFailedAncestor G state node
+  · simp
+      [ propagateFailure
+      , propagateStatus
+      , NodeStatus.requiresOutput
+      , hClosed
+      ] at hRequiresOutput
+  · have hOriginalRequires :
+        NodeStatus.requiresOutput (state.status node) := by
+      simpa [propagateFailure, propagateStatus, hClosed] using hRequiresOutput
+    rcases hOutputs node hOriginalRequires with ⟨value, hOutput⟩
+    exact ⟨value, by simpa [propagateFailure] using hOutput⟩
 
 /-! ## Idempotence -/
 

--- a/theory/Cortex/Pulse/Fact.lean
+++ b/theory/Cortex/Pulse/Fact.lean
@@ -183,6 +183,74 @@ theorem applyNodeFact_preserves_outputsRespectStatuses [DecidableEq ν]
       hOutputs node value hOriginalOutput
     simpa [applyNodeFact, hNode] using hMayHaveOutput
 
+/-- `applyNodeFact_preserves_outputsCompleteForStatuses` preserves required outputs. -/
+theorem applyNodeFact_preserves_outputsCompleteForStatuses [DecidableEq ν]
+    (result : NodeResult ν payload)
+    (state : GraphState ν payload)
+    (hOutputs : GraphState.outputsCompleteForStatuses state) :
+    GraphState.outputsCompleteForStatuses (applyNodeFact result state) := by
+  intro node hRequiresOutput
+  by_cases hNode : node = result.node
+  · subst node
+    cases hOutcome : result.outcome with
+    | succeeded value =>
+        exact ⟨value, by simp [applyNodeFact, NodeOutcome.output, hOutcome]⟩
+    | skipped =>
+        simp
+          [ applyNodeFact
+          , NodeOutcome.status
+          , NodeStatus.requiresOutput
+          , hOutcome
+          ] at hRequiresOutput
+    | suspended =>
+        simp
+          [ applyNodeFact
+          , NodeOutcome.status
+          , NodeStatus.requiresOutput
+          , hOutcome
+          ] at hRequiresOutput
+    | failed =>
+        simp
+          [ applyNodeFact
+          , NodeOutcome.status
+          , NodeStatus.requiresOutput
+          , hOutcome
+          ] at hRequiresOutput
+    | timedOut =>
+        simp
+          [ applyNodeFact
+          , NodeOutcome.status
+          , NodeStatus.requiresOutput
+          , hOutcome
+          ] at hRequiresOutput
+    | cancelled =>
+        simp
+          [ applyNodeFact
+          , NodeOutcome.status
+          , NodeStatus.requiresOutput
+          , hOutcome
+          ] at hRequiresOutput
+    | shutdown =>
+        simp
+          [ applyNodeFact
+          , NodeOutcome.status
+          , NodeStatus.requiresOutput
+          , hOutcome
+          ] at hRequiresOutput
+    | runCancelled =>
+        simp
+          [ applyNodeFact
+          , NodeOutcome.status
+          , NodeStatus.requiresOutput
+          , hOutcome
+          ] at hRequiresOutput
+    | rewritten value =>
+        exact ⟨value, by simp [applyNodeFact, NodeOutcome.output, hOutcome]⟩
+  · have hOriginalRequires : NodeStatus.requiresOutput (state.status node) := by
+      simpa [applyNodeFact, hNode] using hRequiresOutput
+    rcases hOutputs node hOriginalRequires with ⟨value, hOutput⟩
+    exact ⟨value, by simpa [applyNodeFact, hNode] using hOutput⟩
+
 /-- `applyNodeFact_preserves_noRunning` preserves the absence of running nodes. -/
 theorem applyNodeFact_preserves_noRunning [DecidableEq ν]
     (result : NodeResult ν payload)
@@ -275,6 +343,23 @@ theorem applyNodeFacts_preserves_outputsRespectStatuses [DecidableEq ν]
       have hStep :
           GraphState.outputsRespectStatuses (applyNodeFact result state) :=
         applyNodeFact_preserves_outputsRespectStatuses result state hOutputs
+      simpa [applyNodeFacts] using ih (applyNodeFact result state) hStep hRest
+
+/-- `applyNodeFacts_preserves_outputsCompleteForStatuses` preserves required outputs. -/
+theorem applyNodeFacts_preserves_outputsCompleteForStatuses [DecidableEq ν]
+    (G : DAG ν)
+    (results : List (NodeResult ν payload))
+    (state : GraphState ν payload)
+    (hOutputs : GraphState.outputsCompleteForStatuses state)
+    (hResults : AllAdmissibleFold G state results) :
+    GraphState.outputsCompleteForStatuses (applyNodeFacts results state) := by
+  induction results generalizing state with
+  | nil => simpa [applyNodeFacts] using hOutputs
+  | cons result rest ih =>
+      rcases hResults with ⟨_hResult, hRest⟩
+      have hStep :
+          GraphState.outputsCompleteForStatuses (applyNodeFact result state) :=
+        applyNodeFact_preserves_outputsCompleteForStatuses result state hOutputs
       simpa [applyNodeFacts] using ih (applyNodeFact result state) hStep hRest
 
 /-- `applyNodeFacts_preserves_noRunning` preserves the absence of running nodes. -/

--- a/theory/Cortex/Pulse/Recovery.lean
+++ b/theory/Cortex/Pulse/Recovery.lean
@@ -19,7 +19,8 @@ the Lean counterpart of that recovery normalization pipeline.
 
 The page defines the recovered state, proves each structural invariant,
 and packages them into `persistence_safety` under explicit persisted
-topology, output, and causal-history preconditions.
+topology, output-ownership, output-completeness, and causal-history
+preconditions.
 -/
 
 namespace Cortex.Pulse
@@ -40,31 +41,39 @@ noncomputable def recoveredState
 theorem recovered_noRunning
     (G : DAG ν)
     (state : GraphState ν payload) :
-    GraphState.noRunningNodes (recoveredState G state) := by
-  exact
-    propagateFailure_preserves_noRunning
-      G
-      (GraphState.resetRunningToPending state)
-      (GraphState.resetRunning_no_running state)
+    GraphState.noRunningNodes (recoveredState G state) :=
+  propagateFailure_preserves_noRunning
+    G
+    (GraphState.resetRunningToPending state)
+    (GraphState.resetRunning_no_running state)
+
+/-- `recovered_noInterrupted` proves recovery normalization removes interrupted nodes. -/
+theorem recovered_noInterrupted
+    (G : DAG ν)
+    (state : GraphState ν payload) :
+    GraphState.noInterruptedNodes (recoveredState G state) :=
+  propagateFailure_preserves_noInterrupted
+    G
+    (GraphState.resetRunningToPending state)
+    (GraphState.resetRunning_no_interrupted state)
 
 /-- `recovered_topologyDomain` preserves the persisted topology-domain invariant. -/
 theorem recovered_topologyDomain
     (G : DAG ν)
     (state : GraphState ν payload)
     (hDomain : GraphState.topologyDomain G state) :
-    GraphState.topologyDomain G (recoveredState G state) := by
-  exact
-    propagateFailure_preserves_topologyDomain
-      G
-      (GraphState.resetRunningToPending state)
-      (GraphState.resetRunning_preserves_topologyDomain G state hDomain)
+    GraphState.topologyDomain G (recoveredState G state) :=
+  propagateFailure_preserves_topologyDomain
+    G
+    (GraphState.resetRunningToPending state)
+    (GraphState.resetRunning_preserves_topologyDomain G state hDomain)
 
 /-- `recovered_failureClosureComplete` proves recovery normalization is failure-closed. -/
 theorem recovered_failureClosureComplete
     (G : DAG ν)
     (state : GraphState ν payload) :
-    failureClosureComplete G (recoveredState G state) := by
-  exact propagateFailure_failureClosureComplete G (GraphState.resetRunningToPending state)
+    failureClosureComplete G (recoveredState G state) :=
+  propagateFailure_failureClosureComplete G (GraphState.resetRunningToPending state)
 
 /-- `resetRunning_preserves_causalHistoryClosed` preserves causal history closure. -/
 theorem resetRunning_preserves_causalHistoryClosed
@@ -113,121 +122,137 @@ theorem recovered_causalHistoryClosed
     (G : DAG ν)
     (state : GraphState ν payload)
     (hCausal : CausalHistoryClosed G state) :
-    CausalHistoryClosed G (recoveredState G state) := by
-  exact
-    propagateFailure_preserves_causalHistoryClosed
-      G
-      (GraphState.resetRunningToPending state)
-      (resetRunning_preserves_causalHistoryClosed G state hCausal)
+    CausalHistoryClosed G (recoveredState G state) :=
+  propagateFailure_preserves_causalHistoryClosed
+    G
+    (GraphState.resetRunningToPending state)
+    (resetRunning_preserves_causalHistoryClosed G state hCausal)
 
 /-- `recovered_frontierBridge` proves recovery aligns proof and runtime frontiers. -/
 theorem recovered_frontierBridge
     (G : DAG ν)
     (state : GraphState ν payload)
     (hCausal : CausalHistoryClosed G state) :
-    frontierBridge G (recoveredState G state) := by
-  exact
-    frontierBridge_of_closed_causal
-      G
-      (recoveredState G state)
-      (recovered_failureClosureComplete G state)
-      (recovered_causalHistoryClosed G state hCausal)
+    frontierBridge G (recoveredState G state) :=
+  frontierBridge_of_closed_causal
+    G
+    (recoveredState G state)
+    (recovered_failureClosureComplete G state)
+    (recovered_causalHistoryClosed G state hCausal)
 
 /-- `recovered_outputsRespectStatuses` preserves output ownership through recovery. -/
 theorem recovered_outputsRespectStatuses
     (G : DAG ν)
     (state : GraphState ν payload)
     (hOutputs : GraphState.outputsRespectStatuses state) :
-    GraphState.outputsRespectStatuses (recoveredState G state) := by
-  exact
-    propagateFailure_preserves_outputsRespectStatuses
-      G
-      (GraphState.resetRunningToPending state)
-      (GraphState.resetRunning_preserves_outputsRespectStatuses state hOutputs)
+    GraphState.outputsRespectStatuses (recoveredState G state) :=
+  propagateFailure_preserves_outputsRespectStatuses
+    G
+    (GraphState.resetRunningToPending state)
+    (GraphState.resetRunning_preserves_outputsRespectStatuses state hOutputs)
+
+/-- `recovered_outputsCompleteForStatuses` preserves required outputs through recovery. -/
+theorem recovered_outputsCompleteForStatuses
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hOutputs : GraphState.outputsCompleteForStatuses state) :
+    GraphState.outputsCompleteForStatuses (recoveredState G state) :=
+  propagateFailure_preserves_outputsCompleteForStatuses
+    G
+    (GraphState.resetRunningToPending state)
+    (GraphState.resetRunning_preserves_outputsCompleteForStatuses state hOutputs)
 
 /-! ## Structural Safety -/
 
-/-- `persistedRecoveryPreconditions G state` is what recovery must trust or validate. -/
-def persistedRecoveryPreconditions
+/-- `PersistedRecoveryPreconditions G state` is what recovery must trust or validate. -/
+structure PersistedRecoveryPreconditions
+    (G : DAG ν)
+    (state : GraphState ν payload) : Prop where
+  /-- Persisted state has no status/output entries outside the topology. -/
+  topologyDomain : GraphState.topologyDomain G state
+  /-- Persisted outputs are attached only to statuses that may own payloads. -/
+  outputsRespectStatuses : GraphState.outputsRespectStatuses state
+  /-- Persisted payload-owning statuses have their required outputs present. -/
+  outputsCompleteForStatuses : GraphState.outputsCompleteForStatuses state
+  /-- Persisted terminal/unblocking history is causally closed. -/
+  causalHistoryClosed : CausalHistoryClosed G state
+
+/-- `persistedRecoveryPreconditions G state` keeps the published predicate name stable. -/
+abbrev persistedRecoveryPreconditions
     (G : DAG ν)
     (state : GraphState ν payload) : Prop :=
-  GraphState.topologyDomain G state ∧
-    GraphState.outputsRespectStatuses state ∧ CausalHistoryClosed G state
+  PersistedRecoveryPreconditions G state
 
 /-- `persistence_safety` packages structural recovery safety.
 
 Structural recovery safety is conditional on persisted topology-domain,
-payload/output, and causal-history preconditions. Recovery then preserves
-those preconditions while establishing no-running, failure-closure, and
-the proof/runtime frontier bridge. -/
+payload/output, output-completeness, and causal-history preconditions.
+Recovery then preserves those preconditions while establishing
+no-running, no-interrupted, failure-closure, and the proof/runtime
+frontier bridge. -/
 theorem persistence_safety
     (G : DAG ν)
     (state : GraphState ν payload)
     (hPersisted : persistedRecoveryPreconditions G state) :
     wellFormedGraphState G (recoveredState G state) := by
-  rcases hPersisted with ⟨hDomain, hOutputs, hCausal⟩
   exact
-    ⟨ recovered_topologyDomain G state hDomain
-    , recovered_outputsRespectStatuses G state hOutputs
-    , recovered_noRunning G state
-    , recovered_failureClosureComplete G state
-    , recovered_causalHistoryClosed G state hCausal
-    , recovered_frontierBridge G state hCausal
-    ⟩
+    { topologyDomain := recovered_topologyDomain G state hPersisted.topologyDomain
+      outputsRespectStatuses :=
+        recovered_outputsRespectStatuses G state hPersisted.outputsRespectStatuses
+      outputsCompleteForStatuses :=
+        recovered_outputsCompleteForStatuses G state hPersisted.outputsCompleteForStatuses
+      noRunningNodes := recovered_noRunning G state
+      noInterruptedNodes := recovered_noInterrupted G state
+      failureClosureComplete := recovered_failureClosureComplete G state
+      causalHistoryClosed := recovered_causalHistoryClosed G state hPersisted.causalHistoryClosed
+      frontierBridge := recovered_frontierBridge G state hPersisted.causalHistoryClosed }
 
-/-- `frontierFacts_recovered_wellFormedGraphState` safely re-closes admissible fact folds. -/
+/-- `frontierFacts_recovered_wellFormedGraphState` safely recovers admissible fact folds. -/
 theorem frontierFacts_recovered_wellFormedGraphState [DecidableEq ν]
     (G : DAG ν)
     (state : GraphState ν payload)
     (results : List (NodeResult ν payload))
     (hWellFormed : wellFormedGraphState G state)
     (hResults : NodeResult.AllAdmissibleFold G state results) :
-    wellFormedGraphState G (propagateFailure G (NodeResult.applyNodeFacts results state)) := by
-  rcases hWellFormed with
-    ⟨hDomain, hOutputs, hNoRunning, _hClosure, hCausal, _hBridge⟩
+    wellFormedGraphState G (recoveredState G (NodeResult.applyNodeFacts results state)) := by
   have hAccumulatedDomain :
       GraphState.topologyDomain G (NodeResult.applyNodeFacts results state) :=
-    NodeResult.applyNodeFacts_preserves_topologyDomain G results state hDomain hResults
+    NodeResult.applyNodeFacts_preserves_topologyDomain
+      G
+      results
+      state
+      hWellFormed.topologyDomain
+      hResults
   have hAccumulatedOutputs :
       GraphState.outputsRespectStatuses (NodeResult.applyNodeFacts results state) :=
-    NodeResult.applyNodeFacts_preserves_outputsRespectStatuses G results state hOutputs hResults
-  have hAccumulatedNoRunning :
-      GraphState.noRunningNodes (NodeResult.applyNodeFacts results state) :=
-    NodeResult.applyNodeFacts_preserves_noRunning G results state hNoRunning hResults
+    NodeResult.applyNodeFacts_preserves_outputsRespectStatuses
+      G
+      results
+      state
+      hWellFormed.outputsRespectStatuses
+      hResults
+  have hAccumulatedOutputsComplete :
+      GraphState.outputsCompleteForStatuses (NodeResult.applyNodeFacts results state) :=
+    NodeResult.applyNodeFacts_preserves_outputsCompleteForStatuses
+      G
+      results
+      state
+      hWellFormed.outputsCompleteForStatuses
+      hResults
   have hAccumulatedCausal :
       CausalHistoryClosed G (NodeResult.applyNodeFacts results state) :=
-    NodeResult.applyNodeFacts_preserves_causalHistoryClosed G results state hCausal hResults
-  have hFinalClosure :
-      failureClosureComplete G
-        (propagateFailure G (NodeResult.applyNodeFacts results state)) :=
-    propagateFailure_failureClosureComplete G (NodeResult.applyNodeFacts results state)
-  have hFinalCausal :
-      CausalHistoryClosed G
-        (propagateFailure G (NodeResult.applyNodeFacts results state)) :=
-    propagateFailure_preserves_causalHistoryClosed
+    NodeResult.applyNodeFacts_preserves_causalHistoryClosed
       G
-      (NodeResult.applyNodeFacts results state)
-      hAccumulatedCausal
-  exact
-    ⟨ propagateFailure_preserves_topologyDomain
-        G
-        (NodeResult.applyNodeFacts results state)
-        hAccumulatedDomain
-    , propagateFailure_preserves_outputsRespectStatuses
-        G
-        (NodeResult.applyNodeFacts results state)
-        hAccumulatedOutputs
-    , propagateFailure_preserves_noRunning
-        G
-        (NodeResult.applyNodeFacts results state)
-        hAccumulatedNoRunning
-    , hFinalClosure
-    , hFinalCausal
-    , frontierBridge_of_closed_causal
-        G
-        (propagateFailure G (NodeResult.applyNodeFacts results state))
-        hFinalClosure
-        hFinalCausal
-    ⟩
+      results
+      state
+      hWellFormed.causalHistoryClosed
+      hResults
+  have hPersisted :
+      persistedRecoveryPreconditions G (NodeResult.applyNodeFacts results state) :=
+    { topologyDomain := hAccumulatedDomain
+      outputsRespectStatuses := hAccumulatedOutputs
+      outputsCompleteForStatuses := hAccumulatedOutputsComplete
+      causalHistoryClosed := hAccumulatedCausal }
+  exact persistence_safety G (NodeResult.applyNodeFacts results state) hPersisted
 
 end Cortex.Pulse

--- a/theory/Cortex/Pulse/State.lean
+++ b/theory/Cortex/Pulse/State.lean
@@ -75,6 +75,17 @@ def mayHaveOutput : NodeStatus → Prop
   | interrupted => False
   | waiting => False
 
+/-- `NodeStatus.requiresOutput status` means the status must carry a durable payload. -/
+def requiresOutput : NodeStatus → Prop
+  | completed => True
+  | rewritten => True
+  | failed => False
+  | skipped => False
+  | pending => False
+  | running => False
+  | interrupted => False
+  | waiting => False
+
 /-- `NodeStatus.unblocksSuccessors status` means direct successors may run past it. -/
 def unblocksSuccessors : NodeStatus → Prop
   | completed => True
@@ -85,6 +96,13 @@ def unblocksSuccessors : NodeStatus → Prop
   | running => False
   | interrupted => False
   | waiting => False
+
+/-- `failureLe before after` orders states by failure-propagation growth.
+
+A status can stay unchanged, or a still-propagatable status can become
+`failed`. This is the order used for monotonicity of failure closure. -/
+def failureLe : NodeStatus → NodeStatus → Prop
+  | before, after => before = after ∨ (propagatable before ∧ after = failed)
 
 /-- `unblocks_terminal` says successor-unblocking statuses are terminal. -/
 theorem unblocks_terminal {status : NodeStatus}
@@ -110,6 +128,58 @@ theorem failed_not_propagatable :
     ¬ propagatable failed := by
   intro hPropagatable
   exact hPropagatable
+
+/-- `failureLe_refl` says status failure-growth is reflexive. -/
+theorem failureLe_refl (status : NodeStatus) :
+    failureLe status status :=
+  Or.inl rfl
+
+/-- `failureLe_to_failed` turns a propagatable status into a failure-growth step. -/
+theorem failureLe_to_failed {status : NodeStatus}
+    (hPropagatable : propagatable status) :
+    failureLe status failed :=
+  Or.inr ⟨hPropagatable, rfl⟩
+
+/-- `failed_of_failureLe_failed` says failed statuses cannot grow to another status. -/
+theorem failed_of_failureLe_failed {after : NodeStatus}
+    (hLe : failureLe failed after) :
+    after = failed := by
+  rcases hLe with hSame | hFailure
+  · exact hSame.symm
+  · exact False.elim (failed_not_propagatable hFailure.1)
+
+/-- `failureLe_preserves_failed` says failure-growth preserves existing failures. -/
+theorem failureLe_preserves_failed {before after : NodeStatus}
+    (hLe : failureLe before after)
+    (hFailed : before = failed) :
+    after = failed := by
+  subst before
+  exact failed_of_failureLe_failed hLe
+
+/-- `failureLe_reflects_propagatable` pulls propagatability back through failure-growth. -/
+theorem failureLe_reflects_propagatable {before after : NodeStatus}
+    (hLe : failureLe before after)
+    (hPropagatable : propagatable after) :
+    propagatable before := by
+  rcases hLe with hSame | hFailure
+  · cases hSame
+    exact hPropagatable
+  · exact hFailure.1
+
+/-- `failureLe_trans` says status failure-growth is transitive. -/
+theorem failureLe_trans {left middle right : NodeStatus}
+    (hLeft : failureLe left middle)
+    (hRight : failureLe middle right) :
+    failureLe left right := by
+  rcases hLeft with hSame | hFailure
+  · cases hSame
+    exact hRight
+  · rcases hFailure with ⟨hPropagatable, hMiddleFailed⟩
+    cases hMiddleFailed
+    have hRightFailed : right = failed :=
+      failed_of_failureLe_failed hRight
+    cases hRightFailed
+    exact failureLe_to_failed hPropagatable
 
 end NodeStatus
 
@@ -145,6 +215,38 @@ def initial : GraphState ν payload where
   status := fun _ => NodeStatus.pending
   output := fun _ => none
 
+/-! ## Failure-Growth Order -/
+
+/-- `GraphState.failureLe left right` lifts status failure-growth pointwise.
+
+Outputs are intentionally outside this order because failure propagation
+does not inspect them; output ownership and preservation are separate
+invariants. -/
+def failureLe (left right : GraphState ν payload) : Prop :=
+  ∀ node : ν, NodeStatus.failureLe (left.status node) (right.status node)
+
+/-- `failureLe_refl` says graph-state failure-growth is reflexive. -/
+theorem failureLe_refl (state : GraphState ν payload) :
+    failureLe state state := by
+  intro node
+  exact NodeStatus.failureLe_refl (state.status node)
+
+/-- `failureLe_trans` says graph-state failure-growth is transitive. -/
+theorem failureLe_trans {left middle right : GraphState ν payload}
+    (hLeft : failureLe left middle)
+    (hRight : failureLe middle right) :
+    failureLe left right := by
+  intro node
+  exact NodeStatus.failureLe_trans (hLeft node) (hRight node)
+
+/-- `failureLe_preserves_failed` lifts failed-status preservation to graph states. -/
+theorem failureLe_preserves_failed {left right : GraphState ν payload}
+    (hLe : failureLe left right)
+    {node : ν}
+    (hFailed : left.status node = NodeStatus.failed) :
+    right.status node = NodeStatus.failed :=
+  NodeStatus.failureLe_preserves_failed (hLe node) hFailed
+
 /-! ## Recovery Normalization -/
 
 /-- `resetStatus status` resets only volatile execution statuses before resumption. -/
@@ -170,6 +272,12 @@ theorem resetStatus_reflects_unblocks {status : NodeStatus}
     NodeStatus.unblocksSuccessors status := by
   cases status <;> simp [resetStatus, NodeStatus.unblocksSuccessors] at hUnblocks ⊢
 
+/-- `resetStatus_reflects_requiresOutput` recovers original output requirements. -/
+theorem resetStatus_reflects_requiresOutput {status : NodeStatus}
+    (hRequiresOutput : NodeStatus.requiresOutput (resetStatus status)) :
+    NodeStatus.requiresOutput status := by
+  cases status <;> simp [resetStatus, NodeStatus.requiresOutput] at hRequiresOutput ⊢
+
 /-- `resetRunningToPending state` makes in-flight nodes pending again after a crash. -/
 def resetRunningToPending (s : GraphState ν payload) : GraphState ν payload where
   status := fun n => resetStatus (s.status n)
@@ -179,10 +287,18 @@ def resetRunningToPending (s : GraphState ν payload) : GraphState ν payload wh
 def noRunningNodes (s : GraphState ν payload) : Prop :=
   ∀ n : ν, s.status n ≠ NodeStatus.running
 
+/-- `noInterruptedNodes state` means recovery has removed interrupted markers. -/
+def noInterruptedNodes (s : GraphState ν payload) : Prop :=
+  ∀ n : ν, s.status n ≠ NodeStatus.interrupted
+
 /-- `outputsRespectStatuses state` constrains outputs to statuses that may retain them. -/
 def outputsRespectStatuses (s : GraphState ν payload) : Prop :=
   ∀ (n : ν) (value : payload),
     s.output n = some value → NodeStatus.mayHaveOutput (s.status n)
+
+/-- `outputsCompleteForStatuses state` requires payload-owning statuses to have outputs. -/
+def outputsCompleteForStatuses (s : GraphState ν payload) : Prop :=
+  ∀ n : ν, NodeStatus.requiresOutput (s.status n) → ∃ value : payload, s.output n = some value
 
 /-- `topologyDomain G state` says off-topology nodes are absent from durable state. -/
 def topologyDomain (G : DAG ν) (s : GraphState ν payload) : Prop :=
@@ -193,6 +309,13 @@ def topologyDomain (G : DAG ν) (s : GraphState ν payload) : Prop :=
 /-- `resetRunning_no_running` proves status reset removes every `running` marker. -/
 theorem resetRunning_no_running (s : GraphState ν payload) :
     noRunningNodes (resetRunningToPending s) := by
+  intro n
+  cases hStatus : s.status n <;>
+    simp [resetRunningToPending, resetStatus, hStatus]
+
+/-- `resetRunning_no_interrupted` proves status reset removes every `interrupted` marker. -/
+theorem resetRunning_no_interrupted (s : GraphState ν payload) :
+    noInterruptedNodes (resetRunningToPending s) := by
   intro n
   cases hStatus : s.status n <;>
     simp [resetRunningToPending, resetStatus, hStatus]
@@ -224,6 +347,17 @@ theorem resetRunning_preserves_outputsRespectStatuses
       , NodeStatus.mayHaveOutput
       , hStatus
       ] at hMayHaveOutput ⊢
+
+/-- `resetRunning_preserves_outputsCompleteForStatuses` preserves required outputs. -/
+theorem resetRunning_preserves_outputsCompleteForStatuses
+    (s : GraphState ν payload)
+    (hOutputs : outputsCompleteForStatuses s) :
+    outputsCompleteForStatuses (resetRunningToPending s) := by
+  intro node hRequiresOutput
+  have hResetRequires :
+      NodeStatus.requiresOutput (resetStatus (s.status node)) := by
+    simpa [resetRunningToPending] using hRequiresOutput
+  exact hOutputs node (resetStatus_reflects_requiresOutput hResetRequires)
 
 end GraphState
 

--- a/theory/Cortex/Pulse/Validity.lean
+++ b/theory/Cortex/Pulse/Validity.lean
@@ -16,8 +16,9 @@ page packages the structural invariants that recovery can prove today.
 ## Theorem Split
 
 The page first records the bridge between proof-level and executable
-frontiers, then combines topology-domain, output, running, closure,
-causal-history, and frontier obligations into `wellFormedGraphState`.
+frontiers, then combines topology-domain, output, volatile-state,
+closure, causal-history, and frontier obligations into
+`wellFormedGraphState`.
 -/
 
 namespace Cortex.Pulse
@@ -113,15 +114,31 @@ theorem frontierBridge_of_closed_causal
 
 /-! ## Recovered-State Validity -/
 
-/-- `wellFormedGraphState G state` is validity for normalized recovered graph states. -/
-def wellFormedGraphState
+/-- `WellFormedGraphState G state` is validity for normalized recovered graph states. -/
+structure WellFormedGraphState
+    (G : DAG ν)
+    (state : GraphState ν payload) : Prop where
+  /-- Persisted status/output maps mention only topology nodes. -/
+  topologyDomain : GraphState.topologyDomain G state
+  /-- Existing outputs are attached only to statuses that may own payloads. -/
+  outputsRespectStatuses : GraphState.outputsRespectStatuses state
+  /-- Payload-owning statuses have their required outputs present. -/
+  outputsCompleteForStatuses : GraphState.outputsCompleteForStatuses state
+  /-- Recovery normalization removes in-flight running nodes. -/
+  noRunningNodes : GraphState.noRunningNodes state
+  /-- Recovery normalization removes interrupted nodes. -/
+  noInterruptedNodes : GraphState.noInterruptedNodes state
+  /-- Failed nodes have propagated through reachable propagatable descendants. -/
+  failureClosureComplete : failureClosureComplete G state
+  /-- Successor-unblocking nodes have terminal strict ancestors. -/
+  causalHistoryClosed : CausalHistoryClosed G state
+  /-- Proof-level and runtime-style frontiers coincide. -/
+  frontierBridge : frontierBridge G state
+
+/-- `wellFormedGraphState G state` keeps the published predicate name stable. -/
+abbrev wellFormedGraphState
     (G : DAG ν)
     (state : GraphState ν payload) : Prop :=
-  GraphState.topologyDomain G state ∧
-    GraphState.outputsRespectStatuses state ∧
-      GraphState.noRunningNodes state ∧
-        failureClosureComplete G state ∧
-          CausalHistoryClosed G state ∧
-            frontierBridge G state
+  WellFormedGraphState G state
 
 end Cortex.Pulse

--- a/theory/README.md
+++ b/theory/README.md
@@ -63,13 +63,19 @@ Mechanized results now include:
   strict reachability.
 - `NodeResult.applyNodeFact_comm`: node-local facts for distinct nodes
   commute.
+- `NodeResult.applyNodeFacts_perm_invariant`: disjoint-key fact folds
+  are invariant under list permutation.
 - `propagateFailure_extensive`: propagation preserves failed nodes.
+- `propagateFailure_monotone`: failure propagation is monotone over
+  pointwise failure-growth.
 - `propagateFailure_failureClosureComplete`: one propagation pass closes
   failure over propagatable descendants.
 - `propagateFailure_preserves_topologyDomain`: propagation preserves the
   absence of off-topology durable state.
 - `propagateFailure_preserves_outputsRespectStatuses`: propagation
   preserves output ownership.
+- `propagateFailure_preserves_outputsCompleteForStatuses`: propagation
+  preserves required outputs for completed and rewritten nodes.
 - `propagateFailure_idempotent`: failure propagation is idempotent.
 - `directReady_sound`: executable direct-predecessor readiness implies
   proof-level reachability readiness under causal-history closure.
@@ -78,15 +84,16 @@ Mechanized results now include:
 - `NodeResult.Admissible`: node facts must target the topology and come
   from the executable frontier before preservation theorems apply.
 - `frontierFacts_recovered_wellFormedGraphState`: admissible fact folds
-  become structurally well-formed again after failure closure.
+  become structurally well-formed again after recovery normalization and
+  failure closure.
 - `persistence_safety`: recovered states are structurally well-formed,
-  conditional on explicit persisted topology-domain, output, and
-  causal-history preconditions that recovery preserves.
+  conditional on explicit persisted topology-domain, output ownership,
+  output-completeness, and causal-history preconditions that recovery
+  preserves.
 
-Remaining obligations include permutation invariance for whole frontier
-result folds, Haskell-side establishment of the persisted recovery
-preconditions, classification exhaustiveness, and quotient lifting for the
-graph algebra laws.
+Remaining obligations include Haskell-side establishment of the persisted
+recovery preconditions, classification exhaustiveness, the Lean-Haskell
+modeling-boundary note, and quotient lifting for the graph algebra laws.
 
 ### Track 3 — Rewrite soundness
 
@@ -153,7 +160,7 @@ local commits and CI agree on the Lean gate.
 | 1a. Graph relation semantics | finite relation denotation + Mokhov laws | relation-level laws | none |
 | 1b. Graph denotational AST laws | AST laws over graph equivalence | denotational law surface | none |
 | 1c. Graph quotient laws | lifted quotient equality laws | pending | none |
-| 2. Fixed-topology Pulse kernel | edge-derived DAG/state/fact/frontier/closure/recovery surface | frontier antichain, direct/runtime frontier bridge, fact commutativity, admissible fact recovery, closure idempotence, topology-domain/output/causal preservation, structural recovery predicate | none |
+| 2. Fixed-topology Pulse kernel | edge-derived DAG/state/fact/frontier/closure/recovery surface | frontier antichain, direct/runtime frontier bridge, fact commutativity, admissible fact recovery, closure idempotence, topology-domain/output/volatile-state/causal preservation, structural recovery predicate | none |
 | 3. Rewrite soundness | proof-carrying rewrite certificate | acyclicity/contract/budget projections | none |
 | 4. Provider / sparks | — | — | not started |
 | 5. Substrate / consumer boundary | — | — | not started |


### PR DESCRIPTION
## Summary
- prove Pulse failure propagation monotonicity over the failure-growth order
- strengthen recovered-state validity with no-interrupted and output-completeness invariants
- sync Paper 1, Paper 2, roadmap, and theory docs with the updated Lean contract

## Validation
- just lean-build
- just lean-check
- just docs-check
- Lean hygiene searches and git diff --check

Closes #57
Closes #60