### PR TITLE
docs: document Pulse publication boundary

### DIFF
--- a/agents/skills/doc-review-and-fix/SKILL.md
+++ b/agents/skills/doc-review-and-fix/SKILL.md
@@ -5,7 +5,7 @@ description: >
   to review-and-edit architecture/spec/research/publication/blog docs,
   repair frontmatter or staleness, improve Mermaid/math/code blocks,
   tighten claims, or make docs more concise while preserving intent.
-date: 2026-04-25
+date: 2026-04-28
 status: active
 ---
 
@@ -39,6 +39,11 @@ Unless the user explicitly asks for review-only output:
 Fix directly when intent is clear:
 
 - missing or malformed frontmatter
+- publication manuscript frontmatter gaps, including missing
+  `kind: publication`, `authors`, `date`, or `updated`
+- publication `## References` blocks that are paragraph lists instead
+  of Markdown ordered lists
+- template body metadata that duplicates frontmatter-rendered fields
 - stale status, replacement links, and obvious `related` issues
 - broken or misleading headings
 - verbosity, repetition, weak lead sentences

--- a/agents/skills/doc-review/SKILL.md
+++ b/agents/skills/doc-review/SKILL.md
@@ -6,7 +6,7 @@ description: >
   publication/blog docs, check frontmatter and staleness, assess
   Mermaid/math/code blocks, verify claims, improve compactness, or
   enforce Cortex-first canonical docs.
-date: 2026-04-25
+date: 2026-04-28
 status: active
 ---
 
@@ -111,6 +111,18 @@ Check first, report first.
 For old canonical docs, focus on alignment and cleanup before stylistic
 polish.
 
+**Publication frontmatter:**
+
+- `docs/Publications/**/manuscript.md` should declare
+  `kind: publication`, `authors`, `date`, `updated`, `status`, and
+  `related`.
+- Artifact notes under `docs/Publications/**` should at least carry
+  `title`, `description`, `date`, `status`, and `related` when they are
+  part of the publication bundle.
+- Do not duplicate rendered metadata immediately under the H1. Author,
+  status, venue, date, and update information should live in
+  frontmatter so `DocsTitle` owns the byline.
+
 ## Canonical Cortex policy
 
 Apply this aggressively in `canonical` docs.
@@ -127,6 +139,9 @@ Apply this aggressively in `canonical` docs.
   repo paths, and transient package/module layout in canonical docs
   unless the document is specifically about migration or repo
   structure.
+- Avoid internal roadmap numbering such as "Track 3" in canonical
+  publication and reference prose. Prefer stable conceptual names such
+  as "rewrite materialization" or "dynamic-rewrite semantics".
 - If a canonical doc depends on those details, treat it as a real
   content-placement issue, not a nit.
 
@@ -171,6 +186,12 @@ finding.
 - math notation, variable naming, display quality
 - code fence language tags and whether examples look plausible
 - link targets and cross-reference quality
+- publication reference blocks: `## References` should contain a
+  Markdown ordered list, italic titles, autolink URLs, and en-dash page
+  ranges where applicable
+- publication citations: use GFM footnotes (`[^name]`) when a reference
+  is tied to a specific sentence; standalone bibliographies belong
+  under `## References`
 
 Mermaid standard:
 

--- a/agents/skills/doc-review/references/writing-standards.md
+++ b/agents/skills/doc-review/references/writing-standards.md
@@ -11,7 +11,24 @@ Canonical docs should optimize for concept stability, not current repo shape.
 - frame downstream products as examples, not as the system boundary
 - prefer stable conceptual names over file paths and module names
 - keep issue IDs, PR links, commit hashes, and repo-layout trivia out of canon
+- keep internal roadmap track numbers out of publication and reference prose
 - keep prose compact and scannable
+
+## Publication Docs
+
+Publication manuscripts should let frontmatter drive the rendered page
+header.
+
+- include `kind: publication`, `authors`, `date`, `updated`, `status`,
+  and `related` in manuscript frontmatter
+- keep author, status, venue, date, and update metadata out of the body
+  immediately below the H1
+- format standalone bibliographies as `## References` plus a Markdown
+  ordered list
+- italicize reference titles, autolink URLs, and use en-dashes for page
+  ranges
+- use GFM footnotes (`[^name]`) when a citation belongs to a specific
+  sentence
 
 ## Internal Docs
 

