### PR TITLE
feat: add Pulse classification proof

### DIFF
--- a/docs/Publications/Paper-1-staged-reduction/index.md
+++ b/docs/Publications/Paper-1-staged-reduction/index.md
@@ -15,7 +15,7 @@ Staged reduction for durable workflow execution over fixed DAG topology. The pap
 
 Draft manuscript. See [manuscript.md](manuscript.md) for the full text.
 
-The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`, including the structural recovery theorem (`persistence_safety`), frontier antichain, disjoint-key accumulation commutativity, fold permutation invariance, and the extensiveness, monotonicity, and idempotence closure laws. The paper stays `draft` until the remaining obligations in [lean-mechanization.md](lean-mechanization.md) land: classification exhaustiveness and the artifact note describing the Lean ↔ Haskell boundary.
+The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`, including the structural recovery theorem (`persistence_safety`), frontier antichain, disjoint-key accumulation commutativity, fold permutation invariance, classification exhaustiveness, and the extensiveness, monotonicity, and idempotence closure laws. The paper stays `draft` until the remaining artifact note in [lean-mechanization.md](lean-mechanization.md) describes the Lean ↔ Haskell boundary.
 
 ## Abstract
 

--- a/docs/Publications/Paper-1-staged-reduction/lean-mechanization.md
+++ b/docs/Publications/Paper-1-staged-reduction/lean-mechanization.md
@@ -33,7 +33,8 @@ Paper 1 should stay `draft` until all of the following exist in Lean 4:
 1. A machine-checked `wellFormedGraphState` predicate for normalized, closed recovered states. **Done** (`theory/Cortex/Pulse/Validity.lean`).
 2. Proofs of the three closure laws for `propagateFailure`: extensiveness, monotonicity, idempotence. **Done** — `propagateFailure_extensive`, `propagateFailure_monotone`, and `propagateFailure_idempotent` are discharged in `theory/Cortex/Pulse/Closure.lean`.
 3. A machine-checked structural recovery theorem matching Proposition 1 in the manuscript. **Done** (`persistence_safety` in `theory/Cortex/Pulse/Recovery.lean`), conditional on persisted topology-domain, output-ownership, output-completeness, and causal-history preconditions.
-4. A short artifact note explaining the modeling boundary between the Lean kernel and the live Haskell runtime. **Open**.
+4. A machine-checked classification exhaustiveness theorem for normalized, closed states. **Done** (`classifyClosedGraphState_exhaustive_of_wellFormed` and `classifyGraphState_not_stuck_of_wellFormed` in `theory/Cortex/Pulse/Classify.lean`).
+5. A short artifact note explaining the modeling boundary between the Lean kernel and the live Haskell runtime. **Open**.
 
 ## What Must Be Proved
 
@@ -47,7 +48,7 @@ Load-bearing theorems for the paper, with their current Lean status:
 - `propagateFailure_idempotent` — done (`theory/Cortex/Pulse/Closure.lean`)
 - normalization lemmas for `resetRunningToPending` — done (`theory/Cortex/Pulse/State.lean`, `Recovery.lean`)
 - `frontierBridge` on normalized, closed states — done (`theory/Cortex/Pulse/Validity.lean`); the non-trivial bridge `readyNodes_eq_directReadyNodes` lives in the same file
-- classification exhaustiveness on normalized, closed states — open (no `Classify.lean` yet)
+- classification exhaustiveness on normalized, closed states — done (`theory/Cortex/Pulse/Classify.lean`)
 - structural persistence safety after persisted-prefix crashes — done (`persistence_safety` in `theory/Cortex/Pulse/Recovery.lean`)
 
 ## What May Stay Abstract
@@ -88,7 +89,7 @@ theory/Cortex/Pulse/
   Closure.lean    -- propagateFailure, extensiveness, monotonicity, idempotence
   Validity.lean   -- wellFormedGraphState, frontier-bridge theorems
   Recovery.lean   -- recoveredState, persistence_safety
