### PR TITLE
docs: define Wire @ executor boundary

### DIFF
--- a/docs/ADRs/0010-wire-closed-authority-and-three-layer-stack.md
+++ b/docs/ADRs/0010-wire-closed-authority-and-three-layer-stack.md
@@ -12,14 +12,14 @@ related:
   - docs/Architecture/03-formalism-stack.md
   - docs/Architecture/04-graph-and-circuit.md
   - docs/Architecture/05-wire-language.md
-  - docs/Reference/Wire/grammar-v1.md
+  - docs/Reference/Wire/grammar.md
 ---
 
 # ADR 0010 — Wire as Closed-Authority Language over the Graph/Circuit/Wire Stack
 
 ## Status
 
-Accepted — the current Cortex vocabulary and Wire v1 architecture already assume this split and authority rule.
+Accepted — the current Cortex vocabulary and Wire architecture already assume this split and authority rule.
 
 ## Context
 
@@ -73,4 +73,4 @@ The design rule is: Wire composes registered authority, and Haskell owns what th
 - [../Architecture/03-formalism-stack.md](../Architecture/03-formalism-stack.md)
 - [../Architecture/04-graph-and-circuit.md](../Architecture/04-graph-and-circuit.md)
 - [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md)
-- [../Reference/Wire/grammar-v1.md](../Reference/Wire/grammar-v1.md)
+- [../Reference/Wire/grammar.md](../Reference/Wire/grammar.md)

--- a/docs/ADRs/0019-wire-pure-nodes.md
+++ b/docs/ADRs/0019-wire-pure-nodes.md
@@ -9,7 +9,7 @@ date: 2026-04-27
 superseded_by: null
 related:
   - docs/Architecture/05-wire-language.md
-  - docs/Reference/Wire/grammar-v1.md
+  - docs/Reference/Wire/grammar.md
   - docs/Reference/Wire/contracts-ports-and-matching.md
   - docs/ADRs/0014-executor-taxonomy-model-vs-external-call.md
   - docs/ADRs/0018-wire-executor-and-port-catalog-boundary.md
@@ -211,6 +211,6 @@ current DeepReport port extraction.
 - [ADR 0014 — Model vs External Call](./0014-executor-taxonomy-model-vs-external-call.md)
 - [ADR 0018 — Wire Executor and Port Catalog Boundary](./0018-wire-executor-and-port-catalog-boundary.md)
 - [Chapter 05 — Wire Language](../Architecture/05-wire-language.md)
-- [Wire Grammar v1](../Reference/Wire/grammar-v1.md)
+- [Wire Grammar](../Reference/Wire/grammar.md)
 - [Wire Reference — Contracts, Ports, and Matching](../Reference/Wire/contracts-ports-and-matching.md)
 - GitHub #55

--- a/docs/Architecture/01-overview.md
+++ b/docs/Architecture/01-overview.md
@@ -35,7 +35,7 @@ For Wire-specific detail:
 
 - [Chapter 05 — Wire language](05-wire-language.md) for Wire architecture and
   substrate concerns
-- [Wire Grammar v1](../Reference/Wire/grammar-v1.md) for the normative grammar
+- [Wire Grammar](../Reference/Wire/grammar.md) for the normative grammar
   and type-checking rules
 
 ## System Boundary
@@ -85,7 +85,7 @@ end:
 
 - **Authoring and typing** — Wire as the source language for authoring circuits;
   see [Chapter 05 — Wire language](05-wire-language.md) and
-  [Wire Grammar v1](../Reference/Wire/grammar-v1.md).
+  [Wire Grammar](../Reference/Wire/grammar.md).
 - **Topology and compilation** — Graph and Circuit as the formal and executable
   layers below Wire; see [Chapter 04 — Graph and Circuit](04-graph-and-circuit.md).
 - **Durable execution** — Pulse as the runtime that executes compiled circuits;

--- a/docs/Architecture/02-ownership-and-boundaries.md
+++ b/docs/Architecture/02-ownership-and-boundaries.md
@@ -75,7 +75,7 @@ layout.
 
 Cortex is not a thin provider wrapper. It owns the generic substrate end to end, grouped into three layers:
 
-- **Source language and graph layer.** Algebraic graph primitives (`Empty | Vertex | Overlay | Connect`), DAG validation, the validated executable Circuit, and the Wire source language that authors circuits. Normative Wire grammar lives at [`../Reference/Wire/grammar-v1.md`](../Reference/Wire/grammar-v1.md).
+- **Source language and graph layer.** Algebraic graph primitives (`Empty | Vertex | Overlay | Connect`), DAG validation, the validated executable Circuit, and the Wire source language that authors circuits. Normative Wire grammar lives at [`../Reference/Wire/grammar.md`](../Reference/Wire/grammar.md).
 - **Runtime and agent layer.** The Pulse runtime — durable stage execution,
   checkpointing, rewrite hydration, and frontier scheduling — ships as its own
   service. Run lifecycle and stage events sit alongside it, with generic agent

--- a/docs/Architecture/03-formalism-stack.md
+++ b/docs/Architecture/03-formalism-stack.md
@@ -164,7 +164,7 @@ mutating the alphabet.
 - [`../Reference/terminology.md`](../Reference/terminology.md) — normative vocabulary.
 - [`./01-overview.md`](./01-overview.md) — three-layer model and ownership.
 - [`./04-graph-and-circuit.md`](./04-graph-and-circuit.md) — Graph and Circuit mechanics.
-- [`./05-wire-language.md`](./05-wire-language.md) — Wire substrate; grammar at [`../Reference/Wire/grammar-v1.md`](../Reference/Wire/grammar-v1.md).
+- [`./05-wire-language.md`](./05-wire-language.md) — Wire substrate; grammar at [`../Reference/Wire/grammar.md`](../Reference/Wire/grammar.md).
 - [`./07-rewrites-and-materialization.md`](./07-rewrites-and-materialization.md) — rewrite admission mechanics.
 - [`../Publications/Paper-2-algebraic-foundations/manuscript.md`](../Publications/Paper-2-algebraic-foundations/manuscript.md) — algebraic foundations of staged durable execution.
 - [`../Publications/Paper-3-graph-substitution-semantics/manuscript.md`](../Publications/Paper-3-graph-substitution-semantics/manuscript.md) — vertex-anchored substitution semantics.

--- a/docs/Architecture/04-graph-and-circuit.md
+++ b/docs/Architecture/04-graph-and-circuit.md
@@ -162,4 +162,4 @@ and they should not use Circuit as a hiding place for product policy.
 - [./08-artifacts-and-provenance.md](./08-artifacts-and-provenance.md) — envelopes and payload kinds on edges.
 - [./02-ownership-and-boundaries.md](./02-ownership-and-boundaries.md) — Cortex ↔ host boundary.
 - [../Reference/terminology.md](../Reference/terminology.md) — normative vocabulary.
-- [../Reference/Wire/grammar-v1.md](../Reference/Wire/grammar-v1.md) — Wire v1 normative grammar.
+- [../Reference/Wire/grammar.md](../Reference/Wire/grammar.md) — Wire normative grammar.

--- a/docs/Architecture/05-wire-language.md
+++ b/docs/Architecture/05-wire-language.md
@@ -24,7 +24,7 @@ into Cortex.
 
 The normative rules live in the reference:
 
-- [Wire Grammar v1](../Reference/Wire/grammar-v1.md) — grammar, precedence,
+- [Wire Grammar](../Reference/Wire/grammar.md) — grammar, precedence,
   type surface, composition semantics
 - [Contracts, ports, and matching](../Reference/Wire/contracts-ports-and-matching.md) —
   contract namespace, port declarations, `=>` matching
@@ -218,6 +218,6 @@ Cortex still owns the source language, composition rules, and substrate runtime.
   contract, port, executor, and binding separation
 - [ADR 0019 — Wire Pure Nodes](../ADRs/0019-wire-pure-nodes.md) —
   deterministic expression nodes and same-contract labels
-- [Wire Grammar v1](../Reference/Wire/grammar-v1.md) — normative grammar
+- [Wire Grammar](../Reference/Wire/grammar.md) — normative grammar
 - [Cortex Terminology](../Reference/terminology.md) — accepted vocabulary
 - [Consumer examples](../Consumers/) — downstream binding examples

--- a/docs/Architecture/06-pulse-runtime.md
+++ b/docs/Architecture/06-pulse-runtime.md
@@ -22,8 +22,8 @@ If you are evaluating Cortex rather than implementing against Pulse directly,
 the core model and service boundary are the key sections. The later sections
 spell out the runtime mechanics in detail.
 