--- a/docs/Publications/Paper-1-staged-reduction/Figures/index.md
+++ b/docs/Publications/Paper-1-staged-reduction/Figures/index.md
@@ -1,6 +1,8 @@
 ---
 title: "Paper 1 Figures"
 description: Figure inventory and source notes for Paper 1.
+date: 2026-04-28
+updated: 2026-04-28
 status: draft
 ---
 

--- a/docs/Publications/Paper-1-staged-reduction/index.md
+++ b/docs/Publications/Paper-1-staged-reduction/index.md
@@ -5,6 +5,8 @@ sidebar:
   label: Paper 1
   order: 1
 status: draft
+date: 2026-04-28
+updated: 2026-04-28
 ---
 
 # Paper 1 — Staged Reduction
@@ -15,7 +17,7 @@ Staged reduction for durable workflow execution over fixed DAG topology. The pap
 
 Draft manuscript. See [manuscript.md](manuscript.md) for the full text.
 
-The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`, including the structural recovery theorem (`persistence_safety`), frontier antichain, disjoint-key accumulation commutativity, fold permutation invariance, classification exhaustiveness, and the extensiveness, monotonicity, and idempotence closure laws. The paper stays `draft` until the remaining artifact note in [lean-mechanization.md](lean-mechanization.md) describes the Lean ↔ Haskell boundary.
+The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`, including the structural recovery theorem (`persistence_safety`), frontier antichain, disjoint-key accumulation commutativity, fold permutation invariance, classification exhaustiveness, and the extensiveness, monotonicity, and idempotence closure laws. The Lean-Haskell modeling boundary is documented in [lean-haskell-boundary.md](lean-haskell-boundary.md).
 
 ## Abstract
 
@@ -31,5 +33,6 @@ The manuscript presents a durable workflow runtime organized as a staged pure re
 
 - [manuscript.md](manuscript.md) — full manuscript.
 - [lean-mechanization.md](lean-mechanization.md) — paper-local Lean 4 plan and draft exit criteria.
+- [lean-haskell-boundary.md](lean-haskell-boundary.md) — companion note on the Lean model and Haskell runtime boundary.
 - [../../Roadmap/Plans/lean-mechanization.md](../../Roadmap/Plans/lean-mechanization.md) — program-level mechanization plan shared with Paper 2.
 - [../Paper-2-algebraic-foundations/](../Paper-2-algebraic-foundations/) — companion algebraic foundations paper.