-  -- Classify.lean -- pending: classification exhaustiveness
+  Classify.lean    -- classifyGraphState, classification exhaustiveness
 ```
 
 Build order followed by the existing artifacts:
@@ -99,7 +100,7 @@ Build order followed by the existing artifacts:
 4. closure operator laws
 5. recovered-state validity
 6. persisted-prefix recovery theorem
-7. classification correctness *(pending)*
+7. classification correctness
 
 ## Manuscript Mapping
 
@@ -110,24 +111,21 @@ Build order followed by the existing artifacts:
 | Phase 2 closure laws | `propagateFailure_extensive`, `propagateFailure_monotone`, `propagateFailure_idempotent` in `theory/Cortex/Pulse/Closure.lean` |
 | Definition 1: valid recovered graph state | `wellFormedGraphState` in `theory/Cortex/Pulse/Validity.lean` |
 | Proposition 1: structural persistence safety | `persistence_safety` in `theory/Cortex/Pulse/Recovery.lean` |
-| Phase 3 classification split | pending `Classify.lean` |
+| Phase 3 classification split | `classifyClosedGraphState_exhaustive_of_wellFormed` and `classifyGraphState_not_stuck_of_wellFormed` in `theory/Cortex/Pulse/Classify.lean` |
 
 ## Draft Notes for the Manuscript
 
 The mechanized obligations now have direct Lean references in the manuscript body. Remaining manuscript-side guidance:
 
 - keep Proposition 1's preconditions explicit — the Lean theorem is conditional on persisted topology-domain, output-ownership, output-completeness, and causal-history invariants that the runtime must establish
-- keep classification exhaustiveness as proof-sketch wording until `Classify.lean` exists
 
 When the remaining work lands:
 
-- once `Classify.lean` exists, retire the proof-sketch wording around classification exhaustiveness
 - write the artifact note explaining the Lean ↔ Haskell modeling boundary (status, output, payload, and persistence assumptions) and link it from the manuscript
 
 ## Immediate Next Steps
 
-1. Add `Classify.lean` with the four-way classification and an exhaustiveness theorem on `wellFormedGraphState`.
-2. Draft the Lean ↔ Haskell artifact note and link it from the manuscript and landing page.
+1. Draft the Lean ↔ Haskell artifact note and link it from the manuscript and landing page.
 
 ## Related
 

--- a/docs/Publications/Paper-1-staged-reduction/manuscript.md
+++ b/docs/Publications/Paper-1-staged-reduction/manuscript.md
@@ -23,7 +23,6 @@ We present a durable workflow execution runtime organized as a staged pure reduc
 
 The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`; see [lean-mechanization.md](lean-mechanization.md) for the artifact mapping. The manuscript remains `draft` until the following obligations also land:
 
-- prove classification exhaustiveness on normalized, closed states
 - add a short artifact note describing the boundary between the Lean model and the live runtime
 
 ---
@@ -451,7 +450,7 @@ The implementation-level claims are backed by QuickCheck property tests on rando
 | Recovery normalization | §3.4, §3.7 | Partial frontier + `resetRunningToPending` + classify yields a valid closed state |
 | Sequential = batch | §3.6 | Fold of single-element `applyFrontierResults` matches batch application |
 
-Several of these properties are now mechanized in Lean 4 — frontier antichain, disjoint-key commutativity and fold permutation, closure extensiveness, monotonicity, idempotence, and recovery normalization — and the artifacts are listed in [lean-mechanization.md](lean-mechanization.md). The QuickCheck tests remain runtime evidence on the live Haskell implementation; for the still-open classification exhaustiveness obligation, they are not a substitute for proof.
+Several of these properties are now mechanized in Lean 4 — frontier antichain, disjoint-key commutativity and fold permutation, closure extensiveness, monotonicity, idempotence, recovery normalization, and classification exhaustiveness — and the artifacts are listed in [lean-mechanization.md](lean-mechanization.md). The QuickCheck tests remain runtime evidence on the live Haskell implementation; they are not a substitute for the Lean proof surface.
 
 ---
 

--- a/docs/Roadmap/Plans/lean-mechanization.md
+++ b/docs/Roadmap/Plans/lean-mechanization.md
@@ -141,6 +141,19 @@ This is the load-bearing theorem for the crash-recovery model. It should match
 Paper 1's structural persistence-safety claim and Paper 2's recovery theorem in
 intent.
 