-Wire source examples on this page use v1 syntax. The normative grammar is
-[`../Reference/Wire/grammar-v1.md`](../Reference/Wire/grammar-v1.md); the
+Wire source examples on this page use the canonical grammar. The normative grammar is
+[`../Reference/Wire/grammar.md`](../Reference/Wire/grammar.md); the
 substrate story is [`./05-wire-language.md`](./05-wire-language.md).
 
 ## Core model

--- a/docs/Publications/Paper-4-wire-language/index.md
+++ b/docs/Publications/Paper-4-wire-language/index.md
@@ -9,7 +9,7 @@ related:
   - docs/Publications/Paper-2-algebraic-foundations/
   - docs/Publications/Paper-3-graph-substitution-semantics/
   - docs/Architecture/05-wire-language.md
-  - docs/Reference/Wire/grammar-v1.md
+  - docs/Reference/Wire/grammar.md
 ---
 
 # Paper 4 — Wire Language
@@ -36,4 +36,4 @@ This paper presents Wire, a source language for authoring typed workflow and rea
 - [../Paper-2-algebraic-foundations/](../Paper-2-algebraic-foundations/) — algebraic substrate beneath Wire.
 - [../Paper-3-graph-substitution-semantics/](../Paper-3-graph-substitution-semantics/) — substitution and materialization semantics that Wire hands off to.
 - [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) — architecture chapter.
-- [../../Reference/Wire/grammar-v1.md](../../Reference/Wire/grammar-v1.md) — current normative grammar surface.
+- [../../Reference/Wire/grammar.md](../../Reference/Wire/grammar.md) — current normative grammar surface.

--- a/docs/Publications/Paper-4-wire-language/manuscript.md
+++ b/docs/Publications/Paper-4-wire-language/manuscript.md
@@ -7,7 +7,7 @@ related:
   - docs/Publications/Paper-2-algebraic-foundations/
   - docs/Publications/Paper-3-graph-substitution-semantics/
   - docs/Architecture/05-wire-language.md
-  - docs/Reference/Wire/grammar-v1.md
+  - docs/Reference/Wire/grammar.md
 ---
 
 # Wire: Closed Alphabets, Open Composition for Typed Workflow Graphs

--- a/docs/Reference/Wire/conditionality.md
+++ b/docs/Reference/Wire/conditionality.md
@@ -7,7 +7,7 @@ sidebar:
 status: draft
 date: 2026-04-24
 related:
-  - docs/Reference/Wire/grammar-v1.md
+  - docs/Reference/Wire/grammar.md
   - docs/Reference/rewrites.md
   - docs/ADRs/0007-latent-branch-conditional-lowering.md
   - docs/Architecture/05-wire-language.md
@@ -29,7 +29,7 @@ The short version is:
 - productive arms share a common downstream boundary
 - the current Cortex runtime is a narrower binary subset of this model
 
-This page is normative about the intended language model and informative about the current implementation status. [grammar-v1.md](grammar-v1.md) carries the compact grammar and typing rules; this page expands the same conditional model semantically and explains how the current Cortex implementation realizes a narrower subset.
+This page is normative about the intended language model and informative about the current implementation status. [grammar.md](grammar.md) carries the compact grammar and typing rules; this page expands the same conditional model semantically and explains how the current Cortex implementation realizes a narrower subset.
 
 ## 1. Status and Scope
 
@@ -49,7 +49,7 @@ This page therefore does five things:
 - states the main typing, composition, and budgeting rules
 - records how the current Cortex implementation realizes a narrower subset today
 
-This page does not repeat the full EBNF for `select(...)`; that lives in [grammar-v1.md](grammar-v1.md).
+This page does not repeat the full EBNF for `select(...)`; that lives in [grammar.md](grammar.md).
 
 ## 2. Conditionality Is Exclusive-Output Reduction
 
@@ -106,7 +106,7 @@ The conditional model Wire needs is therefore:
 
 ## 4. Exclusive Outputs Are Necessary but Not Sufficient
 
-Wire v1 already has one crucial ingredient: **sum-grouped output ports**.
+Wire already has one crucial ingredient: **sum-grouped output ports**.
 
 ```wire
 node gate :
@@ -121,7 +121,7 @@ The accepted grammar already says:
 - at each evaluation, exactly one variant fires
 - the runtime carries and enforces that mutual-exclusion metadata
 
-See [§6.5 Sum-grouped output ports](grammar-v1.md#65-sum-grouped-output-ports).
+See [§6.5 Sum-grouped output ports](grammar.md#65-sum-grouped-output-ports).
 
 That means the language already knows how to say:
 
@@ -157,7 +157,7 @@ The intended reading is:
 
 This is why the operator belongs **after** the selecting graph, not around it. The left-hand graph is the thing whose output boundary is being reduced.
 
-> **Syntax status.** `select(...)` is now the accepted conditional form in [grammar-v1.md](grammar-v1.md). This page remains the fuller semantic reference for how that form should be understood.
+> **Syntax status.** `select(...)` is now the accepted conditional form in [grammar.md](grammar.md). This page remains the fuller semantic reference for how that form should be understood.
 
 ### 5.1 `select(...)` is a single expression unit
 
@@ -372,7 +372,7 @@ Bn : Vn -> T
 G select(V1: B1, ..., Vn: Bn) : I -> T
 ```
 
-This is enough for the semantic reference. [grammar-v1.md](grammar-v1.md) carries the compact formal grammar and operator precedence.
+This is enough for the semantic reference. [grammar.md](grammar.md) carries the compact formal grammar and operator precedence.
 
 ### 8.3 Shared continuation should stay outside
 