--- a/docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md
+++ b/docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md
@@ -1,0 +1,157 @@
+---
+title: "Paper 1 — Lean-Haskell Pulse Boundary"
+description: "Companion artifact note for the Staged Reduction paper: what the Lean Pulse kernel models, what the Haskell runtime must establish, and where assumptions remain."
+date: 2026-04-28
+updated: 2026-04-28
+status: draft
+related:
+  - docs/Publications/Paper-1-staged-reduction/manuscript.md
+  - docs/Publications/Paper-1-staged-reduction/lean-mechanization.md
+  - docs/Roadmap/Plans/lean-mechanization.md
+---
+
+# Paper 1 — Lean-Haskell Pulse Boundary
+
+This note states the boundary between the fixed-topology Pulse kernel
+mechanized in Lean and the live Haskell Pulse runtime.
+It is the artifact note for the Staged Reduction manuscript's
+implementation claim.
+
+## Boundary Summary
+
+Lean proves structural safety for a finite DAG and an extensional graph
+state after recovery normalization and failure closure. The Haskell
+runtime is responsible for decoding, validating, and persisting concrete
+state; running node executors; and admitting only topology-valid node
+results. The Lean theorem begins once the runtime has supplied a
+candidate graph state and the stated persisted preconditions hold.
+
+The mechanization is intentionally structural. It does not model worker
+I/O, JSON schemas, database transactions, retry policy, signal delivery,
+or the semantic correctness of a node's payload.
+
+## Lean Kernel Model
+
+The Lean model under `theory/Cortex/Pulse/` uses these abstractions:
+
+- `DAG`: a finite node set with an edge relation whose endpoints are in
+  the node set. Reachability is the edge-path transitive closure, not a
+  free relation supplied by callers.
+- `GraphState`: total functions from nodes to statuses and optional
+  outputs. The `topologyDomain` predicate makes off-topology state
+  inert: off-topology statuses are pending and off-topology outputs are
+  absent.
+- `NodeStatus`: the eight runtime lifecycle statuses, with operational
+  payloads erased. `NodeInterrupted reason` becomes `interrupted`;
+  `NodeWaiting signal` becomes `waiting`.
+- `payload`: an abstract type. Lean tracks whether an output exists and
+  whether its status may own it; it does not inspect JSON values.
+- `NodeOutcome` and `NodeResult`: abstract worker results used for the
+  pure accumulation phase. The admissibility predicate requires the
+  target node to be in the topology and executable from the direct
+  runtime frontier.
+
+The public recovered-state structure is `WellFormedGraphState`, exposed
+through the stable `wellFormedGraphState` predicate name. Its fields are
+the proof-side version of the runtime boundary:
+
+- `topologyDomain`
+- `outputsRespectStatuses`
+- `outputsCompleteForStatuses`
+- `noRunningNodes`
+- `noInterruptedNodes`
+- `failureClosureComplete`
+- `causalHistoryClosed`
+- `frontierBridge`
+
+`frontierBridge` states that proof-level reachability readiness and the
+runtime's direct-predecessor frontier coincide. Lean proves this bridge
+from failure closure plus causal-history closure.
+
+`causalHistoryClosed` is the structure field for the standalone
+predicate `CausalHistoryClosed`; the two names denote the same
+conceptual obligation at different levels of the Lean API.
+
+## Runtime Responsibilities
+
+The Haskell runtime carries concrete identifiers, maps, JSON payloads,
+durable storage, and executor effects. To use the Lean theorem as the
+structural justification for recovery, the runtime side must establish
+or preserve the following obligations.
+
+| Runtime obligation | Lean boundary predicate |
+|---|---|
+| Build a finite acyclic topology and reject persisted status keys outside the rebuilt topology. | `DAG` well-formedness and `topologyDomain` |
+| Insert missing topology statuses as pending during reconciliation. | `topologyDomain` |
+| Normalize in-flight execution state before resumption. | `resetRunningToPending`, `noRunningNodes`, `noInterruptedNodes` |
+| Keep outputs only on payload-owning statuses. | `outputsRespectStatuses` |
+| Ensure payload-owning terminal statuses have outputs. | `outputsCompleteForStatuses` |
+| Persist only node facts produced for topology nodes admitted by the executable frontier. | `NodeResult.Admissible` preservation lemmas |
+| Preserve the causal history of successor-unblocking statuses. | `CausalHistoryClosed` |
+| Re-run failure propagation before authoritative classification. | `failureClosureComplete`, closure idempotence |
+
+Some of these are local runtime mechanisms: `initialGraphState` creates
+pending statuses for topology nodes, `reconcileGraphState` rejects
+unknown status nodes and fills missing topology statuses as pending, and
+`normalizeForResume` maps running and interrupted nodes back to
+pending. Others are end-to-end contracts on the execution path: node
+results must come from the ready frontier, persisted outputs must match
+their statuses, and persisted state must not acquire stray topology
+identifiers.
+
+## Status And Output Correspondence
+
+| Haskell status | Lean status | Boundary meaning |
+|---|---|---|
+| `NodePending` | `pending` | Waiting to run; no output. |
+| `NodeRunning` | `running` | Volatile in-flight state; reset to pending on recovery. |
+| `NodeCompleted` | `completed` | Terminal success; owns and requires an output. |
+| `NodeFailed` | `failed` | Terminal failure; owns no output and drives failure closure. |
+| `NodeSkipped` | `skipped` | Terminal non-output status; unblocks successors and contributes no input payload. |
+| `NodeInterrupted reason` | `interrupted` | Volatile interruption; the reason is operational and erased by Lean. |
+| `NodeWaiting signal` | `waiting` | Suspended on an external signal; the signal name is operational and erased by Lean. |
+| `NodeRewritten` | `rewritten` | Terminal rewrite marker; Lean treats well-formed rewritten nodes as payload-owning. Rewrite correctness itself belongs to the rewrite-materialization proof path, not the fixed-topology Paper 1 claim. |
+
+The important invariant is negative as much as positive: failed,
+skipped, pending, running, interrupted, and waiting nodes must not carry
+durable outputs in a well-formed recovered state. This is what prevents
+stale payloads from being read after a skipped or failed dependency.
+
+## Frontier And Classification Boundary
+
+The runtime computes readiness from direct predecessors. The Lean proof
+defines readiness over all strict ancestors because that is the natural
+shape for antichain and stuck-freeness arguments. These agree only under
+the recovered-state invariants:
+
+- failure closure ensures failed ancestors have propagated through
+  propagatable descendants
+- causal-history closure ensures a successor-unblocking node has
+  terminal strict ancestors
+- topology-domain validity prevents off-topology statuses from affecting
+  the runtime-style scan
+
+With those invariants, Lean proves `readyNodes_eq_directReadyNodes`.
+Classification then follows the runtime order: failure, progressing,
+completed, suspended, stuck. The theorem
+`classifyGraphState_not_stuck_of_wellFormed` states that well-formed
+states cannot reach the stuck branch after the runtime closure step.
+
+## What Remains Outside Lean
+
+The fixed-topology kernel does not prove these runtime properties:
+
+- executor I/O is deterministic or replay-equivalent
+- JSON payloads satisfy executor-specific schemas
+- database writes are atomic or ordered correctly
+- host cancellation and signal delivery are fair
+- dynamic rewrite materialization is sound
+- Haskell's concrete map representation is extensionally equal to the
+  Lean total-function model
+
+Those are separate runtime, registry, or rewrite-materialization
+obligations. Paper 1's Lean-backed claim is narrower: if the runtime
+supplies a finite topology-valid recovered state satisfying the
+persisted boundary preconditions, then normalization and failure closure
+produce a structurally well-formed state whose frontier and classifier
+are safe to use.