+### Tier 5: Classification exhaustiveness
+
+```lean
+theorem classifyClosedGraphState_exhaustive_of_wellFormed
+  (G : DAG) (s : GraphState)
+  (h : wellFormedGraphState G s) :
+  -- failed, progressing, completed, or suspended; never stuck
+  ...
+```
+
+The classifier sits above recovery: well-formed recovered states can resume,
+settle, or suspend, but they cannot enter the stuck diagnostic branch.
+
 ## Explicit Non-Goals
 
 Do not expand this plan into:

--- a/theory/Cortex.lean
+++ b/theory/Cortex.lean
@@ -11,6 +11,7 @@ import Cortex.Pulse.Frontier
 import Cortex.Pulse.Closure
 import Cortex.Pulse.Validity
 import Cortex.Pulse.Recovery
+import Cortex.Pulse.Classify
 
 -- Track 3 — Wire rewrite soundness
 import Cortex.Wire.Rewrite

--- a/theory/Cortex/Pulse/Classify.lean
+++ b/theory/Cortex/Pulse/Classify.lean
@@ -1,0 +1,420 @@
+import Cortex.Pulse.Validity
+
+/-!
+## Overview
+
+Classification is the final pure phase of the fixed-topology Pulse
+kernel: accumulated facts are closed under failure propagation and then
+classified into a lifecycle decision. This module models the structural
+decision surface while keeping runtime diagnostics and payload details
+abstract.
+
+## Context
+
+The Haskell runtime classifies by first applying `propagateFailure`, then
+checking for failed nodes, a nonempty executable frontier, completed
+settlement, suspension, and finally stuck diagnostics. Lean keeps that
+precedence for topology-valid states and states the theorem-level surface
+against `wellFormedGraphState`, where the stuck branch is impossible.
+
+## Theorem Split
+
+The page defines classification predicates, the closed-state classifier,
+the closure-wrapping classifier, branch equations, and the
+well-formed-state exhaustiveness theorem.
+-/
+
+namespace Cortex.Pulse
+
+variable {ν : Type u} {payload : Type v}
+
+/-! ## Classification Surface -/
+
+/-- `RunOutcome` is the structural terminal outcome visible to the proof. -/
+inductive RunOutcome : Type where
+  | completed : RunOutcome
+  | failed : RunOutcome
+  deriving Repr, DecidableEq
+
+/-- `StepResult` is the pure classification result for a graph state.
+
+The runtime `StuckDiagnostic` payload is intentionally erased: the Lean
+classification theorem only needs to prove that the stuck constructor is
+unreachable for well-formed structural states. -/
+inductive StepResult (ν : Type u) (payload : Type v) :
+    Type (max (u + 1) (v + 1)) where
+  | progressing : GraphState ν payload → Finset ν → StepResult ν payload
+  | settled : GraphState ν payload → RunOutcome → StepResult ν payload
+  | suspended : GraphState ν payload → StepResult ν payload
+  | stuck : GraphState ν payload → StepResult ν payload
+
+/-- `pendingNodes G state` is the topology-scoped pending-node set. -/
+noncomputable def pendingNodes
+    (G : DAG ν)
+    (state : GraphState ν payload) : Finset ν := by
+  classical
+  exact G.nodes.filter fun node => state.status node = NodeStatus.pending
+
+/-- `hasFailedNodes G state` checks for a failed node in the topology. -/
+def hasFailedNodes
+    (G : DAG ν)
+    (state : GraphState ν payload) : Prop :=
+  ∃ node : ν, node ∈ G.nodes ∧ state.status node = NodeStatus.failed
+
+/-- `allSettled G state` says every topology node is terminal. -/
+def allSettled
+    (G : DAG ν)
+    (state : GraphState ν payload) : Prop :=
+  ∀ node : ν, node ∈ G.nodes → NodeStatus.terminal (state.status node)
+
+/-- `hasWaitingNodes G state` checks for topology-scoped waiting nodes.
+
+Runtime correspondence for this predicate is intended under
+`GraphState.topologyDomain`, where off-topology statuses are normalized to
+`pending`. -/
+def hasWaitingNodes
+    (G : DAG ν)
+    (state : GraphState ν payload) : Prop :=
+  ∃ node : ν, node ∈ G.nodes ∧ state.status node = NodeStatus.waiting
+
+/-- `hasAmbientWaitingNodes state` models a raw status-map scan for waiting statuses. -/
+def hasAmbientWaitingNodes
+    (state : GraphState ν payload) : Prop :=
+  ∃ node : ν, state.status node = NodeStatus.waiting
+
+/-- Topology-domain validity bridges topology-scoped and ambient waiting checks. -/
+theorem hasWaitingNodes_iff_hasAmbientWaitingNodes_of_topologyDomain
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hDomain : GraphState.topologyDomain G state) :
+    hasWaitingNodes G state ↔ hasAmbientWaitingNodes state := by
+  constructor
+  · intro hWaiting
+    rcases hWaiting with ⟨node, _hNode, hStatus⟩
+    exact ⟨node, hStatus⟩
+  · intro hWaiting
+    rcases hWaiting with ⟨node, hStatus⟩
+    by_cases hNode : node ∈ G.nodes
+    · exact ⟨node, hNode, hStatus⟩
+    · have hPending : state.status node = NodeStatus.pending :=
+        (hDomain node hNode).1
+      rw [hPending] at hStatus
+      cases hStatus
+
+/-! ## Classifier -/
+
+/-- `classifyClosedGraphState G state` classifies a topology-valid failure-closed state. -/
+noncomputable def classifyClosedGraphState
+    (G : DAG ν)
+    (state : GraphState ν payload) : StepResult ν payload := by
+  classical
+  exact
+    if hasFailedNodes G state then
+      StepResult.settled state RunOutcome.failed
+    else if (directReadyNodes G state).Nonempty then
+      StepResult.progressing state (directReadyNodes G state)
+    else if allSettled G state then
+      StepResult.settled state RunOutcome.completed
+    else if hasWaitingNodes G state then
+      StepResult.suspended state
+    else
+      StepResult.stuck state
+
+/-- `classifyGraphState G state` is the topology-scoped classifier after failure closure. -/
+noncomputable def classifyGraphState
+    (G : DAG ν)
+    (state : GraphState ν payload) : StepResult ν payload :=
+  classifyClosedGraphState G (propagateFailure G state)
+
+/-! ## Branch Equations -/
+
+/-- Failed nodes take classification precedence over all other branches. -/
+theorem classifyClosedGraphState_failed
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hFailed : hasFailedNodes G state) :
+    classifyClosedGraphState G state = StepResult.settled state RunOutcome.failed := by
+  classical
+  simp [classifyClosedGraphState, hFailed]
+
+/-- A nonempty frontier progresses when no failed node is present. -/
+theorem classifyClosedGraphState_progressing
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hNoFailed : ¬ hasFailedNodes G state)
+    (hFrontier : (directReadyNodes G state).Nonempty) :
+    classifyClosedGraphState G state =
+      StepResult.progressing state (directReadyNodes G state) := by
+  classical
+  simp [classifyClosedGraphState, hNoFailed, hFrontier]
+
+/-- Settled completion applies after failed and frontier branches are absent. -/
+theorem classifyClosedGraphState_settled_completed
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hNoFailed : ¬ hasFailedNodes G state)
+    (hNoFrontier : ¬ (directReadyNodes G state).Nonempty)
+    (hSettled : allSettled G state) :
+    classifyClosedGraphState G state =
+      StepResult.settled state RunOutcome.completed := by
+  classical
+  simp [classifyClosedGraphState, hNoFailed, hNoFrontier, hSettled]
+
+/-- Suspension applies when no earlier branch fires and a topology node is waiting. -/
+theorem classifyClosedGraphState_suspended
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hNoFailed : ¬ hasFailedNodes G state)
+    (hNoFrontier : ¬ (directReadyNodes G state).Nonempty)
+    (hNotSettled : ¬ allSettled G state)
+    (hWaiting : hasWaitingNodes G state) :
+    classifyClosedGraphState G state = StepResult.suspended state := by
+  classical
+  simp [classifyClosedGraphState, hNoFailed, hNoFrontier, hNotSettled, hWaiting]
+
+/-- The stuck branch records the structural complement of the earlier branches. -/
+theorem classifyClosedGraphState_stuck
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hNoFailed : ¬ hasFailedNodes G state)
+    (hNoFrontier : ¬ (directReadyNodes G state).Nonempty)
+    (hNotSettled : ¬ allSettled G state)
+    (hNoWaiting : ¬ hasWaitingNodes G state) :
+    classifyClosedGraphState G state = StepResult.stuck state := by
+  classical
+  simp [classifyClosedGraphState, hNoFailed, hNoFrontier, hNotSettled, hNoWaiting]
+
+/-! ## Well-Formed Classification -/
+
+/-- `ClassificationNormalized state` is the minimal volatile-state bundle for classification.
+
+The minimal-pending-node argument only needs running and interrupted
+statuses to be absent; topology, output, closure, and frontier-bridge
+facts enter later correspondence theorems. -/
+structure ClassificationNormalized
+    (state : GraphState ν payload) : Prop where
+  /-- No node is still in the active runtime state. -/
+  noRunningNodes : GraphState.noRunningNodes state
+  /-- No node still carries an interrupted runtime marker. -/
+  noInterruptedNodes : GraphState.noInterruptedNodes state
+
+/-- Well-formed graph states are classification-normalized. -/
+theorem classificationNormalized_of_wellFormed
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hWellFormed : wellFormedGraphState G state) :
+    ClassificationNormalized state :=
+  { noRunningNodes := hWellFormed.noRunningNodes
+    noInterruptedNodes := hWellFormed.noInterruptedNodes }
+
+/-- Nonterminal topology nodes are pending under normalized, nonfailed, nonwaiting validity. -/
+theorem status_eq_pending_of_not_terminal
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hNormalized : ClassificationNormalized state)
+    (hNoFailed : ¬ hasFailedNodes G state)
+    (hNoWaiting : ¬ hasWaitingNodes G state)
+    {node : ν}
+    (hNode : node ∈ G.nodes)
+    (hNotTerminal : ¬ NodeStatus.terminal (state.status node)) :
+    state.status node = NodeStatus.pending := by
+  cases hStatus : state.status node
+  · rfl
+  · exact False.elim (hNormalized.noRunningNodes node hStatus)
+  · exact False.elim (hNotTerminal (by simp [hStatus, NodeStatus.terminal]))
+  · exact False.elim (hNoFailed ⟨node, hNode, hStatus⟩)
+  · exact False.elim (hNotTerminal (by simp [hStatus, NodeStatus.terminal]))
+  · exact False.elim (hNormalized.noInterruptedNodes node hStatus)
+  · exact False.elim (hNoWaiting ⟨node, hNode, hStatus⟩)
+  · exact False.elim (hNotTerminal (by simp [hStatus, NodeStatus.terminal]))
+
+/-- A normalized nonfailed, nonsettled, nonwaiting state has a proof frontier. -/
+theorem readyNodes_nonempty_of_normalized
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hNormalized : ClassificationNormalized state)
+    (hNoFailed : ¬ hasFailedNodes G state)
+    (hNotSettled : ¬ allSettled G state)
+    (hNoWaiting : ¬ hasWaitingNodes G state) :
+    (readyNodes G state).Nonempty := by
+  classical
+  have hExistsNonterminal :
+      ∃ node : ν, node ∈ G.nodes ∧ ¬ NodeStatus.terminal (state.status node) := by
+    by_contra hNone
+    apply hNotSettled
+    intro node hNode
+    by_contra hNotTerminal
+    exact hNone ⟨node, hNode, hNotTerminal⟩
+  rcases hExistsNonterminal with ⟨seed, hSeedMem, hSeedNotTerminal⟩
+  have hSeedPending : state.status seed = NodeStatus.pending :=
+    status_eq_pending_of_not_terminal
+      G
+      state
+      hNormalized
+      hNoFailed
+      hNoWaiting
+      hSeedMem
+      hSeedNotTerminal
+  have hPendingNonempty : (pendingNodes G state).Nonempty := by
+    exact ⟨seed, by simp [pendingNodes, hSeedMem, hSeedPending]⟩
+  rcases G.exists_reaches_minimal (pendingNodes G state) hPendingNonempty with
+    ⟨node, hNodePending, hMinimal⟩
+  have hPendingInfo :
+      node ∈ G.nodes ∧ state.status node = NodeStatus.pending := by
+    simpa [pendingNodes] using hNodePending
+  have hReady : Ready G state node := by
+    constructor
+    · exact hPendingInfo.1
+    constructor
+    · exact hPendingInfo.2
+    · intro predecessor hReach
+      by_contra hPredecessorNotTerminal
+      have hPredecessorMem : predecessor ∈ G.nodes :=
+        G.reaches_source_mem hReach
+      have hPredecessorPendingStatus :
+          state.status predecessor = NodeStatus.pending :=
+        status_eq_pending_of_not_terminal
+          G
+          state
+          hNormalized
+          hNoFailed
+          hNoWaiting
+          hPredecessorMem
+          hPredecessorNotTerminal
+      have hPredecessorPending : predecessor ∈ pendingNodes G state := by
+        simp [pendingNodes, hPredecessorMem, hPredecessorPendingStatus]
+      exact hMinimal predecessor hPredecessorPending hReach
+  exact ⟨node, (mem_readyNodes G state node).mpr ⟨hPendingInfo.1, hReady⟩⟩
+
+/-- A well-formed nonfailed, nonsettled, nonwaiting state has a runtime frontier. -/
+theorem directReadyNodes_nonempty_of_wellFormed
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hWellFormed : wellFormedGraphState G state)
+    (hNoFailed : ¬ hasFailedNodes G state)
+    (hNotSettled : ¬ allSettled G state)
+    (hNoWaiting : ¬ hasWaitingNodes G state) :
+    (directReadyNodes G state).Nonempty := by
+  rw [← hWellFormed.frontierBridge]
+  exact
+    readyNodes_nonempty_of_normalized
+      G
+      state
+      (classificationNormalized_of_wellFormed G state hWellFormed)
+      hNoFailed
+      hNotSettled
+      hNoWaiting
+
+/-- Well-formed closed states classify into one of the non-stuck branches. -/
+theorem classifyClosedGraphState_exhaustive_of_wellFormed
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hWellFormed : wellFormedGraphState G state) :
+    (hasFailedNodes G state ∧
+        classifyClosedGraphState G state = StepResult.settled state RunOutcome.failed) ∨
+      (¬ hasFailedNodes G state ∧
+        (directReadyNodes G state).Nonempty ∧
+          classifyClosedGraphState G state =
+            StepResult.progressing state (directReadyNodes G state)) ∨
+        (¬ hasFailedNodes G state ∧
+          ¬ (directReadyNodes G state).Nonempty ∧
+            allSettled G state ∧
+              classifyClosedGraphState G state =
+                StepResult.settled state RunOutcome.completed) ∨
+          (¬ hasFailedNodes G state ∧
+            ¬ (directReadyNodes G state).Nonempty ∧
+              ¬ allSettled G state ∧
+                hasWaitingNodes G state ∧
+                  classifyClosedGraphState G state = StepResult.suspended state) := by
+  classical
+  by_cases hFailed : hasFailedNodes G state
+  · exact Or.inl ⟨hFailed, classifyClosedGraphState_failed G state hFailed⟩
+  · right
+    by_cases hFrontier : (directReadyNodes G state).Nonempty
+    · exact Or.inl
+        ⟨hFailed, hFrontier, classifyClosedGraphState_progressing G state hFailed hFrontier⟩
+    · right
+      by_cases hSettled : allSettled G state
+      · exact Or.inl
+          ⟨ hFailed
+          , hFrontier
+          , hSettled
+          , classifyClosedGraphState_settled_completed G state hFailed hFrontier hSettled
+          ⟩
+      · right
+        by_cases hWaiting : hasWaitingNodes G state
+        · exact
+            ⟨ hFailed
+            , hFrontier
+            , hSettled
+            , hWaiting
+            , classifyClosedGraphState_suspended G state hFailed hFrontier hSettled hWaiting
+            ⟩
+        · have hFrontierNonempty :
+              (directReadyNodes G state).Nonempty :=
+            directReadyNodes_nonempty_of_wellFormed
+              G
+              state
+              hWellFormed
+              hFailed
+              hSettled
+              hWaiting
+          exact False.elim (hFrontier hFrontierNonempty)
+
+/-- Well-formed closed states cannot classify as stuck. -/
+theorem classifyClosedGraphState_not_stuck_of_wellFormed
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hWellFormed : wellFormedGraphState G state)
+    (stuckState : GraphState ν payload) :
+    classifyClosedGraphState G state ≠ StepResult.stuck stuckState := by
+  classical
+  by_cases hFailed : hasFailedNodes G state
+  · intro hClass
+    simp [classifyClosedGraphState, hFailed] at hClass
+  · by_cases hFrontier : (directReadyNodes G state).Nonempty
+    · intro hClass
+      simp [classifyClosedGraphState, hFailed, hFrontier] at hClass
+    · by_cases hSettled : allSettled G state
+      · intro hClass
+        simp [classifyClosedGraphState, hFailed, hFrontier, hSettled] at hClass
+      · by_cases hWaiting : hasWaitingNodes G state
+        · intro hClass
+          simp
+            [ classifyClosedGraphState
+            , hFailed
+            , hFrontier
+            , hSettled
+            , hWaiting
+            ] at hClass
+        · have hFrontierNonempty :
+              (directReadyNodes G state).Nonempty :=
+            directReadyNodes_nonempty_of_wellFormed
+              G
+              state
+              hWellFormed
+              hFailed
+              hSettled
+              hWaiting
+          exact False.elim (hFrontier hFrontierNonempty)
+
+/-- On well-formed states, runtime-style classification is already closed-state classification. -/
+theorem classifyGraphState_eq_closed_of_wellFormed
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hWellFormed : wellFormedGraphState G state) :
+    classifyGraphState G state = classifyClosedGraphState G state := by
+  unfold classifyGraphState
+  rw [propagateFailure_of_failureClosureComplete G state hWellFormed.failureClosureComplete]
+
+/-- Well-formed graph states cannot classify as stuck after the runtime closure step. -/
+theorem classifyGraphState_not_stuck_of_wellFormed
+    (G : DAG ν)
+    (state : GraphState ν payload)
+    (hWellFormed : wellFormedGraphState G state)
+    (stuckState : GraphState ν payload) :
+    classifyGraphState G state ≠ StepResult.stuck stuckState := by
+  rw [classifyGraphState_eq_closed_of_wellFormed G state hWellFormed]
+  exact classifyClosedGraphState_not_stuck_of_wellFormed G state hWellFormed stuckState
+
+end Cortex.Pulse