@@ -394,7 +394,7 @@ validate_plan select(
 )
 ```
 
-(The tuple form `(a, b, c, d)` overlays its elements as parallel lanes — see [grammar-v1.md §7.5](grammar-v1.md#75-tuples-of-wires) — and avoids the `<>` / `=>` precedence pitfall: `=> a <> b` parses as `(prior => a) <> b`, not as "connect to the overlay of `a` and `b`".)
+(The tuple form `(a, b, c, d)` overlays its elements as parallel lanes — see [grammar.md §7.5](grammar.md#75-tuples-of-wires) — and avoids the `<>` / `=>` precedence pitfall: `=> a <> b` parses as `(prior => a) <> b`, not as "connect to the overlay of `a` and `b`".)
 
 because the shared continuation should not be duplicated inside the branch alternatives unless it genuinely differs by branch.
 
@@ -488,7 +488,7 @@ The current Cortex implementation is a **narrower subset** of the target model a
 
 What exists today:
 
-- accepted `select(...)` syntax in the Wire v1 grammar
+- accepted `select(...)` syntax in the Wire grammar
 - parser and bridge-compiler support for postfix `select(...)`
 - n-way source `select(...)` lowered by the compiler to nested binary condition trees
 - a binary runtime model
@@ -622,7 +622,7 @@ This chapter is intended to make the target semantics and the current implementa
 
 ## Related
 
-- [grammar-v1.md](grammar-v1.md) — accepted Wire v1 grammar.
+- [grammar.md](grammar.md) — accepted Wire grammar.
 - [../rewrites.md](../rewrites.md) — runtime rewrite algebra and current `AppendAfter` realization.
 - [../../ADRs/0007-latent-branch-conditional-lowering.md](../../ADRs/0007-latent-branch-conditional-lowering.md) — accepted latent-branch architecture decision.
 - [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) — Wire substrate architecture.

--- a/docs/Reference/Wire/contracts-ports-and-matching.md
+++ b/docs/Reference/Wire/contracts-ports-and-matching.md
@@ -7,13 +7,13 @@ sidebar:
 status: draft
 date: 2026-04-24
 related:
-  - docs/Reference/Wire/grammar-v1.md
+  - docs/Reference/Wire/grammar.md
   - docs/Architecture/05-wire-language.md
 ---
 
 # Wire Reference — Contracts, Ports, and Matching
 
-> **Stub.** This page is a scoped entry point into the type-surface rules in [grammar-v1.md](grammar-v1.md). Until it is fleshed out, jump directly to the grammar sections below.
+> **Stub.** This page is a scoped entry point into the type-surface rules in [grammar.md](grammar.md). Until it is fleshed out, jump directly to the grammar sections below.
 
 > **Implementation warning.** Current compiler behavior parses `contract X;` but
 > does not use it to populate registry membership. With an explicit
@@ -22,13 +22,13 @@ related:
 
 ## Where the rules live
 
-- **[§4 Contracts](grammar-v1.md#4-contracts)** — global ambient namespace, contract equality, what contracts are not.
-- **[§6.2 Port declarations](grammar-v1.md#62-port-declarations)** — input and output port syntax, port keys `(direction, contract, label)`, label-required cases, label semantics.
-- **[§6.3 Singular vs list-valued ports](grammar-v1.md#63-singular-vs-list-valued-ports)** — arity rules.
-- **[§6.4 No output ports](grammar-v1.md#64-no-output-ports)** — zero-output nodes.
-- **[§6.5 Sum-grouped output ports](grammar-v1.md#65-sum-grouped-output-ports)** — `-> A | B` with mutual-exclusion metadata.
-- **[§7.1 The three operators](grammar-v1.md#71-the-three-operators)** — `=>` port-key matching rule.
-- **[§7.6 What is and isn't a match](grammar-v1.md#76-what-is-and-isnt-a-match)** — cross-product-with-filter consequences.
+- **[§4 Contracts](grammar.md#4-contracts)** — global ambient namespace, contract equality, what contracts are not.
+- **[§6.2 Port declarations](grammar.md#62-port-declarations)** — input and output port syntax, port keys `(direction, contract, label)`, label-required cases, label semantics.
+- **[§6.3 Singular vs list-valued ports](grammar.md#63-singular-vs-list-valued-ports)** — arity rules.
+- **[§6.4 No output ports](grammar.md#64-no-output-ports)** — zero-output nodes.
+- **[§6.5 Sum-grouped output ports](grammar.md#65-sum-grouped-output-ports)** — `-> A | B` with mutual-exclusion metadata.
+- **[§7.1 The three operators](grammar.md#71-the-three-operators)** — `=>` port-key matching rule.
+- **[§7.6 What is and isn't a match](grammar.md#76-what-is-and-isnt-a-match)** — cross-product-with-filter consequences.
 
 ## Summary of the rules
 

--- a/docs/Reference/Wire/executors-and-alphabet.md
+++ b/docs/Reference/Wire/executors-and-alphabet.md
@@ -7,7 +7,7 @@ sidebar:
 status: draft
 date: 2026-04-24
 related:
-  - docs/Reference/Wire/grammar-v1.md
+  - docs/Reference/Wire/grammar.md
   - docs/Architecture/05-wire-language.md
   - docs/ADRs/0010-wire-closed-authority-and-three-layer-stack.md
   - docs/ADRs/0014-executor-taxonomy-model-vs-external-call.md
@@ -15,27 +15,174 @@ related:
 
 # Wire Reference — Executors and the Alphabet
 
-> **Stub.** This page is a scoped entry point into the executor rules in [grammar-v1.md](grammar-v1.md). Until it is fleshed out, jump directly to the grammar sections below.
+This page defines the semantic boundary behind Wire's executor application
+form:
 
-## Where the rules live
+```wire
+@qualified.name { config }
+```
 
-- **[§5.1 Executor registration](grammar-v1.md#51-executor-registration)** — what an executor is, what each executor declares (config schema, vocabulary, structural constraints, purity class), and how the alphabet is global.
-- **[§5.2 Executor application](grammar-v1.md#52-executor-application)** — `@executor { config }` produces a partial node; schema-checking timing.
-- **[§5.3 Config merge on partial nodes](grammar-v1.md#53-config-merge-on-partial-nodes)** — how `partial // record` produces new partials for "base + delta" reuse.
-- **[§5.5 Ambient identifiers in config values](grammar-v1.md#55-ambient-identifiers-in-config-values)** — tool references and tagged-record config constructors.
+The short version: `@` is **pure staging of registered executor
+authority**. The config record is ordinary Wire data. The executor is a
+registered capability that may later perform effects, call external systems, or
+fail. Applying `@` does not run the executor; it constructs a partial node that
+can be checked, merged, pinned to ports, compiled into a graph, persisted, and
+eventually evaluated by Pulse.
 
-Executor *kinds* (model-mediated generation vs registered external call) and their backend sub-taxonomy are decided in [ADR 0014](../../ADRs/0014-executor-taxonomy-model-vs-external-call.md); this page covers the *grammar-level* surface that sits above that taxonomy.
+Executor *kinds* (model-mediated generation vs registered external call) and
+their backend sub-taxonomy are decided in
+[ADR 0014](../../ADRs/0014-executor-taxonomy-model-vs-external-call.md). This
+page covers the grammar-level and registry-boundary surface above that
+taxonomy.
 
-## Summary of the rules
+## Rule Sources
 
-- **Executors are a closed alphabet registered outside Wire.** User code cannot define new executors; it composes them.
-- **Each registered executor declares** a config schema, a contract vocabulary (or open-vocabulary for contract-polymorphic executors), structural constraints on port signatures, and a purity class.
-- **Application form is `@qualified.name { ... }`.** The leading `@` distinguishes executor references from bare identifiers; qualified names (`@llm.analyst`, `@artifact.log`, `@cortex.report_run`) resolve against the global registry.
-- **Application produces a partial node** — a staged value with no ports pinned. Partial nodes are `let`-bindable, mergeable with `//`, and pinnable via a `node` declaration.
-- **Partial-node config merge is right-biased and shallow.** `base // { k = v; }` creates a new partial with the config record merged; the executor is unchanged.
-- **Ambient identifiers inside config values** (tool references, config constructors like `topological { preset = "analyst" }`) are drawn from sibling registries. The grammar admits qualified identifiers and tagged records opaquely; the executor schema decides which are meaningful.
+- **[§5.1 Executor registration](grammar.md#51-executor-registration)** — what an executor is, what each executor declares (config schema, vocabulary, structural constraints, purity class), and how the alphabet is global.
+- **[§5.2 Executor application](grammar.md#52-executor-application)** — `@executor { config }` produces a partial node; schema-checking timing.
+- **[§5.3 Config merge on partial nodes](grammar.md#53-config-merge-on-partial-nodes)** — how `partial // record` produces new partials for "base + delta" reuse.
+- **[§5.5 Ambient identifiers in config values](grammar.md#55-ambient-identifiers-in-config-values)** — tool references and tagged-record config constructors.
 
-See the grammar for the full definitions.
+## Three Layers
+
+`@` sits at a deliberately narrow boundary between three layers:
+
+| Layer | Owned by | What it contains | What it does not do |
+|---|---|---|---|
+| Pure config data | Wire source language | Records, strings, numbers, booleans, lists, tagged config values, tool-name references | No executor call, host mutation, provider request, persistence side effect, or scheduling |
+| Registry authority | Executor/Capability registries plus consumer bindings | Executor identity, config schema, port/profile declarations, contract vocabulary, purity/effect class, host permissions | No run-state transition; it only admits or rejects staged authority |
+| Runtime evaluation | Pulse plus host interpreters | Durable node scheduling, input snapshots, executor invocation, output validation, retry/cancellation/failure recording | No new executor authority beyond what the compiled graph already materialized |
+
+This separation is the reason Wire can treat executor applications as values.
+The author can bind and transform a configured executor without performing the
+operation:
+
+```wire
+let analyst_base = @llm.analyst {
+  model = "gpt-5.2";
+  temperature = 0.2;
+  memory = topological { preset = "analyst" };
+};
+
+node analyst : <- EvidenceBundle -> AnalysisFragment | ExecutorError =
+  analyst_base // { tools = [webSearch, readArtifact]; };
+```
+
+The `topological { ... }` value is a config constructor, not an executor. The
+leading `@` is what marks a reference to the executor alphabet.
+
+## Executor Applications
+
+Executors are a closed alphabet registered outside Wire. User code cannot
+define new executors; it composes them.
+
+The application form is:
+
+```wire
+@qualified.name { field = value; }
+```
+
+It resolves `qualified.name` against the executor registry and pairs it with a
+pure config record. The result is a **partial node**:
+
+- it has an executor identity;
+- it has config data;
+- it has no authored node identity yet;
+- it may or may not have enough registry-declared port information to stand in
+  graph position;
+- it is `let`-bindable;
+- it can be shallowly, right-biased merged with `//`;
+- it becomes an ordinary node only after a `node` declaration or an admissible
+  port-determined graph use pins its boundary.
+
+`@qualified.name { config }` therefore means "stage this registered executor
+with this pure config", not "run this executor now".
+
+## Registry Admission
+
+Before a partial node may become a graph node, the registry boundary must
+establish the following facts:
+
+| Obligation | Meaning |
+|---|---|
+| Executor exists | The qualified name is present in the loaded executor alphabet. |
+| Config validates | The config record conforms to the executor's schema, including any ambient tool or tagged-constructor references. |
+| Port boundary is declared or derivable | The executor either declares fixed ports, accepts the author's `node` signature, or supplies enough structural constraints for direct graph-position use. |
+| Contracts are known | Every input/output contract is in the executor vocabulary, declared by the loaded Wire program, or admitted by an open-vocabulary executor rule. |
+| Purity/effect class is known | The registry classifies the executor as pure, impure, host-effecting, model-mediated, or another accepted effect category. |
+| Output validation is known | The runtime knows which contract schema or payload-kind check applies to each produced output. |
+| Host authority is explicit | Any external tool, model provider, artifact sink, durable mutation, or host API permission comes from the registry/binding layer, not from Wire syntax alone. |
+
+These obligations are admission facts about a staged node. They do not prove
+that the executor will terminate, succeed, or produce useful content. Runtime
+execution remains fallible.
+
+## Config Purity
+
+Config expressions are pure. They can describe prompts, memory policies,
+provider choices, numeric parameters, tool lists, and nested tagged records, but
+they cannot execute an executor.
+
+This matters for reuse:
+
+```wire
+let gatherer_base = @llm.gatherer {
+  memory = topological { preset = "evidence" };
+  tools = [webSearch];
+};
+
+node gatherer_news : <- PlannerOutput -> EvidenceBundle | ExecutorError =
+  gatherer_base // { tools = [webSearch, getAssetNews]; };
+```
+
+The merge creates a new configured partial node. It does not mutate
+`gatherer_base`, call `@llm.gatherer`, or contact any tool. Tool identifiers in
+config are ordinary names whose meaning is checked by the executor schema and
+host binding.
+
+## Runtime Evaluation
+
+Pulse evaluates materialized nodes after Wire has compiled and validated the
+graph. At that point the node carries:
+
+- a stable materialized identity;
+- an executor reference;
+- validated config;
+- a port boundary;
+- contract metadata for inputs and outputs;
+- effect/purity metadata needed by the runtime and host interpreter.
+
+The executor may still be unsafe or impure in the ordinary sense: it can call a
+model, use a tool, write an artifact, fail, time out, or return invalid output.
+The Cortex boundary is that this authority is explicit and staged before
+runtime. Pulse owns durable scheduling and lifecycle state; the registry and
+host binding own what the executor is allowed to do.
+
+## Rewrites And Materialization
+
+Runtime rewrites may transform topology, but they cannot invent executor
+authority. Any rewrite that introduces or changes an `@` application must still
+pass the same registry admission boundary:
+
+- the executor must already be registered;
+- the config must validate;
+- the new ports/contracts must be compatible with the surrounding graph;
+- the effect class and host permissions must remain explicit;
+- output validation must remain known.
+
+The Cortex theory enforces this as a rewrite-admissibility obligation
+alongside graph acyclicity: an admitted rewrite must preserve the registry
+boundary for every materialized executor node.
+
+## Summary
+
+- `@qualified.name { config }` is pure staging of registered executor
+  authority.
+- Config data is inert until Pulse evaluates a materialized node.
+- `@` produces a partial node, not a running computation.
+- Registry admission is what turns a staged executor into graph-authorable
+  authority.
+- Rewrites can change topology only inside the same registry boundary; they
+  cannot create new authority by syntax alone.
 
 ## Related
 

--- a/docs/Reference/Wire/grammar.md
+++ b/docs/Reference/Wire/grammar.md
@@ -1,8 +1,8 @@
 ---
-title: "Wire Grammar v1 Specification"
-description: "Normative specification of the Wire v1-final grammar: keywords, operators, port typing, executor alphabet, composition semantics."
+title: "Wire Grammar Specification"
+description: "Normative specification of the Wire grammar: keywords, operators, port typing, executor alphabet, composition semantics."
 sidebar:
-  label: Grammar v1
+  label: Grammar
   order: 1
 date: 2026-04-25
 status: accepted
@@ -11,7 +11,7 @@ related:
   - docs/Reference/Wire/conditionality.md
 ---
 
-# The Wire Language — Specification v1
+# The Wire Language — Specification
 
 A DSL for composing typed dataflow graphs. Three declaration forms, explicit imports, one composition algebra, strict port typing, explicit executor alphabet.
 
@@ -25,7 +25,7 @@ A Wire program is a `.wire` file that evaluates to a **wire**: a typed dataflow 
 
 The language has exactly three top-level declaration forms (`contract`, `node`, `let`), one cross-file form (`import`), two graph operators (`<>` overlay and `=>` connect), one postfix conditional form (`select(...)`, see §7.7), one record-merge operator (`//`), one concatenation operator (`++` for strings and lists), one sum-group constructor (`|` at output port positions), and one executor-application form (`@name { ... }`). The `->` token is reserved for output-port declarations in node signatures (§6.2); it is not a graph operator.
 
-Nodes are constructed by applying **executors** — named constructors from a closed alphabet registered outside Wire — to config records. Executors are the only **graph-level** extension point the grammar acknowledges. User code cannot define new executors; it composes them. Config values may also reference other registry-ambient identifiers (tool names, tagged-record constructors); those are scoped to config record positions and documented in §5.5.
+Nodes are constructed by applying **executors** — named constructors from a closed alphabet registered outside Wire — to config records. Executors are the only **graph-level** extension point the grammar acknowledges. User code cannot define new executors; it composes them. Config values may also reference other registry-ambient identifiers (tool names, tagged-record constructors); those are scoped to config record positions and documented in §5.5. The semantic boundary behind `@executor { config }` is expanded in [executors-and-alphabet.md](executors-and-alphabet.md): `@` stages registered authority with pure config data; it does not run the executor.
 
 **Labels are semantic, not cosmetic.** Ports may be labeled (`<- label: Contract`, `-> label: Contract`); a label is part of the port's identity for `=>` matching, not an annotation for humans. A labeled port connects only to an identically-labeled partner of the same contract; an unlabeled port connects only to an unlabeled partner. There is no wildcard. Author labels when you want routing control; do not label for documentation. Full rule in §6.2, matching semantics in §7.1.
 
@@ -71,7 +71,7 @@ contract   node   let   import   from   select   true   false
 
 **Records.** `{ k1 = v1; k2 = v2; }`. Fields are terminated by `;`; every field needs its terminating `;`. Empty record: `{}`.
 
-**Numbers.** Decimal integers and floats: `42`, `3.14`, `-7`. Leading `-` is part of the numeric literal, not an operator — Wire has no arithmetic in v1. No hex, octal, or scientific notation.
+**Numbers.** Decimal integers and floats: `42`, `3.14`, `-7`. Leading `-` is part of the numeric literal, not an operator — Wire has no arithmetic. No hex, octal, or scientific notation.
 
 **Booleans.** `true`, `false`.
 
@@ -100,7 +100,7 @@ Wire has two disjoint algebras of values:
 
 **Strings.** Immutable text. Concatenated with `++`.
 
-**Lists.** Ordered collections. Concatenated with `++`. Homogeneity is enforced only where a consuming executor schema or constructor signature requires it; v1 does not specify standalone ordinary-value typing beyond that. Until a list flows into a typed slot, the grammar is permissive about element types.
+**Lists.** Ordered collections. Concatenated with `++`. Homogeneity is enforced only where a consuming executor schema or constructor signature requires it; the grammar does not specify standalone ordinary-value typing beyond that. Until a list flows into a typed slot, the grammar is permissive about element types.
 
 **Numbers and booleans.** Scalar values. Used only as config values.
 
@@ -140,7 +140,7 @@ Referencing an undeclared contract name is a compile error. "Undeclared" means: 
 
 ### 4.2 Contract equality
 
-Two contracts are equal iff their names are equal. Contracts are flat — no parameters, no refinement, no subtyping in v1.
+Two contracts are equal iff their names are equal. Contracts are flat — no parameters, no refinement, no subtyping.
 
 ### 4.3 What contracts are not
 
@@ -150,7 +150,7 @@ The structural schema of a contract's values (what bytes flow through an `Eviden
 
 ### 4.4 Cost of ambient globality
 
-Contracts declared only in wire files (not anchored to any executor) have no backstop against typos: `contract EvidnceBundle;` silently becomes a different contract from `EvidenceBundle`. The moment such a contract routes through any executor-anchored path, the mismatch surfaces at pinning. For contracts that never touch an executor port, there is no static check beyond name equality. This is acceptable for v1 and will be revisited if it causes problems in practice.
+Contracts declared only in wire files (not anchored to any executor) have no backstop against typos: `contract EvidnceBundle;` silently becomes a different contract from `EvidenceBundle`. The moment such a contract routes through any executor-anchored path, the mismatch surfaces at pinning. For contracts that never touch an executor port, there is no static check beyond name equality. This is acceptable for the current grammar and will be revisited if it causes problems in practice.
 
 ---
 
@@ -166,6 +166,14 @@ An **executor** is a named constructor registered outside Wire. Each executor de
 - A **purity class** — pure or impure. This does not affect static type-checking; it is carried through to the evaluation-model spec.
 
 The alphabet is global. All executors are referenced by qualified name with a leading `@`. There is no mechanism in Wire for defining new executors; they are added by extending the registry externally.
+
+The leading `@` is the executor-authority marker. It separates registered
+executor references from ordinary config constructors such as
+`topological { preset = "analyst" }`. Applying `@` creates a staged partial
+node with pure config data; runtime effects happen only later, after the graph
+has been compiled, materialized, and scheduled by Pulse. See
+[executors-and-alphabet.md](executors-and-alphabet.md) for the registry
+admission obligations.
 
 The boundary between what the executor pins and what the author pins is a degree-of-freedom question. A fully-pinned executor (`@llm.review` with a fixed input/output signature) leaves no choices to the author. A fully-polymorphic executor (`@pure`) leaves every choice open. Most real executors sit in between.
 
@@ -193,7 +201,7 @@ tools, memory, model choice, timeout, step budget, and executor-specific fields
 are all ordinary config fields. Wire does not define a second metadata channel
 for those concerns.
 
-Schema-checking timing for partial nodes is **implementation-defined for v1**. The reference implementation checks the partial's config at pinning time — i.e., in the `node ... = <partial>` declaration — because partial-node reuse (§5.3) routinely omits fields that are filled in later by `//`. Implementations are free to perform eager type-checks on provided fields at `@` application, but must not reject a partial node for missing fields until pinning.
+Schema-checking timing for partial nodes is **implementation-defined**. The reference implementation checks the partial's config at pinning time — i.e., in the `node ... = <partial>` declaration — because partial-node reuse (§5.3) routinely omits fields that are filled in later by `//`. Implementations are free to perform eager type-checks on provided fields at `@` application, but must not reject a partial node for missing fields until pinning.
 
 ### 5.3 Config merge on partial nodes
 
@@ -230,7 +238,7 @@ Authors wanting local reasoning and predictable errors should prefer explicit `n
 
 Rewrite producers use the same surface as authored workflows: explicit `node`
 declarations plus a final graph expression. There is no separate template-use
-syntax in v1.
+syntax.
 
 ### 5.5 Ambient identifiers in config values
 
@@ -328,7 +336,7 @@ This is a **sum group** — a grammar-level construct distinct from independent 
 3. **Mutual exclusion is a grammar-level property.** At each evaluation, exactly one variant fires; the others do not produce a value. The runtime enforces this using the metadata.
 4. `=>` matches variants **individually**. An edge forms for each variant whose contract matches an input on the other side of the connect. The sum-grouping metadata survives on the outgoing edges so the runtime knows which edges are part of the same mutual-exclusion set.
 
-**Sum groups are output-position only in v1.** Input ports may not use `|`.
+**Sum groups are output-position only.** Input ports may not use `|`.
 
 Sum groups are a general feature for any mutually-exclusive output, not a special error-handling construct. The failure-variant pattern (`-> T | ExecutorError`) is the common case, but authors may use sum groups anywhere a node genuinely produces one of several alternatives per evaluation.
 
@@ -354,7 +362,7 @@ planner => gatherer => merge => review => rewriter <> merge => rewriter
 
 the second `merge` and second `rewriter` are the **same nodes** as the first occurrences. `<>` (overlay) is union on nodes and edges; shared nodes retain their identity.
 
-This matches `let` alias semantics (§9.3). There is no node-cloning construct in v1.
+This matches `let` alias semantics (§9.3). There is no node-cloning construct.
 
 ### 6.7 Node well-formedness
 
@@ -391,7 +399,7 @@ A wire has a **port-boundary**: the set of its unconnected input ports (sources)
 
 Unmatched ports on either side remain on the composed wire's boundary. Labels are the mechanism authors use to control matching explicitly; see §6.2.
 
-**No path operator.** An earlier draft included `->` as a singleton-chain specialization of `=>`. It is not part of v1: it added no expressiveness over `=>`, and the `->` glyph collides with the output-port declaration form (§6.2), creating visual ambiguity in mixed contexts. `=>` covers every connect case. See §13.
+**No path operator.** An earlier draft included `->` as a singleton-chain specialization of `=>`. It is not part of Wire: it added no expressiveness over `=>`, and the `->` glyph collides with the output-port declaration form (§6.2), creating visual ambiguity in mixed contexts. `=>` covers every connect case. See §13.
 
 ### 7.2 Precedence and associativity
 
@@ -451,7 +459,7 @@ In graph position, `(a, b, c)` is the overlay `a <> b <> c` — three independen
  ,  gatherer_beneficiaries => analyst_beneficiaries )
 ```
 
-Tuple elements are flattened under composition: `((a, b), c)` is equivalent to `(a, b, c)`. A single-element parenthesized expression `(a)` is just `a`. The single-element tuple spelling `(a,)` is not admitted in v1. The empty tuple `()` is the empty wire (§7.4). Trailing commas are permitted on two-or-more-element tuples.
+Tuple elements are flattened under composition: `((a, b), c)` is equivalent to `(a, b, c)`. A single-element parenthesized expression `(a)` is just `a`. The single-element tuple spelling `(a,)` is not admitted. The empty tuple `()` is the empty wire (§7.4). Trailing commas are permitted on two-or-more-element tuples.
 
 ### 7.6 What is and isn't a match
 
@@ -668,11 +676,12 @@ A `.wire` file type-checks iff all of the following hold:
 
 1. Every referenced contract is declared (in some executor vocabulary or in some loaded `contract` assertion).
 2. Every `@executor { config }` application references a registered executor.
-3. Every `node` declaration is well-formed per §6.7.
-4. Every port label-requirement is satisfied (no two ports on the same node share a port key).
-5. Every graph composition produces a well-formed graph under the arity rules: singular inputs receive at most one edge; list inputs receive zero or more.
-6. The file-return expression (if present) evaluates to a wire value — not a record, string, list, or partial node without resolvable ports.
-7. `//` and `++` are applied only to their permitted value kinds.
+3. Every executor config validates against the executor's registry schema.
+4. Every `node` declaration is well-formed per §6.7.
+5. Every port label-requirement is satisfied (no two ports on the same node share a port key).
+6. Every graph composition produces a well-formed graph under the arity rules: singular inputs receive at most one edge; list inputs receive zero or more.
+7. The file-return expression (if present) evaluates to a wire value — not a record, string, list, or partial node without resolvable ports.
+8. `//` and `++` are applied only to their permitted value kinds.
 
 Well-typed wires may have **open boundaries** — unconnected singular inputs are allowed and are part of the wire's importable/composable surface. An entry wire prepared for execution is a stricter category; see below.
 
@@ -798,18 +807,18 @@ let thesis =
 
 ---
 
-## 13. Out of scope for v1
+## 13. Out of scope
 
-The following are intentionally deferred. Each has a known generalization path that does not invalidate v1 code.
+The following are intentionally deferred. Each has a known generalization path that does not invalidate existing code.
 
 - **Filtered connect `=>?`** — aspect-style composition where `=>` matches only compatible ports and passes the rest through. Admissible later as an additional operator without changing existing `=>`.
 - **Refinement contracts** — `contract A :> B;` with subtyping. Deferred; flat contracts today.
 - **Universal runtime contract `Graph C`** — polymorphic runtimes that accept any graph. Deferred; runtimes today are specialized by input contract.
 - **Executor authoring in `.wire`** — extending the alphabet from within Wire. Deferred; executors are globally registered externally.
 - **First-class functions / lambdas** — user-defined parameterized wire templates. Deferred; reuse today is via partial nodes + `//`.
-- **Zero-port wires** — nodes or wires with no ports at all. Deferred; v1 requires every node to have at least one port.
+- **Zero-port wires** — nodes or wires with no ports at all. Deferred; Wire requires every node to have at least one port.
 - **Sum groups at input positions** — input ports are singular or list-valued; `|` is output-only. Admissible later.
-- **`->` as graph operator** — removed from v1. It was a singleton-chain specialization of `=>` with zero additional expressiveness and a visual collision with the `->` output-port marker. `=>` covers every connect case. If a compelling ergonomic case emerges later, reintroducing `->` is additive and non-breaking.
+- **`->` as graph operator** — removed from the canonical grammar. It was a singleton-chain specialization of `=>` with zero additional expressiveness and a visual collision with the `->` output-port marker. `=>` covers every connect case. If a compelling ergonomic case emerges later, reintroducing `->` is additive and non-breaking.
 - **Port projection and internal addressing** — `wire.node.port` reaching into wire internals. Rejected by design; violates boundary sealing.
 - **Multiple built-in type constructors** — `Result`, `Option`, `List` as type constructors. Rejected; failure is topology (via sum groups), fan-in is `[C]` at input ports.
 - **Evaluation model spec** — gas accounting, topological memory, rewrite bounds, determinism guarantees. Deferred to a sibling doc.
@@ -929,7 +938,7 @@ Notes on ambiguity:
 
 - `partial_expr` (with `@`) can appear in graph-expression or value-expression position; disambiguation is semantic.
 - `constructor_expr` (without `@`) is a plain qualified identifier followed by a record — used for config-value constructors like `topological { preset = "..." }`. It is a value-expression form only; it cannot appear in graph-expression position.
-- `paren_or_tuple` is the empty wire `()` with no contents, ordinary parenthesization with one expression, and a tuple with two or more comma-separated expressions. Single-element `(a,)` is not admissible in v1; use `a` for parenthesization or two-or-more elements for a tuple. In graph-expression position, a tuple overlays its elements; in value-expression position, tuples are not first-class and the form is invalid.
+- `paren_or_tuple` is the empty wire `()` with no contents, ordinary parenthesization with one expression, and a tuple with two or more comma-separated expressions. Single-element `(a,)` is not admitted; use `a` for parenthesization or two-or-more elements for a tuple. In graph-expression position, a tuple overlays its elements; in value-expression position, tuples are not first-class and the form is invalid.
 
 ---
 
@@ -943,8 +952,8 @@ Notes on ambiguity:
 6. **Local reasoning over global inference.** Partial-node admissibility in graph position depends only on the partial and the executor registry, not on the enclosing expression. Port-polymorphic executors require explicit `node` declarations. The grammar has no whole-expression constraint solver.
 7. **Strict where it matters, permissive where it doesn't.** Port contracts (and labels) are strictly matched. Config records are shallowly merged right-biased. Ports are unordered sets. Empty wire is identity.
 8. **Grammar-level what, runtime-level how.** The grammar specifies composition. The runtime specifies evaluation. Mutual-exclusion pruning, gas, memory, rewrite bounds, and runnability checks all live downstream of the grammar and leave it small.
-9. **Defer generalizations until pressure.** Filtered connect, refinement, universal graph contracts, lambdas, bootstrap wires — all admissible later. None required today. v1 ships the minimum that expresses the current production wires cleanly.
+9. **Defer generalizations until pressure.** Filtered connect, refinement, universal graph contracts, lambdas, bootstrap wires — all admissible later. None required today. The current grammar ships the minimum that expresses the current production wires cleanly.
 
 ---
 
-*End of specification v1.*
+*End of specification.*

--- a/docs/Reference/Wire/index.md
+++ b/docs/Reference/Wire/index.md
@@ -12,7 +12,7 @@ The Wire language reference is organized into a normative grammar specification 
 
 ## Contents
 
-- **[grammar-v1.md](grammar-v1.md)** — the normative v1 grammar specification. The authoritative document; other pages in this directory point into its sections.
+- **[grammar.md](grammar.md)** — the normative grammar specification. The authoritative document; other pages in this directory point into its sections.
 - **[modules-imports-and-file-returns.md](modules-imports-and-file-returns.md)** — module model, `import` semantics, file-return expressions, declaration-only files. Corresponds to grammar §9.
 - **[contracts-ports-and-matching.md](contracts-ports-and-matching.md)** — contract namespace, port declarations, sum groups, labels, `=>` port-key matching. Corresponds to grammar §4, §6.2–§6.5, §7.1, §7.6.
 - **[partials-and-execution-boundary.md](partials-and-execution-boundary.md)** — partial nodes in graph position, port-determined rule, evaluation-boundary check. Corresponds to grammar §5.4, §11.

--- a/docs/Reference/Wire/modules-imports-and-file-returns.md
+++ b/docs/Reference/Wire/modules-imports-and-file-returns.md
@@ -7,13 +7,13 @@ sidebar:
 status: draft
 date: 2026-04-24
 related:
-  - docs/Reference/Wire/grammar-v1.md
+  - docs/Reference/Wire/grammar.md
   - docs/Architecture/05-wire-language.md
 ---
 
 # Wire Reference — Modules, Imports, and File Returns
 
-> **Stub.** This page is a scoped entry point into the module-model rules in [grammar-v1.md](grammar-v1.md). Until it is fleshed out, jump directly to the grammar sections below.
+> **Stub.** This page is a scoped entry point into the module-model rules in [grammar.md](grammar.md). Until it is fleshed out, jump directly to the grammar sections below.
 
 > **Implementation warning.** Current compiler behavior parses `contract X;` but
 > does not use it to populate registry membership. With an explicit
@@ -22,11 +22,11 @@ related:
 
 ## Where the rules live
 
-- **[§9 Top-level forms](grammar-v1.md#9-top-level-forms)** — the whole module model: `contract`, `node`, `let`, `import`, file-return expression, wire files vs declaration-only files, closed composition with open vocabulary.
-- **[§9.4 `import`](grammar-v1.md#94-import)** — import forms, what enters local scope, `let`-aliasing pattern for node exports, ambient contract side effects.
-- **[§9.5 File-return expression](grammar-v1.md#95-file-return-expression)** — last-expression semantics, what makes a file a wire file.
-- **[§9.6 Wire files and declaration-only files](grammar-v1.md#96-wire-files-and-declaration-only-files)** — what declaration-only files contribute.
-- **[§9.7 Closed composition, open vocabulary](grammar-v1.md#97-closed-composition-open-vocabulary)** — the compilation-unit definition: program = root file + transitive imports.
+- **[§9 Top-level forms](grammar.md#9-top-level-forms)** — the whole module model: `contract`, `node`, `let`, `import`, file-return expression, wire files vs declaration-only files, closed composition with open vocabulary.
+- **[§9.4 `import`](grammar.md#94-import)** — import forms, what enters local scope, `let`-aliasing pattern for node exports, ambient contract side effects.
+- **[§9.5 File-return expression](grammar.md#95-file-return-expression)** — last-expression semantics, what makes a file a wire file.
+- **[§9.6 Wire files and declaration-only files](grammar.md#96-wire-files-and-declaration-only-files)** — what declaration-only files contribute.
+- **[§9.7 Closed composition, open vocabulary](grammar.md#97-closed-composition-open-vocabulary)** — the compilation-unit definition: program = root file + transitive imports.
 
 ## Summary of the rules
 

--- a/docs/Reference/Wire/partials-and-execution-boundary.md
+++ b/docs/Reference/Wire/partials-and-execution-boundary.md
@@ -7,7 +7,7 @@ sidebar:
 status: draft
 date: 2026-04-24
 related:
-  - docs/Reference/Wire/grammar-v1.md
+  - docs/Reference/Wire/grammar.md
   - docs/Reference/Wire/executors-and-alphabet.md
   - docs/Reference/rewrites.md
   - docs/Architecture/05-wire-language.md
@@ -15,14 +15,14 @@ related:
 
 # Wire Reference — Partials and Execution Boundary
 
-> **Stub.** This page is a scoped entry point into the partial-node and execution-boundary rules in [grammar-v1.md](grammar-v1.md). Until it is fleshed out, jump directly to the grammar sections below.
+> **Stub.** This page is a scoped entry point into the partial-node and execution-boundary rules in [grammar.md](grammar.md). Until it is fleshed out, jump directly to the grammar sections below.
 
 ## Where the rules live
 
-- **[§5.4 Partial nodes in graph position](grammar-v1.md#54-partial-nodes-in-graph-position)** — the **port-determined rule**. Whether a partial may appear in graph position depends only on the partial and the registry; no whole-expression inference.
-- **[§11 Type-checking summary](grammar-v1.md#11-type-checking-summary)** — well-formedness checks; evaluation-boundary check for runnable wires.
+- **[§5.4 Partial nodes in graph position](grammar.md#54-partial-nodes-in-graph-position)** — the **port-determined rule**. Whether a partial may appear in graph position depends only on the partial and the registry; no whole-expression inference.
+- **[§11 Type-checking summary](grammar.md#11-type-checking-summary)** — well-formedness checks; evaluation-boundary check for runnable wires.
 
-For the `//`-on-partials rule (`base // { delta }` producing a new partial), see **[§5.3 Config merge on partial nodes](grammar-v1.md#53-config-merge-on-partial-nodes)**, covered in the [Executors and the alphabet](./executors-and-alphabet.md) stub.
+For the `//`-on-partials rule (`base // { delta }` producing a new partial), see **[§5.3 Config merge on partial nodes](grammar.md#53-config-merge-on-partial-nodes)**, covered in the [Executors and the alphabet](./executors-and-alphabet.md) stub.
 
 Executor registration, application, and config-merge rules are covered separately in [Executors and the alphabet](./executors-and-alphabet.md). The rewrite algebra, admission, and materialization — the runtime-side picture — are in the [Rewrites reference](../rewrites.md); this page does not restate them.
 

--- a/docs/Reference/index.md
+++ b/docs/Reference/index.md
@@ -15,7 +15,7 @@ workflow rather than read front-to-back.
 
 - **[terminology.md](terminology.md)** — accepted Wire and Cortex terms. Canonical definitions; the source of truth for vocabulary.
 - **[Wire/](Wire/)** — Wire language reference:
-  - **[grammar-v1.md](Wire/grammar-v1.md)** — normative v1 grammar specification.
+  - **[grammar.md](Wire/grammar.md)** — normative grammar specification.
   - **[modules-imports-and-file-returns.md](Wire/modules-imports-and-file-returns.md)** — module model, import semantics, file-return rules.
   - **[contracts-ports-and-matching.md](Wire/contracts-ports-and-matching.md)** — contract namespace, port declarations, `=>` port-key matching.
   - **[partials-and-execution-boundary.md](Wire/partials-and-execution-boundary.md)** — partial nodes in graph position, port-determined rule, evaluation-boundary check.

--- a/docs/Reference/terminology.md
+++ b/docs/Reference/terminology.md
@@ -6,7 +6,7 @@ version: "v1"
 related:
   - docs/Architecture/01-overview.md
   - docs/Architecture/05-wire-language.md
-  - docs/Reference/Wire/grammar-v1.md
+  - docs/Reference/Wire/grammar.md
 ---
 
 # Cortex Terminology
@@ -27,7 +27,7 @@ Each layer owns a specific set of terms. This page groups them by layer.
 |---|---|---|
 | **Graph** | The lowest pure algebraic topology layer: vertices, edges, `Empty`, `Overlay`, `Connect`, relation construction, and DAG validation. Pure; no evaluation semantics. | `Cortex.Graph` |
 | **Circuit** | The validated executable topology. Predeclared nodes plus compatible-port edges, ready for execution. A Wire source file compiles to a Circuit. | `Cortex.Circuit` |
-| **Wire** | The source language and file format used to author Circuits. Composes registered authority (nodes and contracts) into a topology. Normative grammar: [grammar-v1.md](Wire/grammar-v1.md). | `Cortex.Wire` |
+| **Wire** | The source language and file format used to author Circuits. Composes registered authority (nodes and contracts) into a topology. Normative grammar: [grammar.md](Wire/grammar.md). | `Cortex.Wire` |
 | **Pulse** | The durable runtime that schedules and executes a compiled Circuit. Standalone service `cortex-pulse`. | `Cortex.Pulse` |
 
 ## Wire language
@@ -125,7 +125,7 @@ Terms used to classify docs in `docs/`. See [../map.md](../map.md) for how each 
 
 ## Related
 
-- [Wire/grammar-v1.md](Wire/grammar-v1.md) — normative Wire grammar.
+- [Wire/grammar.md](Wire/grammar.md) — normative Wire grammar.
 - [../Architecture/01-overview.md](../Architecture/01-overview.md) — canonical overview.
 - [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md) — Wire substrate architecture.
 - [../glossary.md](../glossary.md) — informal quick-reference.

--- a/docs/Research-notes/Wire/2026-04-23-wire-composition-sugar.md
+++ b/docs/Research-notes/Wire/2026-04-23-wire-composition-sugar.md
@@ -6,7 +6,7 @@ status: research
 related:
   - DIG-540
   - DIG-541
-  - docs/Reference/Wire/grammar-v1.md
+  - docs/Reference/Wire/grammar.md
   - docs/Architecture/05-wire-language.md
 ---
 
@@ -14,7 +14,7 @@ related:
 
 ## Context
 
-Wire v1 ships with two graph operators (`<>` overlay and `=>` connect) plus tuples, and one reuse primitive at the node level: partial nodes with `//` merge (§5.3 of the spec). Deliberately small. Deliberately Mokhov-algebraic.
+The Wire grammar ships with two graph operators (`<>` overlay and `=>` connect) plus tuples, and one reuse primitive at the node level: partial nodes with `//` merge (§5.3 of the spec). Deliberately small. Deliberately Mokhov-algebraic.
 
 Two classes of reuse are naturally expressible in v1:
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -19,7 +19,7 @@ casual lookup and orientation.
   connect, and law-bearing graph operations.
 - **Wire** — the source language for authoring executable topology. Its compiled
   circuit form is the artifact Pulse executes. Grammar:
-  [Reference/Wire/grammar-v1.md](Reference/Wire/grammar-v1.md).
+  [Reference/Wire/grammar.md](Reference/Wire/grammar.md).
 - **Pulse** — the durable runtime that executes Circuits. See
   [Architecture/06-pulse-runtime.md](Architecture/06-pulse-runtime.md).
 - **Capability** — external authority surfaces available to execution: models,

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ flowchart LR
    what belongs in Cortex versus a downstream product.
 3. **[Wire language](Architecture/05-wire-language.md)** - how source programs
    describe executable topology.
-4. **[Wire grammar v1](Reference/Wire/grammar-v1.md)** - the normative language
+4. **[Wire grammar](Reference/Wire/grammar.md)** - the normative language
    surface.
 5. **[Pulse runtime](Architecture/06-pulse-runtime.md)** - durable execution,
    events, signals, retries, and host actions.

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -48,6 +48,10 @@ A single Wire value often wears multiple hats. The roles are:
 | **Composed wire** | Result of applying a graph operator. Has a derived boundary. | `planner => gatherer => analyst` |
 | **Runtime wrapper** | A node whose role is to host a whole wire and provide runtime services. | `@cortex.report_run { title = ...; }` |
 
+The leading `@` marks the executor-authority boundary. It stages a registered
+executor with pure config data; it does not run the executor. See
+[Reference/Wire/executors-and-alphabet.md](Reference/Wire/executors-and-alphabet.md).
+
 ## Artifacts a contract can carry
 
 Every contract declares a **payload kind** that selects validation and rendering:
@@ -72,6 +76,8 @@ Cortex has a small closed set of globally-ambient namespaces:
 | **Config constructors** | Executor config schemas | `qualified.name { ... }` inside config values |
 
 Beyond these four, every name is local: introduced by `let`, `node`, or `import`.
+The executor alphabet is authority-bearing; ordinary config constructors are
+not. The syntax distinction is the leading `@`.
 
 ## Nous archetypes and patterns
 

--- a/editors/tree-sitter-wire/README.md
+++ b/editors/tree-sitter-wire/README.md
@@ -3,7 +3,7 @@
 Tree-sitter grammar for the Cortex **Wire** DSL. Checked-in examples
 and regression fixtures use `.wire` files under `test/fixtures/wire-v1/`.
 
-Source of truth for the syntax: `docs/Reference/Wire/grammar-v1.md`.
+Source of truth for the syntax: `docs/Reference/Wire/grammar.md`.
 The production parser is `src/Cortex/Wire/V1/Parser.hs`.
 
 ## What's here

--- a/editors/tree-sitter-wire/grammar.js
+++ b/editors/tree-sitter-wire/grammar.js
@@ -1,7 +1,7 @@
 /**
- * Tree-sitter grammar for the Wire v1 language.
+ * Tree-sitter grammar for the Wire language.
  *
- * Source of truth: docs/Reference/Wire/grammar-v1.md (accepted
+ * Source of truth: docs/Reference/Wire/grammar.md (accepted
  * 2026-04-23). Mirrors the Haskell parser at src/Cortex/Wire/V1.
  *
  * Top-level forms:          contract; node; let; import; and optional
@@ -271,7 +271,7 @@ module.exports = grammar({
     // ( a, b, c )       — tuple
     // ()                — empty wire / unit (handled by $.unit)
     //
-    // v1 explicitly rejects singleton trailing-comma tuples `(a,)`.
+    // the grammar rejects singleton trailing-comma tuples `(a,)`.
     paren_or_tuple: $ => seq(
       '(',
       choice(

--- a/editors/tree-sitter-wire/queries/folds.scm
+++ b/editors/tree-sitter-wire/queries/folds.scm
@@ -1,4 +1,4 @@
-;; Fold queries for Wire v1.
+;; Fold queries for Wire.
 
 (record)          @fold
 (list)            @fold

--- a/editors/tree-sitter-wire/queries/highlights.scm
+++ b/editors/tree-sitter-wire/queries/highlights.scm
@@ -1,4 +1,4 @@
-;; Tree-sitter highlight queries for Wire v1.
+;; Tree-sitter highlight queries for Wire.
 ;; Capture names follow the tree-sitter convention; editors map them to themes.
 
 ; ── Keywords ─────────────────────────────────────────────────────────────

--- a/editors/tree-sitter-wire/queries/indents.scm
+++ b/editors/tree-sitter-wire/queries/indents.scm
@@ -1,4 +1,4 @@
-;; Indent queries for Wire v1.
+;; Indent queries for Wire.
 
 (record         "{" @indent "}" @indent_end)
 (list           "[" @indent "]" @indent_end)

--- a/editors/tree-sitter-wire/test/corpus/v1.txt
+++ b/editors/tree-sitter-wire/test/corpus/v1.txt
@@ -1,5 +1,5 @@
 ==================
-v1 node with sum output and file return
+node with sum output and file return
 ==================
 
 contract EvidenceBundle;

--- a/editors/tree-sitter-wire/test/parse-fixtures.sh
+++ b/editors/tree-sitter-wire/test/parse-fixtures.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Parse every checked-in v1 fixture, then fail on any parse error.
+# Parse every checked-in Wire fixture, then fail on any parse error.
 # Invoked from CI or manually after grammar changes.
 
 set -eu

--- a/flake.lock
+++ b/flake.lock
@@ -734,11 +734,11 @@
         "tree-sitter-json": "tree-sitter-json"
       },
       "locked": {
-        "lastModified": 1777322848,
-        "narHash": "sha256-wydIbpqZNJvxv767I5JeWw+8iJyBdHeLNr1MuAjF3NM=",
+        "lastModified": 1777333278,
+        "narHash": "sha256-V9n49DPwttzdqYz1PjmjsCsSsRh7kj2ScPDw1BvgO4Q=",
         "owner": "Digimuoto",
         "repo": "repo-docs",
-        "rev": "5dcc1b2eda9e945e942a58d57d2ee24847dc4104",
+        "rev": "99581a3052f3fc09c2b835deea5b9f4494baf494",
         "type": "github"
       },
       "original": {

--- a/src/Cortex/Wire/AST.hs
+++ b/src/Cortex/Wire/AST.hs
@@ -204,7 +204,7 @@ renderWireError = \case
   WireParseError msg ->
     "Wire parse error:\n" <> msg
   WireMissingCircuit ->
-    "Wire v1 file must end in a file-return expression."
+    "Wire file must end in a file-return expression."
   WireDuplicateNodeRef nodeRef ->
     "Wire file declared node " <> unCircuitNodeRef nodeRef <> " more than once."
   WireMissingRequiredField nodeRef fieldName ->

--- a/src/Cortex/Wire/Proposal.hs
+++ b/src/Cortex/Wire/Proposal.hs
@@ -343,7 +343,7 @@ wireProposalGrammarReference =
     [ "proposal ::= (node_decl | let_decl)* final_graph_expr",
       "node_decl ::= node IDENT : port_decl* = @executor { config_fields };",
       "let_decl ::= let IDENT = expr;",
-      "final_graph_expr ::= graph_expr   # v1 file-return syntax: no trailing ';' on the final expression",
+      "final_graph_expr ::= graph_expr   # file-return syntax: no trailing ';' on the final expression",
       "graph_expr ::= node | (graph_expr) | () | graph_expr => graph_expr | graph_expr <> graph_expr | graph_expr, graph_expr",
       "hard constraints: every referenced node must be declared locally in this proposal; graph must be a DAG; proposal entries must fit the anchor outputs; proposal exits must fit every original successor; outer workflow nodes are not in proposal scope."
     ]

--- a/src/Cortex/Wire/V1/AST.hs
+++ b/src/Cortex/Wire/V1/AST.hs
@@ -3,10 +3,10 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Wire v1 abstract syntax tree.
+-- | Wire abstract syntax tree.
 --
 -- Mirrors the grammar specified in
--- @docs/Reference/Wire/grammar-v1.md@ (accepted 2026-04-23). Each
+-- @docs/Reference/Wire/grammar.md@ (accepted 2026-04-23). Each
 -- production in §14 has a corresponding constructor here.
 --
 -- Structural rules, port-key matching, and runtime admission are not

--- a/src/Cortex/Wire/V1/Compiler.hs
+++ b/src/Cortex/Wire/V1/Compiler.hs
@@ -297,7 +297,7 @@ lowerTopForm :: LoweringState -> TopForm -> Either WireCore.WireError LoweringSt
 lowerTopForm st = \case
   TopContract _ -> Right st
   TopImport _ ->
-    Left (WireCore.WireParseError "Wire v1 imports are not compiled yet in this bridge.")
+    Left (WireCore.WireParseError "Wire imports are not compiled yet in this bridge.")
   TopLet name expr -> do
     value <- evalValue st expr
     if Map.member name st.lsBindings
@@ -558,7 +558,7 @@ lowerGraphBase st = \case
   other ->
     Left
       ( WireCore.WireParseError
-          ( "Unsupported v1 graph-position expression in bridge compiler: "
+          ( "Unsupported graph-position expression in bridge compiler: "
               <> T.pack (show other)
           )
       )
@@ -1422,9 +1422,9 @@ evalValue st = \case
   ExprConnect {} ->
     Left (WireCore.WireParseError "Graph connect cannot appear in an ordinary-value position.")
   ExprSelect {} ->
-    Left (WireCore.WireParseError "select(...) is graph-position only in v1.")
+    Left (WireCore.WireParseError "select(...) is only supported in graph position.")
   ExprTuple {} ->
-    Left (WireCore.WireParseError "Tuples are graph-position only in v1.")
+    Left (WireCore.WireParseError "Tuples are only supported in graph position.")
 
 evalRecordFields ::
   LoweringState ->

--- a/src/Cortex/Wire/V1/Parser.hs
+++ b/src/Cortex/Wire/V1/Parser.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Megaparsec-based parser for Wire v1 syntax.
+-- | Megaparsec-based parser for Wire syntax.
 --
--- Mirrors the grammar in @docs/Reference/Wire/grammar-v1.md@.
+-- Mirrors the grammar in @docs/Reference/Wire/grammar.md@.
 -- Produces a 'Cortex.Wire.V1.AST.WireFile'; semantic validation
 -- (executor registration, port keys, arity, contract membership) is a
 -- later pass.
@@ -355,7 +355,7 @@ parenOrTuple = do
       case rest of
         []
           | hadTrailingComma ->
-              fail "single-element tuples are not admissible in v1"
+              fail "single-element tuples are not admitted"
           | otherwise ->
               pure first
         _ ->
@@ -472,7 +472,7 @@ nodeDecl = do
   _ <- symbol ":"
   sig <- portSignature
   when (null sig) $
-    fail "v1 requires every node to declare at least one port"
+    fail "Wire requires every node to declare at least one port"
   _ <- symbol "="
   body <- expr
   _ <- symbol ";"

--- a/theory/README.md
+++ b/theory/README.md
@@ -109,11 +109,18 @@ preservation evidence for graph acyclicity, the caller-supplied contract
 predicate, and positive budget consumption. Remaining obligations:
 
 - connect those proof-carrying certificates to the Haskell admission path;
-- instantiate the contract predicate from the registry boundary model;
+- instantiate the contract predicate from the Wire `@` registry boundary
+  model: every materialized executor node must come from a registered
+  executor reference, validated pure config, declared or derivable ports,
+  known contracts, explicit purity/effect metadata, and explicit host
+  authority;
 - lift local positive-cost consumption to a full rewrite-chain
   termination proof.
 
 This is the "sandbox by proof" story for dynamic graph rewriting.
+Rewrites may transform topology, but they cannot invent new `@` executor
+authority outside the registry boundary documented in
+`docs/Reference/Wire/executors-and-alphabet.md`.
 
 ### Track 4 — Provider / spark abstraction (TODO)
 


### PR DESCRIPTION
## Summary
Define `@qualified.name { config }` in Wire as pure staging of registered executor authority, and make `docs/Reference/Wire/grammar.md` the canonical grammar reference.

## Changes
- Expand `docs/Reference/Wire/executors-and-alphabet.md` from a stub into the main boundary reference.
- Separate pure config data, registry authority, and Pulse runtime evaluation.
- State that `@` creates a partial node, not a running computation.
- List registry admission obligations before a staged executor can become a graph node.
- Connect rewrites/materialization to the same registry boundary so rewrites cannot invent executor authority.
- Rename `docs/Reference/Wire/grammar-v1.md` to `docs/Reference/Wire/grammar.md` and remove v1 wording from the grammar title/spec surface.
- Update docs, editor grammar comments, and Wire parser/compiler messages that referenced the old grammar filename or v1 grammar naming.
- Link the boundary from the grammar spec, taxonomy, and Lean theory roadmap.
- Include the repo-docs `flake.lock` update that was already present when the branch started.

## Validation
- `just docs-check`
- `just fmt-check`
- `just test` (578 examples, 0 failures, 89 pending; DB tests pending because `PGHOST` is not set)
- `git diff --check`
- `just check-commit-provenance origin/main..HEAD`

## Issue
Closes #66