--- a/docs/Publications/Paper-1-staged-reduction/lean-mechanization.md
+++ b/docs/Publications/Paper-1-staged-reduction/lean-mechanization.md
@@ -1,9 +1,12 @@
 ---
 title: "Paper 1 — Lean 4 Mechanization Plan"
 description: Paper-local Lean 4 plan for discharging the fixed-topology staged-reduction obligations used by the Staged Reduction manuscript.
+date: 2026-04-28
+updated: 2026-04-28
 status: draft
 related:
   - docs/Publications/Paper-1-staged-reduction/manuscript.md
+  - docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md
   - docs/Publications/Paper-2-algebraic-foundations/
   - docs/Roadmap/Plans/lean-mechanization.md
 ---
@@ -34,7 +37,7 @@ Paper 1 should stay `draft` until all of the following exist in Lean 4:
 2. Proofs of the three closure laws for `propagateFailure`: extensiveness, monotonicity, idempotence. **Done** — `propagateFailure_extensive`, `propagateFailure_monotone`, and `propagateFailure_idempotent` are discharged in `theory/Cortex/Pulse/Closure.lean`.
 3. A machine-checked structural recovery theorem matching Proposition 1 in the manuscript. **Done** (`persistence_safety` in `theory/Cortex/Pulse/Recovery.lean`), conditional on persisted topology-domain, output-ownership, output-completeness, and causal-history preconditions.
 4. A machine-checked classification exhaustiveness theorem for normalized, closed states. **Done** (`classifyClosedGraphState_exhaustive_of_wellFormed` and `classifyGraphState_not_stuck_of_wellFormed` in `theory/Cortex/Pulse/Classify.lean`).
-5. A short artifact note explaining the modeling boundary between the Lean kernel and the live Haskell runtime. **Open**.
+5. A short artifact note explaining the modeling boundary between the Lean kernel and the live Haskell runtime. **Done** ([lean-haskell-boundary.md](lean-haskell-boundary.md)).
 
 ## What Must Be Proved
 
@@ -113,22 +116,20 @@ Build order followed by the existing artifacts:
 | Proposition 1: structural persistence safety | `persistence_safety` in `theory/Cortex/Pulse/Recovery.lean` |
 | Phase 3 classification split | `classifyClosedGraphState_exhaustive_of_wellFormed` and `classifyGraphState_not_stuck_of_wellFormed` in `theory/Cortex/Pulse/Classify.lean` |
 
-## Draft Notes for the Manuscript
+## Manuscript Notes
 
 The mechanized obligations now have direct Lean references in the manuscript body. Remaining manuscript-side guidance:
 
 - keep Proposition 1's preconditions explicit — the Lean theorem is conditional on persisted topology-domain, output-ownership, output-completeness, and causal-history invariants that the runtime must establish
-
-When the remaining work lands:
-
-- write the artifact note explaining the Lean ↔ Haskell modeling boundary (status, output, payload, and persistence assumptions) and link it from the manuscript
+- keep the Lean-Haskell modeling boundary linked from the manuscript and synchronized with the Pulse runtime contract ([lean-haskell-boundary.md](lean-haskell-boundary.md))
 
 ## Immediate Next Steps
 