--- a/theory/Cortex/Pulse/DAG.lean
+++ b/theory/Cortex/Pulse/DAG.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.Finset.Basic
+import Mathlib.Order.WellFoundedSet
 
 /-!
 ## Overview
@@ -135,6 +136,30 @@ theorem not_reaches_reverse {a b : ν} (hReach : G.reaches a b) :
     ¬ G.reaches b a := by
   intro hBack
   exact G.acyclic a (G.reaches_trans hReach hBack)
+
+/-- `exists_reaches_minimal` finds a reachability-minimal member of a finite set. -/
+theorem exists_reaches_minimal
+    (nodes : Finset ν)
+    (hNonempty : nodes.Nonempty) :
+    ∃ node ∈ nodes, ∀ predecessor ∈ nodes, ¬ G.reaches predecessor node := by
+  classical
+  let nodeSet : Set ν := {node | node ∈ nodes}
+  have hFinite : nodeSet.Finite := by
+    simp [nodeSet]
+  letI : IsStrictOrder ν G.reaches :=
+    { irrefl := fun node => G.not_reaches_self node
+      trans := fun _ _ _ hLeft hRight => G.reaches_trans hLeft hRight }
+  have hWFOn : nodeSet.WellFoundedOn G.reaches := hFinite.wellFoundedOn
+  rw [Set.wellFoundedOn_iff] at hWFOn
+  have hSetNonempty : nodeSet.Nonempty := by
+    rcases hNonempty with ⟨node, hNode⟩
+    exact ⟨node, by simpa [nodeSet] using hNode⟩
+  rcases hWFOn.has_min nodeSet hSetNonempty with ⟨node, hNode, hMinimal⟩
+  refine ⟨node, by simpa [nodeSet] using hNode, ?_⟩
+  intro predecessor hPredecessor hReach
+  have hPredecessorSet : predecessor ∈ nodeSet := by
+    simpa [nodeSet] using hPredecessor
+  exact hMinimal predecessor hPredecessorSet ⟨hReach, hPredecessorSet, hNode⟩
 
 end DAG
 