-1. Draft the Lean ↔ Haskell artifact note and link it from the manuscript and landing page.
+1. Keep the boundary note synchronized when `wellFormedGraphState`, recovery normalization, or Pulse persisted-state handling changes.
 
 ## Related
 
 - [manuscript.md](manuscript.md) — Paper 1 manuscript.
 - [index.md](index.md) — paper landing page.
+- [lean-haskell-boundary.md](lean-haskell-boundary.md) — Lean-Haskell runtime boundary note.
 - [../../Roadmap/Plans/lean-mechanization.md](../../Roadmap/Plans/lean-mechanization.md) — program-level plan shared with Paper 2.

--- a/docs/Publications/Paper-1-staged-reduction/manuscript.md
+++ b/docs/Publications/Paper-1-staged-reduction/manuscript.md
@@ -1,17 +1,19 @@
 ---
 title: "Staged Reduction for Durable Workflow Execution"
 description: Draft manuscript on staged reduction, crash recovery, and structural persistence safety for durable workflow execution.
+kind: publication
 status: draft
+authors:
+  - Julius Koskela
+date: 2026-04-28
+updated: 2026-04-28
 related:
+  - docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md
   - docs/Publications/Paper-1-staged-reduction/lean-mechanization.md
   - docs/Publications/Paper-2-algebraic-foundations/
 ---
 
 # Staged Reduction for Durable Workflow Execution
-
-Julius Koskela, Digimuoto Oy
-
----
 
 ## Abstract
 
@@ -19,11 +21,9 @@ We present a durable workflow execution runtime organized as a staged pure reduc
 
 ---
 
-## Draft TODOs
+## Artifact Status
 
-The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`; see [lean-mechanization.md](lean-mechanization.md) for the artifact mapping. The manuscript remains `draft` until the following obligations also land:
-
-- add a short artifact note describing the boundary between the Lean model and the live runtime
+The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`; see [lean-mechanization.md](lean-mechanization.md) for the artifact mapping. The boundary between the Lean model and the live Haskell runtime is documented in [lean-haskell-boundary.md](lean-haskell-boundary.md).
 
 ---
 
@@ -522,18 +522,18 @@ The runtime is not claimed correct because every worker interleaving is directly
 
 ## References
 
-[1] Temporal Technologies. "Temporal." https://temporal.io
-[2] Microsoft. "Azure Durable Functions." https://learn.microsoft.com/en-us/azure/azure-functions/durable/
-[3] Carbone, P. et al. (2015). "Lightweight Asynchronous Snapshots for Distributed Dataflows." arXiv:1506.08603.
-[4] Chandy, K.M., Lamport, L. (1985). "Distributed Snapshots." ACM TOCS 3(1):63-75.
-[5] Apache Software Foundation. "Apache Airflow." https://airflow.apache.org
-[6] Dagster Labs. "Dagster." https://dagster.io
-[7] Mokhov, A. (2017). "Algebraic Graphs with Class." Haskell 2017.
-[8] Kuper, L., Newton, R. (2013). "LVars: Lattice-based Data Structures for Deterministic Parallelism." FHPC 2013.
-[9] Best, E., Devillers, R. (1987). "Sequential and Concurrent Behaviour in Petri Net Theory." TCS 55:87-136.
-[10] Shapiro, M. et al. (2011). "Conflict-free Replicated Data Types." SSS 2011.
-[11] Conway, N. et al. (2012). "Logic and Lattices for Distributed Programming." SoCC 2012.
-[12] Henrio, L. et al. (2026). "Layers of Confluence for Actors." CPP 2026.
-[13] Elnozahy, E. et al. (2002). "A Survey of Rollback-Recovery Protocols." ACM Computing Surveys 34(3):375-408.
-[14] Marlow, S. et al. (2014). "There is No Fork." ICFP 2014.
-[15] Marlow, S. et al. (2011). "A Monad for Deterministic Parallelism." Haskell 2011.
+1. Temporal Technologies. *Temporal*. <https://temporal.io>
+2. Microsoft. *Azure Durable Functions*. <https://learn.microsoft.com/en-us/azure/azure-functions/durable/>
+3. Carbone, P. et al. (2015). *Lightweight Asynchronous Snapshots for Distributed Dataflows*. arXiv:[1506.08603](https://arxiv.org/abs/1506.08603).
+4. Chandy, K. M., Lamport, L. (1985). *Distributed Snapshots*. ACM TOCS 3(1):63–75.
+5. Apache Software Foundation. *Apache Airflow*. <https://airflow.apache.org>
+6. Dagster Labs. *Dagster*. <https://dagster.io>
+7. Mokhov, A. (2017). *Algebraic Graphs with Class*. Haskell 2017.
+8. Kuper, L., Newton, R. (2013). *LVars: Lattice-based Data Structures for Deterministic Parallelism*. FHPC 2013.
+9. Best, E., Devillers, R. (1987). *Sequential and Concurrent Behaviour in Petri Net Theory*. TCS 55:87–136.
+10. Shapiro, M. et al. (2011). *Conflict-free Replicated Data Types*. SSS 2011.
+11. Conway, N. et al. (2012). *Logic and Lattices for Distributed Programming*. SoCC 2012.
+12. Henrio, L. et al. (2026). *Layers of Confluence for Actors*. CPP 2026.
+13. Elnozahy, E. et al. (2002). *A Survey of Rollback-Recovery Protocols*. ACM Computing Surveys 34(3):375–408.
+14. Marlow, S. et al. (2014). *There is No Fork*. ICFP 2014.
+15. Marlow, S. et al. (2011). *A Monad for Deterministic Parallelism*. Haskell 2011.

--- a/docs/Publications/Paper-2-algebraic-foundations/Figures/index.md
+++ b/docs/Publications/Paper-2-algebraic-foundations/Figures/index.md
@@ -1,6 +1,8 @@
 ---
 title: Paper 2 Figure Inventory
 description: Figure inventory and export status for the Algebraic Foundations paper.
+date: 2026-04-28
+updated: 2026-04-28
 status: draft
 ---
 

--- a/docs/Publications/Paper-2-algebraic-foundations/index.md
+++ b/docs/Publications/Paper-2-algebraic-foundations/index.md
@@ -5,6 +5,8 @@ sidebar:
   label: Paper 2
   order: 2
 status: draft
+date: 2026-04-28
+updated: 2026-04-28
 related:
   - docs/Publications/Paper-1-staged-reduction/
   - docs/Publications/Paper-3-graph-substitution-semantics/

--- a/docs/Publications/Paper-2-algebraic-foundations/manuscript.md
+++ b/docs/Publications/Paper-2-algebraic-foundations/manuscript.md
@@ -1,7 +1,12 @@
 ---
 title: "Paper 2: Algebraic Foundations"
 description: Algebraic foundations of staged durable execution.
+kind: publication
 status: draft
+authors:
+  - Julius Koskela
+date: 2026-04-28
+updated: 2026-04-28
 related:
   - docs/Publications/Paper-1-staged-reduction/
   - docs/Publications/Paper-3-graph-substitution-semantics/
@@ -308,3 +313,12 @@ The point of the algebraic foundations paper is not to inflate an implementation
 - structural recovery safety follows only after validity is defined explicitly
 
 Everything stronger must either be proved elsewhere, or named honestly as an assumption.
+
+## References
+
+1. Kuper, L., Newton, R. (2013). *LVars: Lattice-based Data Structures for Deterministic Parallelism*. FHPC 2013.
+2. Shapiro, M. et al. (2011). *Conflict-free Replicated Data Types*. SSS 2011.
+3. Conway, N. et al. (2012). *Logic and Lattices for Distributed Programming*. SoCC 2012.
+4. Hoare, C. A. R., Möller, B., Struth, G., Wehrman, I. (2009). *Foundations of Concurrent Kleene Algebra*. RelMiCS 2009.
+5. Valiant, L. G. (1990). *A Bridging Model for Parallel Computation*. Communications of the ACM 33(8):103–111.
+6. Henrio, L. et al. (2026). *Layers of Confluence for Actors*. CPP 2026.

--- a/docs/Publications/Paper-3-graph-substitution-semantics/Figures/index.md
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/Figures/index.md
@@ -1,6 +1,8 @@
 ---
 title: Paper 3 Figure Inventory
 description: Figure inventory and export status for the Graph Substitution Semantics paper.
+date: 2026-04-28
+updated: 2026-04-28
 status: draft
 ---
 

--- a/docs/Publications/Paper-3-graph-substitution-semantics/index.md
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/index.md
@@ -5,6 +5,8 @@ sidebar:
   label: Paper 3
   order: 3
 status: draft
+date: 2026-04-28
+updated: 2026-04-28
 related:
   - docs/Publications/Paper-2-algebraic-foundations/
   - docs/Roadmap/Plans/rewrite-materialization-and-recovery.md

--- a/docs/Publications/Paper-3-graph-substitution-semantics/manuscript.md
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/manuscript.md
@@ -1,7 +1,12 @@
 ---
 title: "Paper 3: Graph Substitution Semantics"
 description: Typed workflow compilation, vertex-anchored graph substitution, and durable materialization for dynamic workflow execution
+kind: publication
 status: draft
+authors:
+  - Julius Koskela
+date: 2026-04-28
+updated: 2026-04-28
 related:
   - docs/Publications/Paper-2-algebraic-foundations/
   - docs/Roadmap/Plans/rewrite-materialization-and-recovery.md
@@ -1053,3 +1058,11 @@ For motivating contexts such as Cortex and its downstream host applications,
 this theory offers a principled route to dynamic workflow execution without
 collapsing workflow semantics, runtime execution, and graph evolution into a
 single informal notion.
+
+## References
+
+1. Ehrig, H., Ehrig, K., Prange, U., Taentzer, G. (2006). *Fundamentals of Algebraic Graph Transformation*. Springer. <https://link.springer.com/book/10.1007/3-540-31188-2>
+2. Milner, R. (1999). *Communicating and Mobile Systems: The Pi-Calculus*. Cambridge University Press.
+3. van der Aalst, W. M. P. (1998). *The Application of Petri Nets to Workflow Management*. Journal of Circuits, Systems and Computers 8(1):21–66.
+4. Temporal Technologies. *Temporal*. <https://temporal.io>
+5. Restate. *Workflows*. <https://docs.restate.dev/tour/workflows>

--- a/docs/Publications/Paper-4-wire-language/Figures/index.md
+++ b/docs/Publications/Paper-4-wire-language/Figures/index.md
@@ -1,6 +1,8 @@
 ---
 title: "Paper 4 Figures"
 description: Figure inventory and export notes for the Wire Language paper.
+date: 2026-04-24
+updated: 2026-04-28
 status: draft
 ---
 

--- a/docs/Publications/Paper-4-wire-language/index.md
+++ b/docs/Publications/Paper-4-wire-language/index.md
@@ -5,6 +5,8 @@ sidebar:
   label: Paper 4
   order: 4
 status: draft
+date: 2026-04-24
+updated: 2026-04-28
 related:
   - docs/Publications/Paper-2-algebraic-foundations/
   - docs/Publications/Paper-3-graph-substitution-semantics/

--- a/docs/Publications/Paper-4-wire-language/manuscript.md
+++ b/docs/Publications/Paper-4-wire-language/manuscript.md
@@ -1,8 +1,12 @@
 ---
 title: "Wire: Closed Alphabets, Open Composition for Typed Workflow Graphs"
 description: Draft manuscript on Wire as an authoring language for typed workflow graphs, bounded structural proposals, and registered authority.
+kind: publication
 status: draft
+authors:
+  - Julius Koskela
 date: 2026-04-24
+updated: 2026-04-28
 related:
   - docs/Publications/Paper-2-algebraic-foundations/
   - docs/Publications/Paper-3-graph-substitution-semantics/
@@ -235,7 +239,9 @@ The next steps are clear: sharpen the contract regime carried by compiled artifa
 2. Andrey Mokhov, Neil Mitchell, Simon Peyton Jones. *Build Systems a la Carte: Theory and Practice*. 2020.
 3. Andrey Mokhov, Georgy Lukyanov, Simon Marlow, Conor McBride. *Selective Applicative Functors*. 2019.
 4. Alexandra Matache, Nicolas Wu, and Sam Staton. *Scoped Effects as Parameterized Algebraic Theories*. 2024.
-5. Prior workflow and durable execution systems such as Temporal, Durable Functions, and related orchestration runtimes.
+5. Temporal Technologies. *Temporal*. <https://temporal.io>
+6. Microsoft. *Azure Durable Functions*. <https://learn.microsoft.com/en-us/azure/azure-functions/durable/>
+7. Restate. *Workflows*. <https://docs.restate.dev/tour/workflows>
 
 ## Figures
 

--- a/docs/Templates/experiment.md
+++ b/docs/Templates/experiment.md
@@ -10,7 +10,8 @@ related:
 
 # Experiment: {Topic}
 
-**Date:** YYYY-MM-DD
+<!-- Date, scope, status, and related links live in frontmatter. -->
+
 **Type:** {smoke test | dogfood | exploratory trial | benchmark}
 
 ## Hypothesis

--- a/docs/Templates/handoff.md
+++ b/docs/Templates/handoff.md
@@ -11,8 +11,7 @@ related:
 
 # Handoff: {Topic}
 
-**Date:** YYYY-MM-DD
-**Transition:** {from} → {to}
+<!-- Date, from/to, status, and related links live in frontmatter. -->
 
 ## Context
 

--- a/docs/Templates/publication-manuscript.md
+++ b/docs/Templates/publication-manuscript.md
@@ -1,11 +1,13 @@
 ---
 title: "{Paper title}"
 description: "{One-sentence description — the abstract in one line.}"
+kind: publication
 authors:
   - "{Author Name}"
 status: draft   # draft | submitted | accepted | published
 venue: null     # when known
 date: YYYY-MM-DD
+updated: YYYY-MM-DD
 related:
   - docs/Publications/paper-N-*/
   - docs/Research-notes/...
@@ -13,9 +15,11 @@ related:
 
 # {Paper title}
 
-**Authors:** {Authors}
-**Status:** {Draft | Submitted | Accepted | Published}
-**Venue:** {Target venue or "TBD"}
+<!--
+Authors, status, venue, date, and updated metadata render from
+frontmatter through the docs page header. Use this body for the abstract
+and onward.
+-->
 
 ## Abstract
 
@@ -67,8 +71,13 @@ Summarize the contribution and its implications. Point at future work.
 
 ## References
 
+1. {Author}. *{Title}*. {Venue} ({Year}). <{URL}>
+2. ...
+
 <!--
-Bibliography.
+Use GFM footnotes (`[^name]`) when a citation is tied to a specific
+sentence. Keep standalone bibliographies as ordered lists under the
+`## References` heading.
 -->
 
 ## Figures

--- a/docs/Templates/research-memo.md
+++ b/docs/Templates/research-memo.md
@@ -11,8 +11,8 @@ related:
 
 # Research Memo: {Topic}
 
-**Date:** YYYY-MM-DD
-**Scope:** {substrate layer or consumer domain this memo addresses}
+<!-- Date, scope, status, and related links live in frontmatter. -->
+
 **Method:** {cross-source synthesis | implementation reading | external literature review | combined}
 **Confidence profile:** {high on X; medium on Y; low on Z}
 

--- a/theory/README.md
+++ b/theory/README.md
@@ -96,9 +96,11 @@ Mechanized results now include:
 - `classifyGraphState_not_stuck_of_wellFormed`: well-formed states
   cannot classify as stuck after the runtime closure step.
 
-Remaining obligations include Haskell-side establishment of the persisted
-recovery preconditions, the Lean-Haskell modeling-boundary note, and
-quotient lifting for the graph algebra laws.
+The Paper 1 Lean-Haskell modeling boundary is documented in
+`docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md`.
+Remaining obligations include Haskell-side establishment of the
+persisted recovery preconditions and quotient lifting for the graph
+algebra laws.
 
 ### Track 3 — Rewrite soundness
 


### PR DESCRIPTION
## Summary
Document the Lean fixed-topology Pulse kernel, the Haskell runtime obligations, and the correspondence boundary between them, then align the publication corpus with the repo-docs rendering conventions.

## Changes
- Added `lean-haskell-boundary.md` as the Paper 1 companion artifact note.
- Covered status/output correspondence, topology identity, persisted invariants, recovery normalization, frontier bridging, and what remains outside Lean.
- Linked the note from the Paper 1 manuscript, publication landing page, Lean mechanization mapping, and theory README.
- Normalized manuscript frontmatter for Papers 1-4 with publication kind, authors, dates, and updated dates.
- Added dates/updated dates to the Paper 1-4 landing pages, figure inventories, and Paper 1 companion notes.
- Rewrote Paper 1 references as a Markdown ordered bibliography, added ordered bibliographies for Papers 2-3, and normalized Paper 4's workflow-system references.
- Updated publication/research/handoff/experiment templates to avoid body metadata duplication.
- Updated `doc-review` and `doc-review-and-fix` guidance so future reviews catch these conventions.

## Validation
- [x] `just docs-check`
- [x] `just fmt-check`
- [x] Targeted scans for missing Paper corpus dates, old `[N]` reference entries, internal track jargon, and duplicate template metadata blocks

## Checklist
- [x] Implementation complete
- [x] Docs-only change; no runtime tests added
- [ ] Ready for review

## Issue
Closes #59