--- a/theory/Main.lean
+++ b/theory/Main.lean
@@ -22,7 +22,7 @@ proof tracks imported by the root module.
 def main : IO Unit := do
   IO.println "Cortex theory — Lean 4 mechanization (scaffold)"
   IO.println "  Track 1 (Graph algebra) ......... import Cortex.Graph.Core / Laws"
-  IO.println "  Track 2 (Frontier safety) ....... import Cortex.Pulse.Frontier"
+  IO.println "  Track 2 (Pulse kernel) .......... import Cortex.Pulse.Classify"
   IO.println "  Track 3 (Rewrite soundness) ..... import Cortex.Wire.Rewrite"
   IO.println ""
   IO.println "Open obligations: see `theory/README.md`."

--- a/theory/README.md
+++ b/theory/README.md
@@ -90,10 +90,15 @@ Mechanized results now include:
   conditional on explicit persisted topology-domain, output ownership,
   output-completeness, and causal-history preconditions that recovery
   preserves.
+- `classifyClosedGraphState_exhaustive_of_wellFormed`: well-formed
+  closed states classify into failed, progressing, completed, or
+  suspended branches.
+- `classifyGraphState_not_stuck_of_wellFormed`: well-formed states
+  cannot classify as stuck after the runtime closure step.
 
 Remaining obligations include Haskell-side establishment of the persisted
-recovery preconditions, classification exhaustiveness, the Lean-Haskell
-modeling-boundary note, and quotient lifting for the graph algebra laws.
+recovery preconditions, the Lean-Haskell modeling-boundary note, and
+quotient lifting for the graph algebra laws.
 
 ### Track 3 — Rewrite soundness
 
@@ -160,7 +165,7 @@ local commits and CI agree on the Lean gate.
 | 1a. Graph relation semantics | finite relation denotation + Mokhov laws | relation-level laws | none |
 | 1b. Graph denotational AST laws | AST laws over graph equivalence | denotational law surface | none |
 | 1c. Graph quotient laws | lifted quotient equality laws | pending | none |
-| 2. Fixed-topology Pulse kernel | edge-derived DAG/state/fact/frontier/closure/recovery surface | frontier antichain, direct/runtime frontier bridge, fact commutativity, admissible fact recovery, closure idempotence, topology-domain/output/volatile-state/causal preservation, structural recovery predicate | none |
+| 2. Fixed-topology Pulse kernel | edge-derived DAG/state/fact/frontier/closure/recovery/classification surface | frontier antichain, direct/runtime frontier bridge, fact commutativity, admissible fact recovery, closure idempotence, topology-domain/output/volatile-state/causal preservation, structural recovery predicate, classification exhaustiveness | none |
 | 3. Rewrite soundness | proof-carrying rewrite certificate | acyclicity/contract/budget projections | none |
 | 4. Provider / sparks | — | — | not started |
 | 5. Substrate / consumer boundary | — | — | not started |

--- a/theory/lakefile.lean
+++ b/theory/lakefile.lean
@@ -37,6 +37,7 @@ lean_lib «Cortex» where
     `Cortex.Pulse.Closure,
     `Cortex.Pulse.Validity,
     `Cortex.Pulse.Recovery,
+    `Cortex.Pulse.Classify,
     `Cortex.Wire.Rewrite
   ]
 


### PR DESCRIPTION
## Summary
Add the Pulse classification proof module for normalized, closed graph states.

## Changes
- Define the Lean classification surface and runtime-matching classifier precedence.
- Prove classification exhaustiveness and stuck-freeness for `wellFormedGraphState`.
- Add reusable DAG reachability minimality support for finite pending-node sets.
- Document and bridge the Lean/Haskell classification boundary for direct frontiers, topology-scoped waiting nodes, and erased stuck diagnostics.
- Import the module through the theory root and update mechanization/manuscript tracking docs.

## Validation
- `just fmt-check`
- `just lean-check`
- `just docs-check`
- GitHub CI passed on the squashed branch tip.

Closes #58