### PR TITLE
chore: add strict lint gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
               - '!docs/**'
             docs:
               - 'docs/**'
+              - 'agents/skills/doc-review*/**'
               - 'nix/docs.nix'
+              - 'scripts/docs-lint'
             haskell:
               - 'app/**'
               - 'config/cortex/**'
@@ -68,7 +70,9 @@ jobs:
               - 'nix/**'
             theory:
               - 'theory/**'
+              - 'agents/skills/lean-code-style/**'
               - 'nix/lean.nix'
+              - 'scripts/lean-lint'
               - 'flake.lock'
               - 'flake.nix'
             editor:
@@ -156,7 +160,7 @@ jobs:
     name: Format Check
     runs-on: [self-hosted, nix, mercury, cortex]
     needs: [changes]
-    if: needs.changes.outputs.code != 'false'
+    if: needs.changes.outputs.code != 'false' || needs.changes.outputs.docs != 'false'
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -254,13 +258,30 @@ jobs:
       - name: Run HLint
         run: nix run '.#lint-haskell' --print-build-logs
 
-  lean-theory:
-    name: Lean Theory
+  lean-lint:
+    name: Lint Lean
     runs-on: [self-hosted, nix, mercury, cortex]
     needs: [changes, supported-build]
     if: |
       always() &&
       (needs.supported-build.result == 'success' || needs.supported-build.result == 'skipped') &&
+      (needs.changes.outputs.theory != 'false' || needs.changes.outputs.nix != 'false')
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Lean lint
+        run: nix run '.#lean-lint' --print-build-logs
+
+  lean-theory:
+    name: Lean Theory
+    runs-on: [self-hosted, nix, mercury, cortex]
+    needs: [changes, supported-build, lean-lint]
+    if: |
+      always() &&
+      (needs.supported-build.result == 'success' || needs.supported-build.result == 'skipped') &&
+      (needs.lean-lint.result == 'success' || needs.lean-lint.result == 'skipped') &&
       (needs.changes.outputs.theory != 'false' || needs.changes.outputs.nix != 'false')
     timeout-minutes: 20
     steps:
@@ -307,11 +328,27 @@ jobs:
       - name: Run Cortex test suite
         run: nix run '.#cortex-tests' --print-build-logs
 
-  docs-build:
-    name: Build Docs
+  docs-lint:
+    name: Lint Docs
     runs-on: [self-hosted, nix, mercury, cortex]
     needs: [changes]
     if: needs.changes.outputs.docs != 'false' || needs.changes.outputs.nix != 'false'
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run docs lint
+        run: nix run '.#docs-lint' --print-build-logs
+
+  docs-build:
+    name: Build Docs
+    runs-on: [self-hosted, nix, mercury, cortex]
+    needs: [changes, docs-lint]
+    if: |
+      always() &&
+      (needs.docs-lint.result == 'success' || needs.docs-lint.result == 'skipped') &&
+      (needs.changes.outputs.docs != 'false' || needs.changes.outputs.nix != 'false')
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -333,9 +370,11 @@ jobs:
       - format-check
       - supported-build
       - lint
+      - lean-lint
       - lean-theory
       - flake-check
       - test
+      - docs-lint
       - docs-build
     timeout-minutes: 5
     steps:
@@ -352,9 +391,11 @@ jobs:
             "${{ needs.format-check.result }}"
             "${{ needs.supported-build.result }}"
             "${{ needs.lint.result }}"
+            "${{ needs.lean-lint.result }}"
             "${{ needs.lean-theory.result }}"
             "${{ needs.flake-check.result }}"
             "${{ needs.test.result }}"
+            "${{ needs.docs-lint.result }}"
             "${{ needs.docs-build.result }}"
           )
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,7 @@
 # Contributing to Cortex
 
-Cortex is a standalone substrate repository. Contributions need to keep
-the code, docs, and commit history legally clean and mechanically
-verifiable.
+Cortex is a standalone substrate repository. Contributions need to keep the code, docs, and commit
+history legally clean and mechanically verifiable.
 
 ## Core Rules
 
@@ -14,23 +13,19 @@ verifiable.
 
 ## Issue Tracking
 
-Cortex uses GitHub Issues as its active project tracker. Use GitHub
-issues for implementation scope, bugs, roadmap slices, and follow-up
-work. Pull requests should link the issue they resolve when one exists
-(`Closes #123`) and should use GitHub review threads for review
-discussion.
+Cortex uses GitHub Issues as its active project tracker. Use GitHub issues for implementation scope,
+bugs, roadmap slices, and follow-up work. Pull requests should link the issue they resolve when one
+exists (`Closes #123`) and should use GitHub review threads for review discussion.
 
-Do not use Linear or any downstream product tracker as the source of
-truth for Cortex work. Historical docs may mention external issue IDs
-when they explain migration context, but new Cortex planning belongs in
-this repository's GitHub issue system.
+Do not use Linear or any downstream product tracker as the source of truth for Cortex work.
+Historical docs may mention external issue IDs when they explain migration context, but new Cortex
+planning belongs in this repository's GitHub issue system.
 
 ### Issue Templates
 
-`.github/ISSUE_TEMPLATE/` ships four canonical intakes: bug report,
-feature or change request, epic, and a `config.yml` that disables blank
-issues and points new contributors at the docs. Pick the template that
-matches the work; do not file ad-hoc issues outside the templates.
+`.github/ISSUE_TEMPLATE/` ships four canonical intakes: bug report, feature or change request, epic,
+and a `config.yml` that disables blank issues and points new contributors at the docs. Pick the
+template that matches the work; do not file ad-hoc issues outside the templates.
 
 ### Label Policy
 
@@ -47,26 +42,24 @@ Labels are deliberately minimal so triage stays mechanical.
   - `pulse` — Pulse runtime, execution, graph-state durability
   - `wire` — Wire language, compiler, workflow authoring
   - `memory` — memory, retrieval, topological state
-- **Triage labels** (`duplicate`, `invalid`, `wontfix`, `good first issue`,
-  `help wanted`) are GitHub defaults and may be applied as needed.
+- **Triage labels** (`duplicate`, `invalid`, `wontfix`, `good first issue`, `help wanted`) are
+  GitHub defaults and may be applied as needed.
 
-New labels need a written justification in the PR that adds them. Prefer
-splitting an issue over inventing a new label.
+New labels need a written justification in the PR that adds them. Prefer splitting an issue over
+inventing a new label.
 
 ## Authorship and Copyright
 
-Commits in this repository must be authored and committed by a human
-developer using that developer's real configured git identity.
+Commits in this repository must be authored and committed by a human developer using that
+developer's real configured git identity.
 
 Because of copyright and provenance requirements:
 
-- Do not add `Co-authored-by:` trailers for LLMs, coding agents, or AI
-  assistants.
+- Do not add `Co-authored-by:` trailers for LLMs, coding agents, or AI assistants.
 - Do not put AI tools in the author or committer fields.
 - Do not mention LLMs as legal authors of code, docs, or commits.
 
-Agents may help produce patches, but they are tooling. They are not
-authors.
+Agents may help produce patches, but they are tooling. They are not authors.
 
 ## Signed and Verified Commits
 
@@ -91,8 +84,7 @@ git verify-commit HEAD
 just check-commit-provenance origin/main..HEAD
 ```
 
-For SSH signing, configure an allowed signers file so Git can verify
-local history, for example:
+For SSH signing, configure an allowed signers file so Git can verify local history, for example:
 
 ```bash
 git config gpg.format ssh
@@ -103,60 +95,53 @@ git config commit.gpgsign true
 
 ## Git History
 
-Git history is maintained project material. It should preserve the
-semantic shape of a change, not every intermediate coordination accident.
+Git history is maintained project material. It should preserve the semantic shape of a change, not
+every intermediate coordination accident.
 
 Default policy:
 
-- Rebase ordinary feature branches before integration when that makes
-  the commit sequence easier to review, bisect, or audit.
-- Keep `main` immutable. Never force-push trunk except for an explicit,
-  lease-protected history repair approved by the maintainer.
-- Use `git push --force-with-lease` after deliberate branch rewrites.
-  Do not use raw `git push --force`.
+- Rebase ordinary feature branches before integration when that makes the commit sequence easier to
+  review, bisect, or audit.
+- Keep `main` immutable. Never force-push trunk except for an explicit, lease-protected history
+  repair approved by the maintainer.
+- Use `git push --force-with-lease` after deliberate branch rewrites. Do not use raw
+  `git push --force`.
 - CI must pass after the final rebase or rewrite.
-- Integrate PRs by fast-forwarding `main` to the exact signed branch tip.
-  Do not use GitHub's merge, squash, or rebase buttons as the Cortex
-  integration protocol.
-- Use merge commits deliberately for release branches, vendor branches,
-  backports, long-running integration branches, large collaborative
-  features, or audit cases where the parallel topology matters.
+- Integrate PRs by fast-forwarding `main` to the exact signed branch tip. Do not use GitHub's merge,
+  squash, or rebase buttons as the Cortex integration protocol.
+- Use merge commits deliberately for release branches, vendor branches, backports, long-running
+  integration branches, large collaborative features, or audit cases where the parallel topology
+  matters.
 
 Merge is not forbidden. Uncontrolled merge is the antipattern.
 
 ## PR Integration
 
-GitHub's PR buttons manufacture commit objects for merge and squash
-flows. Rebase-and-merge also rewrites commits on GitHub's side. Those
-objects do not preserve the local author, committer, signature, and
-signoff that Cortex requires for `main`.
+GitHub's PR buttons manufacture commit objects for merge and squash flows. Rebase-and-merge also
+rewrites commits on GitHub's side. Those objects do not preserve the local author, committer,
+signature, and signoff that Cortex requires for `main`.
 
-The repository therefore keeps GitHub's merge settings in a deliberately
-constrained state:
+The repository therefore keeps GitHub's merge settings in a deliberately constrained state:
 
 - merge commits disabled
 - squash merge disabled
-- rebase merge left enabled only because GitHub requires at least one
-  merge method for PRs
-- branch rules require signed commits, linear history, PR checks, and
-  rebase-only PR integration
-- branch rules grant an explicit maintainer/integration bypass so the
-  reviewed branch tip can be pushed by local fast-forward after checks
+- rebase merge left enabled only because GitHub requires at least one merge method for PRs
+- branch rules require signed commits, linear history, PR checks, and rebase-only PR integration
+- branch rules grant an explicit maintainer/integration bypass so the reviewed branch tip can be
+  pushed by local fast-forward after checks
 
-With signed commits required, the remaining GitHub rebase button should
-not be used. Integration is local fast-forward:
+With signed commits required, the remaining GitHub rebase button should not be used. Integration is
+local fast-forward:
 
 ```bash
 just integrate-pr <branch-or-pr-number>
 ```
 
-The helper verifies the commits introduced by the branch, checks that
-the branch is a fast-forward from `main`, merges with `--ff-only`, and
-pushes `main`.
+The helper verifies the commits introduced by the branch, checks that the branch is a fast-forward
+from `main`, merges with `--ff-only`, and pushes `main`.
 
-That bypass is only for this integration path or an explicit
-lease-protected history repair. It is not permission to bypass CI,
-signature checks, signoff checks, or review.
+That bypass is only for this integration path or an explicit lease-protected history repair. It is
+not permission to bypass CI, signature checks, signoff checks, or review.
 
 Hard checks:
 
@@ -165,11 +150,10 @@ just check-commit-provenance origin/main..HEAD
 just check-github-merge-policy
 ```
 
-`check-commit-provenance` rejects GitHub/web-flow identities,
-non-Digimuoto author or committer emails, missing matching
-`Signed-off-by` trailers, unverifiable signatures, and merge commits.
-`check-github-merge-policy` rejects repository settings or branch rules
-that would re-enable GitHub-manufactured merge or squash commits.
+`check-commit-provenance` rejects GitHub/web-flow identities, non-Digimuoto author or committer
+emails, missing matching `Signed-off-by` trailers, unverifiable signatures, and merge commits.
+`check-github-merge-policy` rejects repository settings or branch rules that would re-enable
+GitHub-manufactured merge or squash commits.
 
 ## Build and Check Workflow
 
@@ -187,8 +171,7 @@ just lean-check
 just ci-check
 ```
 
-If you change Cabal inputs that affect the Haskell plan, regenerate the
-materialized Nix plan:
+If you change Cabal inputs that affect the Haskell plan, regenerate the materialized Nix plan:
 
 ```bash
 just update-materialized
@@ -199,8 +182,8 @@ just update-materialized
 Repo-local agent workflows live under `agents/`. If you use an agent:
 
 - follow `agents/context.md` and `agents/README.md`
-- regenerate provider symlinks with `just agent-link-codex` or
-  `just agent-link-claude`; generated provider symlinks are gitignored
+- regenerate provider symlinks with `just agent-link-codex` or `just agent-link-claude`; generated
+  provider symlinks are gitignored
 - preserve human authorship on commits
 - preserve signed, verifiable history
 - do not add AI attribution to commit messages or trailers

--- a/README.md
+++ b/README.md
@@ -11,27 +11,25 @@
 
 # Cortex
 
-Cortex is a standalone AI substrate: a typed topology layer, a source language
-for composing that topology, and a durable runtime for executing it.
+Cortex is a standalone AI substrate: a typed topology layer, a source language for composing that
+topology, and a durable runtime for executing it.
 
 The core layers are:
 
-| Layer | Role |
-|---|---|
-| **Graph** | Pure topology: vertices, overlay, connect, and graph laws. |
-| **Circuit** | Validated executable topology with typed port compatibility. |
-| **Wire** | Source language and rewrite notation for authoring circuits. |
-| **Pulse** | Durable execution, checkpoints, events, memory, and rewrites. |
+| Layer       | Role                                                          |
+| ----------- | ------------------------------------------------------------- |
+| **Graph**   | Pure topology: vertices, overlay, connect, and graph laws.    |
+| **Circuit** | Validated executable topology with typed port compatibility.  |
+| **Wire**    | Source language and rewrite notation for authoring circuits.  |
+| **Pulse**   | Durable execution, checkpoints, events, memory, and rewrites. |
 
-Downstream products bind Cortex to their own domain semantics, tools, product
-policy, operators, transport, and persistence. Cortex owns the reusable
-substrate.
+Downstream products bind Cortex to their own domain semantics, tools, product policy, operators,
+transport, and persistence. Cortex owns the reusable substrate.
 
 ## Minimal Wire
 
-Wire composes registered authority. Executors, contracts, tools, and payload
-meaning are registered outside the language; Wire describes how those typed
-pieces connect.
+Wire composes registered authority. Executors, contracts, tools, and payload meaning are registered
+outside the language; Wire describes how those typed pieces connect.
 
 ```wire
 contract Plan;
@@ -47,16 +45,16 @@ plan => gather => write
 
 ## Documentation
 
-- [Docs landing](https://digimuoto.github.io/cortex/) - architecture,
-  reference, ADRs, roadmap, and consumer bindings.
-- [Stable canon](https://digimuoto.github.io/cortex/#stable-canon) -
-  architecture, reference, ADRs, and canonical docs.
-- [Working artifacts](https://digimuoto.github.io/cortex/#working-artifacts) -
-  roadmap, research notes, experiments, handoffs, and templates.
-- [Start here](https://digimuoto.github.io/cortex/#start-here) - the intended
-  first reading path through the published docs.
-- [Consumer examples](https://digimuoto.github.io/cortex/#consumer-examples) -
-  downstream binding examples.
+- [Docs landing](https://digimuoto.github.io/cortex/) - architecture, reference, ADRs, roadmap, and
+  consumer bindings.
+- [Stable canon](https://digimuoto.github.io/cortex/#stable-canon) - architecture, reference, ADRs,
+  and canonical docs.
+- [Working artifacts](https://digimuoto.github.io/cortex/#working-artifacts) - roadmap, research
+  notes, experiments, handoffs, and templates.
+- [Start here](https://digimuoto.github.io/cortex/#start-here) - the intended first reading path
+  through the published docs.
+- [Consumer examples](https://digimuoto.github.io/cortex/#consumer-examples) - downstream binding
+  examples.
 
 ## Repository
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,9 +1,8 @@
 # Cortex agent context
 
-Provider-neutral context and slash-command skills for AI coding agents
-working on this repo. Provider-specific files such as `CLAUDE.md` and
-`AGENTS.md` are generated, gitignored symlinks; do not edit them
-directly.
+Provider-neutral context and slash-command skills for AI coding agents working on this repo.
+Provider-specific files such as `CLAUDE.md` and `AGENTS.md` are generated, gitignored symlinks; do
+not edit them directly.
 
 ```
 agents/
@@ -31,14 +30,12 @@ agents/
     └── doc-review-and-fix/     # Review and edit docs in one pass
 ```
 
-Each skill lives in its own directory with a `SKILL.md` entrypoint. Each
-source-tree context file mirrors the repo path it governs under
-`agents/<repo-path>/context.md`.
+Each skill lives in its own directory with a `SKILL.md` entrypoint. Each source-tree context file
+mirrors the repo path it governs under `agents/<repo-path>/context.md`.
 
-Shared archetype profiles live under `agents/archetypes/`. Skills load
-these profiles as reusable reasoning lenses, for example `kritikos` for
-adversarial review or `themis` for contract audit. Archetypes do not
-grant tool authority and do not replace skill workflows.
+Shared archetype profiles live under `agents/archetypes/`. Skills load these profiles as reusable
+reasoning lenses, for example `kritikos` for adversarial review or `themis` for contract audit.
+Archetypes do not grant tool authority and do not replace skill workflows.
 
 ## Provider links
 
@@ -71,13 +68,12 @@ just agent-link-opencode
 - `agents/archetypes` -> `.opencode/archetypes`
 - `agents/skills/<name>` -> `.opencode/skills/<name>`
 
-Gemini-specific files are intentionally not generated. Add a provider
-only when the repo has a maintained setup command for it.
+Gemini-specific files are intentionally not generated. Add a provider only when the repo has a
+maintained setup command for it.
 
 ## Commit Policy For Agents
 
-Agent tooling may help produce patches, but it must not appear in commit
-authorship metadata.
+Agent tooling may help produce patches, but it must not appear in commit authorship metadata.
 
 - Do not author commits as an LLM or coding agent.
 - Do not add `Co-authored-by:` trailers for AI tools.
@@ -85,32 +81,29 @@ authorship metadata.
 - All commits created from agent workflows must use `git commit -s -S`.
 - All commits must verify locally before publish.
 
-Human authorship and verifiable signatures are mandatory repository
-policy, not optional workflow preferences.
+Human authorship and verifiable signatures are mandatory repository policy, not optional workflow
+preferences.
 
 ## History Policy For Agents
 
-Treat Git history as a maintained artifact. Rebase-first development is
-the default for ordinary feature work: private feature branches may be
-rebased, squashed, fixed up, or reordered so the branch reads as a
-semantic sequence of changes.
+Treat Git history as a maintained artifact. Rebase-first development is the default for ordinary
+feature work: private feature branches may be rebased, squashed, fixed up, or reordered so the
+branch reads as a semantic sequence of changes.
 
 - Never force-push `main`.
 - Never use raw `git push --force`.
-- Use `git push --force-with-lease` only when history was deliberately
-  rewritten and the remote still points where you expect.
+- Use `git push --force-with-lease` only when history was deliberately rewritten and the remote
+  still points where you expect.
 - Make CI pass after the final rebase.
 - Integrate by fast-forwarding `main` to the exact signed branch tip.
-- Do not use GitHub's merge, squash, or rebase buttons for Cortex
-  `main`; use `just integrate-pr <branch-or-pr-number>` after PR
-  review and CI.
-- Use merge commits only when the existence of parallel development
-  lines is itself meaningful.
+- Do not use GitHub's merge, squash, or rebase buttons for Cortex `main`; use
+  `just integrate-pr <branch-or-pr-number>` after PR review and CI.
+- Use merge commits only when the existence of parallel development lines is itself meaningful.
 
 ## Scope
 
-Cortex is a durable runtime substrate plus a structured reasoning
-library on top (per ADR 0015). Skills here assume that substrate scope:
+Cortex is a durable runtime substrate plus a structured reasoning library on top (per ADR 0015).
+Skills here assume that substrate scope:
 
 - No downstream product or domain-specific knowledge.
 - No database migrations, web-UI, or deployment workflows.
@@ -118,24 +111,19 @@ library on top (per ADR 0015). Skills here assume that substrate scope:
 - Build commands go through `just` → `nix`; no direct `cabal` or `ghc`.
 - Repo-level docs live flat under `docs/`, not `docs/cortex/`.
 
-Skills that deal in downstream product workflows (external issue
-trackers, deployment, product soak, domain-specific tests) are
-deliberately absent. Downstream products keep their own fuller
-`agents/` trees.
+Skills that deal in downstream product workflows (external issue trackers, deployment, product soak,
+domain-specific tests) are deliberately absent. Downstream products keep their own fuller `agents/`
+trees.
 
 ## Adding a skill
 
-1. Create `agents/skills/<name>/SKILL.md` with YAML frontmatter
-   (`name`, `description`).
+1. Create `agents/skills/<name>/SKILL.md` with YAML frontmatter (`name`, `description`).
 2. Supporting references go under `agents/skills/<name>/references/`.
 3. Run the provider link command for the runtime that should expose it.
 
 ## Adding an archetype
 
-1. Create `agents/archetypes/<name>.md` with YAML frontmatter
-   (`name`, `description`).
-2. Keep the profile provider-neutral: role, stance, questions, output,
-   and failure modes.
-3. Reference it from skills by repo-root path, such as
-   `agents/archetypes/<name>.md`.
+1. Create `agents/archetypes/<name>.md` with YAML frontmatter (`name`, `description`).
+2. Keep the profile provider-neutral: role, stance, questions, output, and failure modes.
+3. Reference it from skills by repo-root path, such as `agents/archetypes/<name>.md`.
 4. Run the provider link command for the runtime that should expose it.

--- a/agents/archetypes/README.md
+++ b/agents/archetypes/README.md
@@ -1,19 +1,17 @@
 # Cortex Agent Archetypes
 
-Shared archetype profiles live here so skills can compose the same
-reasoning lenses without copying prompt text. They are provider-neutral:
-each file defines a point of view, the questions it asks, the output it
-should return, and the mistakes it should avoid.
+Shared archetype profiles live here so skills can compose the same reasoning lenses without copying
+prompt text. They are provider-neutral: each file defines a point of view, the questions it asks,
+the output it should return, and the mistakes it should avoid.
 
-Archetypes are not agents, roles, tools, or permission grants. A skill
-remains the orchestrator: it owns scope, workflow, validation, file
-ownership, and final priority ordering.
+Archetypes are not agents, roles, tools, or permission grants. A skill remains the orchestrator: it
+owns scope, workflow, validation, file ownership, and final priority ordering.
 
 Skills should load archetypes by repo-root path, for example:
 
 ```markdown
-Load `agents/archetypes/kritikos.md` for the adversarial pass.
-Load `agents/archetypes/themis.md` for the contract-audit pass.
+Load `agents/archetypes/kritikos.md` for the adversarial pass. Load `agents/archetypes/themis.md`
+for the contract-audit pass.
 ```
 
 Use archetypes as distinct lenses:
@@ -26,5 +24,5 @@ Use archetypes as distinct lenses:
 - `techne.md` turns conclusions into repairable artifacts.
 - `themis.md` audits contracts, constraints, and invariants.
 
-When multiple archetypes are used, keep their outputs compact. The value
-is the change of viewpoint, not seven long reports.
+When multiple archetypes are used, keep their outputs compact. The value is the change of viewpoint,
+not seven long reports.

--- a/agents/archetypes/episteme.md
+++ b/agents/archetypes/episteme.md
@@ -6,9 +6,8 @@ description: >
 
 # Episteme
 
-`Episteme` asks what we know and why. Use it when a claim depends on
-runtime behavior, documentation, tests, prior decisions, external
-sources, or empirical evidence.
+`Episteme` asks what we know and why. Use it when a claim depends on runtime behavior,
+documentation, tests, prior decisions, external sources, or empirical evidence.
 
 ## Stance
 
@@ -28,13 +27,12 @@ sources, or empirical evidence.
 
 ## Output
 
-Return an evidence brief: sources read, facts established, inferences,
-unverified assumptions, and evidence gaps.
+Return an evidence brief: sources read, facts established, inferences, unverified assumptions, and
+evidence gaps.
 
 ## Failure Modes
 
 - Treating plausible memory as evidence.
 - Citing secondary summaries when local source exists.
-- Confusing implementation behavior, documentation intent, and formal
-  model.
+- Confusing implementation behavior, documentation intent, and formal model.
 - Overstating confidence from a narrow or stale check.

--- a/agents/archetypes/kritikos.md
+++ b/agents/archetypes/kritikos.md
@@ -6,17 +6,15 @@ description: >
 
 # Kritikos
 
-`Kritikos` asks how the claim breaks. Use it to look for the smallest
-counterexample, corrupted input, edge case, or adversarial state that
-satisfies the stated assumptions while violating the intended claim.
+`Kritikos` asks how the claim breaks. Use it to look for the smallest counterexample, corrupted
+input, edge case, or adversarial state that satisfies the stated assumptions while violating the
+intended claim.
 
 ## Stance
 
 - Search for the smallest counterexample.
-- Try empty, singleton, off-domain, stale, duplicated, cyclic, and
-  inconsistent cases.
-- Treat unconstrained relations, maps, predicates, and payloads as live
-  attack surfaces.
+- Try empty, singleton, off-domain, stale, duplicated, cyclic, and inconsistent cases.
+- Treat unconstrained relations, maps, predicates, and payloads as live attack surfaces.
 - Prefer a concrete witness over a general worry.
 
 ## Questions
@@ -29,9 +27,8 @@ satisfies the stated assumptions while violating the intended claim.
 
 ## Output
 
-Return an adversarial brief: target claim, minimal witness, why the
-hypotheses admit it, intended property violated, severity, and repair
-direction.
+Return an adversarial brief: target claim, minimal witness, why the hypotheses admit it, intended
+property violated, severity, and repair direction.
 
 ## Failure Modes
 

--- a/agents/archetypes/logos.md
+++ b/agents/archetypes/logos.md
@@ -1,15 +1,13 @@
 ---
 name: logos
 description: >
-  Claim mapping, formal structure, argument boundaries, and explicit
-  reasoning.
+  Claim mapping, formal structure, argument boundaries, and explicit reasoning.
 ---
 
 # Logos
 
-`Logos` asks what is actually being claimed. Use it to turn prose,
-theorems, designs, or review comments into explicit claims, premises,
-definitions, quantifiers, and conclusions.
+`Logos` asks what is actually being claimed. Use it to turn prose, theorems, designs, or review
+comments into explicit claims, premises, definitions, quantifiers, and conclusions.
 
 ## Stance
 
@@ -28,8 +26,8 @@ definitions, quantifiers, and conclusions.
 
 ## Output
 
-Return a compact argument map: claim, formal objects, premises,
-inference path, missing side conditions, and any sharper statement.
+Return a compact argument map: claim, formal objects, premises, inference path, missing side
+conditions, and any sharper statement.
 
 ## Failure Modes
 

--- a/agents/archetypes/poiesis.md
+++ b/agents/archetypes/poiesis.md
@@ -1,37 +1,33 @@
 ---
 name: poiesis
 description: >
-  Alternative framings, generative options, naming, and design space
-  exploration.
+  Alternative framings, generative options, naming, and design space exploration.
 ---
 
 # Poiesis
 
-`Poiesis` asks what else this could become. Use it to generate distinct
-encodings, decompositions, names, designs, narratives, or workflows
-before the orchestrating skill chooses.
+`Poiesis` asks what else this could become. Use it to generate distinct encodings, decompositions,
+names, designs, narratives, or workflows before the orchestrating skill chooses.
 
 ## Stance
 
 - Produce meaningfully different options, not wording variants.
 - Make each option concrete enough to evaluate.
-- Explore type-level, predicate-level, process-level, and boundary-level
-  alternatives.
+- Explore type-level, predicate-level, process-level, and boundary-level alternatives.
 - Leave final judgment to synthesis unless asked to choose.
 - Prefer options that evidence, critique, and audit can later test.
 
 ## Questions
 
 - What other framing would expose a hidden path?
-- Could the invariant live in a type, constructor, predicate, theorem,
-  workflow, or policy boundary?
+- Could the invariant live in a type, constructor, predicate, theorem, workflow, or policy boundary?
 - What naming or module split would make the idea easier to use?
 - Which option changes proof burden, user ergonomics, or maintenance?
 
 ## Output
 
-Return an option set: alternatives, trade-offs, compatibility, proof or
-implementation impact, and open questions.
+Return an option set: alternatives, trade-offs, compatibility, proof or implementation impact, and
+open questions.
 
 ## Failure Modes
 

--- a/agents/archetypes/sophia.md
+++ b/agents/archetypes/sophia.md
@@ -6,8 +6,8 @@ description: >
 
 # Sophia
 
-`Sophia` asks what matters most now. Use it to synthesize other lenses,
-weigh risks and trade-offs, decide readiness, and choose a next action.
+`Sophia` asks what matters most now. Use it to synthesize other lenses, weigh risks and trade-offs,
+decide readiness, and choose a next action.
 
 ## Stance
 
@@ -27,13 +27,12 @@ weigh risks and trade-offs, decide readiness, and choose a next action.
 
 ## Output
 
-Return a decision summary: overall judgment, top priorities, readiness
-recommendation, residual risks, and next owner or pass.
+Return a decision summary: overall judgment, top priorities, readiness recommendation, residual
+risks, and next owner or pass.
 
 ## Failure Modes
 
 - Averaging incompatible findings into a bland summary.
 - Treating every issue as equal priority.
 - Ignoring practical implementation cost.
-- Letting style preferences obscure soundness, evidence, or contract
-  failures.
+- Letting style preferences obscure soundness, evidence, or contract failures.

--- a/agents/archetypes/techne.md
+++ b/agents/archetypes/techne.md
@@ -6,9 +6,8 @@ description: >
 
 # Techne
 
-`Techne` asks what concrete change would work. Use it when analysis must
-become a patch, proof repair, test, refactor, operational plan, or
-maintainable artifact.
+`Techne` asks what concrete change would work. Use it when analysis must become a patch, proof
+repair, test, refactor, operational plan, or maintainable artifact.
 
 ## Stance
 
@@ -28,8 +27,7 @@ maintainable artifact.
 
 ## Output
 
-Return an implementation brief: files, concrete edits, validation,
-risks, and material follow-up.
+Return an implementation brief: files, concrete edits, validation, risks, and material follow-up.
 
 ## Failure Modes
 

--- a/agents/archetypes/themis.md
+++ b/agents/archetypes/themis.md
@@ -6,9 +6,9 @@ description: >
 
 # Themis
 
-`Themis` asks whether the declared rules are represented and enforced.
-Use it for validity predicates, invariants, permissions, policy,
-auditability, process requirements, and recovery or preservation claims.
+`Themis` asks whether the declared rules are represented and enforced. Use it for validity
+predicates, invariants, permissions, policy, auditability, process requirements, and recovery or
+preservation claims.
 
 ## Stance
 
@@ -28,8 +28,8 @@ auditability, process requirements, and recovery or preservation claims.
 
 ## Output
 
-Return a contract audit: obligations, formal coverage, preservation or
-establishment evidence, missing rules, process gaps, and required fixes.
+Return a contract audit: obligations, formal coverage, preservation or establishment evidence,
+missing rules, process gaps, and required fixes.
 
 ## Failure Modes
 

--- a/agents/context.md
+++ b/agents/context.md
@@ -1,38 +1,32 @@
 # Cortex Agent Context
 
-This is the provider-neutral agent handbook for Cortex. Provider files
-such as `CLAUDE.md` and `AGENTS.md` are generated symlinks; edit this
-file instead.
+This is the provider-neutral agent handbook for Cortex. Provider files such as `CLAUDE.md` and
+`AGENTS.md` are generated symlinks; edit this file instead.
 
-Cortex is a standalone substrate: a durable runtime plus a
-structured-reasoning library above it (see ADR 0015). The runtime is the
-canonical public surface. `Cortex.Nous` is a library on top of the
-substrate and depends on it, not the other way round.
+Cortex is a standalone substrate: a durable runtime plus a structured-reasoning library above it
+(see ADR 0015). The runtime is the canonical public surface. `Cortex.Nous` is a library on top of
+the substrate and depends on it, not the other way round.
 
 ## Repository Shape
 
-- `src/Cortex/` - main Haskell library. Canonical substrate roots are
-  `Cortex.Graph`, `Cortex.Circuit`, `Cortex.Wire`, `Cortex.Pulse`,
-  `Cortex.Memory`, `Cortex.Capability`, `Cortex.Document`, and
-  `Cortex.Event`. Implementation-era roots such as `Cortex.Task`,
-  `Cortex.Provider`, `Cortex.Research`, and `Cortex.Run` remain only as
-  migration surfaces until the Nous follow-up lands.
-- `src-platform/Platform/` - runtime substrate library Cortex depends
-  on: `Platform.Observability`, `Platform.DurableTask`,
-  `Platform.Database`, `Platform.HTTP.Retry`, `Platform.Text`, etc.
-  Exposed as a public Cabal sub-library (`cortex:platform-runtime`).
-- `app/cortex-pulse/` - substrate shell executable. Ships with an empty
-  task registry; consumers link their own registry when binding.
-- `editors/tree-sitter-wire/` - Wire DSL grammar. Consumed by the docs
-  site for `wire` blocks and by editor integrations.
-- `theory/` - Lean 4 mechanization of substrate guarantees: Mokhov
-  graph laws, Pulse frontier safety, Wire rewrite soundness. Builds
-  through `just lean-build`.
-- `docs/` - canonical Cortex docs. Flat layout, no `/cortex/` prefix.
-  Keep product docs out.
+- `src/Cortex/` - main Haskell library. Canonical substrate roots are `Cortex.Graph`,
+  `Cortex.Circuit`, `Cortex.Wire`, `Cortex.Pulse`, `Cortex.Memory`, `Cortex.Capability`,
+  `Cortex.Document`, and `Cortex.Event`. Implementation-era roots such as `Cortex.Task`,
+  `Cortex.Provider`, `Cortex.Research`, and `Cortex.Run` remain only as migration surfaces until the
+  Nous follow-up lands.
+- `src-platform/Platform/` - runtime substrate library Cortex depends on: `Platform.Observability`,
+  `Platform.DurableTask`, `Platform.Database`, `Platform.HTTP.Retry`, `Platform.Text`, etc. Exposed
+  as a public Cabal sub-library (`cortex:platform-runtime`).
+- `app/cortex-pulse/` - substrate shell executable. Ships with an empty task registry; consumers
+  link their own registry when binding.
+- `editors/tree-sitter-wire/` - Wire DSL grammar. Consumed by the docs site for `wire` blocks and by
+  editor integrations.
+- `theory/` - Lean 4 mechanization of substrate guarantees: Mokhov graph laws, Pulse frontier
+  safety, Wire rewrite soundness. Builds through `just lean-build`.
+- `docs/` - canonical Cortex docs. Flat layout, no `/cortex/` prefix. Keep product docs out.
 - `test/` - hspec-discover driven Cortex-only suite.
-- `agents/` - provider-neutral agent context, archetypes, skills, and setup
-  scripts. Provider-specific files are generated from here.
+- `agents/` - provider-neutral agent context, archetypes, skills, and setup scripts.
+  Provider-specific files are generated from here.
 
 ## Build System
 
@@ -59,49 +53,42 @@ just lean-build-exe
 just lean-clean
 ```
 
-GHC 9.10 is pinned via haskell.nix (`compiler-nix-name = "ghc910"` in
-`nix/haskell.nix`). Materialized plan-nix caches live under
-`nix/materialized/cortex/` and must be regenerated after any Cabal
-change. Entering `nix develop` installs repo-local pre-commit hooks for
-formatting, HLint, and Lean theory checks.
+GHC 9.10 is pinned via haskell.nix (`compiler-nix-name = "ghc910"` in `nix/haskell.nix`).
+Materialized plan-nix caches live under `nix/materialized/cortex/` and must be regenerated after any
+Cabal change. Entering `nix develop` installs repo-local pre-commit hooks for formatting, HLint, and
+Lean theory checks.
 
 ## Git History Policy
 
-Git history is a maintained artifact, not a raw transcript of every
-coordination accident. Merge commits are appropriate when preserving a
-parallel line of development is semantically meaningful. Rebase is the
-default for ordinary feature work because most feature branches are
-private staging areas for a coherent change.
+Git history is a maintained artifact, not a raw transcript of every coordination accident. Merge
+commits are appropriate when preserving a parallel line of development is semantically meaningful.
+Rebase is the default for ordinary feature work because most feature branches are private staging
+areas for a coherent change.
 
 Follow this policy:
 
-- `main` is immutable. Never force-push the shared trunk except for an
-  explicit, lease-protected history repair approved by the maintainer.
-- Feature branches are rewriteable by their owner. Rebase, squash,
-  fixup, and reorder before integration when that makes the branch read
-  as a semantic argument.
-- Shared feature branches require protocol. Use
-  `git push --force-with-lease`, never raw `git push --force`.
+- `main` is immutable. Never force-push the shared trunk except for an explicit, lease-protected
+  history repair approved by the maintainer.
+- Feature branches are rewriteable by their owner. Rebase, squash, fixup, and reorder before
+  integration when that makes the branch read as a semantic argument.
+- Shared feature branches require protocol. Use `git push --force-with-lease`, never raw
+  `git push --force`.
 - CI must pass after the final rebase or rewrite.
-- Integration is fast-forward-only from an already signed branch tip.
-  Do not use GitHub's merge, squash, or rebase buttons for Cortex
-  `main`. The maintainer ruleset bypass exists only for
+- Integration is fast-forward-only from an already signed branch tip. Do not use GitHub's merge,
+  squash, or rebase buttons for Cortex `main`. The maintainer ruleset bypass exists only for
   `just integrate-pr <branch-or-pr-number>` after PR review and CI.
-- Long-running collaborative, release, vendor, backport, or integration
-  branches may use merge commits deliberately when the topology itself
-  carries meaning.
+- Long-running collaborative, release, vendor, backport, or integration branches may use merge
+  commits deliberately when the topology itself carries meaning.
 
 ## Issue And PR Tracking
 
-Cortex uses GitHub Issues and GitHub Pull Requests for active project
-tracking. When starting non-trivial work, prefer an existing GitHub
-issue or open one before implementation. Link PRs to issues with
-`Closes #<number>` when the PR completes the scope.
+Cortex uses GitHub Issues and GitHub Pull Requests for active project tracking. When starting
+non-trivial work, prefer an existing GitHub issue or open one before implementation. Link PRs to
+issues with `Closes #<number>` when the PR completes the scope.
 
-Do not use Linear, downstream issue IDs, or downstream product trackers as
-active Cortex planning state. Historical research notes and handoffs may
-retain those references for provenance, but new Cortex work is tracked
-in this repository.
+Do not use Linear, downstream issue IDs, or downstream product trackers as active Cortex planning
+state. Historical research notes and handoffs may retain those references for provenance, but new
+Cortex work is tracked in this repository.
 
 ## Commit And Authorship Policy
 
@@ -109,10 +96,9 @@ Every commit in this repo must be signed and verifiable.
 
 - Always commit with `git commit -s -S`.
 - Do not create unsigned commits.
-- After rewriting or creating commits, verify them with
-  `git log --show-signature` or `git verify-commit`.
-- Before publishing a branch for integration, run
-  `just check-commit-provenance origin/main..HEAD`.
+- After rewriting or creating commits, verify them with `git log --show-signature` or
+  `git verify-commit`.
+- Before publishing a branch for integration, run `just check-commit-provenance origin/main..HEAD`.
 
 LLMs and coding agents are not authors for copyright purposes.
 
@@ -120,22 +106,20 @@ LLMs and coding agents are not authors for copyright purposes.
 - Never add `Co-authored-by:` trailers for AI tools.
 - Never mention AI tools as legal authors of a commit.
 
-Human developers may use agent tooling to prepare patches, but commits
-must remain human-authored and human-signed.
+Human developers may use agent tooling to prepare patches, but commits must remain human-authored
+and human-signed.
 
 ## Canonical Docs Policy
 
-Cortex docs are the source of truth for substrate design. When editing
-docs:
+Cortex docs are the source of truth for substrate design. When editing docs:
 
-- Architecture chapters describe the substrate. Keep reasoning-layer
-  content explicitly attributed to `Cortex.Nous`.
+- Architecture chapters describe the substrate. Keep reasoning-layer content explicitly attributed
+  to `Cortex.Nous`.
 - ADRs are numbered and append-only. New decisions get new ADR files.
-- `docs/Consumers/<consumer>/` documents downstream consumer bindings
-  and integration contracts, not the frame for Cortex itself.
-- Public and canonical docs must present Cortex as the upstream
-  substrate. Downstream products may appear as examples only after the
-  generic contract is clear.
+- `docs/Consumers/<consumer>/` documents downstream consumer bindings and integration contracts, not
+  the frame for Cortex itself.
+- Public and canonical docs must present Cortex as the upstream substrate. Downstream products may
+  appear as examples only after the generic contract is clear.
 - `docs/Templates/` is excluded from the docs-site build.
 
 ## Agentic Tooling
@@ -146,36 +130,30 @@ Repo-local agent context lives under `agents/`.
 - Source-tree context: `agents/<repo-path>/context.md`.
 - Archetypes: `agents/archetypes/<name>.md`.
 - Skills: `agents/skills/<name>/SKILL.md`.
-- Provider symlinks are gitignored and regenerated with
-  `just agent-link-codex`, `just agent-link-claude`, or
-  `just agent-link-opencode`.
+- Provider symlinks are gitignored and regenerated with `just agent-link-codex`,
+  `just agent-link-claude`, or `just agent-link-opencode`.
 
-Do not edit generated provider files directly. Move reusable guidance
-back into provider-neutral context, archetypes, or skills.
+Do not edit generated provider files directly. Move reusable guidance back into provider-neutral
+context, archetypes, or skills.
 
 ## Principles For This Codebase
 
-1. **Type safety.** Distinct newtypes for distinct concepts; no type
-   aliases for domain types.
-2. **Pure decisions, effectful execution.** Factor decision logic into
-   pure functions and ADTs; let thin effectful interpreters drive them.
-3. **Exhaustive pattern matches on owned ADTs.** Never wildcard an ADT
-   this codebase defines.
-4. **Named records for swap-risk parameters.** Any function with more
-   than eight parameters or adjacent same-typed pairs gets a record.
-5. **Return values, not continuations.** Split "decide" from "continue":
-   return a result, let the caller interpret it.
-6. **Every DB call gets an error path.** No silent
-   `_ <- runTransaction ...` drops.
+1. **Type safety.** Distinct newtypes for distinct concepts; no type aliases for domain types.
+2. **Pure decisions, effectful execution.** Factor decision logic into pure functions and ADTs; let
+   thin effectful interpreters drive them.
+3. **Exhaustive pattern matches on owned ADTs.** Never wildcard an ADT this codebase defines.
+4. **Named records for swap-risk parameters.** Any function with more than eight parameters or
+   adjacent same-typed pairs gets a record.
+5. **Return values, not continuations.** Split "decide" from "continue": return a result, let the
+   caller interpret it.
+6. **Every DB call gets an error path.** No silent `_ <- runTransaction ...` drops.
 7. **Formatting.** `just fmt` uses ormolu. Line length is 100.
 
 ## Non-Goals
 
-- No downstream product code. Cortex and Platform code only; downstream
-  consumers live in their own repos.
-- No UI, frontend, or REST server. Cortex is a library plus a Pulse
-  executor binary.
-- No cross-link to consumer docs from Cortex canon unless the document
-  is explicitly discussing downstream integration examples.
-- No Linear or downstream product tracker workflow for active Cortex
-  issues. Use GitHub Issues.
+- No downstream product code. Cortex and Platform code only; downstream consumers live in their own
+  repos.
+- No UI, frontend, or REST server. Cortex is a library plus a Pulse executor binary.
+- No cross-link to consumer docs from Cortex canon unless the document is explicitly discussing
+  downstream integration examples.
+- No Linear or downstream product tracker workflow for active Cortex issues. Use GitHub Issues.

--- a/agents/skills/ci-fix/SKILL.md
+++ b/agents/skills/ci-fix/SKILL.md
@@ -1,16 +1,14 @@
 ---
 name: ci-fix
 description: >
-  Diagnose and fix a red CI run on the current PR. Inspects failing jobs,
-  reproduces failures locally through `just`/`nix`, applies fixes, and
-  pushes. Use when CI is red on the current branch or when the user says
-  "fix CI", "the build is broken", "why is CI failing".
+  Diagnose and fix a red CI run on the current PR. Inspects failing jobs, reproduces failures
+  locally through `just`/`nix`, applies fixes, and pushes. Use when CI is red on the current branch
+  or when the user says "fix CI", "the build is broken", "why is CI failing".
 ---
 
 # Fix CI
 
-Systematically diagnose and repair a failing CI run. Operates on the
-current PR's latest run.
+Systematically diagnose and repair a failing CI run. Operates on the current PR's latest run.
 
 ## Usage
 
@@ -21,9 +19,10 @@ current PR's latest run.
 ```
 
 **Arguments:**
+
 - `<pr-number>` — Optional. If omitted, detects from current branch.
-- `--job <name>` — Focus on a single failing job (useful when multiple
-  jobs fail and you want to tackle one at a time).
+- `--job <name>` — Focus on a single failing job (useful when multiple jobs fail and you want to
+  tackle one at a time).
 
 ## Workflow
 
@@ -54,45 +53,44 @@ gh run view <run-id> --log-failed | tail -200
 gh run view <run-id> --job <job-id> --log | tail -200
 ```
 
-Scan for the first error line, not the last. Earlier failures cascade;
-fixing the first often clears several.
+Scan for the first error line, not the last. Earlier failures cascade; fixing the first often clears
+several.
 
 ### 3. Classify the failure
 
-Match the error signature to one of the canonical Cortex CI failure
-modes:
+Match the error signature to one of the canonical Cortex CI failure modes:
 
-| Signature | Job | Likely cause | Fix path |
-|---|---|---|---|
-| `error: File is not formatted: …` | `nix fmt --ci` | ormolu or alejandra drift | `just fmt` locally, commit |
-| `Warning: …` promoted to error | Haskell build | `-Werror` unused import / incomplete match / missing export | Read the specific warning; fix the source |
-| `Could not load module 'X'` | Haskell build | Missing `build-depends` entry in `cortex.cabal` | Add the dep under the relevant library/exe stanza |
-| `Couldn't match type … with …` | Haskell build | Real type error; usually a rel8/hasql/crypton upgrade mismatch | Narrow the package version or adjust the call site |
-| `Test failed: …` | Haskell tests | Behavior regression | Run the single spec locally: `just test-match "<name>"` |
-| `HLint: …` | Lint | Banned partial function, style rule | Fix the flagged expression or add a targeted `{-# ANN … #-}` if truly unavoidable |
-| `hash mismatch … got: …` | haskell.nix | `nix/materialized/` drift after a cabal edit | `just update-materialized`, commit the regenerated cache |
-| `docs-site: Downloading wasi-sdk …` | docs-site | Wrapped `tree-sitter` not in use | Check `nix/nixpkgs.nix`; the CLI must receive `TREE_SITTER_WASI_SDK_PATH` |
-| `hlint: exit 1` / style rules | HLint | Banned `head`, `fromJust`, `undefined`, partial function | Replace with safe variant (`listToMaybe`, pattern match, etc.) |
+| Signature                           | Job            | Likely cause                                                   | Fix path                                                                          |
+| ----------------------------------- | -------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `error: File is not formatted: …`   | `nix fmt --ci` | ormolu or alejandra drift                                      | `just fmt` locally, commit                                                        |
+| `Warning: …` promoted to error      | Haskell build  | `-Werror` unused import / incomplete match / missing export    | Read the specific warning; fix the source                                         |
+| `Could not load module 'X'`         | Haskell build  | Missing `build-depends` entry in `cortex.cabal`                | Add the dep under the relevant library/exe stanza                                 |
+| `Couldn't match type … with …`      | Haskell build  | Real type error; usually a rel8/hasql/crypton upgrade mismatch | Narrow the package version or adjust the call site                                |
+| `Test failed: …`                    | Haskell tests  | Behavior regression                                            | Run the single spec locally: `just test-match "<name>"`                           |
+| `HLint: …`                          | Lint           | Banned partial function, style rule                            | Fix the flagged expression or add a targeted `{-# ANN … #-}` if truly unavoidable |
+| `hash mismatch … got: …`            | haskell.nix    | `nix/materialized/` drift after a cabal edit                   | `just update-materialized`, commit the regenerated cache                          |
+| `docs-site: Downloading wasi-sdk …` | docs-site      | Wrapped `tree-sitter` not in use                               | Check `nix/nixpkgs.nix`; the CLI must receive `TREE_SITTER_WASI_SDK_PATH`         |
+| `hlint: exit 1` / style rules       | HLint          | Banned `head`, `fromJust`, `undefined`, partial function       | Replace with safe variant (`listToMaybe`, pattern match, etc.)                    |
 
-If the signature does not match anything above, surface the first error
-line to the user and stop — do not guess.
+If the signature does not match anything above, surface the first error line to the user and stop —
+do not guess.
 
 ### 4. Reproduce locally
 
-Before editing source, reproduce the failure on your machine. CI-only
-failures are rare but real; if the reproduction does not fail locally,
-the issue may be environmental (cache, materialization, index-state).
+Before editing source, reproduce the failure on your machine. CI-only failures are rare but real; if
+the reproduction does not fail locally, the issue may be environmental (cache, materialization,
+index-state).
 
-| Failure | Local reproduction |
-|---|---|
-| Format | `nix fmt -- --ci` |
-| Flake check | `nix flake check --print-build-logs` |
-| Library build | `nix build .#cortex` |
-| Platform build | `nix build .#platform-runtime` |
-| Executable build | `nix build .#cortex-pulse` |
-| Docs site | `nix build .#docs-site` |
-| Tests | `just test` or `just test-match "<pattern>"` |
-| HLint | `just lint` |
+| Failure          | Local reproduction                           |
+| ---------------- | -------------------------------------------- |
+| Format           | `nix fmt -- --ci`                            |
+| Flake check      | `nix flake check --print-build-logs`         |
+| Library build    | `nix build .#cortex`                         |
+| Platform build   | `nix build .#platform-runtime`               |
+| Executable build | `nix build .#cortex-pulse`                   |
+| Docs site        | `nix build .#docs-site`                      |
+| Tests            | `just test` or `just test-match "<pattern>"` |
+| HLint            | `just lint`                                  |
 
 If the failure is only on CI, compare:
 
@@ -105,22 +103,23 @@ If the failure is only on CI, compare:
 Edit the source, not the test, unless the test itself is wrong.
 
 For `-Werror` warnings:
+
 - Unused import → delete or narrow
-- Incomplete pattern → add the missing case or make the match
-  exhaustive per Cortex's core principles (no wildcards on owned ADTs)
+- Incomplete pattern → add the missing case or make the match exhaustive per Cortex's core
+  principles (no wildcards on owned ADTs)
 - Missing export list → add `-Wmissing-export-lists` needs explicit
   `module Foo (symbol1, symbol2) where`
 
 For materialization mismatches:
+
 ```bash
 just update-materialized
 git add nix/materialized
 git commit -s -m "chore: regenerate haskell.nix materialized plans"
 ```
 
-For cabal dep issues, check what actually fails to resolve or compile
-and add the minimum needed. Avoid sweeping dep additions — Cortex keeps
-`cortex.cabal` lean.
+For cabal dep issues, check what actually fails to resolve or compile and add the minimum needed.
+Avoid sweeping dep additions — Cortex keeps `cortex.cabal` lean.
 
 ### 6. Verify locally
 
@@ -130,8 +129,8 @@ just check      # fmt + flake check + build
 just test       # if tests were involved
 ```
 
-Only push once every failing local check passes. Pushing a partial fix
-just to see what CI says wastes a run and pollutes the log.
+Only push once every failing local check passes. Pushing a partial fix just to see what CI says
+wastes a run and pollutes the log.
 
 ### 7. Commit and push
 
@@ -161,22 +160,19 @@ Or:
 gh pr checks "$PR" --watch
 ```
 
-If it fails again on a different signature, re-enter the workflow at
-step 3. If it fails on the same signature, the fix was incomplete —
-re-read the fresh log carefully; do not blindly retry.
+If it fails again on a different signature, re-enter the workflow at step 3. If it fails on the same
+signature, the fix was incomplete — re-read the fresh log carefully; do not blindly retry.
 
 ## Principles
 
-1. **Fix the first error, not the last.** Later errors usually
-   cascade from the first.
+1. **Fix the first error, not the last.** Later errors usually cascade from the first.
 2. **Reproduce locally before pushing.** CI is not an interactive REPL.
-3. **One concern per commit.** `fix(ci): treefmt drift` and
-   `fix(ci): missing warp dep` are two commits, not one.
-4. **Never skip hooks or disable checks.** `--no-verify`, `-Wno-…`,
-   and `allowUnfreePredicate` tweaks are cover-ups. Fix the cause.
-5. **Materialization is a plan cache, not a feature.** When it breaks,
-   regenerate it and move on — don't disable it unless you have a
-   specific reason.
+3. **One concern per commit.** `fix(ci): treefmt drift` and `fix(ci): missing warp dep` are two
+   commits, not one.
+4. **Never skip hooks or disable checks.** `--no-verify`, `-Wno-…`, and `allowUnfreePredicate`
+   tweaks are cover-ups. Fix the cause.
+5. **Materialization is a plan cache, not a feature.** When it breaks, regenerate it and move on —
+   don't disable it unless you have a specific reason.
 
 ## Output
 
@@ -189,5 +185,5 @@ Pushed: <remote branch>
 Next run: <url>
 ```
 
-If multiple failures stacked, enumerate each cause + fix. Do not leave
-any unresolved without calling it out explicitly.
+If multiple failures stacked, enumerate each cause + fix. Do not leave any unresolved without
+calling it out explicitly.

--- a/agents/skills/doc-review-and-fix/SKILL.md
+++ b/agents/skills/doc-review-and-fix/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: doc-review-and-fix
 description: >
-  Review and fix Markdown docs in this repo in one pass. Use when asked
-  to review-and-edit architecture/spec/research/publication/blog docs,
-  repair frontmatter or staleness, improve Mermaid/math/code blocks,
-  tighten claims, or make docs more concise while preserving intent.
+  Review and fix Markdown docs in this repo in one pass. Use when asked to review-and-edit
+  architecture/spec/research/publication/blog docs, repair frontmatter or staleness, improve
+  Mermaid/math/code blocks, tighten claims, or make docs more concise while preserving intent.
+
 date: 2026-04-28
 status: active
 ---
@@ -16,12 +16,11 @@ Edit-first companion to `doc-review`.
 Before reviewing, read:
 
 - `../doc-review/SKILL.md`
-- `../doc-review/references/writing-standards.md` when canonical-doc
-  policy, publication-grade, or reference-grade support matters
+- `../doc-review/references/writing-standards.md` when canonical-doc policy, publication-grade, or
+  reference-grade support matters
 
-Use the same classification, staleness, severity, and output rules as
-`doc-review`, but default to making the fixes yourself instead of
-stopping at findings.
+Use the same classification, staleness, severity, and output rules as `doc-review`, but default to
+making the fixes yourself instead of stopping at findings.
 
 ## Default behavior
 
@@ -39,27 +38,24 @@ Unless the user explicitly asks for review-only output:
 Fix directly when intent is clear:
 
 - missing or malformed frontmatter
-- publication manuscript frontmatter gaps, including missing
-  `kind: publication`, `authors`, `date`, or `updated`
-- publication `## References` blocks that are paragraph lists instead
-  of Markdown ordered lists
+- publication manuscript frontmatter gaps, including missing `kind: publication`, `authors`, `date`,
+  or `updated`
+- publication `## References` blocks that are paragraph lists instead of Markdown ordered lists
 - template body metadata that duplicates frontmatter-rendered fields
 - stale status, replacement links, and obvious `related` issues
 - broken or misleading headings
 - verbosity, repetition, weak lead sentences
 - misplaced content that can be cleanly moved within the same file
 - inconsistent terminology when the canonical term is clear
-- canonical docs that frame Cortex as a subsystem of a downstream
-  product instead of an independent system
-- canonical docs that can be cleanly rewritten from repo-local paths
-  and issue references to stable conceptual names
-- malformed or weak Mermaid blocks, including diagrams that violate
-  the slate cycle composition rules in the doc-review skill (cosmetic
-  `classDef`, awkward node counts, oversized labels, flat sprawl past
-  eight nodes)
+- canonical docs that frame Cortex as a subsystem of a downstream product instead of an independent
+  system
+- canonical docs that can be cleanly rewritten from repo-local paths and issue references to stable
+  conceptual names
+- malformed or weak Mermaid blocks, including diagrams that violate the slate cycle composition
+  rules in the doc-review skill (cosmetic `classDef`, awkward node counts, oversized labels, flat
+  sprawl past eight nodes)
 - math notation cleanup when the intended meaning is clear
-- code-fence languages, obviously broken examples, canonical example
-  drift
+- code-fence languages, obviously broken examples, canonical example drift
 - examples that violate the document's own declared rules
 
 ## When to pause and report
@@ -69,40 +65,35 @@ Don't silently rewrite when the fix depends on an open design choice.
 Prefer findings over edits when:
 
 - the document exposes a real architectural fork
-- current code and target design intentionally diverge and the desired
-  canon is unclear
-- fixing the issue would require broad file moves or cross-doc
-  reorganization
-- claims need external or implementation verification you cannot
-  complete in this pass
+- current code and target design intentionally diverge and the desired canon is unclear
+- fixing the issue would require broad file moves or cross-doc reorganization
+- claims need external or implementation verification you cannot complete in this pass
 - multiple plausible rewrites exist and would materially change meaning
 
-In those cases, make the safest local fixes, then report the remaining
-design questions explicitly.
+In those cases, make the safest local fixes, then report the remaining design questions explicitly.
 
 ## Editing principles
 
-- **Preserve the document's role.** Don't turn a research memo into a
-  spec.
+- **Preserve the document's role.** Don't turn a research memo into a spec.
 - **Be more aggressive in specs and publications than in research notes.**
-- **In canonical docs, preserve Cortex-first framing** and strip
-  repo-local detail. Cortex is a standalone substrate; don't let
-  downstream consumers become the default frame.
-- **Keep edits compact.** Prefer deletion, tightening, and
-  restructuring over adding more prose.
-- **If a paragraph is historically useful but misplaced,** shorten it
-  and move it behind a note, appendix, or link.
-- **If a canonical example is wrong, fix the example or the rule.**
-  Don't leave them inconsistent.
+- **In canonical docs, preserve Cortex-first framing** and strip repo-local detail. Cortex is a
+  standalone substrate; don't let downstream consumers become the default frame.
+- **Keep edits compact.** Prefer deletion, tightening, and restructuring over adding more prose.
+- **If a paragraph is historically useful but misplaced,** shorten it and move it behind a note,
+  appendix, or link.
+- **If a canonical example is wrong, fix the example or the rule.** Don't leave them inconsistent.
 
 ## Validation
 
 After editing:
 
 - rerun a short `doc-review` pass on the final text
+- run `just docs-lint` when the change touches Markdown under `docs/` or updates the doc-review
+  skills
 - use local docs tooling when renderability matters:
 
 ```bash
+just docs-lint
 just docs-build
 just docs-dev      # interactive preview
 ```
@@ -118,8 +109,7 @@ When this skill is used, the response should usually contain:
 3. `Still Open` — findings left open, with severity + file/line refs
 4. `Validation` — whether you ran docs-build / docs-dev and why
 
-If no edits were needed, say so explicitly and fall back to a normal
-review.
+If no edits were needed, say so explicitly and fall back to a normal review.
 
 Use those labels literally when they help scanability:
 

--- a/agents/skills/doc-review/SKILL.md
+++ b/agents/skills/doc-review/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: doc-review
 description: >
-  Review Markdown docs in this repo with doc-type-aware standards. Use
-  when asked to review architecture/spec/reference/research/ADR/
-  publication/blog docs, check frontmatter and staleness, assess
-  Mermaid/math/code blocks, verify claims, improve compactness, or
-  enforce Cortex-first canonical docs.
+  Review Markdown docs in this repo with doc-type-aware standards. Use when asked to review
+  architecture/spec/reference/research/ADR/ publication/blog docs, check frontmatter and staleness,
+  assess Mermaid/math/code blocks, verify claims, improve compactness, or enforce Cortex-first
+  canonical docs.
+
 date: 2026-04-28
 status: active
 ---
@@ -14,12 +14,10 @@ status: active
 
 Read-only review passes over repo documentation under `docs/`.
 
-When the user asks for review **and** edits in one pass, use
-`doc-review-and-fix` instead.
+When the user asks for review **and** edits in one pass, use `doc-review-and-fix` instead.
 
-Read `references/writing-standards.md` when you need a compact reminder
-of the canonical-doc policy or publication/reference writing
-expectations.
+Read `references/writing-standards.md` when you need a compact reminder of the canonical-doc policy
+or publication/reference writing expectations.
 
 ## Review order
 
@@ -46,8 +44,7 @@ Classify both the document kind and its audience/stability class.
 
 **Audience and stability:**
 
-- `canonical` — stable Cortex docs that should survive repo moves and
-  downstream-product changes
+- `canonical` — stable Cortex docs that should survive repo moves and downstream-product changes
 - `internal` — historical, design-process, or implementation-facing
 
 Treat these as `canonical` by default unless the document says otherwise:
@@ -69,8 +66,7 @@ Tune strictness to the class:
 
 - **research notes** — loose; structure and clarity matter more than polish
 - **ADRs** — concise, decision-focused, historically grounded
-- **architecture and reference** — strict on scope, terminology,
-  examples, and internal consistency
+- **architecture and reference** — strict on scope, terminology, examples, and internal consistency
 - **publications** — strictest on claims, figures, notation, and prose
 
 ## Review mode
@@ -81,12 +77,11 @@ State one explicitly near the top of the review:
 - `target-design critique`
 - `historical or migration review`
 
-If the user doesn't specify, infer and say which mode you used. Don't
-collapse a target-design spec into an implementation audit.
+If the user doesn't specify, infer and say which mode you used. Don't collapse a target-design spec
+into an implementation audit.
 
-If the review is scoped to one section, still run a quick file-level
-metadata and staleness pass unless the user explicitly says
-section-only.
+If the review is scoped to one section, still run a quick file-level metadata and staleness pass
+unless the user explicitly says section-only.
 
 ## Frontmatter and staleness
 
@@ -103,71 +98,61 @@ Check first, report first.
 
 - status/date don't obviously contradict the body
 - the doc doesn't send readers to moved, deleted, or superseded docs
-- if a doc predates the canonical doc it points to, only call it stale
-  when the newer canon now overrides its claims and the older doc
-  doesn't say so
+- if a doc predates the canonical doc it points to, only call it stale when the newer canon now
+  overrides its claims and the older doc doesn't say so
 - if a doc is obsolete, it should say what replaced it
 
-For old canonical docs, focus on alignment and cleanup before stylistic
-polish.
+For old canonical docs, focus on alignment and cleanup before stylistic polish.
 
 **Publication frontmatter:**
 
-- `docs/Publications/**/manuscript.md` should declare
-  `kind: publication`, `authors`, `date`, `updated`, `status`, and
-  `related`.
-- Artifact notes under `docs/Publications/**` should at least carry
-  `title`, `description`, `date`, `status`, and `related` when they are
-  part of the publication bundle.
-- Do not duplicate rendered metadata immediately under the H1. Author,
-  status, venue, date, and update information should live in
-  frontmatter so `DocsTitle` owns the byline.
+- `docs/Publications/**/manuscript.md` should declare `kind: publication`, `authors`, `date`,
+  `updated`, `status`, and `related`.
+- Artifact notes under `docs/Publications/**` should at least carry `title`, `description`, `date`,
+  `status`, and `related` when they are part of the publication bundle.
+- Do not duplicate rendered metadata immediately under the H1. Author, status, venue, date, and
+  update information should live in frontmatter so `DocsTitle` owns the byline.
 
 ## Canonical Cortex policy
 
 Apply this aggressively in `canonical` docs.
 
-- Cortex should read as an independent system, not as a subsystem of
-  any consumer.
-- Downstream products may appear as consumers, integration examples, or
-  motivating use cases, but not as the frame through which Cortex is
-  defined.
-- Prefer stable subsystem names (`Pulse runtime`, `graph layer`,
-  `Wire language`, `memory substrate`) over repo-local module and file
-  paths.
-- Avoid issue IDs, PR references, commit hashes, branch names, live
-  repo paths, and transient package/module layout in canonical docs
-  unless the document is specifically about migration or repo
-  structure.
-- Avoid internal roadmap numbering such as "Track 3" in canonical
-  publication and reference prose. Prefer stable conceptual names such
-  as "rewrite materialization" or "dynamic-rewrite semantics".
-- If a canonical doc depends on those details, treat it as a real
-  content-placement issue, not a nit.
+- Cortex should read as an independent system, not as a subsystem of any consumer.
+- Downstream products may appear as consumers, integration examples, or motivating use cases, but
+  not as the frame through which Cortex is defined.
+- Prefer stable subsystem names (`Pulse runtime`, `graph layer`, `Wire language`,
+  `memory substrate`) over repo-local module and file paths.
+- Avoid issue IDs, PR references, commit hashes, branch names, live repo paths, and transient
+  package/module layout in canonical docs unless the document is specifically about migration or
+  repo structure.
+- Avoid internal roadmap numbering such as "Track 3" in canonical publication and reference prose.
+  Prefer stable conceptual names such as "rewrite materialization" or "dynamic-rewrite semantics".
+- If a canonical doc depends on those details, treat it as a real content-placement issue, not a
+  nit.
 
-In `internal` docs, issue links, repo paths, and implementation
-references are allowed when they improve traceability.
+In `internal` docs, issue links, repo paths, and implementation references are allowed when they
+improve traceability.
 
 ## Content checks
 
 Review with the strictness appropriate to the class.
 
 - scope fit for the doc kind
-- content placement: right content in the right doc, especially Cortex
-  canon vs. consumer notes vs. historical/internal records
+- content placement: right content in the right doc, especially Cortex canon vs. consumer notes vs.
+  historical/internal records
 - terminology consistency
 - factual claims vs. speculation vs. inferred design intent
 - contradictions with sibling docs or the file's own rules
 - compactness and scannability
 - whether examples actually support the surrounding prose
 
-Compactness serves clarity. Don't cut material if doing so would make
-the document harder to understand.
+Compactness serves clarity. Don't cut material if doing so would make the document harder to
+understand.
 
 ## Normative docs
 
-For specs, reference docs, and architecture chapters that declare rules,
-add an explicit example sanity pass.
+For specs, reference docs, and architecture chapters that declare rules, add an explicit example
+sanity pass.
 
 Check that canonical examples obey:
 
@@ -176,64 +161,67 @@ Check that canonical examples obey:
 - stated invariants and typing claims
 - module, import, and evaluation rules
 
-If the examples and the rules disagree, that's at least a **Major**
-finding.
+If the examples and the rules disagree, that's at least a **Major** finding.
 
 ## Format checks
 
+- Run `just docs-lint` when the review scope includes local files or when the user asks for
+  lint/format conformance. Treat failures as concrete findings before prose polish.
 - heading structure and section order
 - Mermaid syntax, diagram type choice, labeling, and styling
 - math notation, variable naming, display quality
 - code fence language tags and whether examples look plausible
 - link targets and cross-reference quality
-- publication reference blocks: `## References` should contain a
-  Markdown ordered list, italic titles, autolink URLs, and en-dash page
-  ranges where applicable
-- publication citations: use GFM footnotes (`[^name]`) when a reference
-  is tied to a specific sentence; standalone bibliographies belong
-  under `## References`
+- publication reference blocks: `## References` should contain a Markdown ordered list, italic
+  titles, autolink URLs, and en-dash page ranges where applicable
+- publication citations: use GFM footnotes (`[^name]`) when a reference is tied to a specific
+  sentence; standalone bibliographies belong under `## References`. When the manuscript style
+  requires numbered bracket citations (`[1]`, `[2]`) instead of footnotes, `[N]` is plain text in
+  CommonMark and will not render as a link. Use the portable pattern `[\[N\]](#ref-N)` in prose with
+  a matching `<a id="ref-N"></a>` marker on the corresponding numbered list item under
+  `## References`. No styling will rescue a bare `[N]`; the source needs an explicit anchor or
+  footnote
+- avoid explicit `---` thematic-break separators between top-level sections in publication,
+  reference, and architecture docs. The Cortex docs theme already renders a visual divider above
+  each `<h2>`, so an explicit `---` produces a doubled rule. Frontmatter delimiters (`---` at the
+  top and bottom of the YAML block) are the only legitimate horizontal rules; intentional in-body
+  separators inside a single section are rare and should be justified
+
+`docs-lint` is the build-gated subset of this checklist. It checks frontmatter shape, publication
+reference syntax, local link/anchor integrity, `related` targets, Mermaid cosmetic styling bans, and
+canonical-doc hygiene for transient issue/PR IDs, internal track numbers, and "Cortex Pulse"
+terminology.
 
 Mermaid standard:
 
-- use the right diagram type for the concept: `flowchart LR` for
-  pipelines, `flowchart TB` for hierarchies, `BT` and `RL` almost
-  never, `stateDiagram-v2` for explicit state machines, `sequenceDiagram`
-  for protocol exchanges
-- the Cortex docs site renders dark mode through the `cortex-slate`
-  theme, which cycles node fills through indigo, teal, amber, rose,
-  sage in **node declaration order**, then wraps; light/dark fall back
-  to Mermaid's stock palettes
-- compose for the cycle: declare the conceptual primary node first so
-  it lands on indigo (the accent), declare the terminal or settled
-  node last so it lands on sage; for research-style traces this means
-  inputs first, outputs last
-- aim for diagrams whose node count is a small multiple of 5 (one or
-  two full cycles); 4 leaves the cycle short, 6 wraps with one
-  discordant repeat; 3 also reads cleanly on its own
-- chunk anything past 8 nodes into `subgraph` blocks rather than
-  letting it sprawl flat
-- labels are short — roughly 20 characters or fewer per node;
-  sentences belong in the surrounding prose, not in the diagram
-- sequence diagrams stay at 4 actors or fewer because the docs prose
-  width is roughly 720px
-- **prefer the default theme colours.** No `style X fill:…`, no
-  `classDef` cosmetic colour, no inline hex on nodes or edges. Mermaid
-  bakes inline fills into the SVG, so any pinned colour overrides the
-  per-theme palette and the diagram stops responding to the
-  light/slate toggle. This is the single most common diagram-review
-  finding in this repo
-- the only legitimate use of `classDef` is *semantic* colour — an
-  error or danger state that must read as such regardless of theme.
-  Treat any other use as a finding and strip it
-- diagrams should also flip cleanly between the light theme and slate;
-  edge labels and subgraph titles are the usual under-contrast
-  failures
+- use the right diagram type for the concept: `flowchart LR` for pipelines, `flowchart TB` for
+  hierarchies, `BT` and `RL` almost never, `stateDiagram-v2` for explicit state machines,
+  `sequenceDiagram` for protocol exchanges
+- the Cortex docs site renders dark mode through the `cortex-slate` theme, which cycles node fills
+  through indigo, teal, amber, rose, sage in **node declaration order**, then wraps; light/dark fall
+  back to Mermaid's stock palettes
+- compose for the cycle: declare the conceptual primary node first so it lands on indigo (the
+  accent), declare the terminal or settled node last so it lands on sage; for research-style traces
+  this means inputs first, outputs last
+- aim for diagrams whose node count is a small multiple of 5 (one or two full cycles); 4 leaves the
+  cycle short, 6 wraps with one discordant repeat; 3 also reads cleanly on its own
+- chunk anything past 8 nodes into `subgraph` blocks rather than letting it sprawl flat
+- labels are short — roughly 20 characters or fewer per node; sentences belong in the surrounding
+  prose, not in the diagram
+- sequence diagrams stay at 4 actors or fewer because the docs prose width is roughly 720px
+- **prefer the default theme colours.** No `style X fill:…`, no `classDef` cosmetic colour, no
+  inline hex on nodes or edges. Mermaid bakes inline fills into the SVG, so any pinned colour
+  overrides the per-theme palette and the diagram stops responding to the light/slate toggle. This
+  is the single most common diagram-review finding in this repo
+- the only legitimate use of `classDef` is _semantic_ colour — an error or danger state that must
+  read as such regardless of theme. Treat any other use as a finding and strip it
+- diagrams should also flip cleanly between the light theme and slate; edge labels and subgraph
+  titles are the usual under-contrast failures
 - diagrams should be clean enough to survive printing or design review
 
 ## Implementation and claim checks
 
-When the review mode or doc class requires grounding, verify against
-the code instead of guessing.
+When the review mode or doc class requires grounding, verify against the code instead of guessing.
 
 For Cortex symbol checks, use targeted searches:
 
@@ -241,9 +229,8 @@ For Cortex symbol checks, use targeted searches:
 rg -n "SymbolName|OtherSymbol" src src-platform
 ```
 
-Mismatches between canonical docs and implementation are findings, but
-do not force implementation conformance when the document is clearly a
-target-design spec.
+Mismatches between canonical docs and implementation are findings, but do not force implementation
+conformance when the document is clearly a target-design spec.
 
 ## Severity ladder
 
@@ -274,5 +261,4 @@ Always include:
 - whether frontmatter was intact
 - whether the doc appears stale
 
-If no findings remain, say so explicitly and mention any residual risk
-or validation gap.
+If no findings remain, say so explicitly and mention any residual risk or validation gap.

--- a/agents/skills/doc-review/references/writing-standards.md
+++ b/agents/skills/doc-review/references/writing-standards.md
@@ -1,7 +1,6 @@
 # Writing Standards
 
-Use this note when the review bar needs a compact reminder of what good Cortex
-docs optimize for.
+Use this note when the review bar needs a compact reminder of what good Cortex docs optimize for.
 
 ## Canonical Docs
 
@@ -13,27 +12,24 @@ Canonical docs should optimize for concept stability, not current repo shape.
 - keep issue IDs, PR links, commit hashes, and repo-layout trivia out of canon
 - keep internal roadmap track numbers out of publication and reference prose
 - keep prose compact and scannable
+- `just docs-lint` enforces the mechanical subset: frontmatter, local links, Mermaid cosmetic-style
+  bans, publication references, and transient issue/PR or track-number mentions in canonical docs
 
 ## Publication Docs
 
-Publication manuscripts should let frontmatter drive the rendered page
-header.
+Publication manuscripts should let frontmatter drive the rendered page header.
 
-- include `kind: publication`, `authors`, `date`, `updated`, `status`,
-  and `related` in manuscript frontmatter
-- keep author, status, venue, date, and update metadata out of the body
-  immediately below the H1
-- format standalone bibliographies as `## References` plus a Markdown
-  ordered list
-- italicize reference titles, autolink URLs, and use en-dashes for page
-  ranges
-- use GFM footnotes (`[^name]`) when a citation belongs to a specific
-  sentence
+- include `kind: publication`, `authors`, `date`, `updated`, `status`, and `related` in manuscript
+  frontmatter
+- keep author, status, venue, date, and update metadata out of the body immediately below the H1
+- format standalone bibliographies as `## References` plus a Markdown ordered list
+- italicize reference titles, autolink URLs, and use en-dashes for page ranges
+- use GFM footnotes (`[^name]`) when a citation belongs to a specific sentence
 
 ## Internal Docs
 
-Research notes, ADRs, handoffs, experiments, and plans can be more explicit
-about implementation and history.
+Research notes, ADRs, handoffs, experiments, and plans can be more explicit about implementation and
+history.
 
 - issue links and repo paths are allowed when they improve traceability
 - keep the distinction between decision, evidence, and speculation clear

--- a/agents/skills/haskell-code-style/SKILL.md
+++ b/agents/skills/haskell-code-style/SKILL.md
@@ -1,18 +1,16 @@
 ---
 name: haskell-code-style
 description: >
-  Opinionated Haskell review against branch diff. Diffs the current PR
-  branch against main (or a specified base) and reviews changed .hs
-  files against Cortex's production style guide. Use when: "review my
-  Haskell", "style check", or any request about Haskell structure,
-  patterns, or quality in the current branch.
+  Opinionated Haskell review against branch diff. Diffs the current PR branch against main (or a
+  specified base) and reviews changed .hs files against Cortex's production style guide. Use when:
+  "review my Haskell", "style check", or any request about Haskell structure, patterns, or quality
+  in the current branch.
 ---
 
 # Haskell Code Style Review
 
-Review changed Haskell code in the current branch against an opinionated
-production style guide. Operates on the branch diff (like a PR review)
-by default, not the entire codebase.
+Review changed Haskell code in the current branch against an opinionated production style guide.
+Operates on the branch diff (like a PR review) by default, not the entire codebase.
 
 ## Usage
 
@@ -25,8 +23,8 @@ by default, not the entire codebase.
 - No arguments — diffs current branch vs `main`, reviews changed `.hs` files
 - `--base <branch>` — use a different base branch
 - File paths — review specific files (e.g. `src/Cortex/Pulse/Executor.hs`)
-- Directory paths — review all `.hs` files under the directory
-  (e.g. `src-platform/Platform/DurableTask/`)
+- Directory paths — review all `.hs` files under the directory (e.g.
+  `src-platform/Platform/DurableTask/`)
 
 **Examples:**
 
@@ -65,8 +63,8 @@ If no `.hs` files found, report "No Haskell files to review" and exit.
 
 ### 2. Automated pre-checks
 
-Before any manual review, run these mechanical checks on the target
-files. They catch the highest-value findings with zero ambiguity:
+Before any manual review, run these mechanical checks on the target files. They catch the
+highest-value findings with zero ambiguity:
 
 ```bash
 # Fire-and-forget Platform.Database writes (silent failures)
@@ -76,9 +74,9 @@ grep -rn '_ <- .*runTransaction\|_ <- .*runQuery\|_ <- .*withConnection' $FILES
 grep -rn '_ ->' $FILES | grep -v 'catchError\|Left _\|Right _\|Just _\|Nothing'
 ```
 
-Report fire-and-forget hits as **[P1]** immediately. Wildcard hits need
-manual verification — only flag if the type is declared in Cortex or
-Platform source (not `Text`, `Maybe`, `Int`, `Either`, `Value`).
+Report fire-and-forget hits as **[P1]** immediately. Wildcard hits need manual verification — only
+flag if the type is declared in Cortex or Platform source (not `Text`, `Maybe`, `Int`, `Either`,
+`Value`).
 
 ### 3. Load reference material
 
@@ -86,21 +84,17 @@ Before reviewing, read the references that are in scope for the change:
 
 - **Always** read:
   - `references/review-rubric.md` — scoring axes and weights
-  - `references/architecture.md` — module structure, ADT design, IO
-    organization, layer-cake classification, boundary discipline,
-    concurrency patterns
-  - `references/type-conventions.md` — language extensions, phantom
-    types, partial-function bans, deriving discipline, import conventions
-- Read `references/refactoring-patterns.md` when the change is a
-  non-trivial refactor.
-- Read `references/testing-patterns.md` when any `test/**/*Spec.hs` is
-  in scope (property tests, golden tests, roundtrip tests, algebraic
-  laws).
+  - `references/architecture.md` — module structure, ADT design, IO organization, layer-cake
+    classification, boundary discipline, concurrency patterns
+  - `references/type-conventions.md` — language extensions, phantom types, partial-function bans,
+    deriving discipline, import conventions
+- Read `references/refactoring-patterns.md` when the change is a non-trivial refactor.
+- Read `references/testing-patterns.md` when any `test/**/*Spec.hs` is in scope (property tests,
+  golden tests, roundtrip tests, algebraic laws).
 
-Cortex's Haskell style is repo-local production-Haskell guidance. The
-references should read as Cortex and Platform guidance; examples should
-use `src/Cortex/...` or `src-platform/Platform/...` shapes unless they
-are explicitly downstream consumer examples.
+Cortex's Haskell style is repo-local production-Haskell guidance. The references should read as
+Cortex and Platform guidance; examples should use `src/Cortex/...` or `src-platform/Platform/...`
+shapes unless they are explicitly downstream consumer examples.
 
 ### 4. Read the code
 
@@ -116,31 +110,28 @@ Then read the full current version for context around the changes.
 
 **File / directory mode** (specific targets):
 
-Read each file in full. Review the whole module against the style guide,
-not just a diff — there is nothing to scope it to.
+Read each file in full. Review the whole module against the style guide, not just a diff — there is
+nothing to scope it to.
 
-**Key difference:** directory mode reviews module health; findings
-include structural debt. Classify debt as **[P2]** (track), not **[P1]**
-(block merge). Only findings in *changed* code should block a PR.
+**Key difference:** directory mode reviews module health; findings include structural debt. Classify
+debt as **[P2]** (track), not **[P1]** (block merge). Only findings in _changed_ code should block a
+PR.
 
 ### 5. Review each file
 
 Apply the rubric from `references/review-rubric.md`. Evaluate against:
 
-- **Correctness** — exhaustive patterns, error paths, transaction
-  boundaries, `Platform.DurableTask` lifecycle handling
-- **Architecture** — three-layer cake (pure / constrained effects /
-  effectful wiring), pure decision vs. effectful interpretation, return
-  values vs. continuations
-- **Readability** — nesting depth, function length, export lists,
-  comment discipline (see Cortex's `agents/context.md` principles:
-  "no comments unless the why is non-obvious")
-- **Type safety** — smart constructors, phantom types, `NonEmpty`, no
-  partial functions (`head`, `fromJust`, `read`, `!!`, `undefined`,
-  `error`, `trace` are all HLint-banned; see `.hlint.yaml`)
+- **Correctness** — exhaustive patterns, error paths, transaction boundaries, `Platform.DurableTask`
+  lifecycle handling
+- **Architecture** — three-layer cake (pure / constrained effects / effectful wiring), pure decision
+  vs. effectful interpretation, return values vs. continuations
+- **Readability** — nesting depth, function length, export lists, comment discipline (see Cortex's
+  `agents/context.md` principles: "no comments unless the why is non-obvious")
+- **Type safety** — smart constructors, phantom types, `NonEmpty`, no partial functions (`head`,
+  `fromJust`, `read`, `!!`, `undefined`, `error`, `trace` are all HLint-banned; see `.hlint.yaml`)
 - **Upstream impact** — does the module's API make callers cleaner?
-- **Safety** — swap-risk parameters, DB error handling, async exception
-  discipline, `bracket` / `finally` correctness
+- **Safety** — swap-risk parameters, DB error handling, async exception discipline, `bracket` /
+  `finally` correctness
 - **Testing** — property tests, golden tests, roundtrip tests, law checks
 
 Also apply Cortex's core principles (always in context; see below).
@@ -152,28 +143,30 @@ Output a structured review:
 ```markdown
 ## Haskell Style Review: <branch> vs <base>
 
-**Files reviewed:** N
-**Overall:** one-sentence assessment
+**Files reviewed:** N **Overall:** one-sentence assessment
 
 ### <filename>
 
 **Score:** X/10
 
 **Findings:**
+
 - [P1] <critical issue> — line N
 - [P2] <important issue> — line N
 - [style] <suggestion> — line N
 
 **Good:**
+
 - <positive observation>
 
 ### Summary
 
 | File | Score | Key Issue |
-|---|---|---|
-| ... | X/10 | ... |
+| ---- | ----- | --------- |
+| ...  | X/10  | ...       |
 
 **Top priorities:**
+
 1. <most important fix>
 2. <second>
 3. <third>
@@ -181,17 +174,15 @@ Output a structured review:
 
 Priority levels:
 
-- **[P1]** — Correctness bug, silent error drop, data-loss risk, Cortex
-  layer-boundary violation (runtime importing reasoning layer, or
-  Cortex importing a hypothetical consumer module)
+- **[P1]** — Correctness bug, silent error drop, data-loss risk, Cortex layer-boundary violation
+  (runtime importing reasoning layer, or Cortex importing a hypothetical consumer module)
 - **[P2]** — Architecture issue, maintainability concern, missing error path
 - **[style]** — Naming, formatting, could-be-cleaner
 
 ### 7. Offer fixes
 
-After the review, ask whether to apply any of the findings. When the
-user says yes, apply the changes following the patterns in the
-reference files.
+After the review, ask whether to apply any of the findings. When the user says yes, apply the
+changes following the patterns in the reference files.
 
 ---
 
@@ -199,9 +190,8 @@ reference files.
 
 ### 1. Return values, not continuations
 
-When a function does X then sometimes continues a loop and sometimes
-exits, it's doing two jobs. Split the decision from the continuation.
-Return a value; let the caller decide.
+When a function does X then sometimes continues a loop and sometimes exits, it's doing two jobs.
+Split the decision from the continuation. Return a value; let the caller decide.
 
 ```haskell
 -- BAD: attemptStage calls `go rest newState` on success, `pure outcome`
@@ -223,8 +213,8 @@ go (stageDef : rest) state = do
 
 ### 2. Explicit environments over closures
 
-When helpers close over 5+ variables from a `where` block, extract an
-environment record and promote the helpers to top-level functions.
+When helpers close over 5+ variables from a `where` block, extract an environment record and promote
+the helpers to top-level functions.
 
 ```haskell
 -- BAD: 4 levels of where-nesting, each closing over pool, runId, config …
@@ -245,8 +235,8 @@ persistStageSuccess :: StageEnv -> Text -> Aeson.Value -> IO StageAttemptResult
 
 ### 3. Pure decisions, effectful execution
 
-Factor pure decision logic into its own function/ADT. The effectful
-code just interprets the decision.
+Factor pure decision logic into its own function/ADT. The effectful code just interprets the
+decision.
 
 ```haskell
 -- Pure: no IO, total, exhaustive match
@@ -258,14 +248,13 @@ applyScheduleDecisionTx :: UUID -> UTCTime -> RunOutcome
                         -> ScheduleDecision -> Transaction ()
 ```
 
-Functional core / imperative shell. The decision function is trivially
-testable; the interpreter is thin.
+Functional core / imperative shell. The decision function is trivially testable; the interpreter is
+thin.
 
 ### 4. Named records for swap-risk parameters
 
-When a function takes 2+ adjacent same-typed parameters, use a named
-record. The compiler won't catch `(errType, errMsg)` swapped to
-`(errMsg, errType)`.
+When a function takes 2+ adjacent same-typed parameters, use a named record. The compiler won't
+catch `(errType, errMsg)` swapped to `(errMsg, errType)`.
 
 ```haskell
 -- BAD: 11 positional parameters, Text/Text/Bool at the tail
@@ -286,11 +275,11 @@ data AttemptCtx = AttemptCtx
 
 ### 5. Every DB call gets an error path
 
-No silent drops. Every `IO (Either String a)` from `Platform.Database`
-must be handled. Handling varies by context:
+No silent drops. Every `IO (Either String a)` from `Platform.Database` must be handled. Handling
+varies by context:
 
-- **Must succeed for the run to continue** → `requireTx` pattern: log,
-  fail the run, return `Nothing`.
+- **Must succeed for the run to continue** → `requireTx` pattern: log, fail the run, return
+  `Nothing`.
 - **Best-effort** → log warning, continue.
 - **Last resort** → log error; note recovery happens via lease expiry.
 
@@ -308,8 +297,8 @@ requireTx pool runId context action = do
 
 ### 6. Exhaustive pattern matches on owned ADTs
 
-Never wildcard-match an ADT defined in this codebase. When someone adds
-a variant, the compiler should force it to be handled everywhere.
+Never wildcard-match an ADT defined in this codebase. When someone adds a variant, the compiler
+should force it to be handled everywhere.
 
 ```haskell
 -- BAD
@@ -328,8 +317,7 @@ outcomeLogLevel = \case
 
 ### 7. Respect the Cortex layer boundary
 
-Per ADR 0015, Cortex is a runtime substrate with a structured-reasoning
-library (`Cortex.Nous`, future) on top. The runtime **never** imports
-the reasoning layer, and neither the runtime nor the reasoning layer
-ever imports a consumer-specific module, product binding, or host-edge
-module. A cross-layer import is a **[P1]** finding.
+Per ADR 0015, Cortex is a runtime substrate with a structured-reasoning library (`Cortex.Nous`,
+future) on top. The runtime **never** imports the reasoning layer, and neither the runtime nor the
+reasoning layer ever imports a consumer-specific module, product binding, or host-edge module. A
+cross-layer import is a **[P1]** finding.

--- a/agents/skills/haskell-code-style/references/architecture.md
+++ b/agents/skills/haskell-code-style/references/architecture.md
@@ -1,34 +1,31 @@
 # Architecture Patterns
 
-Module structure, ADT design, error handling, and IO organization for
-production Haskell.
+Module structure, ADT design, error handling, and IO organization for production Haskell.
 
 ## Three Layer Cake
 
 Every module in Cortex belongs to one of three layers:
 
-| Layer | Characteristics | Examples |
-|---|---|---|
-| **Layer 1: Pure** | No IO, no monad constraints. Types, decision logic, parsers, validation, ADT definitions. Trivially testable. | `decideScheduleAction`, `selectCases`, `parseAccountData`, `totalExpectedResultCount` |
-| **Layer 2: Constrained effects** | Uses `ReaderT`, `ExceptT`, `Transaction`, or env-record-passing. Business logic that needs controlled effects. Testable with mock environments. | `syncAccount`, `persistEvalBatch`, `claimAndCreateRun` |
-| **Layer 3: Effectful wiring** | `main`, server setup, connection pools, thread management, concrete IO. Thin orchestration that composes layers 1 and 2. | `main`, `startServer`, `runPulseWorker` |
+| Layer                            | Characteristics                                                                                                                                 | Examples                                                                              |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **Layer 1: Pure**                | No IO, no monad constraints. Types, decision logic, parsers, validation, ADT definitions. Trivially testable.                                   | `decideScheduleAction`, `selectCases`, `parseAccountData`, `totalExpectedResultCount` |
+| **Layer 2: Constrained effects** | Uses `ReaderT`, `ExceptT`, `Transaction`, or env-record-passing. Business logic that needs controlled effects. Testable with mock environments. | `syncAccount`, `persistEvalBatch`, `claimAndCreateRun`                                |
+| **Layer 3: Effectful wiring**    | `main`, server setup, connection pools, thread management, concrete IO. Thin orchestration that composes layers 1 and 2.                        | `main`, `startServer`, `runPulseWorker`                                               |
 
 ### Layer violations to flag
 
-- **Layer 1+3 mixing**: Pure decision logic interleaved with DB writes in
-  the same function. The decision should be a separate pure function; the
-  DB write should interpret its result.
+- **Layer 1+3 mixing**: Pure decision logic interleaved with DB writes in the same function. The
+  decision should be a separate pure function; the DB write should interpret its result.
 
-- **Layer 2 leaking to layer 3**: Business logic functions that take
-  `Pool` directly instead of working through `Transaction` or an env record.
-  This couples the business logic to the specific IO implementation.
+- **Layer 2 leaking to layer 3**: Business logic functions that take `Pool` directly instead of
+  working through `Transaction` or an env record. This couples the business logic to the specific IO
+  implementation.
 
-- **Layer 3 growing logic**: `main` or server setup code that contains
-  branching business logic instead of delegating to layer 2 functions.
+- **Layer 3 growing logic**: `main` or server setup code that contains branching business logic
+  instead of delegating to layer 2 functions.
 
-**[P2] Flag**: A function that mixes pure decision logic (layer 1) with
-direct IO operations (layer 3). The decision and the execution should be
-separate functions.
+**[P2] Flag**: A function that mixes pure decision logic (layer 1) with direct IO operations (layer
+3). The decision and the execution should be separate functions.
 
 ## Module organization
 
@@ -62,6 +59,7 @@ module Cortex.Pulse.Executor
 ```
 
 **Rules**:
+
 - Export constructors (`(..)`) for types that consumers pattern-match on
 - Export only the smart constructor for types with invariants
 - Never export internal helpers; if tests need them, create a `.Internal` module
@@ -69,11 +67,11 @@ module Cortex.Pulse.Executor
 
 ### File size
 
-**What matters is complexity per function, not total lines.** A 1200-line file
-of independent 30-line handlers is healthier than a 400-line file with one
-200-line function.
+**What matters is complexity per function, not total lines.** A 1200-line file of independent
+30-line handlers is healthier than a 400-line file with one 200-line function.
 
 **When size is NOT the problem** (do not split mechanically):
+
 - Query modules: each function is independent, sharing only imports
 - Servant route wiring: mechanical dispatch, low complexity per line
 - Type definition modules: one type per API endpoint, naturally long
@@ -81,12 +79,14 @@ of independent 30-line handlers is healthier than a 400-line file with one
 - Domain-coherent modules: all run-lifecycle operations in one file is correct
 
 **When size IS the problem** (consider splitting):
+
 - Individual functions exceed 80 lines (the function is too big, not the file)
 - Unrelated concerns mixed: auth + CRUD + reporting in one file with shared state
 - Deep coupling between sections: helpers calling each other across domains
 - Merge conflicts from multiple developers editing different domains
 
 If you split, split by concern, not by arbitrary line count:
+
 - Pure logic → `Foo.Core` or `Foo.Types`
 - Effectful execution → `Foo` (main module)
 - Database queries → `Foo.Query`
@@ -94,9 +94,9 @@ If you split, split by concern, not by arbitrary line count:
 
 ### Language extensions
 
-Most extensions are set in `cabal` `default-extensions` and don't need
-per-module pragmas. Per-module pragmas are only for extensions outside
-the defaults. See `type-conventions.md` for the full extension policy.
+Most extensions are set in `cabal` `default-extensions` and don't need per-module pragmas.
+Per-module pragmas are only for extensions outside the defaults. See `type-conventions.md` for the
+full extension policy.
 
 Per-module pragmas should be grouped by category:
 
@@ -105,8 +105,8 @@ Per-module pragmas should be grouped by category:
 {-# LANGUAGE DuplicateRecordFields #-} -- record handling (not in defaults)
 ```
 
-**Banned** (silently break type safety): `IncoherentInstances`,
-`ImpredicativeTypes`, `Strict`, `OverlappingInstances`.
+**Banned** (silently break type safety): `IncoherentInstances`, `ImpredicativeTypes`, `Strict`,
+`OverlappingInstances`.
 
 ## ADT design
 
@@ -125,6 +125,7 @@ data ScheduleDecision
 ```
 
 **Properties of good decision types**:
+
 - Every variant is handled somewhere (exhaustive matches)
 - The decision function is pure (`Config -> Input -> Decision`)
 - The interpreter is thin (maps each variant to 1–3 effectful operations)
@@ -132,8 +133,8 @@ data ScheduleDecision
 
 ### Stable identifiers
 
-When values are persisted to a database or serialized to JSON, use a typeclass
-for stable text conversion:
+When values are persisted to a database or serialized to JSON, use a typeclass for stable text
+conversion:
 
 ```haskell
 class StableStageId stageId where
@@ -146,8 +147,7 @@ instance StableStageId PaperPortfolioCycleStage where
     Planner            -> "planner"              -- frozen
 ```
 
-This separates the Haskell `Show` instance (which can change) from the
-wire format (which cannot).
+This separates the Haskell `Show` instance (which can change) from the wire format (which cannot).
 
 ### Existential wrapping
 
@@ -158,9 +158,8 @@ data SomeStagePlan where
   SomeStagePlan :: (StableStageId stageId) => StagePlan stageId -> SomeStagePlan
 ```
 
-Use sparingly. The existential hides the type parameter, so the consumer
-can only use the typeclass interface. If you find yourself pattern-matching
-to recover the type, the existential is wrong.
+Use sparingly. The existential hides the type parameter, so the consumer can only use the typeclass
+interface. If you find yourself pattern-matching to recover the type, the existential is wrong.
 
 ### Enum-driven stage definitions
 
@@ -179,16 +178,15 @@ data PaperPortfolioCycleStage
 allStages = [minBound .. maxBound]
 ```
 
-This guarantees no stages are accidentally omitted and the order is
-defined in one place.
+This guarantees no stages are accidentally omitted and the order is defined in one place.
 
 ### Typeclass vs record-of-functions
 
 **Use a plain record of functions** when:
+
 - There's exactly one implementation at any given call site
 - The "interface" is module-internal or has <=3 consumers
-- You want to swap implementations at runtime (test doubles via record
-  construction)
+- You want to swap implementations at runtime (test doubles via record construction)
 
 ```haskell
 -- GOOD: record of functions — one impl, easy to mock
@@ -200,20 +198,17 @@ data StageRunner = StageRunner
 ```
 
 **Use a typeclass** when:
-- Multiple distinct types need the same interface (serialization, numeric,
-  comparison)
-- The abstraction is used across 10+ modules and would cause
-  record-threading pain
+
+- Multiple distinct types need the same interface (serialization, numeric, comparison)
+- The abstraction is used across 10+ modules and would cause record-threading pain
 - Laws exist that instances must satisfy (e.g., `Monoid` laws)
 
-**[P2] Flag**: A typeclass with exactly one instance in the codebase. This
-is a record of functions in disguise — it adds orphan risk and global
-namespace pollution for no benefit.
+**[P2] Flag**: A typeclass with exactly one instance in the codebase. This is a record of functions
+in disguise — it adds orphan risk and global namespace pollution for no benefit.
 
 ### Newtype-driven dispatch
 
-Replace `Text`-keyed dispatch with ADT-keyed dispatch when the set of keys
-is known at compile time:
+Replace `Text`-keyed dispatch with ADT-keyed dispatch when the set of keys is known at compile time:
 
 ```haskell
 -- BAD: stringly-typed dispatch over a closed set
@@ -233,12 +228,11 @@ case taskType of
   DataImport     -> handleDataImport
 ```
 
-The `Text` representation is only for DB/API serialization, parsed at the
-boundary (see "Boundary discipline" below).
+The `Text` representation is only for DB/API serialization, parsed at the boundary (see "Boundary
+discipline" below).
 
-**[P2] Flag**: A `case someText of "literal" -> ...` with 3+ branches over
-a closed set of values. The dispatch should be on an ADT, with the `Text`
-parsing happening at the system boundary.
+**[P2] Flag**: A `case someText of "literal" -> ...` with 3+ branches over a closed set of values.
+The dispatch should be on an ADT, with the `Text` parsing happening at the system boundary.
 
 ## Error handling architecture
 
@@ -250,14 +244,12 @@ Standard Haskell conventions — no custom aliases or renamings:
 - `ExceptT e m a` — monad transformer for effectful computations that can fail.
 - `MonadError e m` — typeclass for polymorphic error handling when reuse justifies it.
 
-We use the standard ecosystem. No `Result`, `Ok`, `Err`, or project-specific
-aliases for `Either`.
+We use the standard ecosystem. No `Result`, `Ok`, `Err`, or project-specific aliases for `Either`.
 
 ### When to use `ExceptT`
 
-Prefer `ExceptT` when a function is a **linear sequence of steps** where each
-step may fail and the intent is to follow the happy path, short-circuiting on
-the first failure:
+Prefer `ExceptT` when a function is a **linear sequence of steps** where each step may fail and the
+intent is to follow the happy path, short-circuiting on the first failure:
 
 - parsing → validating → loading → transforming
 - decoding chains
@@ -291,13 +283,12 @@ val2 <- case result2 of
 
 ### When explicit `Either` / `case` is better
 
-Keep explicit pattern matching when the function is doing **decision-tree
-orchestration** rather than linear propagation:
+Keep explicit pattern matching when the function is doing **decision-tree orchestration** rather
+than linear propagation:
 
 - Different failure cases require different observability/logging
 - Different failure cases trigger different recovery behavior
-- `Nothing`, retry, skip, cancellation, timeout, and terminal failure all
-  have distinct meanings
+- `Nothing`, retry, skip, cancellation, timeout, and terminal failure all have distinct meanings
 - Local handling is more important than propagation
 - Forcing everything into one `ExceptT` stack would obscure control flow
 
@@ -317,21 +308,21 @@ case runTransaction pool (claimLease runId) of
   Right lease -> executeWithLease lease
 ```
 
-`ExceptT` is for **sequential failure flow**, not for every function that
-touches `Either`.
+`ExceptT` is for **sequential failure flow**, not for every function that touches `Either`.
 
 ### Refactoring to `ExceptT` — practical rules
 
 **Do:**
+
 - Extract small sequential helpers and convert those helpers to `ExceptT`
 - Keep top-level orchestration explicit where that improves clarity
 - Prefer incremental refactors over rewriting large functions at once
 
 **Don't:**
+
 - Rewrite large orchestrator functions into giant transformer stacks all at once
 - Use `ExceptT` only to immediately unpack everything with ad hoc branching
-- Create monadic soup — if the `ExceptT` version is harder to follow, keep
-  the explicit version
+- Create monadic soup — if the `ExceptT` version is harder to follow, keep the explicit version
 
 ### `MonadError` guidance
 
@@ -339,8 +330,8 @@ Polymorphism over `MonadError` is welcome when it genuinely improves reuse:
 
 - Concrete `ExceptT` is often simplest and best at module boundaries
 - `MonadError` is useful in reusable internal logic shared across contexts
-- Do not introduce large, heavily constrained signatures unless there is a
-  clear benefit across multiple call sites
+- Do not introduce large, heavily constrained signatures unless there is a clear benefit across
+  multiple call sites
 
 ```haskell
 -- GOOD: concrete ExceptT at a boundary
@@ -370,8 +361,8 @@ runExceptT pipeline >>= \case
   Right val -> pure val
 ```
 
-**Convert external errors early.** Don't let `Either String` from external
-libraries spread through the codebase:
+**Convert external errors early.** Don't let `Either String` from external libraries spread through
+the codebase:
 
 ```haskell
 -- BAD: Either String leaking through multiple layers
@@ -388,22 +379,22 @@ fetchData mgr = ExceptT $ do
 
 ### Error type guidance
 
-- Prefer structured domain error ADTs (`AppError`, `MoneyError`) over raw
-  `String` / `Text` in core and orchestration layers
-- Textual errors are acceptable at leaf boundaries or very small internal
-  helpers where the string is immediately converted
-- `Either String a` should not cross module boundaries — convert to a domain
-  error type at the point of origin
+- Prefer structured domain error ADTs (`AppError`, `MoneyError`) over raw `String` / `Text` in core
+  and orchestration layers
+- Textual errors are acceptable at leaf boundaries or very small internal helpers where the string
+  is immediately converted
+- `Either String a` should not cross module boundaries — convert to a domain error type at the point
+  of origin
 
 ### Error type hierarchy
 
 Define a per-layer error type that mirrors the three-layer-cake:
 
-| Layer | Error type | Example |
-|---|---|---|
-| **Layer 1: Pure** | ADTs for validation/parse errors | `ValidationError`, `ParseError`, `ConfigError` |
-| **Layer 2: Business** | Domain-specific error ADTs | `RunError`, `ScheduleError`, `EvalError` |
-| **Layer 3: Operational** | Infrastructure errors | `DbError`, `NetworkError`, `TimeoutError` |
+| Layer                    | Error type                       | Example                                        |
+| ------------------------ | -------------------------------- | ---------------------------------------------- |
+| **Layer 1: Pure**        | ADTs for validation/parse errors | `ValidationError`, `ParseError`, `ConfigError` |
+| **Layer 2: Business**    | Domain-specific error ADTs       | `RunError`, `ScheduleError`, `EvalError`       |
+| **Layer 3: Operational** | Infrastructure errors            | `DbError`, `NetworkError`, `TimeoutError`      |
 
 Each layer converts lower-layer errors at the boundary:
 
@@ -420,18 +411,17 @@ case dbResult of
   Right val -> pure val
 ```
 
-**[P2] Flag**: `Either String a` propagated through 3+ function calls
-without conversion to a domain error type.
+**[P2] Flag**: `Either String a` propagated through 3+ function calls without conversion to a domain
+error type.
 
-**[P2] Flag**: `show` used to convert a structured error into `String` for
-an `Either String` return — preserve the structure.
+**[P2] Flag**: `show` used to convert a structured error into `String` for an `Either String` return
+— preserve the structure.
 
 ### Subsystem error ADT pattern
 
-When a subsystem has multiple internal error types that cross function
-boundaries, define a single error ADT at the subsystem edge. Provide a
-`renderError` function for human messages and an `errorType` function for
-stable observability strings.
+When a subsystem has multiple internal error types that cross function boundaries, define a single
+error ADT at the subsystem edge. Provide a `renderError` function for human messages and an
+`errorType` function for stable observability strings.
 
 ```haskell
 data RewriteError
@@ -452,8 +442,8 @@ rewriteErrorType = \case
   RewriteReconciliationFailed {} -> "graph_state_parse_failed"
 ```
 
-Internal functions return `Either RewriteError`. At the executor boundary,
-pattern match on the error ADT to produce the right `RunFailureSpec`:
+Internal functions return `Either RewriteError`. At the executor boundary, pattern match on the
+error ADT to produce the right `RunFailureSpec`:
 
 ```haskell
 -- GOOD: error category preserved through the pipeline
@@ -467,23 +457,23 @@ case materializeRewrite rewrite plan state of
     failRun pool runId now "invalid_rewrite" errMsg False
 ```
 
-Convert to `Text` only at API boundaries (admin handlers, external
-responses) using `renderRewriteError`.
+Convert to `Text` only at API boundaries (admin handlers, external responses) using
+`renderRewriteError`.
 
-**[P2] Flag**: `Either Text` propagated through 3+ functions within a
-subsystem where the errors come from distinct categories (validation,
-budget, hydration, reconciliation). Replace with a subsystem error ADT.
+**[P2] Flag**: `Either Text` propagated through 3+ functions within a subsystem where the errors
+come from distinct categories (validation, budget, hydration, reconciliation). Replace with a
+subsystem error ADT.
 
 ### Three-tier error handling
 
-1. **Must succeed** (critical path): Failure terminates the operation.
-   Use `requireTx` or equivalent. Returns `Maybe a`.
+1. **Must succeed** (critical path): Failure terminates the operation. Use `requireTx` or
+   equivalent. Returns `Maybe a`.
 
-2. **Best effort** (non-critical): Failure is logged and execution continues.
-   Audit log updates, observability writes. Use `case result of Left -> log; Right -> pure ()`.
+2. **Best effort** (non-critical): Failure is logged and execution continues. Audit log updates,
+   observability writes. Use `case result of Left -> log; Right -> pure ()`.
 
-3. **Last resort** (recovery): If this fails, a higher-level mechanism
-   (lease expiry, cron re-schedule) will eventually clean up. Log prominently.
+3. **Last resort** (recovery): If this fails, a higher-level mechanism (lease expiry, cron
+   re-schedule) will eventually clean up. Log prominently.
 
 ```haskell
 -- Tier 1: must succeed
@@ -505,25 +495,21 @@ failRun pool runId now errType errMsg retryable
 
 ### Error handling anti-patterns
 
-- **Deeply nested `case Left / Right` ladders** for purely sequential logic —
-  use `ExceptT`
-- **Giant `ExceptT` stacks** in orchestration-heavy functions — keep explicit
-  branching where each failure has different recovery
-- **Mixing exceptions and `Either`/`ExceptT` carelessly** — pick one error
-  channel per function; don't catch IO exceptions into `Left` and then throw
-  them again
-- **`Either String` spreading through core layers** — convert to domain error
-  types at the boundary
-- **Using `ExceptT` only to immediately unpack** — if every `throwE` is
-  followed by a `case` that branches differently, the transformer adds noise
+- **Deeply nested `case Left / Right` ladders** for purely sequential logic — use `ExceptT`
+- **Giant `ExceptT` stacks** in orchestration-heavy functions — keep explicit branching where each
+  failure has different recovery
+- **Mixing exceptions and `Either`/`ExceptT` carelessly** — pick one error channel per function;
+  don't catch IO exceptions into `Left` and then throw them again
+- **`Either String` spreading through core layers** — convert to domain error types at the boundary
+- **Using `ExceptT` only to immediately unpack** — if every `throwE` is followed by a `case` that
+  branches differently, the transformer adds noise
 
 ### Practical error handling rules
 
 These rules are derived from recurring patterns in integration and service code.
 
-**1. Use `ExceptT` for linear boundary pipelines.**
-If a function is mostly load → validate → fetch → transform → persist
-and failures should short-circuit, prefer `ExceptT` over nested `case` chains.
+**1. Use `ExceptT` for linear boundary pipelines.** If a function is mostly load → validate → fetch
+→ transform → persist and failures should short-circuit, prefer `ExceptT` over nested `case` chains.
 Top-level workflow should read as business steps:
 
 ```haskell
@@ -535,16 +521,14 @@ runSync = do
   persist pool data'
 ```
 
-**2. Keep retry/recovery loops explicit.**
-Do not force `ExceptT` into retry loops, recovery trees, or orchestration
-code where different failure cases trigger different local behaviors (retry,
-shrink range, skip, cancel, terminal failure). Explicit branching is clearer
-when recovery semantics vary per case.
+**2. Keep retry/recovery loops explicit.** Do not force `ExceptT` into retry loops, recovery trees,
+or orchestration code where different failure cases trigger different local behaviors (retry, shrink
+range, skip, cancel, terminal failure). Explicit branching is clearer when recovery semantics vary
+per case.
 
-**3. Wrap noisy boundary APIs in domain helpers.**
-When an external API or parser repeatedly requires `ExceptT` wrapping and
-error translation, extract small domain helpers so call sites read in domain
-language rather than transformer plumbing:
+**3. Wrap noisy boundary APIs in domain helpers.** When an external API or parser repeatedly
+requires `ExceptT` wrapping and error translation, extract small domain helpers so call sites read
+in domain language rather than transformer plumbing:
 
 ```haskell
 -- BAD: repeated at every call site
@@ -556,24 +540,20 @@ fetchExternalPayloadE mgr cfg = withExceptT (\e -> externalError "host-api" (T.p
   ExceptT (fetchExternalPayload mgr cfg)
 ```
 
-**4. Convert external/string errors into domain errors early.**
-At integration boundaries, convert raw `String`/`Text` errors into domain
-error values as early as practical. Never let unstructured external errors
-spread through core application logic.
+**4. Convert external/string errors into domain errors early.** At integration boundaries, convert
+raw `String`/`Text` errors into domain error values as early as practical. Never let unstructured
+external errors spread through core application logic.
 
-**5. Extract policy helpers from busy functions.**
-When a function mixes policy decisions with IO, parsing, persistence, and
-observability, extract policy-sized helpers so the top-level function reads
-as a workflow. Helper categories: fetch, parse, persist, fallback policy.
+**5. Extract policy helpers from busy functions.** When a function mixes policy decisions with IO,
+parsing, persistence, and observability, extract policy-sized helpers so the top-level function
+reads as a workflow. Helper categories: fetch, parse, persist, fallback policy.
 
-**6. Prefer named helpers over dense transformer expressions.**
-When `ExceptT` expressions become visually dense due to repeated `ExceptT`,
-`except`, `withExceptT`, and `catchE` composition, extract named helpers.
-Optimize for readable workflows, not minimal line count.
+**6. Prefer named helpers over dense transformer expressions.** When `ExceptT` expressions become
+visually dense due to repeated `ExceptT`, `except`, `withExceptT`, and `catchE` composition, extract
+named helpers. Optimize for readable workflows, not minimal line count.
 
-**7. Use domain ADTs when `Either e (Maybe a)` accumulates meanings.**
-When nested control meanings accumulate in types like
-`Either String (Maybe FlexQueryResponse)`, consider a small domain ADT if
+**7. Use domain ADTs when `Either e (Maybe a)` accumulates meanings.** When nested control meanings
+accumulate in types like `Either String (Maybe FlexQueryResponse)`, consider a small domain ADT if
 it improves readability and makes state distinctions explicit:
 
 ```haskell
@@ -583,32 +563,27 @@ data ChunkFetchResult
   | ChunkFetchSucceeded FlexQueryResponse
 ```
 
-**8. Catch exceptions only at deliberate effect boundaries.**
-Use `Either`/`ExceptT` for expected failures. Catch exceptions at explicit
-effect boundaries where you interact with throwing APIs, then translate them
-into domain errors immediately. Do not mix exception catching and
-`Either`/`ExceptT` carelessly within the same function.
+**8. Catch exceptions only at deliberate effect boundaries.** Use `Either`/`ExceptT` for expected
+failures. Catch exceptions at explicit effect boundaries where you interact with throwing APIs, then
+translate them into domain errors immediately. Do not mix exception catching and `Either`/`ExceptT`
+carelessly within the same function.
 
-**9. At boundaries, prefer concrete stacks over premature polymorphism.**
-At service and integration boundaries, prefer concrete monad stacks
-(`ExceptT AppError IO`) and concrete error types over `MonadError`/`MonadIO`
-constraints. Reach for polymorphism only when reuse clearly benefits
-multiple call sites.
+**9. At boundaries, prefer concrete stacks over premature polymorphism.** At service and integration
+boundaries, prefer concrete monad stacks (`ExceptT AppError IO`) and concrete error types over
+`MonadError`/`MonadIO` constraints. Reach for polymorphism only when reuse clearly benefits multiple
+call sites.
 
-**10. Avoid speculative fields and dormant structure.**
-Prefer deleting speculative or dormant fields until they are truly needed.
-Data structures should reflect current semantics, not anticipated future
-branches, unless the extension point is already active and justified.
+**10. Avoid speculative fields and dormant structure.** Prefer deleting speculative or dormant
+fields until they are truly needed. Data structures should reflect current semantics, not
+anticipated future branches, unless the extension point is already active and justified.
 
-**11. Prefer standard combinators over local operator redefinitions.**
-Do not locally redefine widely-recognized operators (`<|>`, `<>`, `>>=`).
-Import the standard version. Local redefinitions increase surprise and reduce
-readability.
+**11. Prefer standard combinators over local operator redefinitions.** Do not locally redefine
+widely-recognized operators (`<|>`, `<>`, `>>=`). Import the standard version. Local redefinitions
+increase surprise and reduce readability.
 
-**12. Name best-effort functions honestly.**
-When a function is best-effort, partially tolerant of failure, or includes
-fallback behavior, make that explicit in documentation and, when helpful,
-in naming. Prevent misleadingly strict-sounding APIs.
+**12. Name best-effort functions honestly.** When a function is best-effort, partially tolerant of
+failure, or includes fallback behavior, make that explicit in documentation and, when helpful, in
+naming. Prevent misleadingly strict-sounding APIs.
 
 ### Async exception safety
 
@@ -627,9 +602,8 @@ case stageResult of
 
 ### Timeout handling
 
-Timeouts manifest as both `System.Timeout.Timeout` exceptions (thrown by
-the timeout mechanism) and `Nothing` returns (from `Timeout.timeout`).
-Handle both:
+Timeouts manifest as both `System.Timeout.Timeout` exceptions (thrown by the timeout mechanism) and
+`Nothing` returns (from `Timeout.timeout`). Handle both:
 
 ```haskell
 case effectiveTimeout of
@@ -645,9 +619,8 @@ case effectiveTimeout of
 
 ### Parse at the boundary, use types internally
 
-Parse unstructured data (`Text`, `Value`, `ByteString`) into domain types
-at the system boundary. Internal functions never operate on raw text when
-a parsed type exists.
+Parse unstructured data (`Text`, `Value`, `ByteString`) into domain types at the system boundary.
+Internal functions never operate on raw text when a parsed type exists.
 
 ```haskell
 -- BAD: business logic parses text inline
@@ -677,11 +650,11 @@ processRun = \case
   Failed    -> handleFailed
 ```
 
-**Pattern**: API handler parses request -> domain type -> business logic.
-DB query returns raw row -> decoded to domain record in the query module.
+**Pattern**: API handler parses request -> domain type -> business logic. DB query returns raw row
+-> decoded to domain record in the query module.
 
-**[P2] Flag**: A business logic function that takes `Text` and does
-`case text of "running" -> ...` — the parsing should happen at the boundary.
+**[P2] Flag**: A business logic function that takes `Text` and does `case text of "running" -> ...`
+— the parsing should happen at the boundary.
 
 ### Monomorphic return types at module boundaries
 
@@ -695,12 +668,11 @@ getUser :: Pool -> UserId -> IO (Maybe User)
 getUser :: (MonadIO m, MonadReader env m, HasPool env) => UserId -> m (Maybe User)
 ```
 
-Polymorphic signatures at module boundaries make error messages worse
-and obscure what the function actually does. Use polymorphism only when
-it's genuinely needed by 3+ callers with different monads.
+Polymorphic signatures at module boundaries make error messages worse and obscure what the function
+actually does. Use polymorphism only when it's genuinely needed by 3+ callers with different monads.
 
-**[P2] Flag**: A public function with 3+ typeclass constraints when all
-callers use the same concrete stack.
+**[P2] Flag**: A public function with 3+ typeclass constraints when all callers use the same
+concrete stack.
 
 ## Concurrency patterns
 
@@ -713,8 +685,8 @@ For distributed work that must not be executed concurrently:
 3. If renewal fails: check if the action completed (race window), then cancel
 4. If the action completes naturally: stop renewing
 
-The critical subtlety: after cancelling an action due to lease loss,
-always check if it completed in the race window:
+The critical subtlety: after cancelling an action due to lease loss, always check if it completed in
+the race window:
 
 ```haskell
 cancel actionAsync
@@ -726,37 +698,34 @@ waitCatch actionAsync >>= \case
 ### Shutdown coordination
 
 Use a `TVar Bool` shutdown flag. Check it:
+
 - Before starting each stage (checkpoint boundary)
 - During retry delays (STM-aware delay)
 - In the scheduler poll loop
 
-Shutdown produces a specific outcome (`OutcomeShutdown`) that is handled
-differently from failure — it doesn't trigger retries or schedule advances.
+Shutdown produces a specific outcome (`OutcomeShutdown`) that is handled differently from failure —
+it doesn't trigger retries or schedule advances.
 
-**[P2] Flag**: `threadDelay` in a loop without a shutdown check.
-**[P2] Flag**: `forever` without a shutdown-aware break condition.
+**[P2] Flag**: `threadDelay` in a loop without a shutdown check. **[P2] Flag**: `forever` without a
+shutdown-aware break condition.
 
 ### Rewrite budget policy
 
-The rewrite budget policy is **fail-fast**: any rewrite whose structural
-cost exceeds the remaining budget in any single dimension is rejected
-immediately, the stage fails, and the run terminates. There is no soft-cap,
-deferred rejection, or configurable policy mode.
+The rewrite budget policy is **fail-fast**: any rewrite whose structural cost exceeds the remaining
+budget in any single dimension is rejected immediately, the stage fails, and the run terminates.
+There is no soft-cap, deferred rejection, or configurable policy mode.
 
-Budget enforcement is type-level via `AdmittedRewriteDelta` — the witness
-type can only be constructed through `admitRewriteDelta`, which checks the
-budget. Functions that persist or materialize rewrites accept
-`AdmittedRewriteDelta`, making it impossible to skip the budget check.
+Budget enforcement is type-level via `AdmittedRewriteDelta` — the witness type can only be
+constructed through `admitRewriteDelta`, which checks the budget. Functions that persist or
+materialize rewrites accept `AdmittedRewriteDelta`, making it impossible to skip the budget check.
 
-Rejected rewrites are persisted to `pulse.graph_rewrites` with
-`status = 'rejected'`, `rejection_reason`, and `exceeded_dimensions` for
-operator visibility. The `EvtRewriteRejected` executor event carries the
-rejection type and message for structured observability.
+Rejected rewrites are persisted to `pulse.graph_rewrites` with `status = 'rejected'`,
+`rejection_reason`, and `exceeded_dimensions` for operator visibility. The `EvtRewriteRejected`
+executor event carries the rejection type and message for structured observability.
 
-A zero-budget (`RewriteBudget 0 0 0 0 0`) disables rewrites entirely while
-preserving graph-state execution for static plans. Tasks that never produce
-rewrites can safely use any budget — budget is only consumed when a stage
-returns `StageRewrite`.
+A zero-budget (`RewriteBudget 0 0 0 0 0`) disables rewrites entirely while preserving graph-state
+execution for static plans. Tasks that never produce rewrites can safely use any budget — budget is
+only consumed when a stage returns `StageRewrite`.
 
 ### Retry policy as data
 
@@ -776,17 +745,17 @@ data RetryBackoff
 withRetry :: RetryPolicy -> IO a -> IO (Either RetryExhausted a)
 ```
 
-A single interpreter (`withRetry`) reads the policy. Individual retry
-call sites construct the policy value; they don't embed retry logic.
+A single interpreter (`withRetry`) reads the policy. Individual retry call sites construct the
+policy value; they don't embed retry logic.
 
-**[P2] Flag**: Retry logic inlined in business code with hardcoded delays
-and attempt counts. Different retry shapes (exponential, linear, with
-jitter) scattered across modules without a shared abstraction.
+**[P2] Flag**: Retry logic inlined in business code with hardcoded delays and attempt counts.
+Different retry shapes (exponential, linear, with jitter) scattered across modules without a shared
+abstraction.
 
 ### Resource acquisition bracket discipline
 
-Every resource that needs cleanup must use `bracket`, `withAsync`,
-`finally`, or equivalent RAII-style acquisition:
+Every resource that needs cleanup must use `bracket`, `withAsync`, `finally`, or equivalent
+RAII-style acquisition:
 
 ```haskell
 -- GOOD: bracket ensures cleanup
@@ -799,9 +768,8 @@ withAsync (renewalLoop pool lease) $ \renewalAsync ->
     cancel renewalAsync >> pure result
 ```
 
-**[P1] Flag**: `forkIO` without corresponding cleanup logic.
-**[P2] Flag**: `openFile` / `createConnection` without a bracket.
-**[P2] Flag**: `async` without `withAsync` or `link`.
+**[P1] Flag**: `forkIO` without corresponding cleanup logic. **[P2] Flag**: `openFile` /
+`createConnection` without a bracket. **[P2] Flag**: `async` without `withAsync` or `link`.
 
 ## Servant server structure
 
@@ -841,17 +809,16 @@ data AppEnv = AppEnv
   }
 ```
 
-Functions take only the capability they need: `handleLogin :: AuthCapability -> ...`
-not `handleLogin :: AppEnv -> ...`.
+Functions take only the capability they need: `handleLogin :: AuthCapability -> ...` not
+`handleLogin :: AppEnv -> ...`.
 
-**[P2] Flag**: A function that receives the full `AppEnv`/`ServerContext`
-but only accesses 1-2 fields — it should take the specific sub-record.
+**[P2] Flag**: A function that receives the full `AppEnv`/`ServerContext` but only accesses 1-2
+fields — it should take the specific sub-record.
 
 ### Has-class for shared capabilities
 
-When 3+ environment records share a common field (e.g., pool, logger),
-define a `Has` class so functions can be polymorphic over which env they
-receive:
+When 3+ environment records share a common field (e.g., pool, logger), define a `Has` class so
+functions can be polymorphic over which env they receive:
 
 ```haskell
 class HasPool env where
@@ -866,8 +833,8 @@ runQuery :: (HasPool env) => env -> Query a -> IO a
 runQuery env query = DB.withConnection (getPool env) query
 ```
 
-**When to introduce**: 3+ env types share the same field. Premature
-Has-classes on a single env type add noise.
+**When to introduce**: 3+ env types share the same field. Premature Has-classes on a single env type
+add noise.
 
 ### Route type naming
 
@@ -886,18 +853,16 @@ Never inline a multi-line type signature in the server wiring module.
 
 ### Authentication consistency
 
-Pass `AuthenticatedUser` to all protected handlers. Let handlers unwrap
-to `UUID` if they need only the ID. Don't unwrap at the routing layer —
-handlers may eventually need role information.
+Pass `AuthenticatedUser` to all protected handlers. Let handlers unwrap to `UUID` if they need only
+the ID. Don't unwrap at the routing layer — handlers may eventually need role information.
 
 ### QueryParam positional parameters
 
-Servant's `QueryParam` produces one handler parameter per query param.
-This is a framework constraint — you cannot bundle them into a record at
-the API type level without custom combinators.
+Servant's `QueryParam` produces one handler parameter per query param. This is a framework
+constraint — you cannot bundle them into a record at the API type level without custom combinators.
 
-**The right fix**: immediately construct a named record on the first line of
-the handler. This is what well-written handlers already do:
+**The right fix**: immediately construct a named record on the first line of the handler. This is
+what well-written handlers already do:
 
 ```haskell
 listCostsHandler ctx maybeFrom maybeTo maybeUserId maybeProvider maybeModel maybeLimit = do
@@ -905,9 +870,9 @@ listCostsHandler ctx maybeFrom maybeTo maybeUserId maybeProvider maybeModel mayb
   -- rest of handler uses filterParams, never the positional names
 ```
 
-**Do NOT flag** QueryParam positional parameters as a parameter safety issue
-when the handler already bundles them. The positional signature is forced by
-Servant, and the code handles it correctly.
+**Do NOT flag** QueryParam positional parameters as a parameter safety issue when the handler
+already bundles them. The positional signature is forced by Servant, and the code handles it
+correctly.
 
 ## Observability
 
@@ -930,15 +895,14 @@ emitEvent = mkEventEmitter "cortex-pulse"
 
 ### Severity calibration
 
-- **Error**: Something is wrong that may require operator attention. Duplicate
-  execution possible. Data loss possible.
-- **Warn**: Something unexpected happened but the system recovered or will
-  recover automatically. Failed non-critical write. Retrying a stage.
-- **Info**: Normal lifecycle events. Task started. Stage completed. Scheduler
-  stopping.
+- **Error**: Something is wrong that may require operator attention. Duplicate execution possible.
+  Data loss possible.
+- **Warn**: Something unexpected happened but the system recovered or will recover automatically.
+  Failed non-critical write. Retrying a stage.
+- **Info**: Normal lifecycle events. Task started. Stage completed. Scheduler stopping.
 
-If it wakes someone up at 3am, it's Error. If it shows up in a daily
-review, it's Warn. If it's noise in normal operation, it's Info.
+If it wakes someone up at 3am, it's Error. If it shows up in a daily review, it's Warn. If it's
+noise in normal operation, it's Info.
 
 ### Structured fields
 
@@ -952,21 +916,21 @@ emitEvent ObsInfo "pulse.executor.stage.completed" "Stage completed"
   ]
 ```
 
-Convention: include `run_id` on all run-scoped events, `task_id` on all
-task-scoped events. Add context-specific fields only when they aid debugging.
+Convention: include `run_id` on all run-scoped events, `task_id` on all task-scoped events. Add
+context-specific fields only when they aid debugging.
 
 ### Required fields per domain
 
 Codify the minimum structured fields per log domain:
 
-| Domain | Required fields |
-|---|---|
-| **Pulse operations** | `run_id`, `task_id`, `stage_name`, `attempt` |
-| **Host-action operations** | `host_action_id`, `operation`, `attempt` |
-| **API handlers** | `request_id`, `handler_name`, `user_id` |
+| Domain                     | Required fields                              |
+| -------------------------- | -------------------------------------------- |
+| **Pulse operations**       | `run_id`, `task_id`, `stage_name`, `attempt` |
+| **Host-action operations** | `host_action_id`, `operation`, `attempt`     |
+| **API handlers**           | `request_id`, `handler_name`, `user_id`      |
 
-Define a `LogContext` record per domain and a helper that attaches all
-fields at once, so individual log calls can't accidentally omit fields:
+Define a `LogContext` record per domain and a helper that attaches all fields at once, so individual
+log calls can't accidentally omit fields:
 
 ```haskell
 data PulseLogContext = PulseLogContext

--- a/agents/skills/haskell-code-style/references/refactoring-patterns.md
+++ b/agents/skills/haskell-code-style/references/refactoring-patterns.md
@@ -1,25 +1,25 @@
 # Refactoring Patterns
 
-Concrete patterns for decomposing Haskell code. Each pattern includes the
-symptom, the principle, and a before/after sketch.
+Concrete patterns for decomposing Haskell code. Each pattern includes the symptom, the principle,
+and a before/after sketch.
 
 ## Pattern 1: Return a value, don't perform a continuation
 
 ### Symptom
 
-A function inside a `where` block sometimes calls the enclosing loop's
-continuation (`go rest newState`) and sometimes returns a terminal value
-(`pure OutcomeFailed`). The function has two exit modes but they look
-identical syntactically.
+A function inside a `where` block sometimes calls the enclosing loop's continuation
+(`go rest newState`) and sometimes returns a terminal value (`pure OutcomeFailed`). The function has
+two exit modes but they look identical syntactically.
 
 ### Principle
 
-Split the decision from the continuation. The inner function returns a
-result type. The loop interprets it.
+Split the decision from the continuation. The inner function returns a result type. The loop
+interprets it.
 
 ### Technique
 
 1. Define a result ADT with one variant per exit mode:
+
    ```haskell
    data StageAttemptResult
      = StageAdvance Aeson.Value  -- caller should continue with this state
@@ -27,8 +27,7 @@ result type. The loop interprets it.
      | StageTerminal RunOutcome  -- caller should stop
    ```
 
-2. Change the inner function's return type from `IO RunOutcome` to
-   `IO StageAttemptResult`.
+2. Change the inner function's return type from `IO RunOutcome` to `IO StageAttemptResult`.
 
 3. Replace all `go rest newState` calls with `pure (StageAdvance newState)`.
 
@@ -44,24 +43,24 @@ result type. The loop interprets it.
 
 ### When NOT to apply
 
-If the function only ever returns (never calls the continuation), it's
-already returning a value. Don't wrap it in a redundant ADT.
+If the function only ever returns (never calls the continuation), it's already returning a value.
+Don't wrap it in a redundant ADT.
 
 ## Pattern 2: Extract environment records from closures
 
 ### Symptom
 
-A `where` block defines 3+ helper functions. Each closes over 5+ bindings
-from the enclosing scope (`pool`, `runId`, `taskType`, `config`, ...).
-The helpers can't be promoted to top-level because they'd need too many
-parameters.
+A `where` block defines 3+ helper functions. Each closes over 5+ bindings from the enclosing scope
+(`pool`, `runId`, `taskType`, `config`, ...). The helpers can't be promoted to top-level because
+they'd need too many parameters.
 
 ### Technique
 
-1. Identify the shared bindings. Usually: a DB pool, an entity ID, some
-   config values, and a shutdown/cancellation flag.
+1. Identify the shared bindings. Usually: a DB pool, an entity ID, some config values, and a
+   shutdown/cancellation flag.
 
 2. Define a record:
+
    ```haskell
    data StageEnv = StageEnv
      { sePool     :: DB.Pool
@@ -72,32 +71,32 @@ parameters.
    ```
 
 3. Construct it once in the enclosing function:
+
    ```haskell
    runStagePlan taskContext runId taskType ... = do
      let env = StageEnv { ... }
      go env remaining initialState
    ```
 
-4. Promote each `where`-bound helper to module scope, taking `env` as
-   first argument.
+4. Promote each `where`-bound helper to module scope, taking `env` as first argument.
 
 ### Naming convention
 
-Use a two-letter prefix matching the record name: `sePool` for `StageEnv`,
-`acRunState` for `AssistantContext`. Avoids record field clashes across
-the module.
+Use a two-letter prefix matching the record name: `sePool` for `StageEnv`, `acRunState` for
+`AssistantContext`. Avoids record field clashes across the module.
 
 ### When it leads to ReaderT
 
-If the environment is threaded through every function in a module, `ReaderT`
-is the natural next step. But start with the plain record — it's simpler,
-explicit, and doesn't require monad transformer knowledge to read.
+If the environment is threaded through every function in a module, `ReaderT` is the natural next
+step. But start with the plain record — it's simpler, explicit, and doesn't require monad
+transformer knowledge to read.
 
 ## Pattern 3: Collapse same-shaped branches
 
 ### Symptom
 
 A case expression with 5+ branches where each branch does:
+
 1. Run a transaction
 2. Case on the result (Left err / Right ())
 3. Log an error or success
@@ -107,6 +106,7 @@ A case expression with 5+ branches where each branch does:
 ### Technique
 
 1. Factor out the common flow:
+
    ```haskell
    finalize :: Pool -> UUID -> Transaction () -> FinalizationLog -> IO ()
    finalize pool taskId tx logSpec = do
@@ -118,6 +118,7 @@ A case expression with 5+ branches where each branch does:
    ```
 
 2. Make the per-branch differences a data type:
+
    ```haskell
    data FinalizationLog = FinalizationLog
      { errorLevel  :: LogLevel
@@ -132,16 +133,15 @@ A case expression with 5+ branches where each branch does:
 
 ### When NOT to apply
 
-If the branches have genuinely different recovery semantics (one retries,
-one fails, one ignores), they're not same-shaped — the differences are
-behavioral, not just textual. Keep them separate.
+If the branches have genuinely different recovery semantics (one retries, one fails, one ignores),
+they're not same-shaped — the differences are behavioral, not just textual. Keep them separate.
 
 ## Pattern 4: Split audit bookkeeping from business logic
 
 ### Symptom
 
-A function interleaves "do the work" with "log that we started the work"
-and "log that we finished the work" and "update the audit table".
+A function interleaves "do the work" with "log that we started the work" and "log that we finished
+the work" and "update the audit table".
 
 ### Technique
 
@@ -158,15 +158,14 @@ executeStage env stageDef stageName state = do
 attemptStage :: StageEnv -> StageDefinition -> Text -> Value -> Int64 -> Int -> IO StageAttemptResult
 ```
 
-The audit function does DB bookkeeping. The business function does the
-actual work. Neither knows about the other's concerns.
+The audit function does DB bookkeeping. The business function does the actual work. Neither knows
+about the other's concerns.
 
 ## Pattern 5: Shutdown-aware delays
 
 ### Symptom
 
-`threadDelay` in a retry loop blocks the entire duration even when
-shutdown is requested.
+`threadDelay` in a retry loop blocks the entire duration even when shutdown is requested.
 
 ### Technique
 
@@ -189,8 +188,8 @@ This wakes immediately on shutdown instead of blocking the full backoff.
 
 ### Symptom
 
-An action needs to run under a renewable lease. The lease renewal is
-interleaved with the action execution using `race` or `withAsync`.
+An action needs to run under a renewable lease. The lease renewal is interleaved with the action
+execution using `race` or `withAsync`.
 
 ### Technique
 
@@ -201,23 +200,21 @@ withLeaseRenewal :: DB.Pool -> UUID -> Int32 -> IO a -> IO a
 ```
 
 Inside:
-1. `withAsync action` to run the action concurrently
-2. `race (waitCatch actionAsync) (threadDelay interval)` to detect
-   completion vs renewal time
-3. On renewal time: attempt renewal, handle loss gracefully
-4. On lease loss: cancel the action, but check if it completed in the
-   race window before declaring failure
 
-The key subtlety: after `cancel actionAsync`, always `waitCatch` and
-check if the action completed naturally. The action might have finished
-between lease loss detection and cancellation.
+1. `withAsync action` to run the action concurrently
+2. `race (waitCatch actionAsync) (threadDelay interval)` to detect completion vs renewal time
+3. On renewal time: attempt renewal, handle loss gracefully
+4. On lease loss: cancel the action, but check if it completed in the race window before declaring
+   failure
+
+The key subtlety: after `cancel actionAsync`, always `waitCatch` and check if the action completed
+naturally. The action might have finished between lease loss detection and cancellation.
 
 ## Pattern 7: Replace repetitive dispatch with a Map registry
 
 ### Symptom
 
-A case expression with 30+ branches, each doing the same thing with
-different strings:
+A case expression with 30+ branches, each doing the same thing with different strings:
 
 ```haskell
 case (name, value) of
@@ -229,6 +226,7 @@ case (name, value) of
 ### Technique
 
 1. Define a dispatch helper that wraps the common per-branch logic:
+
    ```haskell
    tool :: (FromJSON a) => (a -> Handler Text) -> Value -> Handler Text
    tool handler value = case fromJSON value of
@@ -237,6 +235,7 @@ case (name, value) of
    ```
 
 2. Build a `Map Text (Value -> Handler Text)` registry:
+
    ```haskell
    registry = Map.fromList
      [ ("foo", tool fooHandler)
@@ -260,17 +259,16 @@ case (name, value) of
 
 ### When NOT to apply
 
-- If branches have genuinely different structure (some parse JSON, some don't,
-  some need extra context). Forcing them into a uniform shape hides differences.
+- If branches have genuinely different structure (some parse JSON, some don't, some need extra
+  context). Forcing them into a uniform shape hides differences.
 - If there are only 3–4 branches — the case statement is more direct.
 
 ## Pattern 8: Mechanical repetition → combinator module
 
 ### Symptom
 
-The same 3–5 line pattern appears 10+ times across multiple modules, with
-only types or field names varying. Common in: Hasql encoder/decoder
-construction, event emission, error logging boilerplate.
+The same 3–5 line pattern appears 10+ times across multiple modules, with only types or field names
+varying. Common in: Hasql encoder/decoder construction, event emission, error logging boilerplate.
 
 ```haskell
 -- This exact shape appears 15 times across 5 query modules:
@@ -300,25 +298,23 @@ Each call site shrinks from N lines of tuple destructors to 1 function call.
 ### When to apply
 
 - **3+ modules** share the identical pattern shape (not just similar — identical)
-- The pattern is **mechanical** (encoders, decoders, event structures), not
-  business logic
+- The pattern is **mechanical** (encoders, decoders, event structures), not business logic
 - The combinator is **small** (<50 lines) and **stable** (unlikely to change)
 
 ### When NOT to apply
 
 - Only 1–2 modules use the pattern — keep it local
-- The pattern involves business logic decisions — inline duplication is safer
-  because each site may diverge as requirements change
-- Building the combinator requires type-level machinery that makes it harder
-  to understand than the repetition
+- The pattern involves business logic decisions — inline duplication is safer because each site may
+  diverge as requirements change
+- Building the combinator requires type-level machinery that makes it harder to understand than the
+  repetition
 
 ## Pattern 9: Sequential Either chains → ExceptT
 
 ### Symptom
 
-A function runs 3+ steps where each returns `Either e a` or
-`IO (Either e a)`, and each failure is handled identically — propagate
-the error, stop the pipeline:
+A function runs 3+ steps where each returns `Either e a` or `IO (Either e a)`, and each failure is
+handled identically — propagate the error, stop the pipeline:
 
 ```haskell
 -- BAD: repetitive case-of plumbing for purely sequential logic
@@ -351,6 +347,7 @@ syncAccount manager cfg = do
 ```
 
 Key lifting patterns:
+
 - `ExceptT action` — wraps `m (Either e a)` into `ExceptT e m a`
 - `except value` — lifts a pure `Either e a` into `ExceptT e m a`
 - `liftIO action` — lifts `IO a` (infallible) into `ExceptT e IO a`
@@ -367,8 +364,7 @@ case result of
 
 ### Incremental migration
 
-Don't rewrite a 200-line orchestrator into one giant `ExceptT do` block.
-Instead:
+Don't rewrite a 200-line orchestrator into one giant `ExceptT do` block. Instead:
 
 1. Identify the sequential sub-pipeline (the part that's just propagating)
 2. Extract it into a helper function using `ExceptT`
@@ -403,21 +399,21 @@ orchestrate mgr cfg = do
 
 ### When NOT to apply
 
-- Each `Left` branch has materially different behavior (logging, retry,
-  skip, cancel) — keep explicit pattern matching
-- The function is primarily orchestration with occasional fallible steps —
-  `ExceptT` would obscure the control flow
+- Each `Left` branch has materially different behavior (logging, retry, skip, cancel) — keep
+  explicit pattern matching
+- The function is primarily orchestration with occasional fallible steps — `ExceptT` would obscure
+  the control flow
 - Only 1–2 steps — the overhead of `runExceptT` isn't worth it
-- The error types differ across steps and don't share a common type —
-  don't force `withExceptT` gymnastics
+- The error types differ across steps and don't share a common type — don't force `withExceptT`
+  gymnastics
 
 ## Pattern 10: Typed failure domains instead of exceptions
 
 ### Symptom
 
-A function uses `try` to catch `SomeException`, then pattern-matches on
-specific exception types to classify outcomes (skip, timeout, failure).
-The control flow relies on exception-shaped paths for domain-level decisions.
+A function uses `try` to catch `SomeException`, then pattern-matches on specific exception types to
+classify outcomes (skip, timeout, failure). The control flow relies on exception-shaped paths for
+domain-level decisions.
 
 ```haskell
 -- BAD: timeout and skip are domain outcomes, not exceptional conditions
@@ -435,8 +431,8 @@ case result of
 
 ### Technique
 
-Model the outcomes as a sum type. The business function returns the type;
-the caller pattern-matches without exception machinery.
+Model the outcomes as a sum type. The business function returns the type; the caller pattern-matches
+without exception machinery.
 
 ```haskell
 -- GOOD: all outcomes are data, not exceptions
@@ -468,8 +464,7 @@ case runJobWithTimeout timeoutUs env job of
 
 ### When NOT to apply
 
-- True unexpected exceptions (OOM, segfault, async cancel) — those stay as
-  exceptions
+- True unexpected exceptions (OOM, segfault, async cancel) — those stay as exceptions
 - The leaf function is third-party and you can't change its return type
 - Only one exception type matters — a simple `try`/`catch` is fine
 
@@ -477,10 +472,9 @@ case runJobWithTimeout timeoutUs env job of
 
 ### Symptom
 
-A single function (>80 lines) does orchestration + timeout + exception
-classification + DB persistence + observability + post-processing. Each
-concern is entangled with the others, making the function hard to modify
-or test in isolation.
+A single function (>80 lines) does orchestration + timeout + exception classification + DB
+persistence + observability + post-processing. Each concern is entangled with the others, making the
+function hard to modify or test in isolation.
 
 ### Technique
 
@@ -506,8 +500,8 @@ persistJobResult :: Pool -> UUID -> JobResult -> IO ()
 
 ### Naming convention
 
-Name helpers for **what they return or accomplish**, not the mechanical
-steps inside:
+Name helpers for **what they return or accomplish**, not the mechanical steps inside:
+
 - `claimJobRun` (returns `ClaimResult`), not `doCASAndCreateRun`
 - `runJobWithTimeout` (returns `JobResult`), not `executeAndHandleTimeout`
 - `persistJobResult` (persists + advances schedule), not `doStatusUpdateAndSchedule`
@@ -516,16 +510,14 @@ steps inside:
 
 - Function exceeds 80 lines
 - Three or more concerns are interleaved (claim, execute, persist, observe)
-- Same-shaped branches appear for different outcome types (skip/fail/success
-  all do: emit event → persist status → advance schedule)
+- Same-shaped branches appear for different outcome types (skip/fail/success all do: emit event →
+  persist status → advance schedule)
 
 ### When NOT to apply
 
-- Function is already under 50 lines — decomposition adds indirection
-  without reducing complexity
-- Only one caller exists and the helpers would need 5+ threaded parameters —
-  the function boundary is in the wrong place (try an environment record
-  first)
+- Function is already under 50 lines — decomposition adds indirection without reducing complexity
+- Only one caller exists and the helpers would need 5+ threaded parameters — the function boundary
+  is in the wrong place (try an environment record first)
 
 ## General refactoring heuristics
 
@@ -533,34 +525,30 @@ steps inside:
 - **Extract when `where` nesting exceeds 3 levels**
 - **Extract when a `where`-bound function is called from multiple branches**
 - **Don't extract single-use helpers to module scope** unless they're independently testable
-- **Name extracted functions for what they return**, not what they do:
-  `persistStageSuccess` (returns `StageAttemptResult`), not `doCheckpointAndContinue`
-- **Preserve identical behavior**: refactoring is structural, not behavioral.
-  Same DB calls, same log events, same error semantics. Verify by diffing
-  the observable effects.
+- **Name extracted functions for what they return**, not what they do: `persistStageSuccess`
+  (returns `StageAttemptResult`), not `doCheckpointAndContinue`
+- **Preserve identical behavior**: refactoring is structural, not behavioral. Same DB calls, same
+  log events, same error semantics. Verify by diffing the observable effects.
 
 ### The net-complexity test
 
 Before committing an extraction, check:
 
-1. **Does it reduce total lines?** Adding lines is fine when adding error
-   handling or separation of concerns. But an extraction that adds lines
-   without adding testability, error coverage, or caller simplification is
-   just indirection. The goal isn't fewer lines — it's less total complexity.
+1. **Does it reduce total lines?** Adding lines is fine when adding error handling or separation of
+   concerns. But an extraction that adds lines without adding testability, error coverage, or caller
+   simplification is just indirection. The goal isn't fewer lines — it's less total complexity.
 
-2. **How many call sites?** A function extracted from one call site is just
-   indirection. Extract at 2+ sites minimum, prefer 3+.
+2. **How many call sites?** A function extracted from one call site is just indirection. Extract at
+   2+ sites minimum, prefer 3+.
 
-3. **Does it need the upstream context?** If extracting requires threading 5+
-   parameters that were free closures before, the function boundary is in the
-   wrong place. Consider extracting an environment record first (Pattern 2),
-   or leave the code inline.
+3. **Does it need the upstream context?** If extracting requires threading 5+ parameters that were
+   free closures before, the function boundary is in the wrong place. Consider extracting an
+   environment record first (Pattern 2), or leave the code inline.
 
-4. **Is the abstraction simpler than the original?** If reading the extracted
-   function requires jumping back to the call site to understand the context,
-   the extraction made the code harder to follow, not easier.
+4. **Is the abstraction simpler than the original?** If reading the extracted function requires
+   jumping back to the call site to understand the context, the extraction made the code harder to
+   follow, not easier.
 
-5. **Does it improve the caller?** The best extractions make callers cleaner.
-   An environment record is valuable not because the module got shorter, but
-   because the caller passes one record instead of 6 positional params.
-   Always check both sides of the boundary.
+5. **Does it improve the caller?** The best extractions make callers cleaner. An environment record
+   is valuable not because the module got shorter, but because the caller passes one record instead
+   of 6 positional params. Always check both sides of the boundary.

--- a/agents/skills/haskell-code-style/references/review-rubric.md
+++ b/agents/skills/haskell-code-style/references/review-rubric.md
@@ -1,23 +1,24 @@
 # Code Review Rubric
 
-Structured approach to reviewing Haskell modules. Score 1–10 on each axis,
-weight by relevance to the module's role.
+Structured approach to reviewing Haskell modules. Score 1–10 on each axis, weight by relevance to
+the module's role.
 
 ## Axes
 
 ### Correctness (weight: high)
 
-**First-pass automated check** — before reviewing anything else, grep for
-fire-and-forget DB writes. These are the highest-value findings:
+**First-pass automated check** — before reviewing anything else, grep for fire-and-forget DB writes.
+These are the highest-value findings:
 
 ```bash
 grep -rn '_ <- .*runTransaction\|_ <- .*runQuery\|_ <- .*withConnection' src/
 ```
 
-Every hit is a potential silent failure. Classify each as intentional
-(best-effort with comment) or accidental (missing error path).
+Every hit is a potential silent failure. Classify each as intentional (best-effort with comment) or
+accidental (missing error path).
 
 Then check:
+
 - Exhaustive pattern matches on owned ADTs (no wildcards hiding variants)
 - Async exceptions re-thrown, not swallowed
 - Database transaction boundaries correct (atomicity where needed)
@@ -26,9 +27,9 @@ Then check:
 
 ### Architecture (weight: high)
 
-- **Three Layer Cake**: Module classifiable as pure (layer 1), constrained
-  effects (layer 2), or effectful wiring (layer 3). Flag functions that mix
-  layers (see architecture.md "Three Layer Cake").
+- **Three Layer Cake**: Module classifiable as pure (layer 1), constrained effects (layer 2), or
+  effectful wiring (layer 3). Flag functions that mix layers (see architecture.md "Three Layer
+  Cake").
 - Pure decision logic separated from effectful execution
 - Functions operate at one abstraction level (not mixing orchestration with DB writes with logging)
 - Return values rather than performing continuations
@@ -39,15 +40,14 @@ Then check:
 
 - `where` nesting <= 3 levels
 - No function exceeds ~80 lines (soft limit; 50 is better)
-- **Cyclomatic complexity proxy**: count `case`, `if`, `when`, `unless`,
-  and monadic bind points in a single function. Over 15 -> decompose.
+- **Cyclomatic complexity proxy**: count `case`, `if`, `when`, `unless`, and monadic bind points in
+  a single function. Over 15 -> decompose.
 - Happy path visually dominant; error handling doesn't obscure it
 - Named types for API boundaries (not inline 30-line type signatures)
 - Export list curated and intentional — every module has an explicit export list
 - Re-exports only re-export curated public APIs, not internal types
 - New code follows the module's existing import style (qualified vs unqualified)
-- Comment conventions: `-- |` Haddock on exports, `-- TODO(ticket):` with
-  ticket ref, no naked TODOs
+- Comment conventions: `-- |` Haddock on exports, `-- TODO(ticket):` with ticket ref, no naked TODOs
 
 ### Parameter safety (weight: medium)
 
@@ -63,10 +63,10 @@ Then check:
 - Lease/timeout recovery paths exist for operations that can be interrupted
 - Last-resort handlers log enough context to diagnose (run ID, error type, original error)
 - Sequential Either chains use `ExceptT` instead of nested `case Left/Right`
-- `Either String` from external sources is converted to domain errors at
-  the boundary — not propagated through core layers
-- Orchestration functions that need different recovery per failure keep
-  explicit branching (not forced into `ExceptT`)
+- `Either String` from external sources is converted to domain errors at the boundary — not
+  propagated through core layers
+- Orchestration functions that need different recovery per failure keep explicit branching (not
+  forced into `ExceptT`)
 
 ### Observability (weight: low-medium)
 
@@ -78,25 +78,24 @@ Then check:
 ### Upstream impact (weight: medium)
 
 - Does the module's public API (exports, function signatures) make callers cleaner?
-- Does the module force callers into awkward patterns (threading unused params,
-  constructing large records for simple operations)?
-- When reviewing a refactoring, check the call sites — a module that's internally
-  clean but forces callers to pass 6 positional params is mis-abstracted
-- An environment record is valuable not because it makes the module shorter, but
-  because callers construct one record instead of passing 6 separate arguments
+- Does the module force callers into awkward patterns (threading unused params, constructing large
+  records for simple operations)?
+- When reviewing a refactoring, check the call sites — a module that's internally clean but forces
+  callers to pass 6 positional params is mis-abstracted
+- An environment record is valuable not because it makes the module shorter, but because callers
+  construct one record instead of passing 6 separate arguments
 
 ### Type safety (weight: medium)
 
 - Smart constructors for types with invariants (no public data constructors)
 - Phantom types for semantically distinct same-shaped values (2+ UUID params)
 - `NonEmpty` for lists that must have at least one element
-- No partial functions (`head`, `fromJust`, `read`, `!!`, `error`) in
-  production code
+- No partial functions (`head`, `fromJust`, `read`, `!!`, `error`) in production code
 - `DerivingStrategies` explicit on all `deriving` clauses
 - No `Show` derived on types with sensitive fields
 - No orphan instances
-- Optics: `foo { bar = (bar foo) { baz = newBaz } }` appearing 3+ times
-  is a candidate for a lens; otherwise plain record update suffices
+- Optics: `foo { bar = (bar foo) { baz = newBaz } }` appearing 3+ times is a candidate for a lens;
+  otherwise plain record update suffices
 
 ### Style (weight: low)
 
@@ -109,14 +108,14 @@ Then check:
 
 ## Scoring guide
 
-- **9–10**: Production-grade. Clean separation, honest error handling, would trust
-  in a system I operate at 3am.
-- **7–8**: Solid with identifiable improvement areas. Working code that could be
-  made more maintainable with targeted refactoring.
-- **5–6**: Functional but accumulated structural debt. The kind of code that works
-  until someone needs to modify it.
-- **3–4**: Significant issues. Missing error paths, unclear control flow, or
-  architectural problems that will cause bugs under maintenance.
+- **9–10**: Production-grade. Clean separation, honest error handling, would trust in a system I
+  operate at 3am.
+- **7–8**: Solid with identifiable improvement areas. Working code that could be made more
+  maintainable with targeted refactoring.
+- **5–6**: Functional but accumulated structural debt. The kind of code that works until someone
+  needs to modify it.
+- **3–4**: Significant issues. Missing error paths, unclear control flow, or architectural problems
+  that will cause bugs under maintenance.
 - **1–2**: Needs rewrite. Fundamental structural problems.
 
 ## Review structure
@@ -126,24 +125,22 @@ Then check:
 3. **Issues**: Ranked by severity, with concrete fixes (not vague suggestions)
 4. **Style notes**: Minor observations that don't affect the score
 
-Keep reviews concrete. "The error handling is good" is useless. "The `requireTx`
-pattern ensures every critical DB write either succeeds or fails the run with
-context" is useful.
+Keep reviews concrete. "The error handling is good" is useless. "The `requireTx` pattern ensures
+every critical DB write either succeeds or fails the run with context" is useful.
 
 ### Severity classification
 
 Findings must be classified by action required, not just importance:
 
-- **[P1] Block merge** — Correctness bugs, silent error drops, data loss risk,
-  non-exhaustive matches on owned ADTs. These must be fixed before shipping.
-- **[P2] Track as debt** — Architecture issues, structural concerns, oversized
-  functions, missing abstractions. These won't cause bugs today but accumulate
-  friction. Create a follow-up issue or TODO, don't block the PR.
+- **[P1] Block merge** — Correctness bugs, silent error drops, data loss risk, non-exhaustive
+  matches on owned ADTs. These must be fixed before shipping.
+- **[P2] Track as debt** — Architecture issues, structural concerns, oversized functions, missing
+  abstractions. These won't cause bugs today but accumulate friction. Create a follow-up issue or
+  TODO, don't block the PR.
 - **[style]** — Naming, formatting, import style. Note and move on.
 
-A review that marks everything P1 is as useless as one that marks everything
-P2. The distinction is: "would I page someone at 3am for this?" If yes, P1.
-If no, P2.
+A review that marks everything P1 is as useless as one that marks everything P2. The distinction is:
+"would I page someone at 3am for this?" If yes, P1. If no, P2.
 
 ## Review calibration
 
@@ -151,40 +148,38 @@ If no, P2.
 
 A finding is not a finding until verified. Concretely:
 
-- **Wildcard matches**: Only flag `_` on types *declared in this project's source*,
-  not on `Text`, `Maybe`, `Int`, `Either`, `Value`, HTTP status codes, or other
-  standard library types. The test: "if someone added a constructor to this type,
-  would this wildcard hide a bug?" If the type is from `base`, `aeson`, or
-  `servant`, the answer is no.
+- **Wildcard matches**: Only flag `_` on types _declared in this project's source_, not on `Text`,
+  `Maybe`, `Int`, `Either`, `Value`, HTTP status codes, or other standard library types. The test:
+  "if someone added a constructor to this type, would this wildcard hide a bug?" If the type is from
+  `base`, `aeson`, or `servant`, the answer is no.
 
-- **Parameter safety**: Check whether the handler already bundles positional params
-  into a record on the first line. If it does, the positional signature is a Servant
-  `QueryParam` constraint, not a code quality issue.
+- **Parameter safety**: Check whether the handler already bundles positional params into a record on
+  the first line. If it does, the positional signature is a Servant `QueryParam` constraint, not a
+  code quality issue.
 
-- **File size**: Check complexity *per function* before flagging total lines. A
-  1200-line file of independent 30-line handlers is fine. A 400-line file with one
-  200-line function is not.
+- **File size**: Check complexity _per function_ before flagging total lines. A 1200-line file of
+  independent 30-line handlers is fine. A 400-line file with one 200-line function is not.
 
 ### Net complexity principle
 
-A refactoring should reduce total complexity, not just redistribute it. Signals
-that an extraction is not worth it:
+A refactoring should reduce total complexity, not just redistribute it. Signals that an extraction
+is not worth it:
 
 - It adds more lines than it removes
 - The extracted function is called from exactly one site
 - The extracted function requires passing 5+ parameters that were free closures before
 - The abstraction is harder to understand than the original repetition
 
-Three similar 10-line blocks are often better than one 30-line generic abstraction
-with type parameters. Extract when there are 3+ call sites, real repetition risk
-(bugs from forgetting to update one copy), or the function is independently testable.
+Three similar 10-line blocks are often better than one 30-line generic abstraction with type
+parameters. Extract when there are 3+ call sites, real repetition risk (bugs from forgetting to
+update one copy), or the function is independently testable.
 
 ## Anti-patterns to flag
 
 ### The Closure Trap
 
-Deeply nested `where` blocks that close over many variables, making extraction
-feel impossible. The fix is always: define a record, promote to top-level.
+Deeply nested `where` blocks that close over many variables, making extraction feel impossible. The
+fix is always: define a record, promote to top-level.
 
 ```haskell
 -- Symptom: you can't extract `attemptStage` because it calls `go`
@@ -206,9 +201,8 @@ case result of
 
 ### The God Context
 
-A single record threaded through every function containing everything the
-application needs. Every handler receives the admin pepper even if it only
-needs the DB pool.
+A single record threaded through every function containing everything the application needs. Every
+handler receives the admin pepper even if it only needs the DB pool.
 
 ```haskell
 -- Symptom: ServerContext has 13 fields, passed to 120 call sites
@@ -217,8 +211,8 @@ needs the DB pool.
 
 ### Sequential Either ladders
 
-Three or more chained `case result of Left err -> ...; Right val -> ...`
-where every `Left` branch does the same thing (propagate, throw, return Left):
+Three or more chained `case result of Left err -> ...; Right val -> ...` where every `Left` branch
+does the same thing (propagate, throw, return Left):
 
 ```haskell
 -- BAD: 3+ sequential case-of with identical Left handling
@@ -239,8 +233,8 @@ pipeline = do
   ...
 ```
 
-Only flag when the Left handling is uniform. If each Left triggers different
-logging/recovery, explicit branching is correct.
+Only flag when the Left handling is uniform. If each Left triggers different logging/recovery,
+explicit branching is correct.
 
 ### Same-shaped branches
 
@@ -256,8 +250,8 @@ logFinalization taskId decision applyResult = ...
 
 ### Exception-based domain outcomes
 
-Using `fail`, `error`, or thrown exceptions to represent known business
-outcomes (skip, timeout, cancel) rather than returning them as typed data.
+Using `fail`, `error`, or thrown exceptions to represent known business outcomes (skip, timeout,
+cancel) rather than returning them as typed data.
 
 ```haskell
 -- BAD: timeout is a domain outcome, not an exceptional condition
@@ -271,44 +265,41 @@ throw (JobSkipped reason)
 data JobResult = JobCompleted Int | JobSkipped Text | JobTimedOut Int
 ```
 
-Flag when: `try`/`catch` on `SomeException` is followed by `fromException`
-checks to classify 2+ domain-meaningful exception types. The classification
-logic belongs in a return type, not exception dispatch.
+Flag when: `try`/`catch` on `SomeException` is followed by `fromException` checks to classify 2+
+domain-meaningful exception types. The classification logic belongs in a return type, not exception
+dispatch.
 
 ### Orchestration blob
 
-A single function (>80 lines) that interleaves: claim → execute → classify
-→ persist → observe → finalize. Each concern reads differently and changes
-for different reasons, but they are entangled in one control block.
+A single function (>80 lines) that interleaves: claim → execute → classify → persist → observe →
+finalize. Each concern reads differently and changes for different reasons, but they are entangled
+in one control block.
 
-Symptom: skip, failure, and success branches all repeat the same shape
-(emit event → persist status → advance schedule) with only strings
-differing. See refactoring-patterns.md Pattern 11.
+Symptom: skip, failure, and success branches all repeat the same shape (emit event → persist status
+→ advance schedule) with only strings differing. See refactoring-patterns.md Pattern 11.
 
 ### Premature abstraction
 
-Creating a library for a pattern that appears twice. The threshold for
-extraction is:
+Creating a library for a pattern that appears twice. The threshold for extraction is:
 
 - **3+ call sites**: Extract a helper function
 - **3+ modules**: Consider a shared module
 - **Only within one module**: Keep it local
 
-Don't build a "transaction logging framework" when a comment and a helper
-function suffice.
+Don't build a "transaction logging framework" when a comment and a helper function suffice.
 
 ### ADT completeness on new constructors
 
 When a PR adds a constructor to an owned ADT, verify:
 
-| Check | Where |
-|---|---|
-| All pattern matches updated | Compiler enforces if no wildcards |
-| `ToJSON`/`FromJSON` | Serialization instance |
-| DB enum value | If ADT maps to Postgres enum |
-| `Arbitrary` instance | Property test generators |
-| Golden tests | Any affected golden files |
-| Documentation | Supported values lists, tool schemas |
+| Check                       | Where                                |
+| --------------------------- | ------------------------------------ |
+| All pattern matches updated | Compiler enforces if no wildcards    |
+| `ToJSON`/`FromJSON`         | Serialization instance               |
+| DB enum value               | If ADT maps to Postgres enum         |
+| `Arbitrary` instance        | Property test generators             |
+| Golden tests                | Any affected golden files            |
+| Documentation               | Supported values lists, tool schemas |
 
-**[P1] Flag**: PR adds an ADT constructor without updating serialization
-instances or `Arbitrary` generators.
+**[P1] Flag**: PR adds an ADT constructor without updating serialization instances or `Arbitrary`
+generators.

--- a/agents/skills/haskell-code-style/references/testing-patterns.md
+++ b/agents/skills/haskell-code-style/references/testing-patterns.md
@@ -1,13 +1,13 @@
 # Testing Patterns
 
-Property-based testing, golden tests, mock patterns, and algebraic law
-verification for production Haskell.
+Property-based testing, golden tests, mock patterns, and algebraic law verification for production
+Haskell.
 
 ## Algebraic laws for domain types
 
-When defining a domain type with operations, state the algebraic laws it
-must satisfy as comments or QuickCheck properties. Laws make the type's
-contract explicit and catch regressions that unit tests miss.
+When defining a domain type with operations, state the algebraic laws it must satisfy as comments or
+QuickCheck properties. Laws make the type's contract explicit and catch regressions that unit tests
+miss.
 
 ### Examples of laws in Cortex
 
@@ -36,19 +36,18 @@ prop_signal_deterministic cfg prices =
 ### When defining a new type
 
 For `computeIndicator` extensions and similar domain functions, require:
+
 1. State the algebraic properties of the output
 2. Write at least one property test per stated law
 3. Document any intentional violations (e.g., floating-point approximation)
 
-**[P2] Flag**: A domain type with operations but no stated algebraic
-properties. This is not about coverage — it's about making the contract
-explicit.
+**[P2] Flag**: A domain type with operations but no stated algebraic properties. This is not about
+coverage — it's about making the contract explicit.
 
 ## Property-based testing for pure decision functions
 
-Every pure decision function (layer 1 in the three-layer-cake) should
-have property tests, not just example-based unit tests. Properties catch
-edge cases that hand-picked examples miss.
+Every pure decision function (layer 1 in the three-layer-cake) should have property tests, not just
+example-based unit tests. Properties catch edge cases that hand-picked examples miss.
 
 ### Pattern: identify the contract as properties
 
@@ -88,18 +87,18 @@ prop_degrade_finite x =
 
 ## Golden test pattern for serialization boundaries
 
-Any type that crosses a serialization boundary should have golden tests:
-a known input, a known expected output, stored as files. Changes that
-alter serialization break the golden test, forcing explicit acknowledgment.
+Any type that crosses a serialization boundary should have golden tests: a known input, a known
+expected output, stored as files. Changes that alter serialization break the golden test, forcing
+explicit acknowledgment.
 
 ### What needs golden tests
 
-| Boundary | Test shape |
-|---|---|
-| `ToJSON`/`FromJSON` on public API types | JSON file → decode → re-encode → compare |
-| Hasql encoder/decoder pairs | Known row → decode → compare to expected record |
-| Report IR → markdown compilation | Known IR → compile → compare to expected markdown |
-| External XML parsing | Known XML → parse → compare to expected boundary type |
+| Boundary                                | Test shape                                            |
+| --------------------------------------- | ----------------------------------------------------- |
+| `ToJSON`/`FromJSON` on public API types | JSON file → decode → re-encode → compare              |
+| Hasql encoder/decoder pairs             | Known row → decode → compare to expected record       |
+| Report IR → markdown compilation        | Known IR → compile → compare to expected markdown     |
+| External XML parsing                    | Known XML → parse → compare to expected boundary type |
 
 ### Pattern
 
@@ -119,18 +118,17 @@ spec = describe "RunResponse serialization" $ do
 ### Updating golden files
 
 When a serialization change is intentional:
+
 1. Update the golden file
 2. Add a comment in the PR explaining why the format changed
 3. If the API is versioned, add a new golden file for the new version
 
-**[P2] Flag**: A public API type with `ToJSON`/`FromJSON` instances but
-no golden test.
+**[P2] Flag**: A public API type with `ToJSON`/`FromJSON` instances but no golden test.
 
 ## Mock record pattern for IO testing
 
-For any module that takes an environment record, define a `mockEnv` in
-test support that replaces IO actions with pure stubs or IORef-based
-recorders.
+For any module that takes an environment record, define a `mockEnv` in test support that replaces IO
+actions with pure stubs or IORef-based recorders.
 
 ### Pattern
 
@@ -174,9 +172,9 @@ spec = describe "attemptStage" $ do
 - The environment contains IO actions (DB, HTTP, logging)
 - You want to test business logic without infrastructure
 
-**[P2] Flag**: A module that's described as "hard to test" because it
-calls concrete IO functions directly instead of going through an env record.
-This is not a testing problem — it's a design problem.
+**[P2] Flag**: A module that's described as "hard to test" because it calls concrete IO functions
+directly instead of going through an env record. This is not a testing problem — it's a design
+problem.
 
 ## Decoder/encoder roundtrip testing
 
@@ -197,8 +195,8 @@ prop_roundtrip view =
 
 ### Practical approach
 
-For raw Hasql statements where you can't easily unit-test the roundtrip
-in-memory, use integration tests:
+For raw Hasql statements where you can't easily unit-test the roundtrip in-memory, use integration
+tests:
 
 ```haskell
 spec :: Spec
@@ -210,10 +208,9 @@ spec = describe "PulseRunAdminView roundtrip" $ do
     result `shouldBe` Just original
 ```
 
-**Why this matters especially for raw Hasql**: The compiler can't verify
-that the SQL column order matches the decoder's `<*>` chain. A column
-reorder in the SQL that isn't mirrored in the decoder silently maps
-wrong values to wrong fields.
+**Why this matters especially for raw Hasql**: The compiler can't verify that the SQL column order
+matches the decoder's `<*>` chain. A column reorder in the SQL that isn't mirrored in the decoder
+silently maps wrong values to wrong fields.
 
 **[P2] Flag**: A raw Hasql decoder with 10+ columns and no roundtrip test.
 
@@ -221,14 +218,14 @@ wrong values to wrong fields.
 
 When adding a constructor to an owned ADT, the PR must update all of these:
 
-| Area | Check |
-|---|---|
-| Pattern matches | Compiler enforces if no wildcards (which the style guide requires) |
-| `ToJSON`/`FromJSON` | New constructor serializes correctly |
-| DB serialization | If the ADT maps to a Postgres enum, add the new value |
-| Documentation | Supported values lists, tool schemas, API docs |
-| Tests | Add to any `Arbitrary` instances and golden tests |
-| `Bounded`/`Enum` | If derived, verify the new constructor is in the right position |
+| Area                | Check                                                              |
+| ------------------- | ------------------------------------------------------------------ |
+| Pattern matches     | Compiler enforces if no wildcards (which the style guide requires) |
+| `ToJSON`/`FromJSON` | New constructor serializes correctly                               |
+| DB serialization    | If the ADT maps to a Postgres enum, add the new value              |
+| Documentation       | Supported values lists, tool schemas, API docs                     |
+| Tests               | Add to any `Arbitrary` instances and golden tests                  |
+| `Bounded`/`Enum`    | If derived, verify the new constructor is in the right position    |
 
-**[P1] Flag**: A PR that adds an ADT constructor but doesn't update the
-`ToJSON`/`FromJSON` instance or `Arbitrary` instance.
+**[P1] Flag**: A PR that adds an ADT constructor but doesn't update the `ToJSON`/`FromJSON` instance
+or `Arbitrary` instance.

--- a/agents/skills/haskell-code-style/references/type-conventions.md
+++ b/agents/skills/haskell-code-style/references/type-conventions.md
@@ -1,18 +1,16 @@
 # Type & Language Conventions
 
-Language extension policy, type-level safety patterns, and syntactic
-conventions for production Haskell.
+Language extension policy, type-level safety patterns, and syntactic conventions for production
+Haskell.
 
 ## Extension policy
 
-The ban criterion: if it can silently break type safety or produce
-order-dependent instance resolution, it's out. Everything else is a
-judgment call on complexity vs utility.
+The ban criterion: if it can silently break type safety or produce order-dependent instance
+resolution, it's out. Everything else is a judgment call on complexity vs utility.
 
 ### Cabal default-extensions (no per-module pragma needed)
 
-These are load-bearing across the codebase. Requiring per-module pragmas
-for them is just noise:
+These are load-bearing across the codebase. Requiring per-module pragmas for them is just noise:
 
 ```
 OverloadedStrings, OverloadedRecordDot, LambdaCase,
@@ -22,18 +20,16 @@ StrictData, GADTs, DataKinds, RankNTypes,
 MultiParamTypeClasses, FunctionalDependencies
 ```
 
-**Why GADTs and DataKinds in defaults**: They're load-bearing for
-phantom-tagged IDs (`Id "Run"` vs `Id "Task"`), typed workflow states,
-GDPR annotations, and Cortex stage result types. Half the codebase uses
-them; per-module pragmas are noise.
+**Why GADTs and DataKinds in defaults**: They're load-bearing for phantom-tagged IDs (`Id "Run"` vs
+`Id "Task"`), typed workflow states, GDPR annotations, and Cortex stage result types. Half the
+codebase uses them; per-module pragmas are noise.
 
-**Why RankNTypes in defaults**: Required for `forall a. Query a -> IO a`
-in mock records, ST-based safe mutation, and higher-rank callback
-patterns.
+**Why RankNTypes in defaults**: Required for `forall a. Query a -> IO a` in mock records, ST-based
+safe mutation, and higher-rank callback patterns.
 
-**Hard rule**: `DeriveAnyClass` is only valid in modules that also have
-`DerivingStrategies` enabled, and every `deriving` clause must use an
-explicit strategy keyword. This is enforced by the defaults above.
+**Hard rule**: `DeriveAnyClass` is only valid in modules that also have `DerivingStrategies`
+enabled, and every `deriving` clause must use an explicit strategy keyword. This is enforced by the
+defaults above.
 
 ### Allowed per-module, no justification needed
 
@@ -45,67 +41,54 @@ AllowAmbiguousTypes    -- when paired with TypeApplications for
 UndecidableInstances   -- for mechanical passthrough instances only
 ```
 
-**Closed vs open type families**: `type family Foo a where ...` (closed)
-is fine — it's the cleanest way to compute types from promoted ADTs.
-`type family Foo a` (open) requires justification because of injectivity
-issues and confusing error messages. When reviewing, check whether the
-type family is open or closed before accepting.
+**Closed vs open type families**: `type family Foo a where ...` (closed) is fine — it's the cleanest
+way to compute types from promoted ADTs. `type family Foo a` (open) requires justification because
+of injectivity issues and confusing error messages. When reviewing, check whether the type family is
+open or closed before accepting.
 
 **UndecidableInstances**: Fine for MTL-style passthrough
-(`instance (MonadReader r m) => MonadReader r (MyT m)`). Flag when
-someone enables it for a creative type-level computation — that's usually
-a sign the design should be simpler.
+(`instance (MonadReader r m) => MonadReader r (MyT m)`). Flag when someone enables it for a creative
+type-level computation — that's usually a sign the design should be simpler.
 
-**AllowAmbiguousTypes**: The pattern `foo @Text` where
-`foo :: forall a. (Show a) => String` is clean and readable. Flag when
-it's enabling a function that callers find confusing to invoke.
+**AllowAmbiguousTypes**: The pattern `foo @Text` where `foo :: forall a. (Show a) => String` is
+clean and readable. Flag when it's enabling a function that callers find confusing to invoke.
 
 ### Allowed per-module, justification comment required
 
-- `TypeFamilies` (open families) — injectivity issues, instance
-  resolution surprises. Closed families don't need justification.
-- `ExistentialQuantification` — hides type information. The question:
-  is the existential hiding info callers genuinely don't need (good),
-  or hiding info because the author couldn't thread the type parameter
-  (bad)? Usually a GADT with a type index or a parameterized type is
-  better.
-- `TemplateHaskell` — slows compilation, obscures generated code.
-  Discouraged for new code, prefer `Generic`/`DerivingVia`. Existing
-  TH usage (Aeson TH, lens TH, persistent TH) doesn't need migration.
-- `RecordWildCards` — brings all fields into scope invisibly. With
-  `OverloadedRecordDot` the explicit field access is more grep-friendly.
-  Largely redundant in this codebase.
-- `OverloadedLists` — makes list literals polymorphic, causing confusing
-  type inference failures. Use explicit `Set.fromList`, `Map.fromList`.
+- `TypeFamilies` (open families) — injectivity issues, instance resolution surprises. Closed
+  families don't need justification.
+- `ExistentialQuantification` — hides type information. The question: is the existential hiding info
+  callers genuinely don't need (good), or hiding info because the author couldn't thread the type
+  parameter (bad)? Usually a GADT with a type index or a parameterized type is better.
+- `TemplateHaskell` — slows compilation, obscures generated code. Discouraged for new code, prefer
+  `Generic`/`DerivingVia`. Existing TH usage (Aeson TH, lens TH, persistent TH) doesn't need
+  migration.
+- `RecordWildCards` — brings all fields into scope invisibly. With `OverloadedRecordDot` the
+  explicit field access is more grep-friendly. Largely redundant in this codebase.
+- `OverloadedLists` — makes list literals polymorphic, causing confusing type inference failures.
+  Use explicit `Set.fromList`, `Map.fromList`.
 
 ### Banned
 
 These can silently break type safety or produce order-dependent behavior:
 
-- `IncoherentInstances` — makes instance resolution non-deterministic.
-  The compiler can pick different instances depending on how much type
-  information is available at the call site. Two call sites with the same
-  types can resolve differently.
-- `ImpredicativeTypes` — historically buggy GHC support. Allows types
-  that violate the predicativity assumption the rest of the type system
-  relies on. Inference failures change between GHC versions.
-- `Strict` (the module-level one, **not** `StrictData`) — changes
-  `let x = expensive` from lazy to strict, silently altering evaluation
-  order. Can introduce crashes in code that relied on laziness for
-  termination. `StrictData` only affects record fields, which is what
-  you actually want.
-- `OverlappingInstances` — instance resolution becomes order-dependent.
-  Adding a more specific instance in a downstream module can silently
-  change which instance gets picked upstream.
+- `IncoherentInstances` — makes instance resolution non-deterministic. The compiler can pick
+  different instances depending on how much type information is available at the call site. Two call
+  sites with the same types can resolve differently.
+- `ImpredicativeTypes` — historically buggy GHC support. Allows types that violate the predicativity
+  assumption the rest of the type system relies on. Inference failures change between GHC versions.
+- `Strict` (the module-level one, **not** `StrictData`) — changes `let x = expensive` from lazy to
+  strict, silently altering evaluation order. Can introduce crashes in code that relied on laziness
+  for termination. `StrictData` only affects record fields, which is what you actually want.
+- `OverlappingInstances` — instance resolution becomes order-dependent. Adding a more specific
+  instance in a downstream module can silently change which instance gets picked upstream.
 
-**[P2] Flag**: A pragma block with more than 15 per-module extensions when
-the cabal defaults are already set. This suggests the module is doing
-something unusual or the pragmas were copy-pasted.
+**[P2] Flag**: A pragma block with more than 15 per-module extensions when the cabal defaults are
+already set. This suggests the module is doing something unusual or the pragmas were copy-pasted.
 
 ## DerivingStrategies always
 
-When `DerivingStrategies` is enabled (it should be), always specify the
-strategy:
+When `DerivingStrategies` is enabled (it should be), always specify the strategy:
 
 ```haskell
 -- GOOD: explicit strategy
@@ -121,19 +104,17 @@ data Foo = Foo { ... }
   deriving (Show, Eq, FromJSON, ToJSON)
 ```
 
-**Why**: When both `DeriveAnyClass` and `GeneralizedNewtypeDeriving` are
-enabled, GHC's defaulting rules determine which strategy to use. These
-rules have changed across GHC versions. Explicit strategies eliminate
-surprises.
+**Why**: When both `DeriveAnyClass` and `GeneralizedNewtypeDeriving` are enabled, GHC's defaulting
+rules determine which strategy to use. These rules have changed across GHC versions. Explicit
+strategies eliminate surprises.
 
-**[style] Flag**: `deriving (SomeClass)` without a strategy keyword when
-`DerivingStrategies` is enabled in the module.
+**[style] Flag**: `deriving (SomeClass)` without a strategy keyword when `DerivingStrategies` is
+enabled in the module.
 
 ## StrictData as module default
 
-Enable `StrictData` for all modules that define record types used in
-long-lived data structures (environments, state, config). This prevents
-space leaks from unevaluated thunks in record fields.
+Enable `StrictData` for all modules that define record types used in long-lived data structures
+(environments, state, config). This prevents space leaks from unevaluated thunks in record fields.
 
 ```haskell
 {-# LANGUAGE StrictData #-}
@@ -145,8 +126,8 @@ data StageEnv = StageEnv
   }
 ```
 
-For fields that genuinely need laziness (infinite structures, deferred
-computation), use explicit `~` annotation:
+For fields that genuinely need laziness (infinite structures, deferred computation), use explicit
+`~` annotation:
 
 ```haskell
 data LazyStream = LazyStream
@@ -155,21 +136,21 @@ data LazyStream = LazyStream
   }
 ```
 
-**[P2] Flag**: A module without `StrictData` that defines record types
-used in long-lived data structures (environments, state records, config).
+**[P2] Flag**: A module without `StrictData` that defines record types used in long-lived data
+structures (environments, state records, config).
 
 ## Avoid partial functions
 
 Never use these in production code:
 
-| Partial function | Safe alternative |
-|---|---|
-| `head` | Pattern match, `NonEmpty`, `listToMaybe` |
-| `tail` | Pattern match, `NonEmpty` |
-| `fromJust` | Pattern match, `maybe`, `fromMaybe` with default |
-| `read` | `readMaybe` from `Text.Read` |
-| `!!` | `atMay` from `safe`, or `Map`/`IntMap` lookup |
-| `error` | Return `Either`/`Maybe`, use a domain error type |
+| Partial function | Safe alternative                                 |
+| ---------------- | ------------------------------------------------ |
+| `head`           | Pattern match, `NonEmpty`, `listToMaybe`         |
+| `tail`           | Pattern match, `NonEmpty`                        |
+| `fromJust`       | Pattern match, `maybe`, `fromMaybe` with default |
+| `read`           | `readMaybe` from `Text.Read`                     |
+| `!!`             | `atMay` from `safe`, or `Map`/`IntMap` lookup    |
+| `error`          | Return `Either`/`Maybe`, use a domain error type |
 
 ```haskell
 -- BAD
@@ -186,15 +167,13 @@ case readMaybe rawString of
   Nothing -> handleParseError rawString
 ```
 
-**[P1] Flag**: Any use of `head`, `tail`, `fromJust`, `read` (unqualified),
-`!!`, or `error` in production code. Test code gets more latitude but should
-still prefer safe alternatives.
+**[P1] Flag**: Any use of `head`, `tail`, `fromJust`, `read` (unqualified), `!!`, or `error` in
+production code. Test code gets more latitude but should still prefer safe alternatives.
 
 ## NonEmpty for invariant-carrying lists
 
-When a list must have at least one element, use `NonEmpty` from
-`Data.List.NonEmpty`. This eliminates an entire class of "what if the
-list is empty?" runtime checks.
+When a list must have at least one element, use `NonEmpty` from `Data.List.NonEmpty`. This
+eliminates an entire class of "what if the list is empty?" runtime checks.
 
 ```haskell
 -- BAD: runtime check for an invariant the type could enforce
@@ -210,20 +189,21 @@ buildStagePlan (first :| rest) = ...
 ```
 
 **When to use**:
+
 - Stage definitions (a plan always has at least one stage)
 - Signal rules (a suspended node always has at least one awaited signal)
 - Rewrite proposals (a batch always has at least one proposed edit)
 - Batch groups (each batch has at least one item)
 
-**[P2] Flag**: A function that takes `[a]` and immediately `case xs of
-[] -> error "..."` — the type should be `NonEmpty a`.
+**[P2] Flag**: A function that takes `[a]` and immediately `case xs of [] -> error "..."` — the type
+should be `NonEmpty a`.
 
 ## Derived Show/Eq: when NOT to derive
 
 ### Show and sensitive data
 
-Never derive `Show` on types containing passwords, tokens, API keys, or
-other secrets. Use a manual instance that redacts:
+Never derive `Show` on types containing passwords, tokens, API keys, or other secrets. Use a manual
+instance that redacts:
 
 ```haskell
 data Credentials = Credentials
@@ -243,21 +223,22 @@ instance Show Credentials where
     <> " }"
 ```
 
-**[P1] Flag**: `deriving (Show)` on a type with a field named `password`,
-`secret`, `token`, `apiKey`, `pepper`, or `credential`.
+**[P1] Flag**: `deriving (Show)` on a type with a field named `password`, `secret`, `token`,
+`apiKey`, `pepper`, or `credential`.
 
 ### Eq and semantic equality
 
 Don't derive `Eq` on types where structural equality isn't semantic equality:
+
 - Floating-point containers (NaN /= NaN)
 - Unordered collections where element order shouldn't matter
 - Types with normalization requirements
 
 ## Orphan instance prohibition
 
-Never define typeclass instances for types you don't own in modules that
-don't define either the type or the class. Orphan instances cause
-import-order-dependent behavior and are a maintenance hazard.
+Never define typeclass instances for types you don't own in modules that don't define either the
+type or the class. Orphan instances cause import-order-dependent behavior and are a maintenance
+hazard.
 
 ```haskell
 -- BAD: orphan instance — neither Foo nor ToJSON defined here
@@ -275,14 +256,13 @@ instance ToJSON WrappedFoo where
   toJSON (WrappedFoo f) = ...
 ```
 
-**[P2] Flag**: Any `instance` declaration where neither the type nor
-the class is defined in the current module.
+**[P2] Flag**: Any `instance` declaration where neither the type nor the class is defined in the
+current module.
 
 ## Smart constructor pattern
 
-Export the type name but not its data constructor. Provide a smart
-constructor that validates invariants. The export list is the enforcement
-mechanism.
+Export the type name but not its data constructor. Provide a smart constructor that validates
+invariants. The export list is the enforcement mechanism.
 
 ```haskell
 module Cortex.Task.Type
@@ -301,18 +281,17 @@ mkTaskType t
   | otherwise = Right (TaskType t)
 ```
 
-**Applicable to**: Validated IDs, bounded numeric ranges, non-empty text,
-constrained collections, config values with invariants.
+**Applicable to**: Validated IDs, bounded numeric ranges, non-empty text, constrained collections,
+config values with invariants.
 
-**[P2] Flag**: `newtype Foo = Foo { unFoo :: Text }` with `Foo(..)` in the
-export list when the type has documented invariants that the constructor
-doesn't enforce.
+**[P2] Flag**: `newtype Foo = Foo { unFoo :: Text }` with `Foo(..)` in the export list when the type
+has documented invariants that the constructor doesn't enforce.
 
 ## Witness type pattern
 
-When a multi-step pipeline requires that step N has completed before step
-N+1 can proceed, use a witness type whose constructor is hidden. The only
-way to obtain the witness is through the validating function.
+When a multi-step pipeline requires that step N has completed before step N+1 can proceed, use a
+witness type whose constructor is hidden. The only way to obtain the witness is through the
+validating function.
 
 ```haskell
 -- Module exports: AdmittedRewriteDelta (type only), admitRewriteDelta,
@@ -332,25 +311,23 @@ admitRewriteDelta :: RewriteBudget -> PlannedRewriteDelta def
 persistStageRewrite :: ... -> AdmittedRewriteDelta stageId -> IO (...)
 ```
 
-**Differs from smart constructors**: Smart constructors validate a value on
-construction. Witness types prove that a *multi-value relationship* holds
-(e.g., "this delta fits within this budget"). The witness bundles the
-validated inputs with the computed result.
+**Differs from smart constructors**: Smart constructors validate a value on construction. Witness
+types prove that a _multi-value relationship_ holds (e.g., "this delta fits within this budget").
+The witness bundles the validated inputs with the computed result.
 
-**Provide explicit accessor functions**: When the constructor is hidden,
-`OverloadedRecordDot` field selectors are also hidden from external
-modules. Export explicit accessor functions (`admittedDelta`,
-`admittedRemainingBudget`) alongside the type.
+**Provide explicit accessor functions**: When the constructor is hidden, `OverloadedRecordDot` field
+selectors are also hidden from external modules. Export explicit accessor functions
+(`admittedDelta`, `admittedRemainingBudget`) alongside the type.
 
 **When to use**:
+
 - Budget/quota admission before persistence
 - Validation that must precede compilation (e.g., `ValidatedReportIR`)
 - Authorization checks that gate downstream operations
 
-**[P2] Flag**: A function that calls a validation step and then immediately
-uses the result, where the validation could be skipped without a type
-error. If 2+ call sites repeat the same validate-then-use pattern, extract
-a witness type.
+**[P2] Flag**: A function that calls a validation step and then immediately uses the result, where
+the validation could be skipped without a type error. If 2+ call sites repeat the same
+validate-then-use pattern, extract a witness type.
 
 ## Phantom type tagging
 
@@ -370,38 +347,35 @@ type StageLogId = Id "StageLog"
 claimRun :: TaskId -> IO RunId
 ```
 
-**When to use**: When 2+ function parameters are the same underlying type
-(typically UUID or Int64) and swapping them would compile but corrupt data.
+**When to use**: When 2+ function parameters are the same underlying type (typically UUID or Int64)
+and swapping them would compile but corrupt data.
 
-**[P2] Flag**: Functions taking 2+ `UUID` parameters where the parameter
-names are the only distinction between semantically incompatible IDs.
+**[P2] Flag**: Functions taking 2+ `UUID` parameters where the parameter names are the only
+distinction between semantically incompatible IDs.
 
 ## Consistent record prefix convention
 
-Follow the two-letter prefix convention for all record field names.
-The prefix is the lowercase initials of the type name:
+Follow the two-letter prefix convention for all record field names. The prefix is the lowercase
+initials of the type name:
 
-| Type | Prefix | Example field |
-|---|---|---|
-| `StageEnv` | `se` | `sePool`, `seRunId` |
+| Type                | Prefix | Example field             |
+| ------------------- | ------ | ------------------------- |
+| `StageEnv`          | `se`   | `sePool`, `seRunId`       |
 | `PulseRunAdminView` | `prav` | `pravRunId`, `pravStatus` |
-| `AttemptCtx` | `ac` | `acStageName`, `acLogId` |
-| `RunFailure` | `rf` | `rfRunId`, `rfErrType` |
+| `AttemptCtx`        | `ac`   | `acStageName`, `acLogId`  |
+| `RunFailure`        | `rf`   | `rfRunId`, `rfErrType`    |
 
-**Why**: Avoids record field name clashes across the module (important
-before `DuplicateRecordFields` and `OverloadedRecordDot`). Also makes
-grep-based navigation reliable.
+**Why**: Avoids record field name clashes across the module (important before
+`DuplicateRecordFields` and `OverloadedRecordDot`). Also makes grep-based navigation reliable.
 
-**[style] Flag**: A new record type whose field names don't follow the
-project prefix convention.
+**[style] Flag**: A new record type whose field names don't follow the project prefix convention.
 
 ## Aeson instance discipline
 
 ### Public API types: explicit instances
 
-Types that cross API boundaries (request/response bodies, webhook
-payloads) must have explicit `ToJSON`/`FromJSON` instances, not
-`Generic`-derived ones:
+Types that cross API boundaries (request/response bodies, webhook payloads) must have explicit
+`ToJSON`/`FromJSON` instances, not `Generic`-derived ones:
 
 ```haskell
 -- BAD: renaming a field silently changes the API
@@ -431,17 +405,16 @@ instance ToJSON PortfolioResponse where
 
 ### Internal types: derived instances are fine
 
-Types used only within the application (checkpoint state, internal config)
-can use `Generic`-derived instances.
+Types used only within the application (checkpoint state, internal config) can use `Generic`-derived
+instances.
 
-**[P2] Flag**: A `Generic`-derived JSON instance on a type used in a
-public API endpoint without explicit field mapping.
+**[P2] Flag**: A `Generic`-derived JSON instance on a type used in a public API endpoint without
+explicit field mapping.
 
 ## Applicative over Monad when possible
 
-Use `Applicative` style (`<$>`, `<*>`) when operations are independent
-and don't need sequencing. This communicates to the reader that there are
-no data dependencies between sub-expressions.
+Use `Applicative` style (`<$>`, `<*>`) when operations are independent and don't need sequencing.
+This communicates to the reader that there are no data dependencies between sub-expressions.
 
 ```haskell
 -- BAD: unnecessary monadic sequencing
@@ -457,31 +430,31 @@ Config <$> parseField x <*> parseField y
 pure (Config (parseField x) (parseField y))
 ```
 
-**When it matters most**: `Applicative` enables potential parallelism in
-some contexts (e.g., `Concurrently`). More importantly, it signals to
-the reader that the sub-expressions are independent.
+**When it matters most**: `Applicative` enables potential parallelism in some contexts (e.g.,
+`Concurrently`). More importantly, it signals to the reader that the sub-expressions are
+independent.
 
-**[style] Flag**: `do { a <- pure x; b <- pure y; pure (f a b) }` — should
-be `f <$> pure x <*> pure y` or just `pure (f x y)`.
+**[style] Flag**: `do { a <- pure x; b <- pure y; pure (f a b) }` — should be
+`f <$> pure x <*> pure y` or just `pure (f x y)`.
 
 ## Qualified import convention
 
 Use consistent qualification for common modules across the codebase:
 
-| Module | Qualification |
-|---|---|
-| `Data.Map.Strict` | `Map` |
-| `Data.Text` | `T` |
-| `Data.Text.Encoding` | `TE` |
-| `Data.ByteString` | `BS` |
-| `Data.ByteString.Lazy` | `BSL` |
-| `Data.Aeson` | `Aeson` |
-| `Hasql.Session` | `Session` |
-| `Hasql.Transaction` | `Tx` |
-| `Hasql.Decoders` | `D` |
-| `Hasql.Encoders` | `E` |
-| `Platform.Database` | `DB` |
-| `Platform.Database.Encode` | `Enc` |
+| Module                     | Qualification |
+| -------------------------- | ------------- |
+| `Data.Map.Strict`          | `Map`         |
+| `Data.Text`                | `T`           |
+| `Data.Text.Encoding`       | `TE`          |
+| `Data.ByteString`          | `BS`          |
+| `Data.ByteString.Lazy`     | `BSL`         |
+| `Data.Aeson`               | `Aeson`       |
+| `Hasql.Session`            | `Session`     |
+| `Hasql.Transaction`        | `Tx`          |
+| `Hasql.Decoders`           | `D`           |
+| `Hasql.Encoders`           | `E`           |
+| `Platform.Database`        | `DB`          |
+| `Platform.Database.Encode` | `Enc`         |
 
-**[style] Flag**: Inconsistent qualification of the same module across
-files (e.g., `Tx` in one file, `Trans` in another, unqualified in a third).
+**[style] Flag**: Inconsistent qualification of the same module across files (e.g., `Tx` in one
+file, `Trans` in another, unqualified in a third).

--- a/agents/skills/impl/SKILL.md
+++ b/agents/skills/impl/SKILL.md
@@ -1,15 +1,14 @@
 ---
 name: impl
 description: >
-  Start implementation on an issue: create a feature branch, open a draft
-  PR, and enter plan mode for design. Use when beginning new work on a
-  GitHub issue or a freshly defined piece of scope.
+  Start implementation on an issue: create a feature branch, open a draft PR, and enter plan mode
+  for design. Use when beginning new work on a GitHub issue or a freshly defined piece of scope.
 ---
 
 # Start Implementation
 
-Begin implementing a piece of work: create a branch, open a draft PR,
-and enter plan mode. This is the entrypoint for any non-trivial change.
+Begin implementing a piece of work: create a branch, open a draft PR, and enter plan mode. This is
+the entrypoint for any non-trivial change.
 
 ## Usage
 
@@ -18,12 +17,13 @@ and enter plan mode. This is the entrypoint for any non-trivial change.
 ```
 
 **Arguments:**
+
 - `[issue-number]` — GitHub issue number (e.g. `42`). PR will `Closes #42`.
-- `[description]` — If no issue exists yet, a short description
-  ("wire v1 error recovery"). You will be prompted whether to also open
-  a tracking issue.
+- `[description]` — If no issue exists yet, a short description ("wire v1 error recovery"). You will
+  be prompted whether to also open a tracking issue.
 
 **Examples:**
+
 ```
 /impl 42                              # Work against existing issue
 /impl "pulse timeout retry policy"    # New scope; no issue yet
@@ -49,14 +49,12 @@ Extract:
 - `labels` → area hints (`substrate`, `wire`, `pulse`, `docs`)
 - `assignees` → confirm you own this work
 
-If no issue was given and the user provides a description instead, ask
-whether to open a tracking issue first. For small fixes or
-experimentation, proceed without one.
+If no issue was given and the user provides a description instead, ask whether to open a tracking
+issue first. For small fixes or experimentation, proceed without one.
 
 ### 2. Classify the work by Cortex layer
 
-Cortex is vertically split per ADR 0015. Name the layer explicitly in
-your plan:
+Cortex is vertically split per ADR 0015. Name the layer explicitly in your plan:
 
 - `Cortex.Graph` / `Cortex.Circuit` — pure topology and compiled shape
 - `Cortex.Wire` / `Cortex.Wire.V1` — source language + rewrite algebra
@@ -64,13 +62,12 @@ your plan:
 - `Cortex.Memory.*` — memory substrate
 - `Cortex.Capability.*` — model + tool abstractions
 - `Cortex.Document.*` — structured artifacts and reports
-- `Platform.*` — generic runtime substrate (observability, durable task,
-  database, crypto, HTTP retry). Lives in `src-platform/`.
+- `Platform.*` — generic runtime substrate (observability, durable task, database, crypto, HTTP
+  retry). Lives in `src-platform/`.
 
-If the work would introduce reasoning-layer concerns (role taxonomies,
-reasoning templates, memory presets), it probably belongs in a future
-`Cortex.Nous` module set — not in the runtime substrate. Flag this and
-stop to discuss before coding.
+If the work would introduce reasoning-layer concerns (role taxonomies, reasoning templates, memory
+presets), it probably belongs in a future `Cortex.Nous` module set — not in the runtime substrate.
+Flag this and stop to discuss before coding.
 
 ### 3. Prerequisites
 
@@ -86,8 +83,8 @@ gh issue view <number> --json projectItems,body | jq '.body' | rg -i 'blocked by
 git branch -a | rg -i "<issue-number>|<slug>" | head
 ```
 
-If a branch already exists, ask whether to continue on it, start fresh
-(destructive — confirm before deleting), or cancel.
+If a branch already exists, ask whether to continue on it, start fresh (destructive — confirm before
+deleting), or cancel.
 
 **Clean working tree:**
 
@@ -144,26 +141,22 @@ EOF
 )"
 ```
 
-Prefix types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`,
-`perf`. Keep the title under 70 characters; detail goes in the body.
+Prefix types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf`. Keep the title under
+70 characters; detail goes in the body.
 
 ### 6. Enter plan mode
 
-Use `EnterPlanMode` to design the implementation before coding. In plan
-mode:
+Use `EnterPlanMode` to design the implementation before coding. In plan mode:
 
 1. Read the relevant Cortex layer(s) to understand existing patterns.
-2. Identify files to create or modify — list concrete paths, not vague
-   areas.
+2. Identify files to create or modify — list concrete paths, not vague areas.
 3. Note test-suite touch points (`test/Cortex/<area>/*Spec.hs`).
-4. Decide whether the change needs a new ADR (cross-layer design
-   decisions almost always do).
+4. Decide whether the change needs a new ADR (cross-layer design decisions almost always do).
 5. Write the plan for user approval.
 6. Exit plan mode to implement.
 
-Before exiting plan mode, verify the plan respects the substrate/reasoning
-split from ADR 0015: runtime never imports the reasoning layer or
-consumer-specific code.
+Before exiting plan mode, verify the plan respects the substrate/reasoning split from ADR 0015:
+runtime never imports the reasoning layer or consumer-specific code.
 
 ### 7. Implement incrementally
 
@@ -182,8 +175,7 @@ Issue: #<number>
 ```
 
 4. Run `just fmt` before every commit (pre-commit hooks enforce this).
-5. Run `just check` before marking the PR ready — or at minimum
-   `just build` + `just test`.
+5. Run `just check` before marking the PR ready — or at minimum `just build` + `just test`.
 
 ### 8. Debugging workflow
 
@@ -196,23 +188,19 @@ just test-match "<pattern>"  # filtered hspec run
 ./result/bin/cortex-pulse --help
 ```
 
-For deeper investigation of Pulse execution, bring up a local Postgres
-(separate setup — Cortex does not manage database lifecycle) and
-exercise the substrate-shell binary with `--db-host` / `--db-name` flags
-pointing at it. Downstream consumers test their own integration surfaces
-in their own repos.
+For deeper investigation of Pulse execution, bring up a local Postgres (separate setup — Cortex does
+not manage database lifecycle) and exercise the substrate-shell binary with `--db-host` /
+`--db-name` flags pointing at it. Downstream consumers test their own integration surfaces in their
+own repos.
 
 ## Principles
 
-1. **Small commits, one concern each.** Reviewers can follow a story,
-   and the exact signed branch tip may become `main`.
-2. **Plan before coding.** Plan mode surfaces the shape before you sink
-   hours into the wrong one.
-3. **Respect the layer boundary.** Runtime never imports reasoning or
-   consumer code. If a change tempts you across the line, it is a
-   design signal, not an implementation detail.
-4. **Cite the issue in every commit.** Future-you reading `git log`
-   will thank you.
+1. **Small commits, one concern each.** Reviewers can follow a story, and the exact signed branch
+   tip may become `main`.
+2. **Plan before coding.** Plan mode surfaces the shape before you sink hours into the wrong one.
+3. **Respect the layer boundary.** Runtime never imports reasoning or consumer code. If a change
+   tempts you across the line, it is a design signal, not an implementation detail.
+4. **Cite the issue in every commit.** Future-you reading `git log` will thank you.
 
 ## Report
 

--- a/agents/skills/lean-code-style/SKILL.md
+++ b/agents/skills/lean-code-style/SKILL.md
@@ -1,19 +1,17 @@
 ---
 name: lean-code-style
 description: >
-  Strict Lean 4 review and authoring guide for Cortex theory work. Use
-  when asked to review Lean, check proof style, write or edit .lean files,
-  mechanize axioms, refactor proofs, evaluate mathlib/tactic usage, or
-  assess theory/lake/Nix changes for correctness, maintainability, and
+  Strict Lean 4 review and authoring guide for Cortex theory work. Use when asked to review Lean,
+  check proof style, write or edit .lean files, mechanize axioms, refactor proofs, evaluate
+  mathlib/tactic usage, or assess theory/lake/Nix changes for correctness, maintainability, and
   proof robustness.
 ---
 
 # IRONCLAD Lean Code Style
 
-Review or write Lean 4 code as a proof artifact, not as executable
-notation that happens to compile. The standard is intentionally stricter
-than generic Lean style: Cortex proofs must be stable, explicit,
-well-named, and easy to audit months later.
+Review or write Lean 4 code as a proof artifact, not as executable notation that happens to compile.
+The standard is intentionally stricter than generic Lean style: Cortex proofs must be stable,
+explicit, well-named, and easy to audit months later.
 
 ## Usage
 
@@ -23,8 +21,7 @@ well-named, and easy to audit months later.
 
 Arguments:
 
-- No arguments: review changed Lean/theory files in the current branch
-  against `main`.
+- No arguments: review changed Lean/theory files in the current branch against `main`.
 - `--base <branch>`: review the branch diff against another base.
 - File paths: review those files.
 - Directory paths: review `.lean` and theory build files under them.
@@ -37,18 +34,16 @@ Examples:
 /lean-code-style theory/Cortex/Pulse/Frontier.lean
 ```
 
-In authoring mode, apply the same rules while editing Lean code. Do not
-wait for review to enforce them.
+In authoring mode, apply the same rules while editing Lean code. Do not wait for review to enforce
+them.
 
 ## IRONCLAD Standard
 
 - No untracked trusted-base expansion.
-- No proof debt hidden behind automation, wildcard cases, or linter
-  suppression.
-- No local reinvention of mature `Std` or `Mathlib` theory when a robust
-  external library supplies the right abstraction.
-- No theorem statement that proves an artifact of the encoding instead
-  of the intended model.
+- No proof debt hidden behind automation, wildcard cases, or linter suppression.
+- No local reinvention of mature `Std` or `Mathlib` theory when a robust external library supplies
+  the right abstraction.
+- No theorem statement that proves an artifact of the encoding instead of the intended model.
 - No public proof API that compiles today but is hard to reuse tomorrow.
 
 ## Workflow
@@ -73,14 +68,14 @@ git diff --name-only "$BASE"...HEAD -- \
   'nix/lean.nix'
 ```
 
-If no theory files are found, report that there is no Lean/theory scope
-to review and exit.
+If no theory files are found, report that there is no Lean/theory scope to review and exit.
 
 ### 2. Run Mechanical Checks
 
 Run these before manual review:
 
 ```bash
+just lean-lint
 rg -n '\b(sorry|admit|axiom|constant|unsafe|partial)\b|set_option\s+linter\.[A-Za-z0-9_.]+\s+false|set_option\s+autoImplicit\s+true' $FILES
 rg -n '\bsimp_all\b|\baesop\b|\bomega\b|\blinarith\b|\bring_nf\b|\bnorm_num\b|\btauto\b' $FILES
 rg -n '\|[[:space:]]*_[[:space:]]*=>' $FILES
@@ -88,26 +83,28 @@ rg -n '\|[[:space:]]*_[[:space:]]*=>' $FILES
 
 Interpret results manually:
 
-- New `sorry`, `admit`, `axiom`, `constant`, `unsafe`, or `partial` is
-  **[P1]** unless the file is explicitly a tracked scaffold and the debt
-  is documented in `theory/README.md`.
-- New linter suppression is **[P1]** if broad or unexplained, **[P2]** if
-  local but avoidable. Prefer fixing the code or using local `omit`,
-  namespaces, or proof restructuring.
-- Heavy automation and wildcard patterns are review triggers, not
-  automatic failures. They must have a small, stable proof surface.
+- `just lean-lint` is the CI-enforced mechanical gate. It strips Lean comments and strings before
+  rejecting trusted-base/debt keywords, linter suppressions, `autoImplicit true`, wildcard match
+  arms, overlong Lean lines, trailing whitespace, and missing umbrella/root imports. A failure is
+  **[P1]** unless the user explicitly scoped the turn to changing the gate itself.
+- New `sorry`, `admit`, `axiom`, `constant`, `unsafe`, or `partial` in executable Lean code is not
+  allowed. Do not normalize new scaffold debt.
+- New linter suppression is not allowed. Prefer fixing the code or using local `omit`, namespaces,
+  or proof restructuring.
+- Heavy automation and wildcard patterns are review triggers, not automatic failures. They must have
+  a small, stable proof surface.
 
 ### 3. Load References
 
 Read these reference files before giving a substantive review:
 
 - `references/review-rubric.md`: scoring and priority levels.
-- `references/writing-guide.md`: declarations, names, imports,
-  docstrings, theorem statements, and proof style.
-- `references/proof-patterns.md`: tactics, simp discipline,
-  automation, theorem API shape, and axiom policy.
-- `references/theory-architecture.md`: Cortex-specific Lean track
-  boundaries, validation commands, and build-file expectations.
+- `references/writing-guide.md`: declarations, names, imports, docstrings, theorem statements, and
+  proof style.
+- `references/proof-patterns.md`: tactics, simp discipline, automation, theorem API shape, and axiom
+  policy.
+- `references/theory-architecture.md`: Cortex-specific Lean track boundaries, validation commands,
+  and build-file expectations.
 
 ### 4. Read the Code
 
@@ -117,9 +114,8 @@ In branch-diff mode, read the diff first:
 git diff "$BASE"...HEAD -- "$FILE"
 ```
 
-Then read the full current file. Lean review cannot be done from a
-small hunk alone because variable scopes, namespace shape, imports,
-attributes, and local notation alter proof meaning.
+Then read the full current file. Lean review cannot be done from a small hunk alone because variable
+scopes, namespace shape, imports, attributes, and local notation alter proof meaning.
 
 In explicit-target mode, review the whole target file or directory.
 
@@ -132,14 +128,13 @@ Apply the rubric and make findings concrete. Prioritize:
 - Minimal imports and correct dependency management.
 - Namespace/API shape suitable for later theorem reuse.
 - `simp`/attribute discipline.
-- Rendered Theory page quality: each Lean file should read as a
-  standalone Markdown-backed theorem note with useful `/-! ... -/` prose
-  and sectioning where needed.
+- Rendered Theory page quality: each Lean file should read as a standalone Markdown-backed theorem
+  note with useful `/-! ... -/` prose and sectioning where needed.
 - Elimination of scaffold debt rather than normalization of new debt.
 - Validation through both Lake and Nix where relevant.
 
-Treat "compiles" as the floor. A proof can compile and still be too
-fragile, too implicit, or too opaque for Cortex.
+Treat "compiles" as the floor. A proof can compile and still be too fragile, too implicit, or too
+opaque for Cortex.
 
 ### 6. Report
 
@@ -148,39 +143,39 @@ Use this shape:
 ```markdown
 ## Lean Style Review: <branch> vs <base>
 
-**Files reviewed:** N
-**Overall:** one-sentence assessment
+**Files reviewed:** N **Overall:** one-sentence assessment
 
 ### <filename>
 
 **Score:** X/10
 
 **Findings:**
+
 - [P1] <correctness/soundness issue> - line N
 - [P2] <robustness/API/architecture issue> - line N
 - [style] <local cleanup> - line N
 
 **Good:**
+
 - <specific strong choice>
 
 ### Summary
 
 | File | Score | Key Issue |
-|---|---:|---|
-| ... | X/10 | ... |
+| ---- | ----: | --------- |
+| ...  |  X/10 | ...       |
 
 **Top priorities:**
+
 1. <most important fix>
 2. <second>
 3. <third>
 ```
 
-If there are no findings, say so directly and state any residual risk
-or test gap.
+If there are no findings, say so directly and state any residual risk or test gap.
 
 ### 7. Offer Fixes
 
-After review, ask whether to apply findings. When the user asks for
-fixes, edit narrowly and rerun validation. Prefer proving a smaller
-lemma or improving theorem shape over adding automation until the error
-goes away.
+After review, ask whether to apply findings. When the user asks for fixes, edit narrowly and rerun
+validation. Prefer proving a smaller lemma or improving theorem shape over adding automation until
+the error goes away.

--- a/agents/skills/lean-code-style/references/proof-patterns.md
+++ b/agents/skills/lean-code-style/references/proof-patterns.md
@@ -5,64 +5,53 @@ This file defines Cortex's standard for robust Lean proofs.
 ## Axiom And Sorry Policy
 
 - New mechanization work should reduce the axiom surface.
-- A new `axiom` is allowed only in an explicit scaffold file and only
-  when the corresponding proof obligation is listed in `theory/README.md`.
-- Never replace a hard proof with `sorry`, `admit`, `axiom`, or
-  `constant` to make CI pass.
-- If a theorem is intentionally postponed, name the obligation precisely
-  and document the semantic gap.
+- A new `axiom` is allowed only in an explicit scaffold file and only when the corresponding proof
+  obligation is listed in `theory/README.md`.
+- Never replace a hard proof with `sorry`, `admit`, `axiom`, or `constant` to make CI pass.
+- If a theorem is intentionally postponed, name the obligation precisely and document the semantic
+  gap.
 
 ## Tactic Discipline
 
-Use tactics as transparent proof construction, not as an opaque search
-button.
+Use tactics as transparent proof construction, not as an opaque search button.
 
 Prefer:
 
-- `rfl`, `exact`, `refine`, `constructor`, `cases`, `induction`,
-  `simp only`, `simpa only`, and short `calc` blocks.
+- `rfl`, `exact`, `refine`, `constructor`, `cases`, `induction`, `simp only`, `simpa only`, and
+  short `calc` blocks.
 - Small helper lemmas with reusable names.
-- Explicit `rw` lists when the rewrite sequence is the point of the
-  proof.
+- Explicit `rw` lists when the rewrite sequence is the point of the proof.
 - `simp [local_def]` for definitional closure over local definitions.
 
 Use cautiously:
 
-- `simp_all`: acceptable in throwaway local proof cleanup, suspicious in
-  exported theorems because it rewrites from the entire context.
-- `aesop`, `omega`, `linarith`, `ring_nf`, `norm_num`, `tauto`: useful
-  when the theorem is exactly in their domain and the surrounding proof
-  isolates their job.
-- Repeated `<;>` chains: fine for tiny symmetric goals, but split goals
-  explicitly when each side has semantic content.
+- `simp_all`: acceptable in throwaway local proof cleanup, suspicious in exported theorems because
+  it rewrites from the entire context.
+- `aesop`, `omega`, `linarith`, `ring_nf`, `norm_num`, `tauto`: useful when the theorem is exactly
+  in their domain and the surrounding proof isolates their job.
+- Repeated `<;>` chains: fine for tiny symmetric goals, but split goals explicitly when each side
+  has semantic content.
 
 Avoid:
 
-- Broad `simp` relying on a large imported simp set when `simp only`
-  would be stable.
+- Broad `simp` relying on a large imported simp set when `simp only` would be stable.
 - `first | ...` tactic search ladders in public proofs.
-- Proofs that succeed only because a transient hypothesis has a lucky
-  generated name.
+- Proofs that succeed only because a transient hypothesis has a lucky generated name.
 
 ## External Library Use
 
 Prefer robust maintained theory over bespoke local proof infrastructure.
 
-- Look first in `Std` and `Mathlib` for algebraic structures, orders,
-  finite sets/maps, relations, quotients, graph-adjacent abstractions,
-  well-founded recursion, arithmetic, and rewrite support.
-- Import the narrowest module that provides the needed theorem or
-  structure. Do not import broad namespaces to make search tactics
-  succeed.
-- Use library theorem names directly when they express the proof idea.
-  Wrap them only when Cortex needs a domain-specific statement,
-  orientation, or namespace.
-- Do not build a local abstraction merely to avoid learning an existing
-  one. A smaller proof today is not a win if it isolates Cortex from
-  the maintained Lean ecosystem.
-- Add new Lake dependencies only when they materially reduce proof risk
-  or replace a fragile local development path. Pin them through the same
-  toolchain path as the rest of `theory/`.
+- Look first in `Std` and `Mathlib` for algebraic structures, orders, finite sets/maps, relations,
+  quotients, graph-adjacent abstractions, well-founded recursion, arithmetic, and rewrite support.
+- Import the narrowest module that provides the needed theorem or structure. Do not import broad
+  namespaces to make search tactics succeed.
+- Use library theorem names directly when they express the proof idea. Wrap them only when Cortex
+  needs a domain-specific statement, orientation, or namespace.
+- Do not build a local abstraction merely to avoid learning an existing one. A smaller proof today
+  is not a win if it isolates Cortex from the maintained Lean ecosystem.
+- Add new Lake dependencies only when they materially reduce proof risk or replace a fragile local
+  development path. Pin them through the same toolchain path as the rest of `theory/`.
 
 ## Simp Rules
 
@@ -73,42 +62,37 @@ Before adding `@[simp]`, answer:
 3. Does it erase information a downstream proof may need?
 4. Is the theorem name and orientation obvious from the statement?
 
-If any answer is unclear, do not add `@[simp]`. Use the theorem
-explicitly with `rw` or `simp [theorem_name]`.
+If any answer is unclear, do not add `@[simp]`. Use the theorem explicitly with `rw` or
+`simp [theorem_name]`.
 
 ## Attributes And Instances
 
 - Keep attributes near declarations.
 - Avoid global attributes for local proof convenience.
-- Named instances should follow local Lean conventions and expose the
-  class being implemented in the name when ambiguity is possible.
-- Do not add an instance merely to make a single proof shorter if it
-  changes global typeclass search for downstream modules.
+- Named instances should follow local Lean conventions and expose the class being implemented in the
+  name when ambiguity is possible.
+- Do not add an instance merely to make a single proof shorter if it changes global typeclass search
+  for downstream modules.
 
 ## Pattern Matching
 
-- Pattern-match owned inductives explicitly when the constructor set is
-  semantically meaningful.
-- A wildcard branch is allowed only when all remaining constructors have
-  the same meaning and that meaning is obvious from the function name.
+- Pattern-match owned inductives explicitly when the constructor set is semantically meaningful.
+- A wildcard branch is allowed only when all remaining constructors have the same meaning and that
+  meaning is obvious from the function name.
 - In proofs, avoid `_` branches that hide which cases were discharged.
 
 ## Definitional Equality
 
 - Use `rfl` when the definition truly computes to the target.
-- Do not contort definitions solely to make one proof `rfl` if it harms
-  the model's semantic shape.
-- Prefer theorem-level simplification over changing a domain definition
-  to satisfy a local proof.
+- Do not contort definitions solely to make one proof `rfl` if it harms the model's semantic shape.
+- Prefer theorem-level simplification over changing a domain definition to satisfy a local proof.
 
 ## Classical And Decidability
 
 - Prefer constructive definitions and explicit decidability assumptions.
-- Use local `classical` for proofs that need choice or decidable
-  propositions.
-- If a data structure such as `Finset` requires `[DecidableEq α]`, keep
-  that assumption explicit in declarations that need it and out of
-  declarations that do not.
+- Use local `classical` for proofs that need choice or decidable propositions.
+- If a data structure such as `Finset` requires `[DecidableEq α]`, keep that assumption explicit in
+  declarations that need it and out of declarations that do not.
 
 ## Proof Factoring
 
@@ -119,5 +103,5 @@ Factor when:
 - a local `have` names a reusable concept,
 - a proof mixes domain reasoning and algebraic cleanup.
 
-Do not factor into names like `aux`, `helper`, or `foo'` unless the
-result is private and adjacent. Good helper names describe the fact.
+Do not factor into names like `aux`, `helper`, or `foo'` unless the result is private and adjacent.
+Good helper names describe the fact.

--- a/agents/skills/lean-code-style/references/review-rubric.md
+++ b/agents/skills/lean-code-style/references/review-rubric.md
@@ -1,52 +1,50 @@
 # Lean Review Rubric
 
-Use this rubric for Cortex Lean 4 code. The score is secondary; the
-priority findings are what matter.
+Use this rubric for Cortex Lean 4 code. The score is secondary; the priority findings are what
+matter.
 
 ## Priority Levels
 
 **[P1] Block merge**
 
-- New `sorry`, `admit`, `axiom`, `constant`, `unsafe`, or `partial`
-  outside a deliberately tracked scaffold.
-- A proof that depends on an invalid theorem statement, over-generalized
-  precondition, missing side condition, or false simplification lemma.
-- A `simp` attribute or theorem orientation that can loop, erase
-  information, or make downstream proofs unstable.
-- A broad linter suppression, `autoImplicit`, or namespace/import change
-  that hides real proof debt.
-- A theorem whose trusted base grows unintentionally through new axioms,
-  global classical reasoning, or opaque dependencies.
-- A build-file change that makes local Lake, Nix, or CI disagree about
-  Lean/mathlib versions.
+- New `sorry`, `admit`, `axiom`, `constant`, `unsafe`, or `partial` outside a deliberately tracked
+  scaffold.
+- A proof that depends on an invalid theorem statement, over-generalized precondition, missing side
+  condition, or false simplification lemma.
+- A `simp` attribute or theorem orientation that can loop, erase information, or make downstream
+  proofs unstable.
+- A broad linter suppression, `autoImplicit`, or namespace/import change that hides real proof debt.
+- A theorem whose trusted base grows unintentionally through new axioms, global classical reasoning,
+  or opaque dependencies.
+- A build-file change that makes local Lake, Nix, or CI disagree about Lean/mathlib versions.
 
 **[P2] Must address or explicitly track**
 
-- Heavy automation where the proof boundary is opaque and likely to
-  break under harmless import or simp-set changes.
+- Heavy automation where the proof boundary is opaque and likely to break under harmless import or
+  simp-set changes.
 - Missing explicit argument or result types on public definitions.
 - Public declarations without docstrings or unclear theorem names.
-- Rendered theory pages whose prose is too sparse to explain the model,
-  discharged obligations, or remaining proof boundary.
-- Public Lean files that fail as standalone rendered documents: missing
-  `/-! ... -/` page prose, no useful sectioning for a long theorem stack,
-  or comments that do not make the proof narrative auditable.
-- Redundant module-level H1 headings that fight the repo-docs generated
-  title instead of starting the page with overview/context prose.
+- Rendered theory pages whose prose is too sparse to explain the model, discharged obligations, or
+  remaining proof boundary.
+- Public Lean files that fail as standalone rendered documents: missing `/-! ... -/` page prose, no
+  useful sectioning for a long theorem stack, or comments that do not make the proof narrative
+  auditable.
+- Redundant module-level H1 headings that fight the repo-docs generated title instead of starting
+  the page with overview/context prose.
 - Unnecessary classical scope, global `open`, or broad variable scope.
-- Non-minimal imports, unpinned dependency changes, or generated
-  manifest drift without an intentional Lake change.
-- Local definitions or lemmas that duplicate mature `Std`/`Mathlib`
-  abstractions and make later proofs less compatible with the ecosystem.
-- Theorem APIs that are hard to rewrite with: wrong orientation,
-  avoidable anonymous binders, or hypotheses buried right of `:`.
+- Non-minimal imports, unpinned dependency changes, or generated manifest drift without an
+  intentional Lake change.
+- Local definitions or lemmas that duplicate mature `Std`/`Mathlib` abstractions and make later
+  proofs less compatible with the ecosystem.
+- Theorem APIs that are hard to rewrite with: wrong orientation, avoidable anonymous binders, or
+  hypotheses buried right of `:`.
 
 **[style] Local cleanup**
 
-- Indentation, line wrapping, naming, short comments, duplicate namespace
-  names, or cosmetic proof simplifications.
-- Small opportunities to use a clearer local lemma, `simp only`, or
-  `rfl`/`simpa` instead of a longer tactic block.
+- Indentation, line wrapping, naming, short comments, duplicate namespace names, or cosmetic proof
+  simplifications.
+- Small opportunities to use a clearer local lemma, `simp only`, or `rfl`/`simpa` instead of a
+  longer tactic block.
 
 ## Scoring
 
@@ -56,51 +54,44 @@ Start each file at 10 and subtract:
 - 2 for each P2.
 - 0.5 for each repeated style issue.
 
-Do not let a file with any P1 score above 5. Do not let a file with new
-untracked proof debt score above 6.
+Do not let a file with any P1 score above 5. Do not let a file with new untracked proof debt score
+above 6.
 
 ## Review Axes
 
 ### Soundness
 
-The theorem states exactly the intended property. All side conditions
-are explicit. Definitions do not smuggle assumptions through typeclass
-search, `Classical`, impossible branches, or unreviewed attributes.
+The theorem states exactly the intended property. All side conditions are explicit. Definitions do
+not smuggle assumptions through typeclass search, `Classical`, impossible branches, or unreviewed
+attributes.
 
-Review exported theorems for trusted-base drift. When the change claims
-to discharge scaffold debt or reduce assumptions, inspect theorem
-dependencies with Lean's axiom reporting tools and make sure the result
-actually depends on less than before.
+Review exported theorems for trusted-base drift. When the change claims to discharge scaffold debt
+or reduce assumptions, inspect theorem dependencies with Lean's axiom reporting tools and make sure
+the result actually depends on less than before.
 
 ### Proof Robustness
 
-Proof scripts should survive benign import ordering and simp-set changes.
-Prefer small lemmas, stable rewrites, and explicit local reasoning over
-large tactic blasts.
+Proof scripts should survive benign import ordering and simp-set changes. Prefer small lemmas,
+stable rewrites, and explicit local reasoning over large tactic blasts.
 
 ### API Shape
 
-Names, namespaces, theorem direction, and attributes should make the
-next proof easier. A theorem that compiles but cannot be reused cleanly
-is not finished.
+Names, namespaces, theorem direction, and attributes should make the next proof easier. A theorem
+that compiles but cannot be reused cleanly is not finished.
 
 ### Readability
 
-Reviewers should be able to follow the proof state transitions from the
-source. Use comments only for proof strategy or non-obvious mathematical
-intent.
+Reviewers should be able to follow the proof state transitions from the source. Use comments only
+for proof strategy or non-obvious mathematical intent.
 
-Because repo-docs renders Lean files as Theory pages, also review the
-file as a standalone document. The prose should motivate the model,
-section the theorem paper, and explain why the code-level declarations
-matter to the substrate contract.
+Because repo-docs renders Lean files as Theory pages, also review the file as a standalone document.
+The prose should motivate the model, section the theorem paper, and explain why the code-level
+declarations matter to the substrate contract.
 
 ### Build Integrity
 
-The Lean toolchain, Lake manifest, and Nix packaging must describe the
-same dependency story. CI must run the same proof surface the developer
-expects locally.
+The Lean toolchain, Lake manifest, and Nix packaging must describe the same dependency story. CI
+must run the same proof surface the developer expects locally.
 
-External dependencies are welcome when they replace brittle local proof
-work with maintained theory, but every dependency must be pinned through
-Lake/Nix and have a clear proof-level reason to exist.
+External dependencies are welcome when they replace brittle local proof work with maintained theory,
+but every dependency must be pinned through Lake/Nix and have a clear proof-level reason to exist.

--- a/agents/skills/lean-code-style/references/theory-architecture.md
+++ b/agents/skills/lean-code-style/references/theory-architecture.md
@@ -1,32 +1,28 @@
 # Cortex Theory Architecture
 
-The Lean tree lives under `theory/` and mechanizes substrate guarantees.
-It is not a separate research playground.
+The Lean tree lives under `theory/` and mechanizes substrate guarantees. It is not a separate
+research playground.
 
 ## Tracks
 
 - `Cortex.Graph.*`: Mokhov graph algebra and graph equivalence.
-- `Cortex.Pulse.*`: frontier safety, progress, and determinism modulo
-  external sparks.
+- `Cortex.Pulse.*`: frontier safety, progress, and determinism modulo external sparks.
 - `Cortex.Wire.*`: rewrite admission and soundness.
-- Future provider/spark and substrate/consumer boundary models should
-  stay under `Cortex.*` and mirror the documentation roadmap.
+- Future provider/spark and substrate/consumer boundary models should stay under `Cortex.*` and
+  mirror the documentation roadmap.
 
 ## Boundaries
 
 - Lean should model the substrate, not downstream product behavior.
-- Consumer examples may appear only as downstream examples, never as the
-  identity of Cortex.
-- Haskell executable modules are the implementation counterpart; Lean
-  modules are the proof counterpart. Cross-reference exact Haskell files
-  when a definition mirrors runtime behavior.
-- repo-docs renders each Lean file under `theory/` as a separate Theory
-  document. Module organization is therefore also publication structure:
-  split or section files so each rendered page has one coherent proof
-  topic.
-- Rendered pages get their title from the Lean module path. The first
-  module doc block should begin with an overview section and explain the
-  page's proof context rather than repeating the module name as an H1.
+- Consumer examples may appear only as downstream examples, never as the identity of Cortex.
+- Haskell executable modules are the implementation counterpart; Lean modules are the proof
+  counterpart. Cross-reference exact Haskell files when a definition mirrors runtime behavior.
+- repo-docs renders each Lean file under `theory/` as a separate Theory document. Module
+  organization is therefore also publication structure: split or section files so each rendered page
+  has one coherent proof topic.
+- Rendered pages get their title from the Lean module path. The first module doc block should begin
+  with an overview section and explain the page's proof context rather than repeating the module
+  name as an H1.
 
 ## Build Files
 
@@ -40,11 +36,10 @@ Review these as part of Lean changes:
 Rules:
 
 - Lean, Lake, mathlib, and Nix package versions must agree.
-- Manifest changes must correspond to intentional `lakefile.lean`
-  changes.
+- Manifest changes must correspond to intentional `lakefile.lean` changes.
 - Nix checks should build the proof surface used by CI.
-- Do not add dependencies unless they materially simplify proof work or
-  replace bespoke fragile reasoning.
+- Do not add dependencies unless they materially simplify proof work or replace bespoke fragile
+  reasoning.
 
 ## Validation
 
@@ -61,13 +56,11 @@ When Lean modules are rendered by the documentation site, also run:
 just docs-build
 ```
 
-Inspect the generated `result/Theory/` page for new public modules when
-the edit changes module prose, declarations, or import topology. The page
-should read as coherent reference material, not just as a compiled proof
-dump.
+Inspect the generated `result/Theory/` page for new public modules when the edit changes module
+prose, declarations, or import topology. The page should read as coherent reference material, not
+just as a compiled proof dump.
 
-Run this when executable, Lake target, dependency, or `Main.lean` wiring
-changes:
+Run this when executable, Lake target, dependency, or `Main.lean` wiring changes:
 
 ```bash
 nix develop -c just lean-build-exe
@@ -79,25 +72,22 @@ Run formatting for any committed branch:
 just fmt-check
 ```
 
-If pre-commit hooks run during commit, record their result in the final
-summary.
+If pre-commit hooks run during commit, record their result in the final summary.
 
-Paper 1 Pulse kernel work is tracked by Issue #51. Implementation commits
-on that branch should use `git commit -s -S` and include an `Issue: #51`
-trailer unless the commit is pure process scaffolding.
+Paper 1 Pulse kernel work is tracked by Issue #51. Implementation commits on that branch should use
+`git commit -s -S` and include an `Issue: #51` trailer unless the commit is pure process
+scaffolding.
 
 ## Review Expectations
 
-- A proof module should say which obligations it discharges and which
-  remain.
-- A rendered theory page should have enough prose and declaration
-  docstrings for a reader to understand the model boundary without
-  opening the corresponding Haskell file or roadmap note first.
-- Longer rendered theory pages should be divided with Markdown section
-  prose so they read like theorem notes rather than unstructured code
-  dumps.
+- A proof module should say which obligations it discharges and which remain.
+- A rendered theory page should have enough prose and declaration docstrings for a reader to
+  understand the model boundary without opening the corresponding Haskell file or roadmap note
+  first.
+- Longer rendered theory pages should be divided with Markdown section prose so they read like
+  theorem notes rather than unstructured code dumps.
 - A scaffold module should make proof debt explicit and finite.
-- A completed mechanization should replace assumptions, not add another
-  abstraction layer above them.
-- Any theorem expected to support later tracks should have a reusable
-  name and theorem statement, not merely prove the current file compiles.
+- A completed mechanization should replace assumptions, not add another abstraction layer above
+  them.
+- Any theorem expected to support later tracks should have a reusable name and theorem statement,
+  not merely prove the current file compiles.

--- a/agents/skills/lean-code-style/references/writing-guide.md
+++ b/agents/skills/lean-code-style/references/writing-guide.md
@@ -1,142 +1,116 @@
 # Lean Writing Guide
 
-Use this guide when writing or reviewing Lean declarations in Cortex.
-It adapts good ideas from Lean/mathlib community style and CS teaching
-style, but Cortex is stricter about long-lived proof maintainability.
+Use this guide when writing or reviewing Lean declarations in Cortex. It adapts good ideas from
+Lean/mathlib community style and CS teaching style, but Cortex is stricter about long-lived proof
+maintainability.
 
 ## Module Shape
 
-- Keep imports minimal. Every import must justify itself by declarations
-  used in the file.
-- Keep imports grouped and sorted when there is more than one logical
-  group. Avoid importing all of Mathlib unless the file is intentionally
-  exploratory.
-- Preserve the repository's current module-header style unless the
-  change is explicitly about header policy. Do not churn headers merely
-  to imitate mathlib.
+- Keep imports minimal. Every import must justify itself by declarations used in the file.
+- Keep imports grouped and sorted when there is more than one logical group. Avoid importing all of
+  Mathlib unless the file is intentionally exploratory.
+- Preserve the repository's current module-header style unless the change is explicitly about header
+  policy. Do not churn headers merely to imitate mathlib.
 - Each proof module needs a top-level description stating:
   - what structure is modeled,
   - which results are real theorems,
   - which obligations remain,
   - which executable modules or papers it mirrors.
-- Use `/-! ... -/` for module-level prose that should render as Markdown
-  in Theory pages, and place it after the file's imports because Lean
-  requires imports at the beginning of the file. Ordinary `/- ... -/`
-  comments remain code comments in the rendered page and should not carry
-  the page introduction.
+- Use `/-! ... -/` for module-level prose that should render as Markdown in Theory pages, and place
+  it after the file's imports because Lean requires imports at the beginning of the file. Ordinary
+  `/- ... -/` comments remain code comments in the rendered page and should not carry the page
+  introduction.
 
 ## Rendered Document Shape
 
-- repo-docs renders each Lean file as its own Markdown-backed Theory
-  document. Treat every public `.lean` file as a standalone proof note
-  that should make sense when opened directly from the docs site.
-- repo-docs supplies the document title from the Lean module path. Do not
-  start module prose with a redundant `#` heading; after imports, start
-  the module document with `/-! ## Overview ... -/` and then add context
-  and theorem-section headings as needed.
-- Write `/-! ... -/` prose like a short theorem paper, not like source
-  decoration: introduce the object being modeled, state the proof
-  boundary, name the main theorem obligations, and explain what remains
-  outside the current mechanization.
-- Use Markdown headings in `/-! ... -/` blocks to split longer files into
-  coherent sections when that makes the rendered page easier to read.
-  Prefer sections such as model, definitions, invariants, theorem stack,
-  proof support, and remaining obligations over a flat wall of Lean code.
-- Lean code itself must remain legible. Use docstrings and sparse prose
-  comments to explain context, proof intent, and model correspondence;
-  do not rely on tactics or declaration names alone to carry the story.
-- The rendered page should read as reference-quality mathematics: prose
-  motivates the declarations, declarations state precise facts, and proof
-  scripts are organized so a reader can audit the argument locally.
+- repo-docs renders each Lean file as its own Markdown-backed Theory document. Treat every public
+  `.lean` file as a standalone proof note that should make sense when opened directly from the docs
+  site.
+- repo-docs supplies the document title from the Lean module path. Do not start module prose with a
+  redundant `#` heading; after imports, start the module document with `/-! ## Overview ... -/` and
+  then add context and theorem-section headings as needed.
+- Write `/-! ... -/` prose like a short theorem paper, not like source decoration: introduce the
+  object being modeled, state the proof boundary, name the main theorem obligations, and explain
+  what remains outside the current mechanization.
+- Use Markdown headings in `/-! ... -/` blocks to split longer files into coherent sections when
+  that makes the rendered page easier to read. Prefer sections such as model, definitions,
+  invariants, theorem stack, proof support, and remaining obligations over a flat wall of Lean code.
+- Lean code itself must remain legible. Use docstrings and sparse prose comments to explain context,
+  proof intent, and model correspondence; do not rely on tactics or declaration names alone to carry
+  the story.
+- The rendered page should read as reference-quality mathematics: prose motivates the declarations,
+  declarations state precise facts, and proof scripts are organized so a reader can audit the
+  argument locally.
 
 ## Namespaces
 
 - Put declarations in the smallest meaningful namespace.
-- Avoid duplicated fully qualified names such as
-  `Cortex.Graph.Graph.foo` unless matching an existing local convention.
-  If a duplicate is intentional, keep any linter suppression local and
+- Avoid duplicated fully qualified names such as `Cortex.Graph.Graph.foo` unless matching an
+  existing local convention. If a duplicate is intentional, keep any linter suppression local and
   document why.
-- Avoid broad `open` commands. Use qualified names when they make proof
-  dependencies clearer.
-- Avoid global `open Classical`. Prefer explicit `[DecidableEq α]`,
-  local `classical`, or `noncomputable section` when needed.
+- Avoid broad `open` commands. Use qualified names when they make proof dependencies clearer.
+- Avoid global `open Classical`. Prefer explicit `[DecidableEq α]`, local `classical`, or
+  `noncomputable section` when needed.
 
 ## Declarations
 
-- Public `def`, `abbrev`, `structure`, `inductive`, `class`,
-  `instance`, `theorem`, and `lemma` declarations need explicit result
-  types.
-- Public structures and fields need docstrings. Fields should describe
-  the invariant or semantic role, not restate the name.
-- Prefer named records and structures when adjacent arguments have the
-  same type or when a theorem statement becomes swap-prone.
-- Use `where` for structures and instances. Avoid large anonymous record
-  literals when field names carry meaning.
-- Use `theorem` for exported proof API. Use `lemma` for local support
-  facts if the file already follows that convention; otherwise match
-  local style.
+- Public `def`, `abbrev`, `structure`, `inductive`, `class`, `instance`, `theorem`, and `lemma`
+  declarations need explicit result types.
+- Public structures and fields need docstrings. Fields should describe the invariant or semantic
+  role, not restate the name.
+- Prefer named records and structures when adjacent arguments have the same type or when a theorem
+  statement becomes swap-prone.
+- Use `where` for structures and instances. Avoid large anonymous record literals when field names
+  carry meaning.
+- Use `theorem` for exported proof API. Use `lemma` for local support facts if the file already
+  follows that convention; otherwise match local style.
 
 ## Variable Scope
 
 - Keep `variable` blocks close to the declarations that need them.
-- Split variables so typeclass assumptions are not in scope for
-  declarations that do not use them.
-- Prefer `omit [Foo α] in theorem ...` over suppressing
-  `unusedSectionVars`.
-- Do not rely on `autoImplicit`. Declare every type, value, relation,
-  and hypothesis intentionally.
+- Split variables so typeclass assumptions are not in scope for declarations that do not use them.
+- Prefer `omit [Foo α] in theorem ...` over suppressing `unusedSectionVars`.
+- Do not rely on `autoImplicit`. Declare every type, value, relation, and hypothesis intentionally.
 
 ## Naming
 
 - Use Lean-style lower snake case for theorem and definition names.
-- Names should encode the main head symbols and theorem direction:
-  `foo_empty_left`, `map_overlay`, `denote_connect_decomposition`.
-- Hypotheses start with `h` and should be mnemonic:
-  `hReady`, `hDeps`, `hij`, `hmem`, `hterminal`.
+- Names should encode the main head symbols and theorem direction: `foo_empty_left`, `map_overlay`,
+  `denote_connect_decomposition`.
+- Hypotheses start with `h` and should be mnemonic: `hReady`, `hDeps`, `hij`, `hmem`, `hterminal`.
 - Induction hypotheses start with `ih`.
-- Avoid shadowing. If an infoview would show daggered variables, rename
-  the local binder.
-- Avoid names like `this` in long proofs except for a one-line local
-  bridge that is consumed immediately.
+- Avoid shadowing. If an infoview would show daggered variables, rename the local binder.
+- Avoid names like `this` in long proofs except for a one-line local bridge that is consumed
+  immediately.
 
 ## Statement Shape
 
-- Put hypotheses to the left of the colon when the proof starts by
-  introducing them.
-- Keep theorem parameters explicit, especially typeclass assumptions and
-  decidability requirements.
-- Orient equalities for rewriting from complex/source expression to
-  simpler/canonical expression.
-- If a theorem is intended as a simp rule, its statement must be a stable
-  normalization rule.
+- Put hypotheses to the left of the colon when the proof starts by introducing them.
+- Keep theorem parameters explicit, especially typeclass assumptions and decidability requirements.
+- Orient equalities for rewriting from complex/source expression to simpler/canonical expression.
+- If a theorem is intended as a simp rule, its statement must be a stable normalization rule.
 
 ## Formatting
 
 - Target 100 columns.
-- Put `:= by` at the end of the theorem statement line or final
-  continuation line; do not put `by` alone on its own line.
-- Indent theorem continuation lines by four spaces and proof bodies by
-  two spaces.
-- Use focused bullets `·` for generated goals. Do not leave goal changes
-  visually implicit.
-- Keep parentheses with their argument. Do not orphan closing syntax on
-  unrelated lines.
+- Put `:= by` at the end of the theorem statement line or final continuation line; do not put `by`
+  alone on its own line.
+- Indent theorem continuation lines by four spaces and proof bodies by two spaces.
+- Use focused bullets `·` for generated goals. Do not leave goal changes visually implicit.
+- Keep parentheses with their argument. Do not orphan closing syntax on unrelated lines.
 
 ## Comments
 
 - Use docstrings for public API.
-- Public theorem docstrings should say why the result matters to the
-  substrate contract, not merely paraphrase the formal statement.
-- repo-docs renders declaration docstrings as prose immediately before
-  the declaration. Start short docstrings with the declaration name or
-  notation, such as `` `cross left right` is ... ``, so the rendered text
-  cannot read as a caption for the previous code block.
-- Avoid four-space-indented continuation lines inside rendered docstrings,
-  especially after blank lines. Markdown treats those as code blocks in
-  the generated Theory page.
-- Use `/-! ## ... -/` section comments when a file has multiple theorem
-  clusters or the proof narrative benefits from visible rendered
-  structure.
-- Use ordinary comments only for proof strategy, model limitations, or
-  non-obvious correspondence to Haskell/docs.
+- Public theorem docstrings should say why the result matters to the substrate contract, not merely
+  paraphrase the formal statement.
+- repo-docs renders declaration docstrings as prose immediately before the declaration. Start short
+  docstrings with the declaration name or notation, such as `` `cross left right` is ... ``, so the
+  rendered text cannot read as a caption for the previous code block.
+- Avoid four-space-indented continuation lines inside rendered docstrings, especially after blank
+  lines. Markdown treats those as code blocks in the generated Theory page.
+- Use `/-! ## ... -/` section comments when a file has multiple theorem clusters or the proof
+  narrative benefits from visible rendered structure.
+- Use ordinary comments only for proof strategy, model limitations, or non-obvious correspondence to
+  Haskell/docs.
 - Delete comments that narrate tactics or restate code.

--- a/agents/skills/lean-theorem-attack/SKILL.md
+++ b/agents/skills/lean-theorem-attack/SKILL.md
@@ -1,18 +1,16 @@
 ---
 name: lean-theorem-attack
 description: >
-  Adversarial semantic review for Lean theorem statements and proof
-  models. Use when asked to attack a theorem, validate runtime
-  correspondence, check model soundness, or run a multi-archetype Lean
+  Adversarial semantic review for Lean theorem statements and proof models. Use when asked to attack
+  a theorem, validate runtime correspondence, check model soundness, or run a multi-archetype Lean
   review beyond ordinary proof style.
 ---
 
 # Lean Theorem Attack
 
-Review Lean as a model of the intended substrate contract, not merely as
-code that compiles. This skill complements `lean-code-style`: style
-checks proof hygiene, while theorem attack checks whether the formal
-model is strong enough to support the prose claim.
+Review Lean as a model of the intended substrate contract, not merely as code that compiles. This
+skill complements `lean-code-style`: style checks proof hygiene, while theorem attack checks whether
+the formal model is strong enough to support the prose claim.
 
 ## Usage
 
@@ -24,17 +22,15 @@ model is strong enough to support the prose claim.
 
 Arguments:
 
-- No arguments: review changed Lean/theory files in the current branch
-  against `main`.
+- No arguments: review changed Lean/theory files in the current branch against `main`.
 - `--base <branch>`: review against another base.
-- `--multi-agent`: when the runtime supports subagents and the user has
-  explicitly requested multi-agent work, run archetype passes in
-  parallel. Otherwise run the same passes sequentially.
+- `--multi-agent`: when the runtime supports subagents and the user has explicitly requested
+  multi-agent work, run archetype passes in parallel. Otherwise run the same passes sequentially.
 - File paths: review those files.
 - Directory paths: review `.lean` and theory build files under them.
 
-By default this is a review skill. Apply fixes only when the user asks
-for fixes or when the active task is explicitly an implementation task.
+By default this is a review skill. Apply fixes only when the user asks for fixes or when the active
+task is explicitly an implementation task.
 
 ## Shared Archetypes
 
@@ -48,8 +44,8 @@ Load these profiles from repo-root paths:
 - `agents/archetypes/poiesis.md`
 - `agents/archetypes/sophia.md`
 
-The skill remains the orchestrator. Archetypes are lenses, not
-independent authority to expand scope or edit files.
+The skill remains the orchestrator. Archetypes are lenses, not independent authority to expand scope
+or edit files.
 
 ## References
 
@@ -57,13 +53,11 @@ Read only the references needed for the target:
 
 - `references/model-soundness.md`
 - `references/countermodel-patterns.md`
-- `references/pulse-runtime-correspondence.md` when reviewing
-  `Cortex.Pulse.*`.
+- `references/pulse-runtime-correspondence.md` when reviewing `Cortex.Pulse.*`.
 - `templates/theorem-attack-report.md` for report shape.
 
-Also load `agents/skills/lean-code-style/SKILL.md` when proof hygiene,
-imports, tactics, rendered Theory pages, or validation commands are in
-scope.
+Also load `agents/skills/lean-code-style/SKILL.md` when proof hygiene, imports, tactics, rendered
+Theory pages, or validation commands are in scope.
 
 ## Workflow
 
@@ -93,14 +87,13 @@ If there is no Lean/theory scope, say so directly.
 
 For each reviewed theorem, definition, invariant, or structure:
 
-1. Quote or summarize the prose claim from module docs, theorem
-   docstrings, PR text, issue text, or surrounding architecture docs.
+1. Quote or summarize the prose claim from module docs, theorem docstrings, PR text, issue text, or
+   surrounding architecture docs.
 2. Identify the formal declarations intended to carry that claim.
-3. List every free relation, total function, status constructor,
-   predicate field, and domain set in those declarations.
+3. List every free relation, total function, status constructor, predicate field, and domain set in
+   those declarations.
 4. Identify the executable or documented runtime counterpart, if any.
-5. Record what the theorem proves, what it assumes, and what remains
-   outside the model.
+5. Record what the theorem proves, what it assumes, and what remains outside the model.
 
 ### 3. Run Mechanical Checks
 
@@ -118,20 +111,19 @@ Mechanical checks are not enough. Continue with the semantic passes.
 
 Run these passes in this order when working sequentially:
 
-| Pass | Archetype | Required output |
-|---|---|---|
-| Statement map | Logos | Formal claim, assumptions, quantifiers, theorem boundary |
-| Evidence map | Episteme | Runtime/docs/source correspondence and evidence gaps |
-| Countermodel search | Kritikos | Minimal models that satisfy hypotheses but violate intent |
-| Contract audit | Themis | Validity/invariant coverage matrix |
-| Repair sketch | Techne | Smallest plausible encoding or proof repair |
-| Alternative encodings | Poiesis | Type-level, predicate-level, and theorem-boundary options |
-| Synthesis | Sophia | Prioritized findings and readiness judgment |
+| Pass                  | Archetype | Required output                                           |
+| --------------------- | --------- | --------------------------------------------------------- |
+| Statement map         | Logos     | Formal claim, assumptions, quantifiers, theorem boundary  |
+| Evidence map          | Episteme  | Runtime/docs/source correspondence and evidence gaps      |
+| Countermodel search   | Kritikos  | Minimal models that satisfy hypotheses but violate intent |
+| Contract audit        | Themis    | Validity/invariant coverage matrix                        |
+| Repair sketch         | Techne    | Smallest plausible encoding or proof repair               |
+| Alternative encodings | Poiesis   | Type-level, predicate-level, and theorem-boundary options |
+| Synthesis             | Sophia    | Prioritized findings and readiness judgment               |
 
-In `--multi-agent` mode, spawn subagents only when the user explicitly
-asked for multi-agent or parallel agent work. Give each subagent one
-archetype pass, a bounded target, and read-only instructions unless a
-fix task was explicitly requested. Merge their outputs; do not paste raw
+In `--multi-agent` mode, spawn subagents only when the user explicitly asked for multi-agent or
+parallel agent work. Give each subagent one archetype pass, a bounded target, and read-only
+instructions unless a fix task was explicitly requested. Merge their outputs; do not paste raw
 transcripts.
 
 ### 5. Attack The Model
@@ -141,16 +133,12 @@ Apply the semantic checks from `references/model-soundness.md` and
 
 Always ask:
 
-- Can an arbitrary relation, function, or predicate satisfy the formal
-  assumptions while violating the intended runtime graph?
-- Are all endpoints, keys, statuses, outputs, and recovered-state facts
-  tied to the topology domain?
-- Does every validity predicate include the full recovery or safety
-  contract it is named for?
-- Does the theorem prove preservation of the desired property or merely
-  restate a definition?
-- Could an off-domain, stale, missing, duplicated, or impossible value
-  pass the current predicate?
+- Can an arbitrary relation, function, or predicate satisfy the formal assumptions while violating
+  the intended runtime graph?
+- Are all endpoints, keys, statuses, outputs, and recovered-state facts tied to the topology domain?
+- Does every validity predicate include the full recovery or safety contract it is named for?
+- Does the theorem prove preservation of the desired property or merely restate a definition?
+- Could an off-domain, stale, missing, duplicated, or impossible value pass the current predicate?
 
 ### 6. Report
 
@@ -159,9 +147,7 @@ Use this shape:
 ```markdown
 ## Lean Theorem Attack: <target>
 
-**Overall:** <one-sentence judgment>
-**Mode:** sequential | multi-agent
-**Files reviewed:** <N>
+**Overall:** <one-sentence judgment> **Mode:** sequential | multi-agent **Files reviewed:** <N>
 
 ### Findings
 
@@ -170,20 +156,20 @@ Use this shape:
 
 ### Archetype Passes
 
-| Pass | Result |
-|---|---|
-| Logos | ... |
-| Episteme | ... |
-| Kritikos | ... |
-| Themis | ... |
-| Techne | ... |
-| Poiesis | ... |
-| Sophia | ... |
+| Pass     | Result |
+| -------- | ------ |
+| Logos    | ...    |
+| Episteme | ...    |
+| Kritikos | ...    |
+| Themis   | ...    |
+| Techne   | ...    |
+| Poiesis  | ...    |
+| Sophia   | ...    |
 
 ### Coverage Matrix
 
 | Runtime/prose obligation | Lean declaration | Preserved/proved by | Status |
-|---|---|---|---|
+| ------------------------ | ---------------- | ------------------- | ------ |
 
 ### Top Priorities
 
@@ -198,12 +184,11 @@ If no issues are found, say so directly and state residual risk.
 
 When the user asks for fixes:
 
-1. Prefer strengthening definitions or theorem statements over adding
-   ad hoc assumptions to a downstream proof.
-2. Make illegal states unrepresentable when the codebase can bear the
-   proof cost; otherwise add explicit named domain predicates.
-3. Add preservation lemmas for any invariant added to a validity
-   predicate.
+1. Prefer strengthening definitions or theorem statements over adding ad hoc assumptions to a
+   downstream proof.
+2. Make illegal states unrepresentable when the codebase can bear the proof cost; otherwise add
+   explicit named domain predicates.
+3. Add preservation lemmas for any invariant added to a validity predicate.
 4. Rerun relevant Lean validation, usually:
 
 ```bash

--- a/agents/skills/lean-theorem-attack/references/countermodel-patterns.md
+++ b/agents/skills/lean-theorem-attack/references/countermodel-patterns.md
@@ -1,7 +1,7 @@
 # Countermodel Patterns
 
-Use these patterns to search for small formal models that satisfy the
-current hypotheses while violating the intended claim.
+Use these patterns to search for small formal models that satisfy the current hypotheses while
+violating the intended claim.
 
 ## Minimal Topologies
 
@@ -9,64 +9,51 @@ current hypotheses while violating the intended claim.
 - Singleton node set with no edges.
 - Two nodes with no edge but a spurious reachability relation.
 - Edge endpoint outside the finite node set.
-- Disconnected component that nevertheless influences readiness or
-  closure.
+- Disconnected component that nevertheless influences readiness or closure.
 - Cycle hidden in a derived relation but absent from direct edges.
 
 ## State Corruption
 
 - Status exists for a node outside the topology.
 - Output exists for a node outside the topology.
-- A failed, skipped, pending, running, interrupted, or waiting node has
-  a stale output.
+- A failed, skipped, pending, running, interrupted, or waiting node has a stale output.
 - A terminal status and output disagree about ownership.
-- Recovery leaves volatile state because normalization only changes one
-  field.
-- A validity predicate accepts a state the runtime cannot write but a
-  corrupted persistence layer could load.
+- Recovery leaves volatile state because normalization only changes one field.
+- A validity predicate accepts a state the runtime cannot write but a corrupted persistence layer
+  could load.
 
 ## Relation And Closure Gaps
 
-- A reachability relation is transitive and irreflexive but not the
-  transitive closure of edges.
+- A reachability relation is transitive and irreflexive but not the transitive closure of edges.
 - A closure predicate includes non-topology predecessors.
-- A frontier predicate blocks a node because of an off-domain
-  dependency.
-- A failure propagation rule can fail a node because of a non-edge
-  relation witness.
-- A theorem proves every ready node is in the frontier but not every
-  frontier node is ready, or vice versa.
+- A frontier predicate blocks a node because of an off-domain dependency.
+- A failure propagation rule can fail a node because of a non-edge relation witness.
+- A theorem proves every ready node is in the frontier but not every frontier node is ready, or vice
+  versa.
 
 ## Quantifier Traps
 
-- The theorem quantifies over all ambient nodes but only some are in the
-  graph.
-- A hypothesis is too far right of the colon to be reusable as an
-  explicit assumption.
+- The theorem quantifies over all ambient nodes but only some are in the graph.
+- A hypothesis is too far right of the colon to be reusable as an explicit assumption.
 - An existential witness is unconstrained and can be chosen off-domain.
-- A universal predicate over total functions hides the need for map
-  key-domain checks.
+- A universal predicate over total functions hides the need for map key-domain checks.
 
 ## Encoding Mismatches
 
-- Runtime maps are modeled as total functions without an absence
-  predicate.
-- Runtime constructors enforce an invariant, but Lean uses an arbitrary
-  structure field.
-- Runtime transition functions are partial or error-returning, but Lean
-  models them as total state transforms.
+- Runtime maps are modeled as total functions without an absence predicate.
+- Runtime constructors enforce an invariant, but Lean uses an arbitrary structure field.
+- Runtime transition functions are partial or error-returning, but Lean models them as total state
+  transforms.
 - Runtime never observes a field, but Lean theorems depend on it.
-- Runtime stores durable facts, but Lean erases them without preserving
-  the corresponding safety obligation.
+- Runtime stores durable facts, but Lean erases them without preserving the corresponding safety
+  obligation.
 
 ## Countermodel Report Shape
 
 For each candidate:
 
 ```markdown
-Countermodel: <short name>
-Formal setup: <nodes, edges, statuses, outputs, relations>
-Hypotheses satisfied: <why Lean accepts it>
-Intended property violated: <runtime/prose claim that fails>
-Repair direction: <derive, constrain, subtype, or add validity field>
+Countermodel: <short name> Formal setup: <nodes, edges, statuses, outputs, relations> Hypotheses
+satisfied: <why Lean accepts it> Intended property violated: <runtime/prose claim that fails> Repair
+direction: <derive, constrain, subtype, or add validity field>
 ```

--- a/agents/skills/lean-theorem-attack/references/model-soundness.md
+++ b/agents/skills/lean-theorem-attack/references/model-soundness.md
@@ -1,34 +1,31 @@
 # Model Soundness Checks
 
-Use these checks when Lean declarations are intended to justify a
-runtime, recovery, safety, determinism, topology, or rewrite claim.
+Use these checks when Lean declarations are intended to justify a runtime, recovery, safety,
+determinism, topology, or rewrite claim.
 
 ## Contract Coverage
 
 Build a matrix before judging the theorem:
 
 | Obligation | Formal carrier | Establishing theorem | Preservation theorem | Gap |
-|---|---|---|---|---|
+| ---------- | -------------- | -------------------- | -------------------- | --- |
 
-An obligation is not covered merely because the surrounding prose names
-it. It must appear in a type, constructor, predicate, field law, theorem
-hypothesis, or theorem conclusion.
+An obligation is not covered merely because the surrounding prose names it. It must appear in a
+type, constructor, predicate, field law, theorem hypothesis, or theorem conclusion.
 
 ## Free Data Audit
 
 Inspect every free component:
 
-- Relations: are they derived from constructors or constrained by
-  exactness laws?
+- Relations: are they derived from constructors or constrained by exactness laws?
 - Functions: are off-domain inputs constrained or excluded?
 - Predicates: do their names overclaim compared to their definitions?
 - Sets and maps: are keys/endpoints tied to the intended domain?
 - Status values: do all constructors have explicit semantics?
 - Optional payloads: is ownership tied to status and lifecycle?
 
-Free data is acceptable only when the theorem is explicitly parametric
-in that freedom. It is suspicious when a runtime-derived concept is
-modeled as an arbitrary field.
+Free data is acceptable only when the theorem is explicitly parametric in that freedom. It is
+suspicious when a runtime-derived concept is modeled as an arbitrary field.
 
 ## Domain Closure
 
@@ -37,21 +34,20 @@ For each graph-like or state-like model, check:
 - Direct relation endpoints are in the finite domain.
 - Derived relation endpoints are in the finite domain.
 - State keys outside the domain are impossible or normalized away.
-- Theorems that quantify over the ambient type guard with domain
-  membership where needed.
-- Validity predicates mention domain exactness when they are used as
-  recovered-state or persisted-state safety claims.
+- Theorems that quantify over the ambient type guard with domain membership where needed.
+- Validity predicates mention domain exactness when they are used as recovered-state or
+  persisted-state safety claims.
 
 ## Exactness
 
-If a declaration says "derived from", "closure of", "frontier for",
-"valid state", "ready nodes", or "well formed", require both directions:
+If a declaration says "derived from", "closure of", "frontier for", "valid state", "ready nodes", or
+"well formed", require both directions:
 
 - Every constructed witness satisfies the predicate.
 - Every predicate witness corresponds to the intended construction.
 
-One-way implications often prove an implementation convenience instead
-of the intended model property.
+One-way implications often prove an implementation convenience instead of the intended model
+property.
 
 ## Runtime Correspondence
 
@@ -59,31 +55,23 @@ For each modeled runtime concept:
 
 - Identify the Haskell module, docs page, ADR, or issue claim it mirrors.
 - Check whether the Lean abstraction erases data safely.
-- Check whether erased payloads leave behind ownership or lifecycle
-  obligations.
-- Distinguish "runtime never writes this" from "the Lean model forbids
-  this".
-- Treat persisted/recovered state as adversarial input unless a theorem
-  proves normalization.
+- Check whether erased payloads leave behind ownership or lifecycle obligations.
+- Distinguish "runtime never writes this" from "the Lean model forbids this".
+- Treat persisted/recovered state as adversarial input unless a theorem proves normalization.
 
 ## Preservation
 
-Every invariant added to a validity predicate should have preservation
-or establishment lemmas for the transitions that claim to maintain it.
-If the theorem proves only the final validity predicate, inspect whether
-the proof assumes the hardest invariant instead of deriving it.
+Every invariant added to a validity predicate should have preservation or establishment lemmas for
+the transitions that claim to maintain it. If the theorem proves only the final validity predicate,
+inspect whether the proof assumes the hardest invariant instead of deriving it.
 
 ## Red Flags
 
-- A relation field has transitivity/acyclicity laws but no link to the
-  edge relation.
-- A validity predicate name includes "well formed", "safe", "recovered",
-  or "closed" but omits domain or payload constraints.
-- A status predicate allows payloads for statuses whose runtime behavior
-  cannot produce or consume them safely.
-- A theorem's hypotheses include the theorem's advertised conclusion in
-  renamed form.
-- A model uses total functions over a larger type but has no off-domain
-  normalization predicate.
-- A proof succeeds because definitions are too weak, not because the
-  property is true.
+- A relation field has transitivity/acyclicity laws but no link to the edge relation.
+- A validity predicate name includes "well formed", "safe", "recovered", or "closed" but omits
+  domain or payload constraints.
+- A status predicate allows payloads for statuses whose runtime behavior cannot produce or consume
+  them safely.
+- A theorem's hypotheses include the theorem's advertised conclusion in renamed form.
+- A model uses total functions over a larger type but has no off-domain normalization predicate.
+- A proof succeeds because definitions are too weak, not because the property is true.

--- a/agents/skills/lean-theorem-attack/references/pulse-runtime-correspondence.md
+++ b/agents/skills/lean-theorem-attack/references/pulse-runtime-correspondence.md
@@ -1,8 +1,7 @@
 # Pulse Runtime Correspondence
 
-Use this reference when attacking `Cortex.Pulse.*` Lean modules. The goal
-is not to model every Haskell payload, but to preserve the structural
-safety obligations that the runtime relies on.
+Use this reference when attacking `Cortex.Pulse.*` Lean modules. The goal is not to model every
+Haskell payload, but to preserve the structural safety obligations that the runtime relies on.
 
 ## Topology
 
@@ -11,14 +10,14 @@ Pulse graph topology obligations:
 - `nodes` is the finite set of materialized runtime nodes.
 - `edge a b = true` means `a` is a direct dependency of `b`.
 - Direct-edge endpoints must be in `nodes`.
-- Strict reachability should be edge-derived unless the model includes
-  exactness laws tying it to edges.
+- Strict reachability should be edge-derived unless the model includes exactness laws tying it to
+  edges.
 - Derived reachability endpoints must remain in `nodes`.
-- Acyclicity must apply to the same reachability relation used by
-  readiness, frontier, and failure closure.
+- Acyclicity must apply to the same reachability relation used by readiness, frontier, and failure
+  closure.
 
-Attack pattern: a singleton graph with no edges and a spurious
-reachability witness should not affect readiness or failure closure.
+Attack pattern: a singleton graph with no edges and a spurious reachability witness should not
+affect readiness or failure closure.
 
 ## Status And Output Ownership
 
@@ -29,14 +28,12 @@ Review every `NodeStatus` constructor against these questions:
 - Does recovery preserve, clear, or rewrite this status?
 - Is the status terminal, propagatable, both, or neither?
 
-The abstract model may erase payload contents, but it must not erase
-payload ownership. If a status does not own a durable payload, a validity
-predicate should reject `some payload` for that status.
+The abstract model may erase payload contents, but it must not erase payload ownership. If a status
+does not own a durable payload, a validity predicate should reject `some payload` for that status.
 
-For the current Pulse kernel, completed and rewritten statuses may own
-outputs. Failed, skipped, pending, running, interrupted, and waiting
-statuses should not own outputs unless a later runtime design explicitly
-changes the contract and updates this reference.
+For the current Pulse kernel, completed and rewritten statuses may own outputs. Failed, skipped,
+pending, running, interrupted, and waiting statuses should not own outputs unless a later runtime
+design explicitly changes the contract and updates this reference.
 
 ## Recovered-State Validity
 
@@ -47,36 +44,30 @@ A recovered-state validity predicate should cover:
 - Off-topology state is absent or normalized.
 - Failure closure is complete for the topology relation.
 - Ready frontier is exact for the readiness predicate.
-- Any runtime-specific persisted-state corruption that the theorem
-  claims to rule out.
+- Any runtime-specific persisted-state corruption that the theorem claims to rule out.
 
-If `GraphState` is modeled as total functions over `ν`, validity must
-either range over the node subtype or include an explicit off-topology
-domain predicate.
+If `GraphState` is modeled as total functions over `ν`, validity must either range over the node
+subtype or include an explicit off-topology domain predicate.
 
 ## Frontier And Readiness
 
 Readiness/frontier obligations:
 
 - A ready node is in `G.nodes`.
-- A ready node is pending or otherwise eligible according to the runtime
-  lifecycle.
+- A ready node is pending or otherwise eligible according to the runtime lifecycle.
 - All direct dependencies that matter to readiness are topology edges.
-- Skipped or failed predecessors do not contribute stale successful
-  outputs.
-- `readyNodes` is exact for `Ready`, not merely sound or complete in one
-  direction.
+- Skipped or failed predecessors do not contribute stale successful outputs.
+- `readyNodes` is exact for `Ready`, not merely sound or complete in one direction.
 
 ## Failure Closure
 
 Failure propagation obligations:
 
-- Closure follows topology reachability, not an arbitrary ambient
-  relation.
+- Closure follows topology reachability, not an arbitrary ambient relation.
 - Propagation does not invent failures from off-domain nodes.
 - Terminal statuses that should not be overwritten remain protected.
-- The closure theorem proves the named closure property rather than
-  assuming it through a broad predicate.
+- The closure theorem proves the named closure property rather than assuming it through a broad
+  predicate.
 
 ## Recovery Normalization
 
@@ -85,15 +76,13 @@ Recovery obligations:
 - Volatile execution marks are reset.
 - Durable outputs are preserved only when their status owns them.
 - Domain exactness is preserved.
-- Recovery theorems establish the recovered-state validity predicate or
-  explicitly state any required persistence assumptions.
+- Recovery theorems establish the recovered-state validity predicate or explicitly state any
+  required persistence assumptions.
 
 ## Common Pulse P1s
 
 - Arbitrary `reaches` accepted as a DAG field without edge exactness.
 - Validity accepts outputs on failed or skipped nodes.
 - Well-formed recovered state omits off-topology status/output checks.
-- Readiness or failure closure quantifies over ambient nodes without
-  domain protection.
-- A theorem claims persisted-state safety but assumes a corruption-free
-  state as input.
+- Readiness or failure closure quantifies over ambient nodes without domain protection.
+- A theorem claims persisted-state safety but assumes a corruption-free state as input.

--- a/agents/skills/lean-theorem-attack/templates/theorem-attack-report.md
+++ b/agents/skills/lean-theorem-attack/templates/theorem-attack-report.md
@@ -1,8 +1,6 @@
 # Lean Theorem Attack: {target}
 
-**Overall:** {judgment}
-**Mode:** {sequential|multi-agent}
-**Files reviewed:** {count}
+**Overall:** {judgment} **Mode:** {sequential|multi-agent} **Files reviewed:** {count}
 
 ## Findings
 
@@ -11,30 +9,28 @@
 
 ## Archetype Passes
 
-| Pass | Result |
-|---|---|
-| Logos | {formal claim and theorem boundary} |
-| Episteme | {evidence and runtime correspondence} |
-| Kritikos | {countermodels and stress cases} |
-| Themis | {contract and invariant coverage} |
-| Techne | {minimal repair direction} |
-| Poiesis | {alternative encodings} |
-| Sophia | {priority synthesis and readiness judgment} |
+| Pass     | Result                                      |
+| -------- | ------------------------------------------- |
+| Logos    | {formal claim and theorem boundary}         |
+| Episteme | {evidence and runtime correspondence}       |
+| Kritikos | {countermodels and stress cases}            |
+| Themis   | {contract and invariant coverage}           |
+| Techne   | {minimal repair direction}                  |
+| Poiesis  | {alternative encodings}                     |
+| Sophia   | {priority synthesis and readiness judgment} |
 
 ## Coverage Matrix
 
-| Runtime/prose obligation | Lean declaration | Preserved/proved by | Status |
-|---|---|---|---|
-| {obligation} | `{declaration}` | `{theorem}` | {covered|partial|missing} |
+| Runtime/prose obligation | Lean declaration | Preserved/proved by | Status   |
+| ------------------------ | ---------------- | ------------------- | -------- | ------- | -------- |
+| {obligation}             | `{declaration}`  | `{theorem}`         | {covered | partial | missing} |
 
 ## Countermodels
 
 ```markdown
-Countermodel: {name}
-Formal setup: {nodes, edges, statuses, outputs, relations}
-Hypotheses satisfied: {why Lean accepts it}
-Intended property violated: {runtime/prose claim that fails}
-Repair direction: {derive, constrain, subtype, or add validity field}
+Countermodel: {name} Formal setup: {nodes, edges, statuses, outputs, relations} Hypotheses
+satisfied: {why Lean accepts it} Intended property violated: {runtime/prose claim that fails} Repair
+direction: {derive, constrain, subtype, or add validity field}
 ```
 
 ## Top Priorities

--- a/agents/skills/pr-resolve-review/SKILL.md
+++ b/agents/skills/pr-resolve-review/SKILL.md
@@ -1,21 +1,19 @@
 ---
 name: pr-resolve-review
 description: >
-  Fetch and systematically address all review comments on the current
-  PR. Every comment gets both a code fix (or explanation) and a reply
-  in the thread. Use when a reviewer leaves comments, when CI passes
-  but review is blocking, or when the user says "resolve the review".
+  Fetch and systematically address all review comments on the current PR. Every comment gets both a
+  code fix (or explanation) and a reply in the thread. Use when a reviewer leaves comments, when CI
+  passes but review is blocking, or when the user says "resolve the review".
 ---
 
 # Resolve Review Comments
 
-Fetch review comments on the current PR, address each one with both a
-code change (or reasoned decline) and a thread reply, then request
-re-review.
+Fetch review comments on the current PR, address each one with both a code change (or reasoned
+decline) and a thread reply, then request re-review.
 
 **Every comment must be addressed with both:**
-1. A code change (or an inline comment / explanation if no code change
-   is the right answer).
+
+1. A code change (or an inline comment / explanation if no code change is the right answer).
 2. A reply on the review thread stating what was done.
 
 ## Usage
@@ -25,10 +23,12 @@ re-review.
 ```
 
 **Options:**
+
 - `--new` — Only show unresolved or post-last-push comments.
 - (default) — Show every comment.
 
 **Arguments:**
+
 - `[pr-number]` — Optional. Detected from the current branch by default.
 
 ---
@@ -50,8 +50,7 @@ gh pr view "$PR" --json headRefName --jq '.headRefName'
 git branch --show-current
 ```
 
-If they differ, check out the PR branch before editing
-(`gh pr checkout "$PR"`).
+If they differ, check out the PR branch before editing (`gh pr checkout "$PR"`).
 
 ### 3. Fetch PR + reviews + comments
 
@@ -62,6 +61,7 @@ gh api "repos/Digimuoto/cortex/pulls/$PR/comments" --jq '.[] | {id, path, line, 
 ```
 
 Extract for each comment:
+
 - `id` (needed to reply)
 - `path` and `line`
 - `user.login`
@@ -72,6 +72,7 @@ Extract for each comment:
 ### 4. Filter to unresolved (if `--new`)
 
 A comment counts as "already addressed" if:
+
 - It has a reply containing `Fixed`, `Done`, `Addressed`, or `Declined`
 - It was created before the last push to the PR branch
 
@@ -83,13 +84,13 @@ gh api "repos/Digimuoto/cortex/pulls/$PR/commits" --jq '[.[].commit.committer.da
 
 ### 5. Categorize each comment
 
-| Pattern | Intent | Default action |
-|---|---|---|
-| "should", "must", "change", "fix", "remove" | Required change | Apply the code change |
-| "?", "why", "how", "can you explain" | Question | Reply with an answer; maybe link the relevant ADR |
-| "consider", "could", "might", "what about" | Suggestion | Decide, then reply; implement if reasonable |
-| "nit:", "style:", "minor:" | Nitpick | Fix if trivial; otherwise reply acknowledging |
-| "LGTM", "ship it", "looks good" | Approval | No action needed |
+| Pattern                                     | Intent          | Default action                                    |
+| ------------------------------------------- | --------------- | ------------------------------------------------- |
+| "should", "must", "change", "fix", "remove" | Required change | Apply the code change                             |
+| "?", "why", "how", "can you explain"        | Question        | Reply with an answer; maybe link the relevant ADR |
+| "consider", "could", "might", "what about"  | Suggestion      | Decide, then reply; implement if reasonable       |
+| "nit:", "style:", "minor:"                  | Nitpick         | Fix if trivial; otherwise reply acknowledging     |
+| "LGTM", "ship it", "looks good"             | Approval        | No action needed                                  |
 
 ### 6. Display a structured summary before editing
 
@@ -97,21 +98,26 @@ gh api "repos/Digimuoto/cortex/pulls/$PR/commits" --jq '[.[].commit.committer.da
 ## PR #<n> — Review Comments
 
 ### Required changes
+
 1. `src/Cortex/Pulse/Executor.hs:142` — @reviewer
+
    > Wildcard match on PulseOutcome — ADR 0014 requires exhaustive patterns.
 
 2. `src-platform/Platform/Observability/Emit.hs:88` — @reviewer
    > Missing redaction on the JWT token field.
 
 ### Questions
+
 3. `src/Cortex/Graph/Core.hs:30` — @reviewer
    > Why was overlay separated from connect?
 
 ### Suggestions
+
 4. `src/Cortex/Wire/V1/Compiler.hs:410` — @reviewer
    > Consider caching the resolved contract lookup.
 
 ### Already addressed (skipped with --new)
+
 - 3 comments resolved in the previous round
 ```
 
@@ -122,8 +128,7 @@ Then write a TodoWrite list mirroring the required/questions/suggestions.
 #### Code change
 
 1. Read the file at the cited line.
-2. Understand the suggested change — re-read neighboring code if the
-   request is unclear.
+2. Understand the suggested change — re-read neighboring code if the request is unclear.
 3. Make the fix. Stay within the scope of the comment; don't scope-creep.
 4. Commit with:
 
@@ -135,8 +140,8 @@ Addresses <file>:<line>.
 
 #### Reply to the thread
 
-After pushing the fix, reply to the inline comment. Use JSON input
-whenever the reply contains backticks, markdown, or multiple lines:
+After pushing the fix, reply to the inline comment. Use JSON input whenever the reply contains
+backticks, markdown, or multiple lines:
 
 ```bash
 reply_body="Fixed in \`$(git rev-parse --short HEAD)\`. <short reason>."
@@ -147,8 +152,8 @@ jq -n --arg body "$reply_body" '{body: $body}' \
 
 #### Question
 
-Formulate the answer, post the reply. Link the authoritative source
-when one exists — ADRs, architecture chapters, or other docs:
+Formulate the answer, post the reply. Link the authoritative source when one exists — ADRs,
+architecture chapters, or other docs:
 
 ```bash
 reply_body=$'Short answer: <n>.\n\nSee [ADR 0016](docs/ADRs/0016-canonical-cortex-epistemological-archetypes.md) for the full reasoning.'
@@ -161,9 +166,8 @@ jq -n --arg body "$reply_body" '{body: $body}' \
 
 If you implement: reply with "Implemented in `<sha>`. <one-line note>."
 
-If you decline: reply explaining the trade-off in one short paragraph.
-Be respectful — reviewers are investing attention, even in suggestions
-you don't adopt.
+If you decline: reply explaining the trade-off in one short paragraph. Be respectful — reviewers are
+investing attention, even in suggestions you don't adopt.
 
 ### 8. Check CI after your changes
 
@@ -209,10 +213,9 @@ jq -n --arg body "$body" '{body: $body}' \
       --method POST --input -
 ```
 
-Keep the summary concise. List actions, not raw logs. If a command
-output matters, include only the relevant few lines in a fenced block.
-If you accidentally post a malformed comment, edit it in place with
-`PATCH /issues/comments/<id>`.
+Keep the summary concise. List actions, not raw logs. If a command output matters, include only the
+relevant few lines in a fenced block. If you accidentally post a malformed comment, edit it in place
+with `PATCH /issues/comments/<id>`.
 
 ## Reply templates
 
@@ -252,23 +255,22 @@ the underlying concern, not just the surface comment.
 ## Principles
 
 1. **Reply to every comment.** Silence is disrespect.
-2. **Address, don't just acknowledge.** Fix the code, answer the
-   question, or explicitly decline — then reply.
+2. **Address, don't just acknowledge.** Fix the code, answer the question, or explicitly decline —
+   then reply.
 3. **Be brief.** Multi-paragraph apologies waste the reviewer's time.
 4. **One commit per logical change.** Makes the re-review traceable.
-5. **Never mark "resolved" on behalf of the reviewer.** Leave that to
-   them.
-6. **Use JSON input for `gh api` comment bodies.** Shell escaping in
-   markdown-heavy replies goes wrong often enough to be a rule.
+5. **Never mark "resolved" on behalf of the reviewer.** Leave that to them.
+6. **Use JSON input for `gh api` comment bodies.** Shell escaping in markdown-heavy replies goes
+   wrong often enough to be a rule.
 
 ## Tools
 
-| Operation | Tool |
-|---|---|
-| Get PR meta | `gh pr view --json …` |
-| Get reviews | `gh api repos/.../pulls/<n>/reviews` |
-| Get inline comments | `gh api repos/.../pulls/<n>/comments` |
+| Operation               | Tool                                               |
+| ----------------------- | -------------------------------------------------- |
+| Get PR meta             | `gh pr view --json …`                              |
+| Get reviews             | `gh api repos/.../pulls/<n>/reviews`               |
+| Get inline comments     | `gh api repos/.../pulls/<n>/comments`              |
 | Reply to inline comment | `gh api repos/.../pulls/<n>/comments/<id>/replies` |
-| Post PR-level summary | `gh api repos/.../issues/<n>/comments` |
-| Edit a posted summary | `gh api repos/.../issues/comments/<id> -X PATCH` |
-| Track progress | `TodoWrite` |
+| Post PR-level summary   | `gh api repos/.../issues/<n>/comments`             |
+| Edit a posted summary   | `gh api repos/.../issues/comments/<id> -X PATCH`   |
+| Track progress          | `TodoWrite`                                        |

--- a/agents/skills/publish/SKILL.md
+++ b/agents/skills/publish/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: publish
 description: >
-  Publish the current branch: review git state, commit what should be
-  committed (signed), iterate until pre-commit hooks pass, and push to
-  the remote. Use when the user says publish, push, ship the branch, or
-  when work is done and should be pushed.
+  Publish the current branch: review git state, commit what should be committed (signed), iterate
+  until pre-commit hooks pass, and push to the remote. Use when the user says publish, push, ship
+  the branch, or when work is done and should be pushed.
 ---
 
 # Publish
 
-Publish the current branch cleanly: inspect the worktree, commit what
-should be committed, and push to the tracked remote.
+Publish the current branch cleanly: inspect the worktree, commit what should be committed, and push
+to the tracked remote.
 
 ## Usage
 
@@ -19,8 +18,8 @@ should be committed, and push to the tracked remote.
 /publish "split refactor and CI repair into separate commits"
 ```
 
-Optional free text can steer how staged work is grouped into commits.
-Default behavior is to infer from the current diff.
+Optional free text can steer how staged work is grouped into commits. Default behavior is to infer
+from the current diff.
 
 ## Workflow
 
@@ -36,31 +35,25 @@ git diff --cached --stat
 
 Confirm:
 
-- which branch is active; `publish` is for feature branches, not
-  direct `main` integration
+- which branch is active; `publish` is for feature branches, not direct `main` integration
 - whether there are staged/unstaged changes worth pushing
 - whether the branch has an upstream
 
 ### 2. Commit everything that should be published
 
-Inspect, group, and commit. Use small semantic commits, not one giant
-dump. Every commit:
+Inspect, group, and commit. Use small semantic commits, not one giant dump. Every commit:
 
 - Uses `git commit -s -S`
-- Follows the conventional prefix scheme: `feat:`, `fix:`, `refactor:`,
-  `docs:`, `test:`, `chore:`, `ci:`, `perf:`
+- Follows the conventional prefix scheme: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`,
+  `ci:`, `perf:`
 - Mentions the issue or PR in the body when relevant
-- Must verify after creation (`git verify-commit` or
-  `git log --show-signature`)
-- Must not mention LLMs or agents in author, committer, or
-  `Co-authored-by:` trailers
+- Must verify after creation (`git verify-commit` or `git log --show-signature`)
+- Must not mention LLMs or agents in author, committer, or `Co-authored-by:` trailers
 
-Iterate until pre-commit hooks pass. Do not skip hooks
-(`--no-verify`) — fix the underlying issue.
+Iterate until pre-commit hooks pass. Do not skip hooks (`--no-verify`) — fix the underlying issue.
 
-Do not sweep unrelated local changes into the publish. If the worktree
-has drift that is not part of the intended publish, stash or leave it
-alone and call it out in the report.
+Do not sweep unrelated local changes into the publish. If the worktree has drift that is not part of
+the intended publish, stash or leave it alone and call it out in the report.
 
 ### 3. Push to the remote
 
@@ -74,12 +67,11 @@ If the branch has no upstream:
 git push -u origin "$(git branch --show-current)"
 ```
 
-History is a maintained artifact in this repo. Rebase-first development
-is the default for ordinary feature work: make the branch read as a
-semantic sequence before publishing. Use `--force-with-lease` only when
-history was intentionally rewritten (rebase, squash, fixup, amend after
-review) and a normal push is rejected. Never use raw `--force` against
-shared branches; never force-push `main`.
+History is a maintained artifact in this repo. Rebase-first development is the default for ordinary
+feature work: make the branch read as a semantic sequence before publishing. Use
+`--force-with-lease` only when history was intentionally rewritten (rebase, squash, fixup, amend
+after review) and a normal push is rejected. Never use raw `--force` against shared branches; never
+force-push `main`.
 
 Before pushing, verify the branch's commit provenance:
 
@@ -87,14 +79,12 @@ Before pushing, verify the branch's commit provenance:
 just check-commit-provenance origin/main..HEAD
 ```
 
-Cortex `main` is integrated by fast-forwarding to exact signed branch
-commits after PR review and CI. Do not assume the branch will be merged
-with a GitHub squash, merge, or rebase button.
+Cortex `main` is integrated by fast-forwarding to exact signed branch commits after PR review and
+CI. Do not assume the branch will be merged with a GitHub squash, merge, or rebase button.
 
-If the active branch is `main`, stop unless the user explicitly asked
-for an approved lease-protected history repair. To land a ready PR, use
-the `ship` skill / `just integrate-pr <branch-or-pr-number>` instead of
-publishing `main` directly.
+If the active branch is `main`, stop unless the user explicitly asked for an approved
+lease-protected history repair. To land a ready PR, use the `ship` skill /
+`just integrate-pr <branch-or-pr-number>` instead of publishing `main` directly.
 
 ### 4. Verify
 
@@ -112,18 +102,14 @@ Expected end state:
 
 ## Principles
 
-1. **Commit before push.** Publishing means the remote reflects the
-   current intended local state. Do not leave validated work only in
-   the worktree.
-2. **Hooks are part of publishing.** If pre-commit fails, fix the
-   issue — don't bypass. Publishing is not done until the commit lands
-   and the push succeeds.
-3. **Preserve user changes.** Don't auto-stage unrelated drift. When in
-   doubt, ask.
-4. **Semantic history.** Prefer a small number of meaningful commits.
-   Rebase or fix up private branch history when it removes process
-   noise. The branch tip may become `main` by fast-forward, so optimize
-   for review clarity, bisectability, and the final artifact.
+1. **Commit before push.** Publishing means the remote reflects the current intended local state. Do
+   not leave validated work only in the worktree.
+2. **Hooks are part of publishing.** If pre-commit fails, fix the issue — don't bypass. Publishing
+   is not done until the commit lands and the push succeeds.
+3. **Preserve user changes.** Don't auto-stage unrelated drift. When in doubt, ask.
+4. **Semantic history.** Prefer a small number of meaningful commits. Rebase or fix up private
+   branch history when it removes process noise. The branch tip may become `main` by fast-forward,
+   so optimize for review clarity, bisectability, and the final artifact.
 
 ## Output
 

--- a/agents/skills/ship/SKILL.md
+++ b/agents/skills/ship/SKILL.md
@@ -1,18 +1,16 @@
 ---
 name: ship
 description: >
-  Ship a reviewed Cortex PR by verifying CI, reviews, documentation,
-  commit provenance, and rebase state, then integrating with the local
-  fast-forward-only `just integrate-pr` workflow. Use when the user says
-  ship, merge, land, integrate, or close a ready PR.
+  Ship a reviewed Cortex PR by verifying CI, reviews, documentation, commit provenance, and rebase
+  state, then integrating with the local fast-forward-only `just integrate-pr` workflow. Use when
+  the user says ship, merge, land, integrate, or close a ready PR.
 ---
 
 # Ship
 
-Ship a Cortex PR without manufacturing new commit objects. Cortex `main`
-is fast-forward-only: do not use GitHub's merge, squash, or rebase
-buttons. The final branch tip must already contain the exact signed,
-signed-off commits that will become `main`.
+Ship a Cortex PR without manufacturing new commit objects. Cortex `main` is fast-forward-only: do
+not use GitHub's merge, squash, or rebase buttons. The final branch tip must already contain the
+exact signed, signed-off commits that will become `main`.
 
 ## Usage
 
@@ -32,15 +30,13 @@ If detection fails, ask for the PR number or branch name.
 
 - Never use GitHub PR buttons for Cortex `main`.
 - Never create a merge commit while shipping.
-- Never squash on GitHub. If history needs cleanup, rebase or fix up the
-  PR branch locally, then push with `--force-with-lease`.
-- Never raw force-push. Use `git push --force-with-lease` only after a
-  deliberate local rewrite.
-- Never integrate unsigned, unverifiable, GitHub-authored, or
-  GitHub-committed objects.
+- Never squash on GitHub. If history needs cleanup, rebase or fix up the PR branch locally, then
+  push with `--force-with-lease`.
+- Never raw force-push. Use `git push --force-with-lease` only after a deliberate local rewrite.
+- Never integrate unsigned, unverifiable, GitHub-authored, or GitHub-committed objects.
 - After any rebase or history rewrite, CI must run and pass again.
-- `main` advances only through `just integrate-pr <pr-or-branch>` from a
-  clean worktree after review and CI.
+- `main` advances only through `just integrate-pr <pr-or-branch>` from a clean worktree after review
+  and CI.
 
 ## Workflow
 
@@ -57,8 +53,8 @@ Stop if:
 - the PR is not open
 - the PR is draft
 - the base branch is not `main`
-- the PR comes from a fork that cannot be safely integrated by local
-  fast-forward without fetching the exact head ref
+- the PR comes from a fork that cannot be safely integrated by local fast-forward without fetching
+  the exact head ref
 
 Check out the PR branch if needed:
 
@@ -73,15 +69,14 @@ git fetch origin main
 git fetch origin "$(gh pr view "$PR" --json headRefName --jq .headRefName)"
 ```
 
-Confirm the worktree is clean before any rebase, verification, or
-integration:
+Confirm the worktree is clean before any rebase, verification, or integration:
 
 ```bash
 git status --short
 ```
 
-If dirty, stop and report the local changes. Do not stash or commit
-unrelated work unless the user explicitly asks.
+If dirty, stop and report the local changes. Do not stash or commit unrelated work unless the user
+explicitly asks.
 
 ### 3. Inspect readiness
 
@@ -90,12 +85,11 @@ gh pr checks "$PR"
 gh pr view "$PR" --json reviewDecision,mergeStateStatus
 ```
 
-Stop if required checks are failing, pending without an explicit reason
-to wait, or if reviews request changes.
+Stop if required checks are failing, pending without an explicit reason to wait, or if reviews
+request changes.
 
-The expected review state is `APPROVED` or no required review decision
-with an explicit maintainer instruction to ship. The expected merge
-state is clean or behind-only.
+The expected review state is `APPROVED` or no required review decision with an explicit maintainer
+instruction to ship. The expected merge state is clean or behind-only.
 
 ### 4. Review documentation parity
 
@@ -105,8 +99,8 @@ Inspect changed files:
 gh pr diff "$PR" --name-only
 ```
 
-Block shipping if the PR changes public or canonical behavior without
-docs or an explicit no-docs-needed rationale in the PR:
+Block shipping if the PR changes public or canonical behavior without docs or an explicit
+no-docs-needed rationale in the PR:
 
 - Wire syntax, grammar, or examples
 - Pulse API, state, events, host actions, or persistence semantics
@@ -114,8 +108,7 @@ docs or an explicit no-docs-needed rationale in the PR:
 - build, CI, signing, release, or contributor workflow
 - public README or docs-site navigation
 
-Docs-only changes should still pass `just docs-check` or the CI docs
-job.
+Docs-only changes should still pass `just docs-check` or the CI docs job.
 
 ### 5. Review commit shape
 
@@ -131,8 +124,7 @@ Look for process noise before shipping:
 
 - `fixup!`, `squash!`, `wip`, `tmp`, `review`, or CI retry commits
 - commits that only repair an immediately previous commit
-- tests split from code in a way that leaves an intermediate commit
-  broken
+- tests split from code in a way that leaves an intermediate commit broken
 - generated files separated from the source change that produced them
 - unrelated themes that should have been separate PRs
 - too many commits for the actual semantic surface
@@ -145,15 +137,15 @@ If it should be squashed or reordered, stop and ask before rewriting:
 The PR history should be cleaned before shipping.
 
 Recommended final sequence:
+
 1. `<type>: <scope>`
 2. `<type>: <scope>`
 
 Run `/squash <pr-number>` with this plan?
 ```
 
-If the PR is thematically mixed, recommend splitting it and ask the user
-whether to split or keep one PR. Do not split or rewrite history without
-approval.
+If the PR is thematically mixed, recommend splitting it and ask the user whether to split or keep
+one PR. Do not split or rewrite history without approval.
 
 ### 6. Rebase when needed
 
@@ -182,22 +174,19 @@ Then wait for CI to rerun and pass:
 gh pr checks "$PR" --watch
 ```
 
-Do not ship a branch immediately after rewriting it unless the new tip
-has passed CI.
+Do not ship a branch immediately after rewriting it unless the new tip has passed CI.
 
 ### 7. Verify commit provenance
 
-Run the hard local provenance gate against the exact commits that would
-enter `main`:
+Run the hard local provenance gate against the exact commits that would enter `main`:
 
 ```bash
 git fetch origin main
 just check-commit-provenance origin/main..HEAD
 ```
 
-This rejects merge commits, GitHub/web-flow identities,
-non-Digimuoto email, missing matching `Signed-off-by` trailers, and
-unverifiable signatures.
+This rejects merge commits, GitHub/web-flow identities, non-Digimuoto email, missing matching
+`Signed-off-by` trailers, and unverifiable signatures.
 
 When repo or ruleset configuration changed, also run:
 
@@ -213,13 +202,11 @@ From a clean worktree, integrate with the repo helper:
 just integrate-pr "$PR"
 ```
 
-The helper fetches the PR branch, verifies provenance for the introduced
-commits, checks that `main` can fast-forward, merges with `--ff-only`,
-and pushes `main`.
+The helper fetches the PR branch, verifies provenance for the introduced commits, checks that `main`
+can fast-forward, merges with `--ff-only`, and pushes `main`.
 
-If integration fails because the branch is not a fast-forward, rebase
-the PR branch onto `origin/main`, push with `--force-with-lease`, wait
-for CI, and retry.
+If integration fails because the branch is not a fast-forward, rebase the PR branch onto
+`origin/main`, push with `--force-with-lease`, wait for CI, and retry.
 
 ### 9. Verify GitHub state
 
@@ -229,19 +216,17 @@ After pushing `main`, confirm GitHub recognized the PR as merged:
 gh pr view "$PR" --json state,mergedAt,mergeCommit,url
 ```
 
-If GitHub has not closed the PR even though `main` contains the branch
-tip, report that manual PR state cleanup is needed. Do not close a PR
-as unmerged unless the user explicitly asks.
+If GitHub has not closed the PR even though `main` contains the branch tip, report that manual PR
+state cleanup is needed. Do not close a PR as unmerged unless the user explicitly asks.
 
-Confirm linked GitHub issues closed automatically when the PR body uses
-`Closes #<number>`:
+Confirm linked GitHub issues closed automatically when the PR body uses `Closes #<number>`:
 
 ```bash
 gh pr view "$PR" --json closingIssuesReferences
 ```
 
-If issues remain open because the PR lacked closing keywords, report
-the issue numbers and ask before closing them manually.
+If issues remain open because the PR lacked closing keywords, report the issue numbers and ask
+before closing them manually.
 
 ## Blocked Report
 

--- a/agents/skills/squash/SKILL.md
+++ b/agents/skills/squash/SKILL.md
@@ -1,32 +1,28 @@
 ---
 name: squash
 description: >
-  Rewrite a Cortex PR branch into the minimum coherent sequence of
-  signed, buildable commits before integration. Use when the user asks
-  to squash, clean up commits, rebase history, fix process-noise
+  Rewrite a Cortex PR branch into the minimum coherent sequence of signed, buildable commits before
+  integration. Use when the user asks to squash, clean up commits, rebase history, fix process-noise
   commits, or prepare a PR history for fast-forward shipping.
 ---
 
 # Squash
 
-Clean a PR branch by rebasing it into a small semantic commit sequence.
-Do not blindly squash the whole PR. The goal is the minimum number of
-commits that still tells the correct story and leaves `main` working at
-every commit.
+Clean a PR branch by rebasing it into a small semantic commit sequence. Do not blindly squash the
+whole PR. The goal is the minimum number of commits that still tells the correct story and leaves
+`main` working at every commit.
 
 ## Hard Rules
 
 - Ask before rewriting branch history.
 - Never rewrite `main`.
 - Never use GitHub squash, merge, or rebase buttons.
-- Never raw force-push. Use `git push --force-with-lease` after an
-  approved rewrite.
+- Never raw force-push. Use `git push --force-with-lease` after an approved rewrite.
 - Every final commit must be signed, signed off, and verifiable.
 - Every final commit must build with the relevant CI-aligned checks.
-- Keep tests and code together when separating them would leave an
-  intermediate commit broken.
-- If the PR is thematically mixed, propose splitting the PR and ask the
-  user. Do not split without approval.
+- Keep tests and code together when separating them would leave an intermediate commit broken.
+- If the PR is thematically mixed, propose splitting the PR and ask the user. Do not split without
+  approval.
 
 ## Usage
 
@@ -50,8 +46,8 @@ git branch --show-current
 git fetch origin main
 ```
 
-Stop if the worktree is dirty. Do not stash, commit, or discard local
-changes unless the user explicitly asks.
+Stop if the worktree is dirty. Do not stash, commit, or discard local changes unless the user
+explicitly asks.
 
 Confirm the active branch is not `main`:
 
@@ -88,8 +84,7 @@ Look for:
 - commits that only repair immediately previous commits
 - commits that mix unrelated docs, CI, source, and generated files
 - tests split after code in a way that leaves earlier commits untested
-- dependency or generated-output changes that must precede source
-  changes
+- dependency or generated-output changes that must precede source changes
 - merge commits, unsigned commits, or GitHub-authored commits
 
 ### 3. Propose a semantic commit plan
@@ -117,16 +112,14 @@ Rules for the plan:
 - Prefer one commit for one independently reviewable concern.
 - Use the fewest commits that preserve reviewability and bisectability.
 - Put enabling infrastructure before code that depends on it.
-- Put schema/type/API changes before implementations only when the
-  intermediate commit still builds.
-- Keep docs with the feature when the docs are part of the same semantic
-  change; use a separate docs commit when the docs are independent.
+- Put schema/type/API changes before implementations only when the intermediate commit still builds.
+- Keep docs with the feature when the docs are part of the same semantic change; use a separate docs
+  commit when the docs are independent.
 - Keep generated files with the source change that produced them.
-- Do not create a commit that knowingly breaks build, tests, docs, or
-  theory.
+- Do not create a commit that knowingly breaks build, tests, docs, or theory.
 
-If the branch contains two or more unrelated themes that would be better
-reviewed independently, stop and ask:
+If the branch contains two or more unrelated themes that would be better reviewed independently,
+stop and ask:
 
 ```markdown
 This PR is thematically mixed. I recommend splitting it before shipping.
@@ -134,28 +127,25 @@ This PR is thematically mixed. I recommend splitting it before shipping.
 - Chunk A: <scope>
 - Chunk B: <scope>
 
-Do you want me to split the PR, or keep it as one branch and squash into
-separate commits?
+Do you want me to split the PR, or keep it as one branch and squash into separate commits?
 ```
 
 ### 4. Rewrite only after approval
 
-After the user approves the plan, use local Git tools. Prefer
-interactive rebase for reordering/fixups:
+After the user approves the plan, use local Git tools. Prefer interactive rebase for
+reordering/fixups:
 
 ```bash
 git rebase -i origin/main
 ```
 
-For mechanical fixups, `--autosquash` is allowed when commits are
-already marked:
+For mechanical fixups, `--autosquash` is allowed when commits are already marked:
 
 ```bash
 git rebase -i --autosquash origin/main
 ```
 
-For a full manual regrouping, use a soft reset only on the feature
-branch:
+For a full manual regrouping, use a soft reset only on the feature branch:
 
 ```bash
 git reset --soft origin/main
@@ -169,8 +159,7 @@ git add <paths-for-chunk>
 git commit -s -S -m "<type>: <summary>"
 ```
 
-Do not use `--no-verify`. Do not include AI authorship or
-`Co-authored-by` trailers for tools.
+Do not use `--no-verify`. Do not include AI authorship or `Co-authored-by` trailers for tools.
 
 ### 5. Verify every final commit
 
@@ -180,8 +169,7 @@ First verify provenance for the whole rewritten range:
 just check-commit-provenance origin/main..HEAD
 ```
 
-Then verify each final commit in a temporary worktree so the current
-checkout remains stable:
+Then verify each final commit in a temporary worktree so the current checkout remains stable:
 
 ```bash
 for sha in $(git rev-list --reverse origin/main..HEAD); do
@@ -196,13 +184,12 @@ for sha in $(git rev-list --reverse origin/main..HEAD); do
 done
 ```
 
-If the branch is docs-only, `just docs-check` may replace `just check`.
-If the branch touches Lean theory, include `just lean-check`. If the
-branch touches docs rendering, include `just docs-check`. State any
-reduced check surface in the final report.
+If the branch is docs-only, `just docs-check` may replace `just check`. If the branch touches Lean
+theory, include `just lean-check`. If the branch touches docs rendering, include `just docs-check`.
+State any reduced check surface in the final report.
 
-If any intermediate commit fails, fix the plan and rewrite again. Do not
-publish a sequence where only the final tip works.
+If any intermediate commit fails, fix the plan and rewrite again. Do not publish a sequence where
+only the final tip works.
 
 ### 6. Publish the rewritten branch
 

--- a/agents/src-platform/Platform/Database/context.md
+++ b/agents/src-platform/Platform/Database/context.md
@@ -1,38 +1,34 @@
 # Platform.Database Raw Hasql Context
 
-This guide covers raw Hasql `Statement` queries. Rel8-based queries
-should follow the local Rel8TH conventions; this file only covers raw
-SQL.
+This guide covers raw Hasql `Statement` queries. Rel8-based queries should follow the local Rel8TH
+conventions; this file only covers raw SQL.
 
 ## When To Use Raw Hasql
 
-Use Rel8 by default. Raw `Statement` is appropriate when the query
-requires CTEs, window functions, `FOR UPDATE SKIP LOCKED`, complex
-upserts, lateral joins, or other SQL constructs that Rel8 cannot
-express. When using raw SQL, use `Platform.Database.Encode` combinators
-and follow this style guide.
+Use Rel8 by default. Raw `Statement` is appropriate when the query requires CTEs, window functions,
+`FOR UPDATE SKIP LOCKED`, complex upserts, lateral joins, or other SQL constructs that Rel8 cannot
+express. When using raw SQL, use `Platform.Database.Encode` combinators and follow this style guide.
 
 ## Encoder Rules
 
 ### Tuple Arity Cap
 
-Use `encode1` through `encode8` for up to eight parameters. For nine or
-more parameters, use `encodeParams` with a list of `col` calls. Do not
-chain `encodeN` combinators with `(<>)` in new code.
+Use `encode1` through `encode8` for up to eight parameters. For nine or more parameters, use
+`encodeParams` with a list of `col` calls. Do not chain `encodeN` combinators with `(<>)` in new
+code.
 
 ### Swap-Risk Threshold
 
-Queries with four or more parameters where two or more share the same
-Hasql type should use a named record to prevent silent swap bugs. Two
-adjacent `Text` params in a flat tuple have no compile-time guard.
+Queries with four or more parameters where two or more share the same Hasql type should use a named
+record to prevent silent swap bugs. Two adjacent `Text` params in a flat tuple have no compile-time
+guard.
 
 ### Use Platform.Database.Encode
 
-Import `Platform.Database.Encode` instead of `Hasql.Encoders` directly.
-It re-exports the common encoder primitives and provides
-`encode1` through `encode8`, `col`, and `encodeParams`. `E.param` is
-intentionally not re-exported; seeing `Platform.Database.Encode` in an
-import list signals combinator-style usage.
+Import `Platform.Database.Encode` instead of `Hasql.Encoders` directly. It re-exports the common
+encoder primitives and provides `encode1` through `encode8`, `col`, and `encodeParams`. `E.param` is
+intentionally not re-exported; seeing `Platform.Database.Encode` in an import list signals
+combinator-style usage.
 
 Each `encodeN` takes N `(accessor, encoder)` pairs:
 
@@ -56,8 +52,7 @@ encoder =
     (.rfRetryable, Enc.nonNullable Enc.bool)
 ```
 
-For queries with nine or more parameters, use `encodeParams` with a
-`NonEmpty` of `col` calls:
+For queries with nine or more parameters, use `encodeParams` with a `NonEmpty` of `col` calls:
 
 ```haskell
 encoder =
@@ -68,22 +63,21 @@ encoder =
          ]
 ```
 
-`encodeParams` takes a `NonEmpty (E.Params t)` so an empty list is a
-compile error rather than a silent runtime mismatch.
+`encodeParams` takes a `NonEmpty (E.Params t)` so an empty list is a compile error rather than a
+silent runtime mismatch.
 
 ### Named Parameter Records
 
-Define parameter records next to the query in the same module, not in a
-shared types file. Use `OverloadedRecordDot` accessors as `encodeN`
-field selectors. The record does not need to be exported unless callers
-outside the module construct it.
+Define parameter records next to the query in the same module, not in a shared types file. Use
+`OverloadedRecordDot` accessors as `encodeN` field selectors. The record does not need to be
+exported unless callers outside the module construct it.
 
 ## Decoder Rules
 
 ### Column Annotation Convention
 
-Decoders with ten or more fields should annotate each `<*>` line with a
-comment matching the SQL column name:
+Decoders with ten or more fields should annotate each `<*>` line with a comment matching the SQL
+column name:
 
 ```haskell
 MyRow
@@ -96,8 +90,8 @@ This makes column-order mismatches visible during review.
 
 ### No Decoder Abstraction
 
-Do not wrap `Hasql.Decoders` in combinators. The `<$>` / `<*>` chain is
-idiomatic and grep-friendly. Comments are sufficient for safety.
+Do not wrap `Hasql.Decoders` in combinators. The `<$>` / `<*>` chain is idiomatic and grep-friendly.
+Comments are sufficient for safety.
 
 ## Anti-Patterns
 

--- a/agents/src-platform/Platform/DurableTask/context.md
+++ b/agents/src-platform/Platform/DurableTask/context.md
@@ -1,14 +1,12 @@
 # Platform DurableTask Context
 
-The `src-platform/Platform/DurableTask/` directory contains shared
-durable-task infrastructure that is generic enough to sit below Pulse
-and future runtime adapters.
+The `src-platform/Platform/DurableTask/` directory contains shared durable-task infrastructure that
+is generic enough to sit below Pulse and future runtime adapters.
 
 Current contents:
 
 - `Cron.hs` for shared cron parsing and next-fire-time calculation.
-- `Types.hs` for shared run status, trigger source, and
-  schedule-facing run outcome types.
+- `Types.hs` for shared run status, trigger source, and schedule-facing run outcome types.
 - `Schedule.hs` for pure schedule-finalization decisions.
 - `Pool.hs` for bounded concurrent task execution pools.
 - `Polling.hs` for jittered polling utilities.
@@ -16,59 +14,48 @@ Current contents:
 - `Error.hs` for best-effort DB failure logging combinators.
 - `Workflow.hs` for generic plan/execute/persist worker loop skeleton.
 
-This directory holds stable shared durable-task contracts used by Pulse
-and generic runtime infrastructure.
+This directory holds stable shared durable-task contracts used by Pulse and generic runtime
+infrastructure.
 
 ## Boundary Rules
 
 - Code here must remain runtime-generic.
 - Do not import downstream product modules.
-- Do not hardcode Pulse-specific table shapes, task names, or
-  checkpoint formats.
-- If logic needs concrete task registration, run state machines, or
-  domain task implementations, it belongs above this layer.
+- Do not hardcode Pulse-specific table shapes, task names, or checkpoint formats.
+- If logic needs concrete task registration, run state machines, or domain task implementations, it
+  belongs above this layer.
 
 ## Cron Rules
 
 - Keep cron parsing deterministic and side-effect free.
-- Preserve the existing five-field cron semantics unless there is an
-  explicit migration plan.
-- Treat parser behavior as operator-visible infrastructure. Avoid
-  accidental semantic drift.
+- Preserve the existing five-field cron semantics unless there is an explicit migration plan.
+- Treat parser behavior as operator-visible infrastructure. Avoid accidental semantic drift.
 
 ## Type And Schedule Rules
 
-- `RunStatus` is the persisted runtime-status space shared across
-  runtimes.
-- `RunOutcome` is the scheduler-facing abstraction; it is allowed to be
-  lossy relative to persisted statuses.
-- `OutcomeShutdown` is a sentinel used by Pulse drain/shutdown paths and
-  must map to "do not finalize schedule state".
-- `Schedule` stays pure. Cron advancement, backoff timestamps, and
-  "record outcome only" are decided here; database writes stay in
-  adapters.
-- Scheduled recurring work always advances to the next cron fire time,
-  regardless of success/failure/cancel/timeout.
-- Manual or retry-triggered recurring work records outcome only and does
-  not advance cron.
+- `RunStatus` is the persisted runtime-status space shared across runtimes.
+- `RunOutcome` is the scheduler-facing abstraction; it is allowed to be lossy relative to persisted
+  statuses.
+- `OutcomeShutdown` is a sentinel used by Pulse drain/shutdown paths and must map to "do not
+  finalize schedule state".
+- `Schedule` stays pure. Cron advancement, backoff timestamps, and "record outcome only" are decided
+  here; database writes stay in adapters.
+- Scheduled recurring work always advances to the next cron fire time, regardless of
+  success/failure/cancel/timeout.
+- Manual or retry-triggered recurring work records outcome only and does not advance cron.
 
 ## Runtime Model Principles
 
-- A run is the unit of durable execution identity. Checkpoints belong to
-  a run.
-- Resume means same-run continuation after crash or lease loss,
-  automatic via scheduler reclaim.
+- A run is the unit of durable execution identity. Checkpoints belong to a run.
+- Resume means same-run continuation after crash or lease loss, automatic via scheduler reclaim.
 - Retry means a fresh new run, linked to its parent for audit.
-- Any future checkpoint-based restart is a distinct Tier 2 operation,
-  not retry.
-- Host-action calls with side effects must use idempotency keys to
-  prevent double writes on resume or retry. The concrete idempotency
-  layer belongs above this directory.
+- Any future checkpoint-based restart is a distinct Tier 2 operation, not retry.
+- Host-action calls with side effects must use idempotency keys to prevent double writes on resume
+  or retry. The concrete idempotency layer belongs above this directory.
 
 ## Future Work Boundary
 
-These do not belong in this directory yet unless the follow-up issue
-explicitly moves them:
+These do not belong in this directory yet unless the follow-up issue explicitly moves them:
 
 - shared task registry abstractions
 - domain task implementations
@@ -77,5 +64,4 @@ explicitly moves them:
 
 - Treating this directory as a dumping ground for random helpers.
 - Hiding domain behavior behind generic-sounding durable-task utilities.
-- Changing shared cron, status, or schedule semantics without focused
-  regression coverage.
+- Changing shared cron, status, or schedule semantics without focused regression coverage.

--- a/agents/src-platform/Platform/context.md
+++ b/agents/src-platform/Platform/context.md
@@ -1,78 +1,70 @@
 # Platform Layer Context
 
-The `src-platform/Platform/` directory is the runtime substrate layer
-below `Cortex.*`. It contains reusable infrastructure and low-level
-helpers that Cortex and downstream consumers may depend on.
+The `src-platform/Platform/` directory is the runtime substrate layer below `Cortex.*`. It contains
+reusable infrastructure and low-level helpers that Cortex and downstream consumers may depend on.
 
 Design intent:
 
-- `Platform.*` is for domain-neutral infrastructure and low-level
-  helpers.
+- `Platform.*` is for domain-neutral infrastructure and low-level helpers.
 - `Platform.*` must not import downstream product modules.
-- `Platform.*` should avoid importing `Cortex.*`; if a dependency points
-  upward, the boundary is wrong.
-- Keep APIs stable and explicit. Do not widen shim or re-export
-  surfaces casually.
+- `Platform.*` should avoid importing `Cortex.*`; if a dependency points upward, the boundary is
+  wrong.
+- Keep APIs stable and explicit. Do not widen shim or re-export surfaces casually.
 
 Current shared scope:
 
-| Module | Purpose |
-| --- | --- |
-| `Platform.Database` | Hasql pool, sessions, transactions, Rel8TH, encode combinators |
+| Module                   | Purpose                                                         |
+| ------------------------ | --------------------------------------------------------------- |
+| `Platform.Database`      | Hasql pool, sessions, transactions, Rel8TH, encode combinators  |
 | `Platform.Observability` | Structured logging, tracing, subsystem emitters, WAI middleware |
-| `Platform.DurableTask.*` | Cron, scheduling, run types, task pools, workflow skeleton |
-| `Platform.Error` | Typed error model (`AppError`), client-safe messages |
-| `Platform.Error.Servant` | HTTP status mapping, convenience constructors |
-| `Platform.Require` | Handler building blocks (`requireMaybe`, `requireEither`) |
-| `Platform.Patch` | Optional field update combinators (`setMaybe`, `setMaybeN`) |
-| `Platform.Crypto` | AES-256-GCM credential encryption at rest |
-| `Platform.HTTP.Retry` | Exponential backoff, HTTP error classification |
-| `Platform.Config` | Typed environment variable loading |
-| `Platform.Text` | Safe text truncation |
+| `Platform.DurableTask.*` | Cron, scheduling, run types, task pools, workflow skeleton      |
+| `Platform.Error`         | Typed error model (`AppError`), client-safe messages            |
+| `Platform.Error.Servant` | HTTP status mapping, convenience constructors                   |
+| `Platform.Require`       | Handler building blocks (`requireMaybe`, `requireEither`)       |
+| `Platform.Patch`         | Optional field update combinators (`setMaybe`, `setMaybeN`)     |
+| `Platform.Crypto`        | AES-256-GCM credential encryption at rest                       |
+| `Platform.HTTP.Retry`    | Exponential backoff, HTTP error classification                  |
+| `Platform.Config`        | Typed environment variable loading                              |
+| `Platform.Text`          | Safe text truncation                                            |
 
 ## Dependency Rules
 
 - Keep this layer domain-neutral.
-- If code needs product entities, auth, internal APIs, or
-  assistant-specific logic, it belongs above `Platform.*`.
-- If code is pure runtime logic and generic enough to be reused by
-  Cortex and downstream consumers, it can live here.
+- If code needs product entities, auth, internal APIs, or assistant-specific logic, it belongs above
+  `Platform.*`.
+- If code is pure runtime logic and generic enough to be reused by Cortex and downstream consumers,
+  it can live here.
 - Prefer small modules with explicit export lists.
 
 ## Compatibility Rules
 
-- When moving existing infrastructure into `Platform.*`, preserve
-  behavior first.
-- Compatibility shims should re-export an explicit API, not `module X`
-  wholesale, so future Platform changes do not silently widen public
-  surfaces.
+- When moving existing infrastructure into `Platform.*`, preserve behavior first.
+- Compatibility shims should re-export an explicit API, not `module X` wholesale, so future Platform
+  changes do not silently widen public surfaces.
 
 ## Design Patterns
 
 - Favor simple total helpers and typed configuration records.
 - Keep error messages safe for logs by default.
-- Preserve operator-visible behavior intentionally; if semantics change,
-  make that explicit in code comments and PR notes.
-- Prefer generic names only for genuinely generic helpers. Put text
-  utilities in `Platform.Text`, not under a narrower domain namespace.
+- Preserve operator-visible behavior intentionally; if semantics change, make that explicit in code
+  comments and PR notes.
+- Prefer generic names only for genuinely generic helpers. Put text utilities in `Platform.Text`,
+  not under a narrower domain namespace.
 
 ## Module Notes
 
 - `Platform.Database` should stay a thin Hasql infrastructure layer.
-- `Platform.Observability` is still compatibility-shaped today; preserve
-  existing operator-visible behavior unless a focused migration changes
-  it deliberately.
-- `Platform.Text` is the home for generic text truncation and similar
-  helpers.
-- `Platform.DurableTask.Types` is the canonical home for shared run
-  status, trigger source, and scheduler-facing run outcome types.
-- `Platform.DurableTask.Schedule` is the shared schedule decision
-  engine. Runtime-specific DB writes stay in adapters above it.
+- `Platform.Observability` is still compatibility-shaped today; preserve existing operator-visible
+  behavior unless a focused migration changes it deliberately.
+- `Platform.Text` is the home for generic text truncation and similar helpers.
+- `Platform.DurableTask.Types` is the canonical home for shared run status, trigger source, and
+  scheduler-facing run outcome types.
+- `Platform.DurableTask.Schedule` is the shared schedule decision engine. Runtime-specific DB writes
+  stay in adapters above it.
 
 ## Anti-Patterns
 
 - Importing downstream product modules from `Platform.*`.
 - Importing domain models just to avoid a small conversion boundary.
-- Adding convenience re-exports that obscure where behavior really
-  lives.
+- Adding convenience re-exports that obscure where behavior really lives.
 - Mixing temporary compatibility choices with final architecture claims.

--- a/docs/ADRs/0001-structured-report-ir.md
+++ b/docs/ADRs/0001-structured-report-ir.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0001 - Structured Document IR"
-description: "Cortex document artifacts use a typed intermediate representation that is validated before deterministic rendering."
+description:
+  "Cortex document artifacts use a typed intermediate representation that is validated before
+  deterministic rendering."
 sidebar:
   label: "0001. Structured Document IR"
   order: 1
@@ -16,79 +18,71 @@ related:
 
 ## Status
 
-Accepted. Cortex exposes `ReportIR` as the typed document-artifact contract for
-workflows that need deterministic rendering instead of raw model-authored
-Markdown.
+Accepted. Cortex exposes `ReportIR` as the typed document-artifact contract for workflows that need
+deterministic rendering instead of raw model-authored Markdown.
 
 ## Context
 
-LLM-generated Markdown is useful for drafts, but it is a weak final artifact
-contract. It makes presentation, validation, escaping, citation placement, and
-tool provenance dependent on generated prose. That is especially risky for
-domains where numbers, formulas, tables, and cited evidence must survive
-rendering intact.
+LLM-generated Markdown is useful for drafts, but it is a weak final artifact contract. It makes
+presentation, validation, escaping, citation placement, and tool provenance dependent on generated
+prose. That is especially risky for domains where numbers, formulas, tables, and cited evidence must
+survive rendering intact.
 
-The architectural problem is generic: a host may want a Cortex workflow to
-produce a durable document artifact, while the host still owns the artifact's
-domain meaning and publication policy.
+The architectural problem is generic: a host may want a Cortex workflow to produce a durable
+document artifact, while the host still owns the artifact's domain meaning and publication policy.
 
-Downstream report generation is one concrete consumer of this surface, but the
-decision belongs to Cortex because the rendering and validation contract is
-reusable.
+Downstream report generation is one concrete consumer of this surface, but the decision belongs to
+Cortex because the rendering and validation contract is reusable.
 
 ## Decision
 
-Cortex document artifacts pass through a typed intermediate representation
-before rendering.
+Cortex document artifacts pass through a typed intermediate representation before rendering.
 
-The model and runtime may produce structured section outputs, evidence records,
-and narrative fragments, but the final renderer consumes a validated IR. The IR
-is the local contract between workflow output and rendered artifact.
+The model and runtime may produce structured section outputs, evidence records, and narrative
+fragments, but the final renderer consumes a validated IR. The IR is the local contract between
+workflow output and rendered artifact.
 
 The IR contract has these rules:
 
 - The artifact is structured data first, rendered text second.
 - Validation happens before final rendering.
 - The renderer is deterministic and local.
-- Escaping, formula delimiting, table shape, heading structure, and code-fence
-  metadata are renderer concerns.
+- Escaping, formula delimiting, table shape, heading structure, and code-fence metadata are renderer
+  concerns.
 - Domain-specific assembly policy remains downstream.
-- Provenance references may be embedded in the IR, but provenance semantics are
-  decided by the artifact-provenance contract in ADR 0013.
+- Provenance references may be embedded in the IR, but provenance semantics are decided by the
+  artifact-provenance contract in ADR 0013.
 
-In the current implementation, this contract is named `ReportIR`. The name is
-historical; the architectural decision is "structured document IR", not
-"Portman owns reports inside Cortex".
+In the current implementation, this contract is named `ReportIR`. The name is historical; the
+architectural decision is "structured document IR", not "Portman owns reports inside Cortex".
 
 ## Consequences
 
 Positive consequences:
 
-- Rendered artifacts no longer depend on prompt discipline for basic Markdown
-  correctness.
+- Rendered artifacts no longer depend on prompt discipline for basic Markdown correctness.
 - Validation failures are explicit and local.
-- Hosts can keep product-specific document meaning downstream while reusing
-  Cortex's structured rendering surface.
-- Provenance and annotation can target stable IR nodes instead of brittle spans
-  in generated Markdown.
+- Hosts can keep product-specific document meaning downstream while reusing Cortex's structured
+  rendering surface.
+- Provenance and annotation can target stable IR nodes instead of brittle spans in generated
+  Markdown.
 
 Costs and obligations:
 
 - Workflow outputs must be assembled into IR before final rendering.
 - Schema evolution requires versioning discipline.
 - Hosts must not treat the IR as a dumping ground for product policy.
-- If a future artifact family is not report-shaped, Cortex should add a new IR
-  or generalize the document layer deliberately rather than overloading
-  `ReportIR`.
+- If a future artifact family is not report-shaped, Cortex should add a new IR or generalize the
+  document layer deliberately rather than overloading `ReportIR`.
 
 ## Alternatives Considered
 
-- **Render raw model-authored Markdown.** Rejected because it makes validation
-  and presentation probabilistic.
-- **Fix Markdown with regex post-processing.** Rejected because it patches
-  symptoms and remains format-fragile.
-- **Move all report semantics into Cortex.** Rejected because Cortex owns the
-  artifact substrate; hosts own domain meaning and product policy.
+- **Render raw model-authored Markdown.** Rejected because it makes validation and presentation
+  probabilistic.
+- **Fix Markdown with regex post-processing.** Rejected because it patches symptoms and remains
+  format-fragile.
+- **Move all report semantics into Cortex.** Rejected because Cortex owns the artifact substrate;
+  hosts own domain meaning and product policy.
 
 ## Related
 

--- a/docs/ADRs/0002-cortex-downstream-ownership-boundary.md
+++ b/docs/ADRs/0002-cortex-downstream-ownership-boundary.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0002 - Cortex and Downstream Ownership Boundary"
-description: "Reusable AI substrate lives in Cortex; host applications own domain semantics, product policy, transport, and persistence."
+description:
+  "Reusable AI substrate lives in Cortex; host applications own domain semantics, product policy,
+  transport, and persistence."
 sidebar:
   label: "0002. Ownership boundary"
   order: 2
@@ -16,69 +18,62 @@ related:
 
 ## Status
 
-Accepted. Cortex is a standalone substrate. Downstream consumers integrate it
-through product bindings and host actions.
+Accepted. Cortex is a standalone substrate. Downstream consumers integrate it through product
+bindings and host actions.
 
 ## Context
 
-Cortex started inside a product codebase, so early module and documentation
-boundaries followed the first consumer's call sites. That was useful for
-shipping, but it is not a stable architecture. A reusable substrate must be
-defined by semantic ownership, not by whichever product first exercised a
+Cortex started inside a product codebase, so early module and documentation boundaries followed the
+first consumer's call sites. That was useful for shipping, but it is not a stable architecture. A
+reusable substrate must be defined by semantic ownership, not by whichever product first exercised a
 runtime path.
 
-Portman remains the primary downstream example in this repository. That is
-intentional: concrete consumer documentation keeps Cortex honest. The boundary
-problem appears only when Portman becomes the frame through which Cortex itself
-is defined.
+Portman remains the primary downstream example in this repository. That is intentional: concrete
+consumer documentation keeps Cortex honest. The boundary problem appears only when Portman becomes
+the frame through which Cortex itself is defined.
 
 ## Decision
 
 Adopt a strict three-part ownership boundary:
 
-- **Cortex substrate** owns reusable authoring, topology, execution,
-  capability, provenance, memory, provider, and artifact mechanics.
-- **Downstream product binding** owns prompts, tools, domain semantics, product
-  policy, task registration, artifact meaning, and operator choices.
-- **Host edge** owns transport, auth, persistence, streaming, route conversion,
-  and delivery behavior.
+- **Cortex substrate** owns reusable authoring, topology, execution, capability, provenance, memory,
+  provider, and artifact mechanics.
+- **Downstream product binding** owns prompts, tools, domain semantics, product policy, task
+  registration, artifact meaning, and operator choices.
+- **Host edge** owns transport, auth, persistence, streaming, route conversion, and delivery
+  behavior.
 
 Dependency direction follows ownership:
 
 `host edge -> product binding -> Cortex substrate`
 
-Runtime callbacks may move the other way through registered handlers, but those
-callbacks do not change ownership. A Cortex module must not import downstream
-domain or host-edge concepts.
+Runtime callbacks may move the other way through registered handlers, but those callbacks do not
+change ownership. A Cortex module must not import downstream domain or host-edge concepts.
 
 ## Consequences
 
 Positive consequences:
 
 - Cortex can be adopted by another host without inheriting Portman semantics.
-- Portman can remain a rich downstream example without becoming Cortex's
-  architectural boundary.
-- Code review has a clear placement rule for reusable runtime and provider
-  work.
-- Consumer-specific docs can stay under `docs/Consumers/` without polluting
-  canonical architecture chapters.
+- Portman can remain a rich downstream example without becoming Cortex's architectural boundary.
+- Code review has a clear placement rule for reusable runtime and provider work.
+- Consumer-specific docs can stay under `docs/Consumers/` without polluting canonical architecture
+  chapters.
 
 Costs and obligations:
 
-- Some refactors are larger because ownership has to be corrected, not only
-  local helper placement.
-- Generic abstractions sometimes need to be introduced before the second
-  consumer exists.
+- Some refactors are larger because ownership has to be corrected, not only local helper placement.
+- Generic abstractions sometimes need to be introduced before the second consumer exists.
 - Documentation must distinguish "Portman as example" from "Portman as frame".
 
 ## Alternatives Considered
 
-- **Let the first consumer define Cortex's shape.** Rejected because it bakes a
-  product boundary into a substrate.
-- **Forbid consumer docs from Cortex.** Rejected because downstream examples are
-  useful when they are clearly scoped.
-- **Move all product workflow semantics into Cortex.** Rejected because domain
-  meaning and product policy belong downstream.
+- **Let the first consumer define Cortex's shape.** Rejected because it bakes a product boundary
+  into a substrate.
+- **Forbid consumer docs from Cortex.** Rejected because downstream examples are useful when they
+  are clearly scoped.
+- **Move all product workflow semantics into Cortex.** Rejected because domain meaning and product
+  policy belong downstream.
 
 ## Related
 

--- a/docs/ADRs/0003-pulse-service-and-host-action-boundary.md
+++ b/docs/ADRs/0003-pulse-service-and-host-action-boundary.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0003 — Pulse Service and Host-Action Boundary"
-description: "Pulse runs as a standalone durable execution service; host applications own operator and domain behavior through authenticated host-action APIs."
+description:
+  "Pulse runs as a standalone durable execution service; host applications own operator and domain
+  behavior through authenticated host-action APIs."
 sidebar:
   label: "0003. Pulse boundary"
   order: 3
@@ -15,32 +17,45 @@ related:
 
 ## Status
 
-Accepted — the standalone Pulse runtime and host-action split are reflected in the shipped runtime design and surrounding implementation.
+Accepted — the standalone Pulse runtime and host-action split are reflected in the shipped runtime
+design and surrounding implementation.
 
 ## Context
 
-Durable execution needs its own scheduler, checkpoints, leases, recovery path, and health model. Embedding those concerns directly inside a host application's request-serving process would couple workflow runtime behavior to API restarts, handler concerns, and product persistence.
+Durable execution needs its own scheduler, checkpoints, leases, recovery path, and health model.
+Embedding those concerns directly inside a host application's request-serving process would couple
+workflow runtime behavior to API restarts, handler concerns, and product persistence.
 
-At the same time, Pulse cannot directly own host domain tables and product semantics. Domain mutations, host artifacts, and operator-facing admin surfaces remain host responsibilities.
+At the same time, Pulse cannot directly own host domain tables and product semantics. Domain
+mutations, host artifacts, and operator-facing admin surfaces remain host responsibilities.
 
-The system therefore needed a boundary that keeps runtime mechanics isolated without allowing Pulse to become a second application server for any consumer.
+The system therefore needed a boundary that keeps runtime mechanics isolated without allowing Pulse
+to become a second application server for any consumer.
 
 ## Decision
 
 Pulse is a standalone durable execution service.
 
-- Pulse owns task definitions, runs, checkpoints, scheduling, leases, signals, and lifecycle transitions
-- the host owns operator surfaces, product APIs, artifact stores, domain tables, and domain-specific semantics
-- Pulse reaches domain behavior only through authenticated, idempotent host-action APIs exposed by the host
+- Pulse owns task definitions, runs, checkpoints, scheduling, leases, signals, and lifecycle
+  transitions
+- the host owns operator surfaces, product APIs, artifact stores, domain tables, and domain-specific
+  semantics
+- Pulse reaches domain behavior only through authenticated, idempotent host-action APIs exposed by
+  the host
 - Pulse does not write host-owned tables directly
 
-This makes Pulse the runtime owner and the host the domain and operator owner. Communication between them is HTTP or JSON with a dedicated service credential and idempotency keys on mutating host actions.
+This makes Pulse the runtime owner and the host the domain and operator owner. Communication between
+them is HTTP or JSON with a dedicated service credential and idempotency keys on mutating host
+actions.
 
 ## Alternatives considered
 
-- **Embed Pulse directly in the host server or worker process** — rejected because runtime restarts, resource isolation, and health management would stay entangled with product serving.
-- **Let Pulse write host tables directly** — rejected because it breaks ownership boundaries and turns runtime code into domain persistence code.
-- **Use a single shared scheduler for both Pulse and host jobs** — rejected because durable workflow execution has different lifecycle and recovery semantics from ordinary worker jobs.
+- **Embed Pulse directly in the host server or worker process** — rejected because runtime restarts,
+  resource isolation, and health management would stay entangled with product serving.
+- **Let Pulse write host tables directly** — rejected because it breaks ownership boundaries and
+  turns runtime code into domain persistence code.
+- **Use a single shared scheduler for both Pulse and host jobs** — rejected because durable workflow
+  execution has different lifecycle and recovery semantics from ordinary worker jobs.
 
 ## Consequences
 

--- a/docs/ADRs/0004-graph-native-pulse-execution.md
+++ b/docs/ADRs/0004-graph-native-pulse-execution.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0004 — Graph-Native Pulse Execution"
-description: "Pulse executes algebraic graph topology directly rather than treating graphs as presentation over linear stage counters."
+description:
+  "Pulse executes algebraic graph topology directly rather than treating graphs as presentation over
+  linear stage counters."
 sidebar:
   label: "0004. Graph-native execution"
   order: 4
@@ -17,17 +19,21 @@ related:
 
 ## Status
 
-Accepted — graph-native execution semantics replaced linear stage plans and the later runtime work builds on that substrate.
+Accepted — graph-native execution semantics replaced linear stage plans and the later runtime work
+builds on that substrate.
 
 ## Context
 
-Linear stage lists are easy to schedule, but they misrepresent the workflows Cortex needs to execute:
+Linear stage lists are easy to schedule, but they misrepresent the workflows Cortex needs to
+execute:
 
 - fan-out and join become awkward encodings instead of first-class topology
 - ready work is derived from stage position rather than predecessor satisfaction
 - restart and inspection center on counters rather than on the actual graph state
 
-Cortex's broader direction is graph-native: Wire authors topology, Circuit validates executable topology, and Pulse executes that topology durably. The runtime therefore needed to stop treating graphs as a UI or planning convenience over an imperative core.
+Cortex's broader direction is graph-native: Wire authors topology, Circuit validates executable
+topology, and Pulse executes that topology durably. The runtime therefore needed to stop treating
+graphs as a UI or planning convenience over an imperative core.
 
 ## Decision
 
@@ -38,13 +44,17 @@ Pulse executes graph topology directly.
 - suspension, resume, and recovery operate over graph state, not stage counters
 - legacy linear workflows remain valid only as the degenerate path case inside the graph model
 
-The runtime model is therefore partial-order native. Scheduling is over frontiers of ready nodes, not over "current stage index plus next stage."
+The runtime model is therefore partial-order native. Scheduling is over frontiers of ready nodes,
+not over "current stage index plus next stage."
 
 ## Alternatives considered
 
-- **Keep a linear executor and treat graphs as presentation only** — rejected because it hides the real execution semantics and makes fan-out, joins, and inspection unnatural.
-- **Encode workflow behavior as imperative control flow inside large stage bodies** — rejected because it weakens replay, operator visibility, and structural validation.
-- **Introduce graph notation only at authoring time, then erase it before runtime** — rejected because the runtime still needs graph semantics for correctness and recovery.
+- **Keep a linear executor and treat graphs as presentation only** — rejected because it hides the
+  real execution semantics and makes fan-out, joins, and inspection unnatural.
+- **Encode workflow behavior as imperative control flow inside large stage bodies** — rejected
+  because it weakens replay, operator visibility, and structural validation.
+- **Introduce graph notation only at authoring time, then erase it before runtime** — rejected
+  because the runtime still needs graph semantics for correctness and recovery.
 
 ## Consequences
 
@@ -63,7 +73,8 @@ The runtime model is therefore partial-order native. Scheduling is over frontier
 
 - Keep linear compatibility as a degenerate case rather than as a separate runtime path.
 - Keep graph semantics below Pulse-specific IO and persistence concerns.
-- Explain new runtime features in graph-native terms rather than reintroducing stage-list vocabulary.
+- Explain new runtime features in graph-native terms rather than reintroducing stage-list
+  vocabulary.
 
 ## Related
 

--- a/docs/ADRs/0005-budgeted-rewrite-admission-and-materialization.md
+++ b/docs/ADRs/0005-budgeted-rewrite-admission-and-materialization.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0005 — Budgeted Rewrite Admission and Materialization"
-description: "Runtime graph evolution happens only through admitted rewrite deltas that fit a durable rewrite budget and materialize into graph state."
+description:
+  "Runtime graph evolution happens only through admitted rewrite deltas that fit a durable rewrite
+  budget and materialize into graph state."
 sidebar:
   label: "0005. Rewrite admission"
   order: 5
@@ -17,11 +19,15 @@ related:
 
 ## Status
 
-Accepted — structured rewrite admission, rewrite budgets, and durable materialization are implemented and now anchor the graph-execution architecture.
+Accepted — structured rewrite admission, rewrite budgets, and durable materialization are
+implemented and now anchor the graph-execution architecture.
 
 ## Context
 
-Static DAG execution is not enough for Cortex's target workflows. A running node may discover missing evidence, need to elaborate follow-up work, or need to prune and repair future topology. Allowing that kind of evolution without a law would turn the runtime into arbitrary mutable control flow.
+Static DAG execution is not enough for Cortex's target workflows. A running node may discover
+missing evidence, need to elaborate follow-up work, or need to prune and repair future topology.
+Allowing that kind of evolution without a law would turn the runtime into arbitrary mutable control
+flow.
 
 The runtime therefore needed a way to support dynamic topology while preserving:
 
@@ -37,15 +43,21 @@ Graph evolution during execution is allowed only through runtime-admitted rewrit
 - stages and planners may propose rewrites
 - only the runtime may admit them
 - admission requires validation against rewrite safety rules and a finite per-run rewrite budget
-- admitted rewrites materialize durably into the graph state and become part of the run's execution history
+- admitted rewrites materialize durably into the graph state and become part of the run's execution
+  history
 
-Budget is a runtime law, not a prompt convention. Structural change consumes explicit authority measured in bounded dimensions such as added nodes, edges, depth, frontier breadth, and rewrite operations.
+Budget is a runtime law, not a prompt convention. Structural change consumes explicit authority
+measured in bounded dimensions such as added nodes, edges, depth, frontier breadth, and rewrite
+operations.
 
 ## Alternatives considered
 
-- **Let planner prompts impose the growth limit informally** — rejected because prompt discipline is not a correctness boundary and cannot support replay or auditability.
-- **Allow arbitrary mutation of the materialized graph** — rejected because it destroys analyzability and makes runtime trust too expensive.
-- **Ban execution-time graph evolution entirely** — rejected because real repair, adaptation, and conditional elaboration would collapse back into ad hoc imperative stage logic.
+- **Let planner prompts impose the growth limit informally** — rejected because prompt discipline is
+  not a correctness boundary and cannot support replay or auditability.
+- **Allow arbitrary mutation of the materialized graph** — rejected because it destroys
+  analyzability and makes runtime trust too expensive.
+- **Ban execution-time graph evolution entirely** — rejected because real repair, adaptation, and
+  conditional elaboration would collapse back into ad hoc imperative stage logic.
 
 ## Consequences
 
@@ -57,7 +69,8 @@ Budget is a runtime law, not a prompt convention. Structural change consumes exp
 
 ### Negative
 
-- Rewrite-capable tasks must encode their changes through the runtime algebra rather than directly mutating future work.
+- Rewrite-capable tasks must encode their changes through the runtime algebra rather than directly
+  mutating future work.
 - Budget design becomes part of runtime correctness, not just tuning.
 
 ### Obligations

--- a/docs/ADRs/0006-compiled-workflow-artifact-boundary.md
+++ b/docs/ADRs/0006-compiled-workflow-artifact-boundary.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0006 — Compiled Workflow Artifact Boundary"
-description: "Workflow intent compiles into a first-class artifact that separates product semantics from Pulse lowering and execution."
+description:
+  "Workflow intent compiles into a first-class artifact that separates product semantics from Pulse
+  lowering and execution."
 sidebar:
   label: "0006. Workflow artifact"
   order: 6
@@ -21,13 +23,15 @@ Accepted — the workflow compiler boundary is the basis for current workflow ar
 
 ## Context
 
-Before the workflow compilation work, product workflows mostly lived as task-specific code paths and ad hoc lowering conventions. That made three things hard:
+Before the workflow compilation work, product workflows mostly lived as task-specific code paths and
+ad hoc lowering conventions. That made three things hard:
 
 - expressing product intent as a reusable artifact
 - exposing workflows honestly in APIs and UI
 - keeping product semantics out of Pulse internals
 
-The runtime already knew how to execute and materialize graph state. What was missing was a first-class artifact between product intent and runtime lowering.
+The runtime already knew how to execute and materialize graph state. What was missing was a
+first-class artifact between product intent and runtime lowering.
 
 ## Decision
 
@@ -35,15 +39,21 @@ Workflow intent compiles into a first-class compiled artifact.
 
 - product or domain code defines workflow intent above Pulse
 - the compiler lowers that intent into a reusable workflow artifact
-- Pulse lowers and executes that artifact; it does not own the product compiler semantics that produced it
+- Pulse lowers and executes that artifact; it does not own the product compiler semantics that
+  produced it
 
-The compiled artifact is therefore the canonical boundary between product semantics and durable runtime execution. It is useful even when a given construct is not yet fully executable, because it carries the honest shape of the workflow contract above the runtime.
+The compiled artifact is therefore the canonical boundary between product semantics and durable
+runtime execution. It is useful even when a given construct is not yet fully executable, because it
+carries the honest shape of the workflow contract above the runtime.
 
 ## Alternatives considered
 
-- **Lower product workflows directly into Pulse stage plans** — rejected because it tangles product semantics with runtime mechanics and leaves no honest artifact boundary.
-- **Treat compiled workflows as documentation-only shadow structures** — rejected because the same artifact is needed for APIs, UI, and runtime lowering.
-- **Move workflow compilation entirely into Pulse** — rejected because workflow compilation is a semantic layer above the generic runtime, not part of the executor core.
+- **Lower product workflows directly into Pulse stage plans** — rejected because it tangles product
+  semantics with runtime mechanics and leaves no honest artifact boundary.
+- **Treat compiled workflows as documentation-only shadow structures** — rejected because the same
+  artifact is needed for APIs, UI, and runtime lowering.
+- **Move workflow compilation entirely into Pulse** — rejected because workflow compilation is a
+  semantic layer above the generic runtime, not part of the executor core.
 
 ## Consequences
 
@@ -51,7 +61,8 @@ The compiled artifact is therefore the canonical boundary between product semant
 
 - Product workflow intent has a stable place to live above Pulse.
 - APIs and UI can talk about compiled workflows directly instead of reverse-engineering task code.
-- Conditional and rewrite-aware execution can be framed as artifact-lowering questions instead of ad hoc runtime patches.
+- Conditional and rewrite-aware execution can be framed as artifact-lowering questions instead of ad
+  hoc runtime patches.
 
 ### Negative
 

--- a/docs/ADRs/0007-latent-branch-conditional-lowering.md
+++ b/docs/ADRs/0007-latent-branch-conditional-lowering.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0007 — Latent-Branch Conditional Lowering"
-description: "Conditionals compile to condition anchors with latent branch fragments; Pulse materializes only the selected branch."
+description:
+  "Conditionals compile to condition anchors with latent branch fragments; Pulse materializes only
+  the selected branch."
 sidebar:
   label: "0007. Conditional lowering"
   order: 7
@@ -17,13 +19,19 @@ related:
 
 ## Status
 
-Accepted — the conditional lowering model is now the documented execution semantics for built-in workflow conditionals.
+Accepted — the conditional lowering model is now the documented execution semantics for built-in
+workflow conditionals.
 
 ## Context
 
-Conditionals exposed a real semantic gap in the workflow stack. If a conditional were lowered as plain DAG fan-out, both branches would become runnable under ordinary readiness rules. If it were hidden in stage-local imperative code, the workflow artifact would stop telling the truth about future obligations.
+Conditionals exposed a real semantic gap in the workflow stack. If a conditional were lowered as
+plain DAG fan-out, both branches would become runnable under ordinary readiness rules. If it were
+hidden in stage-local imperative code, the workflow artifact would stop telling the truth about
+future obligations.
 
-The missing piece was not a new runtime mutation mechanism. The runtime already had rewrite and materialization machinery. What was missing was a truthful representation of latent alternatives at the workflow boundary.
+The missing piece was not a new runtime mutation mechanism. The runtime already had rewrite and
+materialization machinery. What was missing was a truthful representation of latent alternatives at
+the workflow boundary.
 
 ## Decision
 
@@ -34,21 +42,27 @@ Compile conditionals as condition anchors with latent branch fragments.
 - Pulse materializes only the selected branch into the materialized graph
 - the condition anchor remains available for lineage and provenance
 
-This makes branch selection a first-class lowering concept rather than plain graph fan-out or hidden imperative logic.
+This makes branch selection a first-class lowering concept rather than plain graph fan-out or hidden
+imperative logic.
 
 ## Alternatives considered
 
-- **Lower conditionals as ordinary fan-out** — rejected because both branches would appear runnable under current graph readiness semantics.
-- **Hide branch choice inside stage-local imperative code** — rejected because it destroys the honesty of the compiled artifact and weakens operator explanation.
-- **Treat every conditional as an open-ended rewrite authored at runtime** — rejected because built-in conditionals are structured semantic alternatives, not arbitrary planner invention.
+- **Lower conditionals as ordinary fan-out** — rejected because both branches would appear runnable
+  under current graph readiness semantics.
+- **Hide branch choice inside stage-local imperative code** — rejected because it destroys the
+  honesty of the compiled artifact and weakens operator explanation.
+- **Treat every conditional as an open-ended rewrite authored at runtime** — rejected because
+  built-in conditionals are structured semantic alternatives, not arbitrary planner invention.
 
 ## Consequences
 
 ### Positive
 
 - The compiled artifact can represent what obligations may arise without materializing all of them.
-- Pulse reuses existing rewrite and materialization machinery instead of gaining a special conditional executor path.
-- Provenance and lineage remain attached to the condition anchor rather than disappearing into branch-local code.
+- Pulse reuses existing rewrite and materialization machinery instead of gaining a special
+  conditional executor path.
+- Provenance and lineage remain attached to the condition anchor rather than disappearing into
+  branch-local code.
 
 ### Negative
 
@@ -57,9 +71,12 @@ This makes branch selection a first-class lowering concept rather than plain gra
 
 ### Obligations
 
-- Keep conditional branch selection expressed at the workflow or circuit boundary, not as product-only convention.
-- Preserve the distinction between the compiled artifact and the materialized graph in docs and operator tooling.
-- Revisit this ADR only if the retained-anchor model is intentionally replaced by a different provenance law.
+- Keep conditional branch selection expressed at the workflow or circuit boundary, not as
+  product-only convention.
+- Preserve the distinction between the compiled artifact and the materialized graph in docs and
+  operator tooling.
+- Revisit this ADR only if the retained-anchor model is intentionally replaced by a different
+  provenance law.
 
 ## Related
 

--- a/docs/ADRs/0008-pulse-operator-visibility-surfaces.md
+++ b/docs/ADRs/0008-pulse-operator-visibility-surfaces.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0008 — Pulse Operator Visibility Surfaces"
-description: "Pulse operator visibility is built from append-only run events and graph-native inspection rather than inferred mutable state alone."
+description:
+  "Pulse operator visibility is built from append-only run events and graph-native inspection rather
+  than inferred mutable state alone."
 sidebar:
   label: "0008. Operator visibility"
   order: 8
@@ -17,11 +19,14 @@ related:
 
 ## Status
 
-Accepted — append-only run events and graph-native admin inspection are now part of the runtime's operator contract.
+Accepted — append-only run events and graph-native admin inspection are now part of the runtime's
+operator contract.
 
 ## Context
 
-Mutable run rows, checkpoints, and stage logs are necessary for execution, but they are not enough for operators. Once Pulse became graph-native and rewrite-capable, operators needed to answer questions that mutable state alone does not answer well:
+Mutable run rows, checkpoints, and stage logs are necessary for execution, but they are not enough
+for operators. Once Pulse became graph-native and rewrite-capable, operators needed to answer
+questions that mutable state alone does not answer well:
 
 - what happened to this run over time
 - why is it blocked or waiting now
@@ -35,15 +40,23 @@ Relying on host logs or task-specific reconstruction would make inspection parti
 Pulse exposes operator visibility through two first-class surfaces:
 
 - an append-only per-run event history for lifecycle-significant facts
-- graph-native run inspection that exposes the materialized execution state in terms of rewrites, waiting and blocked diagnostics, and graph evolution
+- graph-native run inspection that exposes the materialized execution state in terms of rewrites,
+  waiting and blocked diagnostics, and graph evolution
 
-These surfaces supplement mutable runtime state rather than being inferred from it after the fact. Event recording is best-effort and must never block run progress, but the operator model itself is part of the runtime contract.
+These surfaces supplement mutable runtime state rather than being inferred from it after the fact.
+Event recording is best-effort and must never block run progress, but the operator model itself is
+part of the runtime contract.
 
 ## Alternatives considered
 
-- **Infer operator history from mutable run rows and stage logs only** — rejected because rewrite-capable graph execution loses too much explanatory structure when collapsed to latest state plus attempt history.
-- **Rely on observability logs outside the runtime contract** — rejected because operators need queryable per-run facts, not just external log streams.
-- **Build task-specific inspection paths in each host product for each workflow kind** — rejected because graph-native visibility belongs to the generic runtime, not to each downstream product task.
+- **Infer operator history from mutable run rows and stage logs only** — rejected because
+  rewrite-capable graph execution loses too much explanatory structure when collapsed to latest
+  state plus attempt history.
+- **Rely on observability logs outside the runtime contract** — rejected because operators need
+  queryable per-run facts, not just external log streams.
+- **Build task-specific inspection paths in each host product for each workflow kind** — rejected
+  because graph-native visibility belongs to the generic runtime, not to each downstream product
+  task.
 
 ## Consequences
 
@@ -60,7 +73,8 @@ These surfaces supplement mutable runtime state rather than being inferred from 
 
 ### Obligations
 
-- Keep new lifecycle-significant transitions visible through run events or graph inspection, not only through logs.
+- Keep new lifecycle-significant transitions visible through run events or graph inspection, not
+  only through logs.
 - Preserve the graph-native vocabulary of blocked, waiting, rewritten, and materialized state.
 - Avoid baking task-specific explanation formats into the generic Pulse surfaces.
 

--- a/docs/ADRs/0009-rewrite-provenance-and-topology-integrity.md
+++ b/docs/ADRs/0009-rewrite-provenance-and-topology-integrity.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0009 — Rewrite Provenance and Topology Integrity"
-description: "Materialized graph state carries per-node provenance and a topology integrity witness so rewrite history can be trusted on resume and inspection."
+description:
+  "Materialized graph state carries per-node provenance and a topology integrity witness so rewrite
+  history can be trusted on resume and inspection."
 sidebar:
   label: "0009. Graph integrity"
   order: 9
@@ -16,41 +18,51 @@ related:
 
 ## Status
 
-Accepted — provenance-bearing graph state and topology integrity checks are part of the landed rewrite substrate.
+Accepted — provenance-bearing graph state and topology integrity checks are part of the landed
+rewrite substrate.
 
 ## Context
 
-Once Pulse began admitting and materializing rewrites, the system needed more than a coarse rewrite log. Operators and the resume path both needed to know:
+Once Pulse began admitting and materializing rewrites, the system needed more than a coarse rewrite
+log. Operators and the resume path both needed to know:
 
 - which rewrite introduced which nodes
 - whether the persisted materialized topology still agrees with the stored graph state
 - whether graph evolution can be trusted after crashes, restarts, and replay
 
-Without explicit provenance and integrity witnesses, the runtime would still execute, but explanation and trust would stay weaker than the durability story implied.
+Without explicit provenance and integrity witnesses, the runtime would still execute, but
+explanation and trust would stay weaker than the durability story implied.
 
 ## Decision
 
 Persist rewrite provenance and topology integrity as part of graph state.
 
-- graph state carries per-node provenance describing whether a node came from the initial plan or from an admitted rewrite
+- graph state carries per-node provenance describing whether a node came from the initial plan or
+  from an admitted rewrite
 - graph state carries a topology integrity witness that can be checked on resume
-- admin inspection surfaces expose these facts directly instead of reconstructing them loosely from surrounding events
+- admin inspection surfaces expose these facts directly instead of reconstructing them loosely from
+  surrounding events
 
 This makes provenance and integrity runtime facts, not offline audit conveniences.
 
 ## Alternatives considered
 
-- **Persist only a coarse rewrite history** — rejected because it does not answer which current nodes came from which rewrite.
-- **Trust reconstructed topology without an integrity witness** — rejected because resume and inspection need to detect drift or corruption explicitly.
-- **Compute provenance only in admin tools after the fact** — rejected because trust and resume correctness belong in the runtime substrate itself.
+- **Persist only a coarse rewrite history** — rejected because it does not answer which current
+  nodes came from which rewrite.
+- **Trust reconstructed topology without an integrity witness** — rejected because resume and
+  inspection need to detect drift or corruption explicitly.
+- **Compute provenance only in admin tools after the fact** — rejected because trust and resume
+  correctness belong in the runtime substrate itself.
 
 ## Consequences
 
 ### Positive
 
 - Resume can detect mismatches between persisted graph state and expected topology.
-- Operators can inspect graph evolution with node-level provenance instead of only reading rewrite IDs in isolation.
-- The runtime's durability claims become easier to justify because current state carries its own witness.
+- Operators can inspect graph evolution with node-level provenance instead of only reading rewrite
+  IDs in isolation.
+- The runtime's durability claims become easier to justify because current state carries its own
+  witness.
 
 ### Negative
 

--- a/docs/ADRs/0010-wire-closed-authority-and-three-layer-stack.md
+++ b/docs/ADRs/0010-wire-closed-authority-and-three-layer-stack.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0010 — Wire as Closed-Authority Language over the Graph/Circuit/Wire Stack"
-description: "Cortex separates Graph, Circuit, and Wire, and Wire composes only registered authority rather than inventing executors, contracts, or domain semantics."
+description:
+  "Cortex separates Graph, Circuit, and Wire, and Wire composes only registered authority rather
+  than inventing executors, contracts, or domain semantics."
 sidebar:
   label: "0010. Wire authority"
   order: 10
@@ -19,13 +21,19 @@ related:
 
 ## Status
 
-Accepted — the current Cortex vocabulary and Wire architecture already assume this split and authority rule.
+Accepted — the current Cortex vocabulary and Wire architecture already assume this split and
+authority rule.
 
 ## Context
 
-Cortex needed a source language small enough to author and rewrite graph topology safely, while still preserving a principled substrate below it. The design pressure came from both human authoring and LLM-proposed rewrites: if the language could invent new executors, new contracts, or ad hoc edge semantics at runtime, validation would become too semantic and too expensive.
+Cortex needed a source language small enough to author and rewrite graph topology safely, while
+still preserving a principled substrate below it. The design pressure came from both human authoring
+and LLM-proposed rewrites: if the language could invent new executors, new contracts, or ad hoc edge
+semantics at runtime, validation would become too semantic and too expensive.
 
-At the same time, collapsing topology, executable artifact, and source language into one layer would hide which invariants belong to pure graph algebra, which belong to validated execution, and which belong only to authoring syntax.
+At the same time, collapsing topology, executable artifact, and source language into one layer would
+hide which invariants belong to pure graph algebra, which belong to validated execution, and which
+belong only to authoring syntax.
 
 ## Decision
 
@@ -45,9 +53,14 @@ The design rule is: Wire composes registered authority, and Haskell owns what th
 
 ## Alternatives considered
 
-- **Make Wire a host language that invents executors, contracts, or rich edge semantics inline** — rejected because it would turn topology authoring into an open semantic programming surface and make rewrites harder to trust.
-- **Collapse Graph, Circuit, and Wire into one undifferentiated layer** — rejected because pure graph laws, executable validation, and authoring syntax have different responsibilities and different invariants.
-- **Put semantic meaning on edges rather than endpoints** — rejected because it makes the core graph model heavier and weakens cheap compatibility checks during composition and rewrite admission.
+- **Make Wire a host language that invents executors, contracts, or rich edge semantics inline** —
+  rejected because it would turn topology authoring into an open semantic programming surface and
+  make rewrites harder to trust.
+- **Collapse Graph, Circuit, and Wire into one undifferentiated layer** — rejected because pure
+  graph laws, executable validation, and authoring syntax have different responsibilities and
+  different invariants.
+- **Put semantic meaning on edges rather than endpoints** — rejected because it makes the core graph
+  model heavier and weakens cheap compatibility checks during composition and rewrite admission.
 
 ## Consequences
 
@@ -60,13 +73,15 @@ The design rule is: Wire composes registered authority, and Haskell owns what th
 ### Negative
 
 - Some seemingly convenient inline language features are ruled out on purpose.
-- Authoring ergonomics must respect the closed-authority rule rather than reaching for general-purpose language escape hatches.
+- Authoring ergonomics must respect the closed-authority rule rather than reaching for
+  general-purpose language escape hatches.
 
 ### Obligations
 
 - Keep grammar growth aligned with topology authoring, not with general programming.
 - Keep contract and executor authority outside Wire source.
-- Maintain architecture docs so the Graph/Circuit/Wire split stays visible rather than collapsing back into "workflow" as one vague layer.
+- Maintain architecture docs so the Graph/Circuit/Wire split stays visible rather than collapsing
+  back into "workflow" as one vague layer.
 
 ## Related
 

--- a/docs/ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md
+++ b/docs/ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0011 — Compatibility Barriers and Fresh-Run Recovery"
-description: "Incompatible checkpoints fail explicitly; recovery across version drift happens through fresh-run recovery rather than silent resume."
+description:
+  "Incompatible checkpoints fail explicitly; recovery across version drift happens through fresh-run
+  recovery rather than silent resume."
 sidebar:
   label: "0011. Compatibility barriers"
   order: 11
@@ -15,13 +17,17 @@ related:
 
 ## Status
 
-Accepted — versioned checkpoint compatibility and non-silent recovery behavior are part of the current Pulse runtime contract.
+Accepted — versioned checkpoint compatibility and non-silent recovery behavior are part of the
+current Pulse runtime contract.
 
 ## Context
 
-Long-lived durable runs inevitably cross code and runtime evolution. A stored checkpoint may no longer match the current task type, task version, runtime version, or checkpoint shape after deployment changes.
+Long-lived durable runs inevitably cross code and runtime evolution. A stored checkpoint may no
+longer match the current task type, task version, runtime version, or checkpoint shape after
+deployment changes.
 
-Allowing best-effort resume across such mismatches would create a dangerous ambiguity: a run might appear resumable while actually executing against semantics it was not checkpointed under.
+Allowing best-effort resume across such mismatches would create a dangerous ambiguity: a run might
+appear resumable while actually executing against semantics it was not checkpointed under.
 
 Pulse therefore needed an explicit law for version drift and operator recovery.
 
@@ -31,15 +37,20 @@ Checkpoint compatibility failures are explicit runtime barriers.
 
 - version and shape mismatches are classified as typed compatibility failures
 - incompatible checkpoints do not resume silently
-- the default operator recovery path across version drift is to create a fresh run rather than to force checkpoint-based continuation
+- the default operator recovery path across version drift is to create a fresh run rather than to
+  force checkpoint-based continuation
 
-Fresh-run recovery preserves operator intent and parent provenance while avoiding the fiction that an old checkpoint is still valid under new code.
+Fresh-run recovery preserves operator intent and parent provenance while avoiding the fiction that
+an old checkpoint is still valid under new code.
 
 ## Alternatives considered
 
-- **Attempt best-effort resume against newer code** — rejected because it hides semantic drift behind optimistic control flow.
-- **Treat every mismatch as generic corruption** — rejected because operators need to distinguish version drift from damaged state.
-- **Default to checkpoint migration or copied restart state** — rejected because the current system has not adopted a general migration law and should not pretend one exists.
+- **Attempt best-effort resume against newer code** — rejected because it hides semantic drift
+  behind optimistic control flow.
+- **Treat every mismatch as generic corruption** — rejected because operators need to distinguish
+  version drift from damaged state.
+- **Default to checkpoint migration or copied restart state** — rejected because the current system
+  has not adopted a general migration law and should not pretend one exists.
 
 ## Consequences
 
@@ -52,13 +63,15 @@ Fresh-run recovery preserves operator intent and parent provenance while avoidin
 ### Negative
 
 - Version drift can force re-execution rather than seamless continuation.
-- Any future checkpoint-migration story will need a deliberate new design, not an implicit extension of the current one.
+- Any future checkpoint-migration story will need a deliberate new design, not an implicit extension
+  of the current one.
 
 ### Obligations
 
 - Keep compatibility failure categories explicit in runtime and operator surfaces.
 - Do not add silent or best-effort resume paths around the barrier.
-- Treat future migration support as a separate architectural decision, not as incidental implementation detail.
+- Treat future migration support as a separate architectural decision, not as incidental
+  implementation detail.
 
 ## Related
 

--- a/docs/ADRs/0012-topological-memory-as-deterministic-graph-query.md
+++ b/docs/ADRs/0012-topological-memory-as-deterministic-graph-query.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0012 — Topological Memory as Deterministic Graph Query"
-description: "Memory is a deterministic stage-entry query over settled graph state, with the read surface selected per node."
+description:
+  "Memory is a deterministic stage-entry query over settled graph state, with the read surface
+  selected per node."
 sidebar:
   label: "0012. Topological memory"
   order: 12
@@ -16,29 +18,40 @@ related:
 
 ## Status
 
-Accepted — topological memory and per-node memory strategy are now part of the shipped runtime and Wire surface.
+Accepted — topological memory and per-node memory strategy are now part of the shipped runtime and
+Wire surface.
 
 ## Context
 
-Classic chain-scoped inputs work for simple linear flows, but they are too narrow for graph-native workflows where a node may need principled access to settled upstream observations beyond its direct input bundle. At the same time, turning memory into a separate mutable store would weaken replay, inspection, and causal clarity.
+Classic chain-scoped inputs work for simple linear flows, but they are too narrow for graph-native
+workflows where a node may need principled access to settled upstream observations beyond its direct
+input bundle. At the same time, turning memory into a separate mutable store would weaken replay,
+inspection, and causal clarity.
 
-The runtime needed a memory surface that respects graph topology, remains deterministic, and does not blur past observations with live orchestration state.
+The runtime needed a memory surface that respects graph topology, remains deterministic, and does
+not blur past observations with live orchestration state.
 
 ## Decision
 
 Define memory as a deterministic graph query over settled graph state at stage entry.
 
 - memory is read from the Pulse substrate, not from a separate mutable memory database
-- the snapshot is bound at stage entry so same-frontier execution does not bleed into the current node's view
-- the memory read surface is selected per node through declared strategy rather than by one global runtime switch
+- the snapshot is bound at stage entry so same-frontier execution does not bleed into the current
+  node's view
+- the memory read surface is selected per node through declared strategy rather than by one global
+  runtime switch
 
-Classic direct-input reads remain valid, but topological memory is the graph-native read model when a node needs broader settled context.
+Classic direct-input reads remain valid, but topological memory is the graph-native read model when
+a node needs broader settled context.
 
 ## Alternatives considered
 
-- **Keep memory as direct chain inputs only** — rejected because graph-native review and rewrite nodes need a principled way to read settled upstream context beyond one chain-shaped bundle.
-- **Introduce a separate mutable memory store** — rejected because it would weaken determinism and make memory diverge from the actual graph substrate.
-- **Use only a run-level environment override** — rejected because memory policy belongs to node semantics and workflow authoring, not to one global toggle.
+- **Keep memory as direct chain inputs only** — rejected because graph-native review and rewrite
+  nodes need a principled way to read settled upstream context beyond one chain-shaped bundle.
+- **Introduce a separate mutable memory store** — rejected because it would weaken determinism and
+  make memory diverge from the actual graph substrate.
+- **Use only a run-level environment override** — rejected because memory policy belongs to node
+  semantics and workflow authoring, not to one global toggle.
 
 ## Consequences
 
@@ -46,12 +59,14 @@ Classic direct-input reads remain valid, but topological memory is the graph-nat
 
 - Memory reads stay tied to durable graph state and causal topology.
 - Per-node strategy keeps the read surface explicit in the authoring layer.
-- Review and rewrite nodes can ground themselves in settled upstream evidence without violating replay discipline.
+- Review and rewrite nodes can ground themselves in settled upstream evidence without violating
+  replay discipline.
 
 ### Negative
 
 - Memory policy becomes part of workflow authoring and runtime metadata.
-- The runtime has to maintain walk, scoring, and snapshot rules as semantic infrastructure rather than as incidental helpers.
+- The runtime has to maintain walk, scoring, and snapshot rules as semantic infrastructure rather
+  than as incidental helpers.
 
 ### Obligations
 

--- a/docs/ADRs/0013-report-provenance-artifact-contract.md
+++ b/docs/ADRs/0013-report-provenance-artifact-contract.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0013 - Artifact Provenance Contract"
-description: "Cortex artifacts attach provenance through stable artifact-local references rather than raw rendered spans."
+description:
+  "Cortex artifacts attach provenance through stable artifact-local references rather than raw
+  rendered spans."
 sidebar:
   label: "0013. Artifact provenance"
   order: 13
@@ -16,52 +18,47 @@ related:
 
 ## Status
 
-Accepted. Cortex artifact provenance is modeled as structured metadata attached
-to artifact-local references.
+Accepted. Cortex artifact provenance is modeled as structured metadata attached to artifact-local
+references.
 
 ## Context
 
-Structured rendering solves only one side of trustworthy artifacts. A rendered
-document can be syntactically valid and still fail to explain where a number,
-claim, table, or derived value came from.
+Structured rendering solves only one side of trustworthy artifacts. A rendered document can be
+syntactically valid and still fail to explain where a number, claim, table, or derived value came
+from.
 
-Raw span annotation is too fragile as the primary contract. Rendering changes,
-Markdown normalization, and HTML transformations can move spans even when the
-artifact's semantic nodes stay stable. Provenance needs to attach before final
-presentation.
+Raw span annotation is too fragile as the primary contract. Rendering changes, Markdown
+normalization, and HTML transformations can move spans even when the artifact's semantic nodes stay
+stable. Provenance needs to attach before final presentation.
 
-Downstream report provenance is one concrete consumer of this contract, but the
-underlying rule applies to any host that turns Cortex workflow outputs into
-auditable artifacts.
+Downstream report provenance is one concrete consumer of this contract, but the underlying rule
+applies to any host that turns Cortex workflow outputs into auditable artifacts.
 
 ## Decision
 
-Artifact provenance is represented through stable artifact-local references,
-not through raw rendered-text spans.
+Artifact provenance is represented through stable artifact-local references, not through raw
+rendered-text spans.
 
 The contract has four parts:
 
-- **Artifact-local anchors.** Structured artifact nodes carry stable local
-  identifiers that survive deterministic rendering.
-- **Provenance records.** Each record names the source of a claim, value, tool
-  result, computation, or model-produced section.
-- **Coverage metadata.** Artifacts may summarize how much of the rendered output
-  has explicit provenance.
-- **Renderer projection.** Markdown and HTML renderers project the provenance
-  metadata into annotations, links, or sidecar metadata without changing the
-  provenance source of truth.
+- **Artifact-local anchors.** Structured artifact nodes carry stable local identifiers that survive
+  deterministic rendering.
+- **Provenance records.** Each record names the source of a claim, value, tool result, computation,
+  or model-produced section.
+- **Coverage metadata.** Artifacts may summarize how much of the rendered output has explicit
+  provenance.
+- **Renderer projection.** Markdown and HTML renderers project the provenance metadata into
+  annotations, links, or sidecar metadata without changing the provenance source of truth.
 
-The host remains responsible for deciding which sources are valid in its domain
-and which provenance gaps are acceptable for publication.
+The host remains responsible for deciding which sources are valid in its domain and which provenance
+gaps are acceptable for publication.
 
 ## Consequences
 
 Positive consequences:
 
-- Provenance survives formatting changes because it targets structured artifact
-  nodes.
-- Hosts can build domain-specific audit surfaces without changing Cortex's core
-  document renderer.
+- Provenance survives formatting changes because it targets structured artifact nodes.
+- Hosts can build domain-specific audit surfaces without changing Cortex's core document renderer.
 - Rendered HTML annotations can be regenerated from the same artifact source.
 - Provenance coverage becomes measurable instead of implicit.
 
@@ -70,17 +67,15 @@ Costs and obligations:
 - Artifact IRs need stable local identifiers where provenance is expected.
 - Renderers must preserve enough structure to expose provenance cleanly.
 - Hosts must decide domain-specific trust policy downstream.
-- Raw span offsets may still exist as derived display data, but they are not the
-  source of truth.
+- Raw span offsets may still exist as derived display data, but they are not the source of truth.
 
 ## Alternatives Considered
 
-- **Annotate rendered Markdown or HTML directly.** Rejected because it makes
-  provenance dependent on formatting and renderer behavior.
-- **Keep provenance only in run logs.** Rejected because artifact readers need a
-  local explanation of claims and values.
-- **Make Cortex own domain trust policy.** Rejected because accepted evidence is
-  host-specific.
+- **Annotate rendered Markdown or HTML directly.** Rejected because it makes provenance dependent on
+  formatting and renderer behavior.
+- **Keep provenance only in run logs.** Rejected because artifact readers need a local explanation
+  of claims and values.
+- **Make Cortex own domain trust policy.** Rejected because accepted evidence is host-specific.
 
 ## Related
 

--- a/docs/ADRs/0014-executor-taxonomy-model-vs-external-call.md
+++ b/docs/ADRs/0014-executor-taxonomy-model-vs-external-call.md
@@ -1,6 +1,9 @@
 ---
 title: "ADR 0014 — Model vs External Call"
-description: "Cortex node executors reduce to two kinds — ModelExecutor (model-mediated generation) and ExternalCallExecutor (registered external backend call). Sub-workflow composition is delegated to the rewrite algebra."
+description:
+  "Cortex node executors reduce to two kinds — ModelExecutor (model-mediated generation) and
+  ExternalCallExecutor (registered external backend call). Sub-workflow composition is delegated to
+  the rewrite algebra."
 sidebar:
   label: "0014. Model vs external call"
   order: 14
@@ -17,62 +20,116 @@ related:
 
 ## Status
 
-Proposed — clarifies an implicit distinction the substrate already makes and pins the extensibility story for new backends.
+Proposed — clarifies an implicit distinction the substrate already makes and pins the extensibility
+story for new backends.
 
 ## Context
 
-Every Cortex node carries a `StageAction` that the runtime dispatches. In practice this action resolves to one of three things today: a model call (LLM executor), a tool call (gatherer dispatch), or an HTTP host-action call into a consumer service. The substrate treats these as operationally distinct — different retry semantics, different trust boundaries, different observability — but has no explicit taxonomy.
+Every Cortex node carries a `StageAction` that the runtime dispatches. In practice this action
+resolves to one of three things today: a model call (LLM executor), a tool call (gatherer dispatch),
+or an HTTP host-action call into a consumer service. The substrate treats these as operationally
+distinct — different retry semantics, different trust boundaries, different observability — but has
+no explicit taxonomy.
 
-A first sketch for the reasoning layer proposed three executor kinds: `Model | Tool | Composite`. Two of those don't hold up. `Composite` is not a node-level executor — a sub-workflow is graph structure inserted via rewrite algebra, not a leaf action. `Tool` and host-action collapse into one kind: both are typed external calls under a registered name, differing only in where the call lands.
+A first sketch for the reasoning layer proposed three executor kinds: `Model | Tool | Composite`.
+Two of those don't hold up. `Composite` is not a node-level executor — a sub-workflow is graph
+structure inserted via rewrite algebra, not a leaf action. `Tool` and host-action collapse into one
+kind: both are typed external calls under a registered name, differing only in where the call lands.
 
-New backends are coming: OpenAPI-derived tool surfaces, WASM-packaged executors, MCP adapters. Without an explicit taxonomy each new backend either introduces a parallel executor kind and forces Wire grammar changes, or leaks backend specifics into the substrate — both outcomes erode the closed-authority stance established in ADR 0010.
+New backends are coming: OpenAPI-derived tool surfaces, WASM-packaged executors, MCP adapters.
+Without an explicit taxonomy each new backend either introduces a parallel executor kind and forces
+Wire grammar changes, or leaks backend specifics into the substrate — both outcomes erode the
+closed-authority stance established in ADR 0010.
 
-Picking the wrong defining axis risks a related failure. External backend calls are not uniformly deterministic: HTTP host actions that write to databases, OpenAPI calls against stateful services, and MCP adapters wrapping mutable systems all have side effects. If determinism is treated as the defining property of "external call," the taxonomy collapses the moment a real backend violates it.
+Picking the wrong defining axis risks a related failure. External backend calls are not uniformly
+deterministic: HTTP host actions that write to databases, OpenAPI calls against stateful services,
+and MCP adapters wrapping mutable systems all have side effects. If determinism is treated as the
+defining property of "external call," the taxonomy collapses the moment a real backend violates it.
 
 ## Decision
 
 Cortex defines exactly two node-level executor kinds, split on **mode of production**:
 
-- **`ModelExecutor`** — model-mediated generation. Produces output by running an LLM under a constrained schema. Stochastic internally; bounded and explainable at the contract boundary. Retry, rate-limit, token-cost, and provenance semantics are model-aware.
-- **`ExternalCallExecutor`** — a registered external backend call. Typed I/O under a registered name; no inline generation. One kind, many backend variants: native Haskell tools, HTTP host actions into consumer services, OpenAPI-derived calls, WASM modules, MCP adapters, and future additions. The backend list is evolvable; Wire is agnostic to which backend produced a given registration.
+- **`ModelExecutor`** — model-mediated generation. Produces output by running an LLM under a
+  constrained schema. Stochastic internally; bounded and explainable at the contract boundary.
+  Retry, rate-limit, token-cost, and provenance semantics are model-aware.
+- **`ExternalCallExecutor`** — a registered external backend call. Typed I/O under a registered
+  name; no inline generation. One kind, many backend variants: native Haskell tools, HTTP host
+  actions into consumer services, OpenAPI-derived calls, WASM modules, MCP adapters, and future
+  additions. The backend list is evolvable; Wire is agnostic to which backend produced a given
+  registration.
 
-Sub-workflow composition is **not an executor kind**. A region of more-graph enters a plan through rewrite algebra (`AppendAfter`, `ExpandNode`) from ADR 0005 / chapter 07, not through a `Composite` action.
+Sub-workflow composition is **not an executor kind**. A region of more-graph enters a plan through
+rewrite algebra (`AppendAfter`, `ExpandNode`) from ADR 0005 / chapter 07, not through a `Composite`
+action.
 
-Determinism, replay-safety, and side-effect class are **separate metadata axes**, not properties of the executor kind. Any executor — model or external — can be tagged as replay-safe, idempotent, irreversible, and so on. Policy (retry eligibility, resume-on-irreversible warnings, gas class) keys off the metadata, not off the kind.
+Determinism, replay-safety, and side-effect class are **separate metadata axes**, not properties of
+the executor kind. Any executor — model or external — can be tagged as replay-safe, idempotent,
+irreversible, and so on. Policy (retry eligibility, resume-on-irreversible warnings, gas class) keys
+off the metadata, not off the kind.
 
-Registration invariant: Wire references registered executor names with typed contracts and policy metadata. Wire is agnostic to which backend produced the registration. New backends slot in under `ExternalCallExecutor` without changes to Wire grammar or the executor-kind taxonomy.
+Registration invariant: Wire references registered executor names with typed contracts and policy
+metadata. Wire is agnostic to which backend produced the registration. New backends slot in under
+`ExternalCallExecutor` without changes to Wire grammar or the executor-kind taxonomy.
 
 ## Alternatives considered
 
-- **Three-kind taxonomy (`Model | Tool | Composite`).** Rejected because `Composite` is structural — a sub-workflow is Circuit inserted by a rewrite, not a leaf action — and `Tool` and host-action calls collapse into one kind with backend variants.
-- **Per-backend executor kinds** (`ToolExecutor`, `HostActionExecutor`, `WasmExecutor`, …). Rejected because every new backend would require a change to the executor-kind taxonomy and potentially to Wire grammar, defeating the extensibility goal. Backend diversity belongs one level below the kind boundary.
-- **Split on determinism** (`DeterministicExecutor` vs `StochasticExecutor`). Rejected because many registered external backends are not deterministic — HTTP host actions, stateful-service OpenAPI calls, MCP adapters. Using determinism as the defining axis makes the taxonomy collapse the first time a real backend violates it. Determinism belongs on a metadata axis that cross-cuts both kinds.
-- **One executor kind with runtime type dispatch.** Rejected because `ModelExecutor` and `ExternalCallExecutor` differ on load-bearing dimensions — mode of production, rate-limit policy, token economics, provenance shape — and collapsing them pushes policy into ad hoc branches inside the executor.
+- **Three-kind taxonomy (`Model | Tool | Composite`).** Rejected because `Composite` is structural —
+  a sub-workflow is Circuit inserted by a rewrite, not a leaf action — and `Tool` and host-action
+  calls collapse into one kind with backend variants.
+- **Per-backend executor kinds** (`ToolExecutor`, `HostActionExecutor`, `WasmExecutor`, …). Rejected
+  because every new backend would require a change to the executor-kind taxonomy and potentially to
+  Wire grammar, defeating the extensibility goal. Backend diversity belongs one level below the kind
+  boundary.
+- **Split on determinism** (`DeterministicExecutor` vs `StochasticExecutor`). Rejected because many
+  registered external backends are not deterministic — HTTP host actions, stateful-service OpenAPI
+  calls, MCP adapters. Using determinism as the defining axis makes the taxonomy collapse the first
+  time a real backend violates it. Determinism belongs on a metadata axis that cross-cuts both
+  kinds.
+- **One executor kind with runtime type dispatch.** Rejected because `ModelExecutor` and
+  `ExternalCallExecutor` differ on load-bearing dimensions — mode of production, rate-limit policy,
+  token economics, provenance shape — and collapsing them pushes policy into ad hoc branches inside
+  the executor.
 
 ## Consequences
 
 ### Positive
 
-- New backends (OpenAPI, WASM, MCP) slot in as `ExternalCallExecutor` variants without touching Wire grammar or the executor-kind taxonomy.
-- Policy keys off the two kinds consistently for model-aware concerns (rate limit, token cost, schema validation) and off cross-cutting metadata for execution concerns (retry eligibility, replay safety, side-effect class).
-- Stage-action metadata stays small and typed; registration surface remains the single place where backend detail lives.
-- The rewrite algebra stays the only path by which a plan gains more graph structure — composition concerns do not leak into executor dispatch.
+- New backends (OpenAPI, WASM, MCP) slot in as `ExternalCallExecutor` variants without touching Wire
+  grammar or the executor-kind taxonomy.
+- Policy keys off the two kinds consistently for model-aware concerns (rate limit, token cost,
+  schema validation) and off cross-cutting metadata for execution concerns (retry eligibility,
+  replay safety, side-effect class).
+- Stage-action metadata stays small and typed; registration surface remains the single place where
+  backend detail lives.
+- The rewrite algebra stays the only path by which a plan gains more graph structure — composition
+  concerns do not leak into executor dispatch.
 
 ### Negative
 
-- Backend-specific metadata (OpenAPI spec IDs, WASM module hashes, MCP capability descriptors) must live in registration records, not inline in Wire source.
-- Authoring helpers that declaratively derive a registered palette from an OpenAPI document must compile through the registration path rather than short-circuit into Wire semantics.
+- Backend-specific metadata (OpenAPI spec IDs, WASM module hashes, MCP capability descriptors) must
+  live in registration records, not inline in Wire source.
+- Authoring helpers that declaratively derive a registered palette from an OpenAPI document must
+  compile through the registration path rather than short-circuit into Wire semantics.
 
 ### Obligations
 
-- Document the backend sub-taxonomy in the runtime reference so each backend's registration shape is explicit.
-- Document the cross-cutting metadata axes (determinism, replay safety, side-effect class) as a distinct reference surface so policy rules can be written against it cleanly.
-- Keep Wire grammar agnostic to backend — grammar growth is about topology and authoring, not about backend vocabulary.
-- Any future proposal for a third executor kind requires its own ADR with a distinctness argument beyond backend diversity.
+- Document the backend sub-taxonomy in the runtime reference so each backend's registration shape is
+  explicit.
+- Document the cross-cutting metadata axes (determinism, replay safety, side-effect class) as a
+  distinct reference surface so policy rules can be written against it cleanly.
+- Keep Wire grammar agnostic to backend — grammar growth is about topology and authoring, not about
+  backend vocabulary.
+- Any future proposal for a third executor kind requires its own ADR with a distinctness argument
+  beyond backend diversity.
 
 ## Related
 
-- [0010-wire-closed-authority-and-three-layer-stack.md](./0010-wire-closed-authority-and-three-layer-stack.md) — this ADR extends closed authority into the executor layer.
-- [0005-budgeted-rewrite-admission-and-materialization.md](./0005-budgeted-rewrite-admission-and-materialization.md) — owns sub-workflow composition; this ADR delegates to it.
-- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md) — Wire references registered executor names under this taxonomy.
-- [../Architecture/06-pulse-runtime.md](../Architecture/06-pulse-runtime.md) — executors are dispatched here.
+- [0010-wire-closed-authority-and-three-layer-stack.md](./0010-wire-closed-authority-and-three-layer-stack.md)
+  — this ADR extends closed authority into the executor layer.
+- [0005-budgeted-rewrite-admission-and-materialization.md](./0005-budgeted-rewrite-admission-and-materialization.md)
+  — owns sub-workflow composition; this ADR delegates to it.
+- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md) — Wire references
+  registered executor names under this taxonomy.
+- [../Architecture/06-pulse-runtime.md](../Architecture/06-pulse-runtime.md) — executors are
+  dispatched here.

--- a/docs/ADRs/0015-cortex-logoi-reasoning-layer.md
+++ b/docs/ADRs/0015-cortex-logoi-reasoning-layer.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0015 — Structured Reasoning Above the Cortex Substrate"
-description: "Cortex is a durable runtime substrate with a structured reasoning library above it. Cortex.Logoi is a namespace and library on top of the substrate, not a peer layer."
+description:
+  "Cortex is a durable runtime substrate with a structured reasoning library above it. Cortex.Logoi
+  is a namespace and library on top of the substrate, not a peer layer."
 sidebar:
   label: "0015. Structured reasoning"
   order: 15
@@ -23,84 +25,140 @@ related:
 
 Superseded by
 [ADR 0016 — Canonical Cortex Nous Archetypes](./0016-canonical-cortex-epistemological-archetypes.md).
-ADR 0015 recorded the first vertical split between the runtime substrate and a
-structured reasoning library. ADR 0016 keeps that split, replaces the `Logoi`
-namespace with `Cortex.Nous`, and defines the canonical archetypes.
+ADR 0015 recorded the first vertical split between the runtime substrate and a structured reasoning
+library. ADR 0016 keeps that split, replaces the `Logoi` namespace with `Cortex.Nous`, and defines
+the canonical archetypes.
 
 ## Context
 
-Cortex conflates two concerns in its public narrative: a generic durable runtime substrate (Graph, Circuit, Wire grammar, Pulse execution, rewrite algebra, memory mechanics, contract registry infrastructure) and an opinionated reasoning stack (contract vocabularies, role semantics, reasoning templates, memory presets, executor palettes). This conflation hurts two stories at once. A consumer wanting the runtime alone for non-reasoning durable workflows has to ignore reasoning baggage. A third party wanting to build their own reasoning system on Cortex cannot see where the seams are.
+Cortex conflates two concerns in its public narrative: a generic durable runtime substrate (Graph,
+Circuit, Wire grammar, Pulse execution, rewrite algebra, memory mechanics, contract registry
+infrastructure) and an opinionated reasoning stack (contract vocabularies, role semantics, reasoning
+templates, memory presets, executor palettes). This conflation hurts two stories at once. A consumer
+wanting the runtime alone for non-reasoning durable workflows has to ignore reasoning baggage. A
+third party wanting to build their own reasoning system on Cortex cannot see where the seams are.
 
-The current architecture book reinforces the conflation. Chapters 03–08 are runtime-centric, but reasoning-facing concepts — role taxonomies, memory presets, template programs — sit awkwardly inside those chapters.
+The current architecture book reinforces the conflation. Chapters 03–08 are runtime-centric, but
+reasoning-facing concepts — role taxonomies, memory presets, template programs — sit awkwardly
+inside those chapters.
 
-A first sketch proposed a new "Cortex.Logoi" layer as a peer of Graph / Circuit / Wire / Pulse. That proposal duplicated ownership of executors, contracts, and memory — the substrate already owns those mechanisms under ADR 0010 and the chapter 08 contract registry. The useful residue is not a new substrate layer; it is an opinionated library of reasoning patterns built on top of the closed authority the substrate already defines.
+A first sketch proposed a new "Cortex.Logoi" layer as a peer of Graph / Circuit / Wire / Pulse. That
+proposal duplicated ownership of executors, contracts, and memory — the substrate already owns those
+mechanisms under ADR 0010 and the chapter 08 contract registry. The useful residue is not a new
+substrate layer; it is an opinionated library of reasoning patterns built on top of the closed
+authority the substrate already defines.
 
 ## Decision
 
 Cortex is explicitly two things:
 
-- a **durable runtime substrate** — Graph algebra, Circuit validation, Wire grammar and compiler, Pulse execution, rewrite admission and materialization, memory query substrate, envelope mechanics, contract registry infrastructure;
-- a **structured reasoning library** built on that substrate — executor families, contract entries and their meanings, role taxonomy, reasoning templates, memory strategy presets, reasoning policy.
+- a **durable runtime substrate** — Graph algebra, Circuit validation, Wire grammar and compiler,
+  Pulse execution, rewrite admission and materialization, memory query substrate, envelope
+  mechanics, contract registry infrastructure;
+- a **structured reasoning library** built on that substrate — executor families, contract entries
+  and their meanings, role taxonomy, reasoning templates, memory strategy presets, reasoning policy.
 
-The split is **vertical, not horizontal**. `Cortex.Logoi` is a namespace and library on top of the substrate, not a peer of Graph / Circuit / Wire / Pulse. Dependency direction is strict: runtime never imports Logoi; Logoi depends on runtime.
+The split is **vertical, not horizontal**. `Cortex.Logoi` is a namespace and library on top of the
+substrate, not a peer of Graph / Circuit / Wire / Pulse. Dependency direction is strict: runtime
+never imports Logoi; Logoi depends on runtime.
 
-**Logoi introduces no new runtime registries.** The runtime has two: executors (per ADR 0014) and contracts (per chapter 08). Logoi does not add a third. What Logoi libraries ship instead are **library-owned catalogs** — code, data, and source artifacts exported by stable names and imported by consumer programs:
+**Logoi introduces no new runtime registries.** The runtime has two: executors (per ADR 0014) and
+contracts (per chapter 08). Logoi does not add a third. What Logoi libraries ship instead are
+**library-owned catalogs** — code, data, and source artifacts exported by stable names and imported
+by consumer programs:
 
-| Logoi artifact | Shape | Discovery |
-|---|---|---|
-| Template programs | `.wire` source modules | Imported by consumer `.wire` programs by module path. |
-| Memory-strategy presets | Library-exposed `WalkSpec` / `MemoryStrategy` values | Referenced in `.wire` by stable name (e.g. `preset = "reviewer"`). |
-| Role tag conventions | Metadata tags on executor registrations and on nodes | Optional field on existing executor-registration records; no new registry. |
+| Logoi artifact          | Shape                                                | Discovery                                                                  |
+| ----------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------- |
+| Template programs       | `.wire` source modules                               | Imported by consumer `.wire` programs by module path.                      |
+| Memory-strategy presets | Library-exposed `WalkSpec` / `MemoryStrategy` values | Referenced in `.wire` by stable name (e.g. `preset = "reviewer"`).         |
+| Role tag conventions    | Metadata tags on executor registrations and on nodes | Optional field on existing executor-registration records; no new registry. |
 
-Templates are not registered — they are authored source shipped by libraries. Presets are not registered — they are Haskell values exposed by libraries. Role tags extend the *existing* executor-registration metadata with an optional field; they do not create a parallel registration surface.
+Templates are not registered — they are authored source shipped by libraries. Presets are not
+registered — they are Haskell values exposed by libraries. Role tags extend the _existing_
+executor-registration metadata with an optional field; they do not create a parallel registration
+surface.
 
 Three concepts straddle the Runtime/Logoi line and must be consciously partitioned:
 
-| Concept | Runtime | Logoi |
-|---|---|---|
-| Wire | Grammar, compiler, port-matching algebra | Concrete `.wire` programs; vocabulary of registered names |
-| Contracts | Registry mechanics, schemas, codecs, lint | Entries and their meanings (`thesis_claim`, `verdict`) |
-| Memory | `queryMemory` substrate, stage-entry snapshot binding, scoring pipeline | Strategy preset catalog (`analystWalkSpec`, `reviewerWalkSpec`), per-role defaults |
+| Concept   | Runtime                                                                 | Logoi                                                                              |
+| --------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Wire      | Grammar, compiler, port-matching algebra                                | Concrete `.wire` programs; vocabulary of registered names                          |
+| Contracts | Registry mechanics, schemas, codecs, lint                               | Entries and their meanings (`thesis_claim`, `verdict`)                             |
+| Memory    | `queryMemory` substrate, stage-entry snapshot binding, scoring pipeline | Strategy preset catalog (`analystWalkSpec`, `reviewerWalkSpec`), per-role defaults |
 
-This ADR fixes the split and the naming. Decisions that follow from the split — the role-authority guardrail, the canonical program set, the library integration model, per-run admission policy, and the reorganized reasoning-facing documentation — are scoped as follow-up ADRs or plans so each can be amended or superseded independently.
+This ADR fixes the split and the naming. Decisions that follow from the split — the role-authority
+guardrail, the canonical program set, the library integration model, per-run admission policy, and
+the reorganized reasoning-facing documentation — are scoped as follow-up ADRs or plans so each can
+be amended or superseded independently.
 
 ## Alternatives considered
 
-- **Logoi as a peer substrate layer beside Graph / Circuit / Wire / Pulse.** Rejected because the sketch duplicated ownership of executors, contracts, and memory mechanics that the substrate already owns. The useful residue is not a new layer but a library of opinionated patterns on top of the closed authority already defined.
-- **No separation — keep the reasoning stack unnamed inside the substrate narrative.** Rejected because the runtime story (extraction, non-reasoning workflow reuse, third-party integration) becomes incoherent when reasoning-specific taxonomy sits inside substrate chapters.
-- **Multiple peer reasoning namespaces** (for example `Cortex.Assistant`, `Cortex.Logoi`, `Cortex.Reasoning.Domain` at the same level). Rejected because reasoning is one layer with product bindings below it. Horizontal fragmentation at the reasoning level hides the single registration model integrators need.
-- **Introduce a new Logoi-specific registry** for templates, presets, and role tags. Rejected because it duplicates the runtime registration surface without adding semantics; library-owned catalogs referenced by stable name are simpler and sufficient.
+- **Logoi as a peer substrate layer beside Graph / Circuit / Wire / Pulse.** Rejected because the
+  sketch duplicated ownership of executors, contracts, and memory mechanics that the substrate
+  already owns. The useful residue is not a new layer but a library of opinionated patterns on top
+  of the closed authority already defined.
+- **No separation — keep the reasoning stack unnamed inside the substrate narrative.** Rejected
+  because the runtime story (extraction, non-reasoning workflow reuse, third-party integration)
+  becomes incoherent when reasoning-specific taxonomy sits inside substrate chapters.
+- **Multiple peer reasoning namespaces** (for example `Cortex.Assistant`, `Cortex.Logoi`,
+  `Cortex.Reasoning.Domain` at the same level). Rejected because reasoning is one layer with product
+  bindings below it. Horizontal fragmentation at the reasoning level hides the single registration
+  model integrators need.
+- **Introduce a new Logoi-specific registry** for templates, presets, and role tags. Rejected
+  because it duplicates the runtime registration surface without adding semantics; library-owned
+  catalogs referenced by stable name are simpler and sufficient.
 
 ## Consequences
 
 ### Positive
 
-- Runtime stays extractable for non-reasoning durable workflows; the chapter 02 extraction story remains coherent.
-- Public framing crystallizes: *Cortex is a durable runtime substrate; Cortex.Logoi is its structured reasoning library.*
-- The library-owned-catalog model explains how third parties extend reasoning without opening a new registration surface: ship Haskell values and `.wire` modules; consumers import by name.
-- Downstream assistants split cleanly in follow-up work: generic conversational patterns live in Logoi; domain persona, domain tools, and product policy stay in the product binding.
+- Runtime stays extractable for non-reasoning durable workflows; the chapter 02 extraction story
+  remains coherent.
+- Public framing crystallizes: _Cortex is a durable runtime substrate; Cortex.Logoi is its
+  structured reasoning library._
+- The library-owned-catalog model explains how third parties extend reasoning without opening a new
+  registration surface: ship Haskell values and `.wire` modules; consumers import by name.
+- Downstream assistants split cleanly in follow-up work: generic conversational patterns live in
+  Logoi; domain persona, domain tools, and product policy stay in the product binding.
 
 ### Negative
 
-- Three existing concepts (Wire, contracts, memory) acquire dual identity and must be consciously partitioned in docs and code. Ambiguity here will leak responsibilities back across the line.
-- The name "Logoi" carries connotations (λόγοι = structured speech / reasoning forms) that must be actively defended against drift into vague "intelligence layer" framing.
-- Several consequential decisions — role semantics, canonical program set, integration model, admission policy, doc IA — are explicitly out of scope here and must land as separate ADRs or plans before the split becomes operational.
+- Three existing concepts (Wire, contracts, memory) acquire dual identity and must be consciously
+  partitioned in docs and code. Ambiguity here will leak responsibilities back across the line.
+- The name "Logoi" carries connotations (λόγοι = structured speech / reasoning forms) that must be
+  actively defended against drift into vague "intelligence layer" framing.
+- Several consequential decisions — role semantics, canonical program set, integration model,
+  admission policy, doc IA — are explicitly out of scope here and must land as separate ADRs or
+  plans before the split becomes operational.
 
 ### Obligations
 
-- Partition the three straddlers with explicit statements in chapter 05 (Wire), chapter 08 (contracts), and chapter 06 (memory).
+- Partition the three straddlers with explicit statements in chapter 05 (Wire), chapter 08
+  (contracts), and chapter 06 (memory).
 - Write follow-up ADRs before the split can be shipped operationally:
   - **Role authority guardrail** — establish that roles are node metadata, not authority bearers.
-  - **Canonical Logoi program set** — fix the reference programs (conversational suspended wire, batch, planner-driven) that libraries build against.
-  - **Library integration and per-run admission policy** — how libraries register, how `.wire` composes registered authority, and how per-run admission bounds what a single assistant run can do.
-- Treat any proposal to introduce a new Logoi-specific runtime registry as a supersession of this ADR; default is to extend existing executor and contract registries with reasoning metadata.
-- Defer the reasoning-facing documentation layout (`docs/reasoning/` or equivalent) to a plan, not an ADR — structure is execution, not decision.
+  - **Canonical Logoi program set** — fix the reference programs (conversational suspended wire,
+    batch, planner-driven) that libraries build against.
+  - **Library integration and per-run admission policy** — how libraries register, how `.wire`
+    composes registered authority, and how per-run admission bounds what a single assistant run can
+    do.
+- Treat any proposal to introduce a new Logoi-specific runtime registry as a supersession of this
+  ADR; default is to extend existing executor and contract registries with reasoning metadata.
+- Defer the reasoning-facing documentation layout (`docs/reasoning/` or equivalent) to a plan, not
+  an ADR — structure is execution, not decision.
 
 ## Related
 
-- [0016-canonical-cortex-epistemological-archetypes.md](./0016-canonical-cortex-epistemological-archetypes.md) — supersedes this ADR with the canonical `Cortex.Nous` namespace and taxonomy.
-- [0010-wire-closed-authority-and-three-layer-stack.md](./0010-wire-closed-authority-and-three-layer-stack.md) — Logoi inherits closed authority; this ADR extends the principle upward.
-- [0014-executor-taxonomy-model-vs-external-call.md](./0014-executor-taxonomy-model-vs-external-call.md) — Logoi uses this taxonomy; it does not introduce new executor kinds.
-- [../Architecture/01-overview.md](../Architecture/01-overview.md), [../Architecture/02-ownership-and-boundaries.md](../Architecture/02-ownership-and-boundaries.md) — ownership model; Logoi extends it upward without changing the runtime extraction story.
-- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md) — site of the Wire straddle.
-- [../Architecture/08-artifacts-and-provenance.md](../Architecture/08-artifacts-and-provenance.md) — site of the contract-registry straddle.
+- [0016-canonical-cortex-epistemological-archetypes.md](./0016-canonical-cortex-epistemological-archetypes.md)
+  — supersedes this ADR with the canonical `Cortex.Nous` namespace and taxonomy.
+- [0010-wire-closed-authority-and-three-layer-stack.md](./0010-wire-closed-authority-and-three-layer-stack.md)
+  — Logoi inherits closed authority; this ADR extends the principle upward.
+- [0014-executor-taxonomy-model-vs-external-call.md](./0014-executor-taxonomy-model-vs-external-call.md)
+  — Logoi uses this taxonomy; it does not introduce new executor kinds.
+- [../Architecture/01-overview.md](../Architecture/01-overview.md),
+  [../Architecture/02-ownership-and-boundaries.md](../Architecture/02-ownership-and-boundaries.md) —
+  ownership model; Logoi extends it upward without changing the runtime extraction story.
+- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md) — site of the Wire
+  straddle.
+- [../Architecture/08-artifacts-and-provenance.md](../Architecture/08-artifacts-and-provenance.md) —
+  site of the contract-registry straddle.

--- a/docs/ADRs/0016-canonical-cortex-epistemological-archetypes.md
+++ b/docs/ADRs/0016-canonical-cortex-epistemological-archetypes.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0016 — Canonical Cortex Nous Archetypes"
-description: "Cortex.Nous.Archetypes defines the canonical epistemological taxonomy for Cortex reasoning modes: Logos, Sophia, Techne, Episteme, Kritikos, Themis, and Poiesis."
+description:
+  "Cortex.Nous.Archetypes defines the canonical epistemological taxonomy for Cortex reasoning modes:
+  Logos, Sophia, Techne, Episteme, Kritikos, Themis, and Poiesis."
 sidebar:
   label: "0016. Nous archetypes"
   order: 16
@@ -20,56 +22,50 @@ related:
 
 ## Status
 
-Proposed - supersedes ADR 0015's `Cortex.Logoi` naming with `Cortex.Nous`,
-establishes `Cortex.Nous.Archetypes` as the canonical epistemological taxonomy,
-and reserves `Cortex.Nous.Thought`, `Cortex.Nous.Memory`, and
-`Cortex.Nous.Patterns` for model-mediated cognition. Concrete prompts, corpora,
-embedding indexes, tool surfaces, memory policies, evaluation suites, runtime
-contracts, workflow templates, and role-contract refinements remain follow-up
+Proposed - supersedes ADR 0015's `Cortex.Logoi` naming with `Cortex.Nous`, establishes
+`Cortex.Nous.Archetypes` as the canonical epistemological taxonomy, and reserves
+`Cortex.Nous.Thought`, `Cortex.Nous.Memory`, and `Cortex.Nous.Patterns` for model-mediated
+cognition. Concrete prompts, corpora, embedding indexes, tool surfaces, memory policies, evaluation
+suites, runtime contracts, workflow templates, and role-contract refinements remain follow-up
 implementation work.
 
-> **Implementation staging.** Haskell modules currently exist at staging paths
-> such as `Cortex.Nous.Logos` and `Cortex.Nous.Logos.Capability`. Canonical paths
-> such as `Cortex.Nous.Archetypes.Logos` and
-> `Cortex.Nous.Archetypes.Logos.Activation` land in the migration tracked by ADR
-> 0017.
+> **Implementation staging.** Haskell modules currently exist at staging paths such as
+> `Cortex.Nous.Logos` and `Cortex.Nous.Logos.Capability`. Canonical paths such as
+> `Cortex.Nous.Archetypes.Logos` and `Cortex.Nous.Archetypes.Logos.Activation` land in the migration
+> tracked by ADR 0017.
 
 ## Context
 
-Cortex needs a stable vocabulary for describing distinct modes of reasoning used
-by thoughts, workflows, tools, and runtime structures. These modes should not be
-framed as durable "agents" or "personas," because that language is too shallow
-and too identity-shaped for the system being built. Cortex models reasoning as
-structured work over
-evidence, judgment, construction, critique, constraint, and expression.
+Cortex needs a stable vocabulary for describing distinct modes of reasoning used by thoughts,
+workflows, tools, and runtime structures. These modes should not be framed as durable "agents" or
+"personas," because that language is too shallow and too identity-shaped for the system being built.
+Cortex models reasoning as structured work over evidence, judgment, construction, critique,
+constraint, and expression.
 
-We therefore define a canonical set of epistemological archetypes under
-`Cortex.Nous.Archetypes`. `Nous` represents the broader faculty of intelligence
-or mind within Cortex. Its `Archetypes` children represent specialized modes of
-cognition that can be composed, invoked, constrained, audited, and eventually
-made concrete as thought frames, tool surfaces, prompt contracts, memory policy,
-or workflow policies.
+We therefore define a canonical set of epistemological archetypes under `Cortex.Nous.Archetypes`.
+`Nous` represents the broader faculty of intelligence or mind within Cortex. Its `Archetypes`
+children represent specialized modes of cognition that can be composed, invoked, constrained,
+audited, and eventually made concrete as thought frames, tool surfaces, prompt contracts, memory
+policy, or workflow policies.
 
-`Cortex.Nous.Thought` is reserved for one model-mediated cognitive evaluation
-bound to a graph node. A thought has a frame, policy, prompt/context, memory
-surface, tool surface, and output contract. It is not a durable persona.
+`Cortex.Nous.Thought` is reserved for one model-mediated cognitive evaluation bound to a graph node.
+A thought has a frame, policy, prompt/context, memory surface, tool surface, and output contract. It
+is not a durable persona.
 
-`Cortex.Nous.Memory` is reserved for cognitive memory: retrieval, ranking,
-packing, compaction, topological context, memory tools, and source selection.
-Pulse owns durable execution state such as checkpoints, run events, frontier,
-and persistence. When settled Pulse state is shaped into model context, the
-context-building API belongs in Nous memory while Pulse remains the substrate.
+`Cortex.Nous.Memory` is reserved for cognitive memory: retrieval, ranking, packing, compaction,
+topological context, memory tools, and source selection. Pulse owns durable execution state such as
+checkpoints, run events, frontier, and persistence. When settled Pulse state is shaped into model
+context, the context-building API belongs in Nous memory while Pulse remains the substrate.
 
-`Cortex.Nous.Patterns` is reserved for reusable model-mediated reasoning
-programs built from those archetypes. A pattern is not a new runtime primitive;
-it is a library-owned composition of Wire programs, contract catalogs, prompt
-families, memory presets, and evaluation policy interpreted through the existing
-substrate. Pattern modules are planned surfaces until their corresponding
+`Cortex.Nous.Patterns` is reserved for reusable model-mediated reasoning programs built from those
+archetypes. A pattern is not a new runtime primitive; it is a library-owned composition of Wire
+programs, contract catalogs, prompt families, memory presets, and evaluation policy interpreted
+through the existing substrate. Pattern modules are planned surfaces until their corresponding
 implementation slices land.
 
-This ADR also supersedes ADR 0015's `Cortex.Logoi` namespace. The vertical split
-from ADR 0015 remains: runtime substrate below, structured reasoning library
-above. The canonical reasoning library root is now `Cortex.Nous`.
+This ADR also supersedes ADR 0015's `Cortex.Logoi` namespace. The vertical split from ADR 0015
+remains: runtime substrate below, structured reasoning library above. The canonical reasoning
+library root is now `Cortex.Nous`.
 
 These archetypes are not decorative names. They define semantic expectations.
 
@@ -91,41 +87,38 @@ Cortex.Nous
 
 ## Decision
 
-Adopt the following seven archetypes as the canonical Cortex epistemological
-taxonomy under `Cortex.Nous.Archetypes`, and reserve the rest of the top-level
-Nous tree for thought execution, cognitive memory, and reusable reasoning
-patterns.
+Adopt the following seven archetypes as the canonical Cortex epistemological taxonomy under
+`Cortex.Nous.Archetypes`, and reserve the rest of the top-level Nous tree for thought execution,
+cognitive memory, and reusable reasoning patterns.
 
 The canonical public roots are:
 
-| Root | Owns |
-|---|---|
-| `Cortex.Nous.Archetypes` | Semantic reasoning modes and their activation bundles. |
-| `Cortex.Nous.Thought` | One model-mediated node evaluation: frame, policy, prompt/context, tool loop, structured output, and thought events. |
-| `Cortex.Nous.Memory` | Cognitive memory, retrieval, packing, compaction, topological context, and memory tools. |
-| `Cortex.Nous.Patterns` | Reusable LLM-shaped reasoning programs assembled from archetypes, contracts, prompts, memory presets, and Wire templates. |
+| Root                     | Owns                                                                                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `Cortex.Nous.Archetypes` | Semantic reasoning modes and their activation bundles.                                                                    |
+| `Cortex.Nous.Thought`    | One model-mediated node evaluation: frame, policy, prompt/context, tool loop, structured output, and thought events.      |
+| `Cortex.Nous.Memory`     | Cognitive memory, retrieval, packing, compaction, topological context, and memory tools.                                  |
+| `Cortex.Nous.Patterns`   | Reusable LLM-shaped reasoning programs assembled from archetypes, contracts, prompts, memory presets, and Wire templates. |
 
-The default target for LLM-shaped reasoning modules is `Cortex.Nous`, but exact
-homes are resolved per module by ADR 0017's migration table. This ADR decides the
-conceptual taxonomy; it does not claim that every current `Cortex.Agent`,
-`Cortex.Task`, `Cortex.Research`, `Cortex.Run`, or `Cortex.Memory` module has
-already been audited and moved.
+The default target for LLM-shaped reasoning modules is `Cortex.Nous`, but exact homes are resolved
+per module by ADR 0017's migration table. This ADR decides the conceptual taxonomy; it does not
+claim that every current `Cortex.Agent`, `Cortex.Task`, `Cortex.Research`, `Cortex.Run`, or
+`Cortex.Memory` module has already been audited and moved.
 
 ## Archetypes, activations, and thoughts
 
 The taxonomy separates three meanings:
 
-| Concept | Meaning |
-|---|---|
-| Archetype | Semantic definition of a reasoning mode. |
-| Archetype activation | Concrete implementation bundle for that mode. |
-| Thought frame | Composition of activated archetypes, memory, tools, and model policy for one cognitive evaluation. |
+| Concept              | Meaning                                                                                            |
+| -------------------- | -------------------------------------------------------------------------------------------------- |
+| Archetype            | Semantic definition of a reasoning mode.                                                           |
+| Archetype activation | Concrete implementation bundle for that mode.                                                      |
+| Thought frame        | Composition of activated archetypes, memory, tools, and model policy for one cognitive evaluation. |
 
-Cortex epistemological archetypes are not merely descriptive labels. Each
-archetype may correspond to a concrete activation bundle: curated prompts,
-retrieval indexes, embedding spaces, tool permissions, memory policies,
-evaluation suites, and runtime contracts. A thought expresses an archetype by
-being connected to that activation, not by carrying a nominal tag.
+Cortex epistemological archetypes are not merely descriptive labels. Each archetype may correspond
+to a concrete activation bundle: curated prompts, retrieval indexes, embedding spaces, tool
+permissions, memory policies, evaluation suites, and runtime contracts. A thought expresses an
+archetype by being connected to that activation, not by carrying a nominal tag.
 
 The canonical activation bundle shape is:
 
@@ -141,220 +134,188 @@ Cortex.Nous.Archetypes.<Archetype>.Activation
 `-- RuntimeContract
 ```
 
-A thought frame can activate multiple archetypes. A research-analysis thought may
-primarily activate `Episteme`, with supporting activation of `Logos`,
-`Kritikos`, and `Sophia`. An implementation thought may primarily activate
-`Techne`, with supporting activation of `Themis` and `Logos`.
+A thought frame can activate multiple archetypes. A research-analysis thought may primarily activate
+`Episteme`, with supporting activation of `Logos`, `Kritikos`, and `Sophia`. An implementation
+thought may primarily activate `Techne`, with supporting activation of `Themis` and `Logos`.
 
-This design prevents archetypes from becoming loose personality tags. The
-archetype affects what context is retrieved, how evidence is weighted, which
-tools are available, what prompt discipline is applied, and how the result is
-evaluated.
+This design prevents archetypes from becoming loose personality tags. The archetype affects what
+context is retrieved, how evidence is weighted, which tools are available, what prompt discipline is
+applied, and how the result is evaluated.
 
-This first implementation slice only lands the taxonomy, Haskell data model, and
-module slots. Current `Cortex.Nous.<Archetype>.Capability` modules are staging
-stubs. The canonical target is
-`Cortex.Nous.Archetypes.<Archetype>.Activation`, populated by later PRs with real
-prompts, corpus selectors, embedding spaces, tool surfaces, evaluation checks,
-memory policies, and runtime contracts. A stub activation bundle is not
-operational evidence that the archetype has been implemented.
+This first implementation slice only lands the taxonomy, Haskell data model, and module slots.
+Current `Cortex.Nous.<Archetype>.Capability` modules are staging stubs. The canonical target is
+`Cortex.Nous.Archetypes.<Archetype>.Activation`, populated by later PRs with real prompts, corpus
+selectors, embedding spaces, tool surfaces, evaluation checks, memory policies, and runtime
+contracts. A stub activation bundle is not operational evidence that the archetype has been
+implemented.
 
 ## `Cortex.Nous.Archetypes.Logos`
 
-`Logos` represents discursive reason: argument, symbolic reasoning, explanation,
-formal structure, and coherent inference. It is the archetype responsible for
-making reasoning explicit. Where other archetypes may gather evidence, judge
-consequences, build artifacts, or generate possibilities, `Logos` turns thought
-into structured claims that can be followed, challenged, and refined.
+`Logos` represents discursive reason: argument, symbolic reasoning, explanation, formal structure,
+and coherent inference. It is the archetype responsible for making reasoning explicit. Where other
+archetypes may gather evidence, judge consequences, build artifacts, or generate possibilities,
+`Logos` turns thought into structured claims that can be followed, challenged, and refined.
 
-In Cortex, `Logos` is the natural home for theorem-like reasoning, argument
-chains, decomposition, formal comparison, symbolic manipulation, and explanatory
-synthesis. A `Logos`-oriented thought should prefer clarity over flourish,
-explicit premises over intuition, and traceable inference over opaque
-conclusion. It is the archetype of "show the reasoning as structure."
+In Cortex, `Logos` is the natural home for theorem-like reasoning, argument chains, decomposition,
+formal comparison, symbolic manipulation, and explanatory synthesis. A `Logos`-oriented thought
+should prefer clarity over flourish, explicit premises over intuition, and traceable inference over
+opaque conclusion. It is the archetype of "show the reasoning as structure."
 
-`Logos` should be used when the task requires argumentation, derivation,
-conceptual analysis, formalization, or the transformation of messy thought into
-disciplined reasoning.
+`Logos` should be used when the task requires argumentation, derivation, conceptual analysis,
+formalization, or the transformation of messy thought into disciplined reasoning.
 
 ## `Cortex.Nous.Archetypes.Sophia`
 
-`Sophia` represents wisdom, judgment, synthesis, and practical discernment. It
-is not merely knowledge and not merely logic; it is the capacity to weigh
-competing goods, recognize context, identify what matters, and make a sound
-judgment under uncertainty.
+`Sophia` represents wisdom, judgment, synthesis, and practical discernment. It is not merely
+knowledge and not merely logic; it is the capacity to weigh competing goods, recognize context,
+identify what matters, and make a sound judgment under uncertainty.
 
-In Cortex, `Sophia` is the archetype most closely associated with high-level
-synthesis and executive understanding. It integrates outputs from other modes:
-the evidence of `Episteme`, the arguments of `Logos`, the constraints of
-`Themis`, the critique of `Kritikos`, the implementation realities of `Techne`,
-and the generative possibilities of `Poiesis`. Its role is to decide what is
-salient, balanced, timely, and wise.
+In Cortex, `Sophia` is the archetype most closely associated with high-level synthesis and executive
+understanding. It integrates outputs from other modes: the evidence of `Episteme`, the arguments of
+`Logos`, the constraints of `Themis`, the critique of `Kritikos`, the implementation realities of
+`Techne`, and the generative possibilities of `Poiesis`. Its role is to decide what is salient,
+balanced, timely, and wise.
 
-`Sophia` should be used when the task requires prioritization, strategic
-judgment, synthesis across domains, trade-off analysis, or deciding what
-conclusion best survives complexity.
+`Sophia` should be used when the task requires prioritization, strategic judgment, synthesis across
+domains, trade-off analysis, or deciding what conclusion best survives complexity.
 
 ## `Cortex.Nous.Archetypes.Techne`
 
-`Techne` represents craft, engineering, implementation, construction, and
-skillful making. It is the archetype of turning understanding into working
-artifacts. Where `Logos` reasons and `Sophia` judges, `Techne` builds.
+`Techne` represents craft, engineering, implementation, construction, and skillful making. It is the
+archetype of turning understanding into working artifacts. Where `Logos` reasons and `Sophia`
+judges, `Techne` builds.
 
-In Cortex, `Techne` governs implementation-oriented thoughts and workflows:
-writing code, designing systems, producing operational plans, defining
-interfaces, constructing tests, shaping infrastructure, and turning abstract
-designs into executable reality. A `Techne`-oriented thought should be concrete,
-practical, precise, and sensitive to failure modes that appear only when ideas
+In Cortex, `Techne` governs implementation-oriented thoughts and workflows: writing code, designing
+systems, producing operational plans, defining interfaces, constructing tests, shaping
+infrastructure, and turning abstract designs into executable reality. A `Techne`-oriented thought
+should be concrete, practical, precise, and sensitive to failure modes that appear only when ideas
 meet machinery.
 
-`Techne` should be used when the task requires engineering execution, artifact
-production, code generation, system design, operational planning, refactoring,
-or the conversion of a specification into a working form.
+`Techne` should be used when the task requires engineering execution, artifact production, code
+generation, system design, operational planning, refactoring, or the conversion of a specification
+into a working form.
 
 ## `Cortex.Nous.Archetypes.Episteme`
 
-`Episteme` represents knowledge, evidence, research, and justified belief. It is
-the archetype responsible for grounding cognition in what is known, observed,
-measured, cited, or otherwise supported. Its concern is not merely to answer,
-but to know why an answer deserves to be trusted.
+`Episteme` represents knowledge, evidence, research, and justified belief. It is the archetype
+responsible for grounding cognition in what is known, observed, measured, cited, or otherwise
+supported. Its concern is not merely to answer, but to know why an answer deserves to be trusted.
 
-In Cortex, `Episteme` is the natural archetype for research thoughts, evidence
-gatherers, source evaluators, retrieval systems, factual grounding, literature
-review, market data analysis, and empirical validation. A task operating under
-`Episteme` should distinguish between fact, inference, assumption, uncertainty,
-and speculation. It should prefer verifiable claims and explicitly mark weak
-evidence.
+In Cortex, `Episteme` is the natural archetype for research thoughts, evidence gatherers, source
+evaluators, retrieval systems, factual grounding, literature review, market data analysis, and
+empirical validation. A task operating under `Episteme` should distinguish between fact, inference,
+assumption, uncertainty, and speculation. It should prefer verifiable claims and explicitly mark
+weak evidence.
 
-`Episteme` should be used when the task requires research, evidence gathering,
-factual validation, source comparison, empirical grounding, or the construction
-of a knowledge base.
+`Episteme` should be used when the task requires research, evidence gathering, factual validation,
+source comparison, empirical grounding, or the construction of a knowledge base.
 
 ## `Cortex.Nous.Archetypes.Kritikos`
 
-`Kritikos` represents criticism, adversarial review, stress testing, and
-disciplined doubt. It is the archetype responsible for attacking claims, finding
-hidden assumptions, exposing contradictions, and identifying where a system or
-argument may fail.
+`Kritikos` represents criticism, adversarial review, stress testing, and disciplined doubt. It is
+the archetype responsible for attacking claims, finding hidden assumptions, exposing contradictions,
+and identifying where a system or argument may fail.
 
-In Cortex, `Kritikos` should be used to create adversarial branches, red-team
-analyses, counterarguments, failure-mode reviews, thesis attacks, security
-critiques, and robustness checks. A `Kritikos`-oriented thought is not merely
-negative; its purpose is constructive severity. It strengthens the system by
-refusing to let weak reasoning, fragile design, or unsupported confidence pass
-unchallenged.
+In Cortex, `Kritikos` should be used to create adversarial branches, red-team analyses,
+counterarguments, failure-mode reviews, thesis attacks, security critiques, and robustness checks. A
+`Kritikos`-oriented thought is not merely negative; its purpose is constructive severity. It
+strengthens the system by refusing to let weak reasoning, fragile design, or unsupported confidence
+pass unchallenged.
 
-`Kritikos` should be used when the task requires opposition, falsification,
-stress testing, risk discovery, adversarial review, or critique of an existing
-claim, design, workflow, or artifact.
+`Kritikos` should be used when the task requires opposition, falsification, stress testing, risk
+discovery, adversarial review, or critique of an existing claim, design, workflow, or artifact.
 
 ## `Cortex.Nous.Archetypes.Themis`
 
-`Themis` represents audit, law, correctness, constraint, procedure, and
-legitimacy. It is the archetype responsible for ensuring that reasoning and
-action remain within defined bounds. Where `Kritikos` attacks weakness,
-`Themis` enforces order.
+`Themis` represents audit, law, correctness, constraint, procedure, and legitimacy. It is the
+archetype responsible for ensuring that reasoning and action remain within defined bounds. Where
+`Kritikos` attacks weakness, `Themis` enforces order.
 
-In Cortex, `Themis` governs correctness checks, policy enforcement, compliance
-review, type discipline, runtime invariants, audit trails, contract validation,
-permissions, safety boundaries, and procedural guarantees. A `Themis`-oriented
-thought should care about whether something is allowed, whether it satisfies its
-contract, whether it is reproducible, whether it leaves evidence, and whether
-the system can defend its behavior after the fact.
+In Cortex, `Themis` governs correctness checks, policy enforcement, compliance review, type
+discipline, runtime invariants, audit trails, contract validation, permissions, safety boundaries,
+and procedural guarantees. A `Themis`-oriented thought should care about whether something is
+allowed, whether it satisfies its contract, whether it is reproducible, whether it leaves evidence,
+and whether the system can defend its behavior after the fact.
 
-`Themis` should be used when the task requires validation, auditability, legal
-or policy review, correctness checking, invariant enforcement, permissioning, or
-constraint-aware execution.
+`Themis` should be used when the task requires validation, auditability, legal or policy review,
+correctness checking, invariant enforcement, permissioning, or constraint-aware execution.
 
 ## `Cortex.Nous.Archetypes.Poiesis`
 
-`Poiesis` represents creative generation, composition, imagination, and the
-bringing-forth of new forms. It is the archetype responsible for producing
-possibilities that did not previously exist in the graph.
+`Poiesis` represents creative generation, composition, imagination, and the bringing-forth of new
+forms. It is the archetype responsible for producing possibilities that did not previously exist in
+the graph.
 
-In Cortex, `Poiesis` governs ideation, drafting, naming, design language,
-narrative construction, conceptual invention, speculative synthesis, and
-creative composition. It is especially important in workflows that need to
-explore a space before narrowing it. A `Poiesis`-oriented thought should generate
-rich alternatives, discover latent patterns, and create expressive forms that
-can later be judged by `Sophia`, grounded by `Episteme`, sharpened by
-`Kritikos`, constrained by `Themis`, formalized by `Logos`, or built by
-`Techne`.
+In Cortex, `Poiesis` governs ideation, drafting, naming, design language, narrative construction,
+conceptual invention, speculative synthesis, and creative composition. It is especially important in
+workflows that need to explore a space before narrowing it. A `Poiesis`-oriented thought should
+generate rich alternatives, discover latent patterns, and create expressive forms that can later be
+judged by `Sophia`, grounded by `Episteme`, sharpened by `Kritikos`, constrained by `Themis`,
+formalized by `Logos`, or built by `Techne`.
 
-`Poiesis` should be used when the task requires invention, composition, naming,
-storytelling, design exploration, creative synthesis, or generative expansion of
-the possibility space.
+`Poiesis` should be used when the task requires invention, composition, naming, storytelling, design
+exploration, creative synthesis, or generative expansion of the possibility space.
 
 ## Alternatives considered
 
-- **No fixed archetype set.** Rejected because reusable Nous templates would
-  keep accumulating near-duplicate local role names, making structural
-  comparisons across programs harder.
-- **Downstream-specific roles only.** Rejected because evidence, reasoning,
-  judgment, implementation, critique, audit, and generation are reusable modes
-  of cognition. A downstream product may specialize them, but the generic
-  taxonomy belongs in Nous.
-- **Archetypes as a runtime registry.** Rejected because ADR 0015 keeps runtime
-  authority in the existing executor and contract registries. Archetypes are
-  semantic expectations and catalog entries, not a third registry.
-- **Archetypes as nominal tags only.** Rejected because tag-only roles do not
-  change retrieval, tools, evaluation, memory, or runtime obligations. The
-  taxonomy therefore reserves activation-bundle slots, while this PR clearly
-  marks those slots as non-operational stubs.
+- **No fixed archetype set.** Rejected because reusable Nous templates would keep accumulating
+  near-duplicate local role names, making structural comparisons across programs harder.
+- **Downstream-specific roles only.** Rejected because evidence, reasoning, judgment,
+  implementation, critique, audit, and generation are reusable modes of cognition. A downstream
+  product may specialize them, but the generic taxonomy belongs in Nous.
+- **Archetypes as a runtime registry.** Rejected because ADR 0015 keeps runtime authority in the
+  existing executor and contract registries. Archetypes are semantic expectations and catalog
+  entries, not a third registry.
+- **Archetypes as nominal tags only.** Rejected because tag-only roles do not change retrieval,
+  tools, evaluation, memory, or runtime obligations. The taxonomy therefore reserves
+  activation-bundle slots, while this PR clearly marks those slots as non-operational stubs.
 
 ## Consequences
 
-This taxonomy gives Cortex a stable, philosophically coherent language for
-modeling reasoning roles without reducing them to generic "AI assistant"
-categories. It allows thoughts, nodes, workflows, prompts, tools, and memory
-contexts to be described in terms of epistemic function rather than surface
-behavior.
+This taxonomy gives Cortex a stable, philosophically coherent language for modeling reasoning roles
+without reducing them to generic "AI assistant" categories. It allows thoughts, nodes, workflows,
+prompts, tools, and memory contexts to be described in terms of epistemic function rather than
+surface behavior.
 
-Those descriptions become operational through archetype activations. A node is not
-"a Logos" or "an Episteme" in the abstract; it runs with one or more Nous
-activations active. Runtime assembly can then retrieve from archetype-specific
-indexes, inject archetype-specific prompt discipline, restrict or enable tools,
-apply memory policy, and evaluate output under the activation's contract.
+Those descriptions become operational through archetype activations. A node is not "a Logos" or "an
+Episteme" in the abstract; it runs with one or more Nous activations active. Runtime assembly can
+then retrieve from archetype-specific indexes, inject archetype-specific prompt discipline, restrict
+or enable tools, apply memory policy, and evaluate output under the activation's contract.
 
-The module stubs in this PR do not yet provide those operational assets. They
-establish the public paths and expected component shape so follow-up PRs can
-fill in one activation at a time without revisiting the taxonomy.
+The module stubs in this PR do not yet provide those operational assets. They establish the public
+paths and expected component shape so follow-up PRs can fill in one activation at a time without
+revisiting the taxonomy.
 
-The taxonomy also supports composition. A deep research workflow may begin with
-`Episteme`, pass through `Logos`, be attacked by `Kritikos`, constrained by
-`Themis`, implemented through `Techne`, and synthesized by `Sophia`. A creative
-product workflow may begin in `Poiesis`, be structured by `Logos`, judged by
-`Sophia`, and realized by `Techne`.
+The taxonomy also supports composition. A deep research workflow may begin with `Episteme`, pass
+through `Logos`, be attacked by `Kritikos`, constrained by `Themis`, implemented through `Techne`,
+and synthesized by `Sophia`. A creative product workflow may begin in `Poiesis`, be structured by
+`Logos`, judged by `Sophia`, and realized by `Techne`.
 
-The archetypes are intentionally broad enough to remain stable as Cortex
-evolves, while precise enough to guide implementation, naming, module
-boundaries, thought contracts, and workflow semantics.
+The archetypes are intentionally broad enough to remain stable as Cortex evolves, while precise
+enough to guide implementation, naming, module boundaries, thought contracts, and workflow
+semantics.
 
 ### Obligations
 
-- Expose archetype module stubs at exactly the canonical paths under
-  `Cortex.Nous.Archetypes`.
-- Expose activation-bundle stubs at
-  `Cortex.Nous.Archetypes.<Archetype>.Activation`.
+- Expose archetype module stubs at exactly the canonical paths under `Cortex.Nous.Archetypes`.
+- Expose activation-bundle stubs at `Cortex.Nous.Archetypes.<Archetype>.Activation`.
 - Use `Cortex.Nous.Patterns` for reusable LLM-shaped reasoning programs.
-- Move existing direct `Cortex.Nous.<Archetype>` and
-  `Cortex.Nous.<Archetype>.Capability` staging modules to the canonical
-  `Cortex.Nous.Archetypes.<Archetype>` and
-  `Cortex.Nous.Archetypes.<Archetype>.Activation` paths before accepting this
-  ADR.
+- Move existing direct `Cortex.Nous.<Archetype>` and `Cortex.Nous.<Archetype>.Capability` staging
+  modules to the canonical `Cortex.Nous.Archetypes.<Archetype>` and
+  `Cortex.Nous.Archetypes.<Archetype>.Activation` paths before accepting this ADR.
 - Keep archetype names semantic rather than persona labels.
-- Preserve the authority boundary: archetypes do not grant executor, tool,
-  provider, contract, or host authority.
+- Preserve the authority boundary: archetypes do not grant executor, tool, provider, contract, or
+  host authority.
 - Future workflow templates must choose archetypes by epistemic function.
 
 ## Related
 
-- [0015-cortex-logoi-reasoning-layer.md](./0015-cortex-logoi-reasoning-layer.md)
-  is superseded by this ADR. It established the vertical split; this ADR keeps
-  the split and renames the structured reasoning namespace to `Cortex.Nous`.
-- [../Architecture/09-nous-reasoning-library.md](../Architecture/09-nous-reasoning-library.md)
-  is the canonical architecture chapter for the taxonomy.
+- [0015-cortex-logoi-reasoning-layer.md](./0015-cortex-logoi-reasoning-layer.md) is superseded by
+  this ADR. It established the vertical split; this ADR keeps the split and renames the structured
+  reasoning namespace to `Cortex.Nous`.
+- [../Architecture/09-nous-reasoning-library.md](../Architecture/09-nous-reasoning-library.md) is
+  the canonical architecture chapter for the taxonomy.
 - [0017-cortex-roots-and-nous-pattern-extraction.md](./0017-cortex-roots-and-nous-pattern-extraction.md)
   defines the root namespace target and module migration table.
-- GitHub #14, #31, and #32 are the immediate role-typing, debate, and critique
-  pressures that need a stable vocabulary.
+- GitHub #14, #31, and #32 are the immediate role-typing, debate, and critique pressures that need a
+  stable vocabulary.

--- a/docs/ADRs/0017-cortex-roots-and-nous-pattern-extraction.md
+++ b/docs/ADRs/0017-cortex-roots-and-nous-pattern-extraction.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0017 — Cortex Roots and Nous Pattern Extraction"
-description: "Cortex uses a small root taxonomy while Cortex.Nous extracts reusable LLM-shaped reasoning programs with shared port contracts."
+description:
+  "Cortex uses a small root taxonomy while Cortex.Nous extracts reusable LLM-shaped reasoning
+  programs with shared port contracts."
 sidebar:
   label: "0017. Cortex roots"
   order: 17
@@ -25,53 +27,46 @@ related:
 
 ## Status
 
-Proposed - records the canonical root namespace target, the intended extraction
-path for the current DeepReport system, and the contract/executor model needed
-before that system can become a principled `Cortex.Nous.Patterns.DeepReport`
-library. These decisions are recorded together because Slice 0 root alignment is
-the namespace prerequisite for extracting DeepReport without preserving
+Proposed - records the canonical root namespace target, the intended extraction path for the current
+DeepReport system, and the contract/executor model needed before that system can become a principled
+`Cortex.Nous.Patterns.DeepReport` library. These decisions are recorded together because Slice 0
+root alignment is the namespace prerequisite for extracting DeepReport without preserving
 implementation-era roots. Implementation remains pending.
 
 ## Context
 
-As of 2026-04-27, the current DeepReport implementation is split across Cortex
-and Portman:
+As of 2026-04-27, the current DeepReport implementation is split across Cortex and Portman:
 
-- Cortex owns generic Wire contract registry mechanics, port metadata,
-  compile-time port compatibility, runtime `WireValue` envelopes, and payload
-  kind checks.
-- Portman owns `portmanWorkflowWireContractRegistry`,
-  `portmanWorkflowWireCompileEnv`, bundled `.wire` workflows, DB-backed workflow
-  loading, DeepReport execution, product tools, user/workspace policy, portfolio
-  context, and artifact emission.
-- Some names in Portman's DeepReport catalog are generic reasoning contracts:
-  `PlannerOutput`, `EvidenceBundle`, `AnalysisFragment`, `ReportFragment`,
-  `ReviewBundle`, `ReviewConcerns`, and `WorkflowAudit`.
-- Other pieces are downstream bindings: finance/portfolio tools, workspace
-  destinations, workflow selection heuristics, DB persistence, user settings,
-  model-provider configuration, and product artifact semantics.
+- Cortex owns generic Wire contract registry mechanics, port metadata, compile-time port
+  compatibility, runtime `WireValue` envelopes, and payload kind checks.
+- Portman owns `portmanWorkflowWireContractRegistry`, `portmanWorkflowWireCompileEnv`, bundled
+  `.wire` workflows, DB-backed workflow loading, DeepReport execution, product tools, user/workspace
+  policy, portfolio context, and artifact emission.
+- Some names in Portman's DeepReport catalog are generic reasoning contracts: `PlannerOutput`,
+  `EvidenceBundle`, `AnalysisFragment`, `ReportFragment`, `ReviewBundle`, `ReviewConcerns`, and
+  `WorkflowAudit`.
+- Other pieces are downstream bindings: finance/portfolio tools, workspace destinations, workflow
+  selection heuristics, DB persistence, user settings, model-provider configuration, and product
+  artifact semantics.
 
 This creates three problems:
 
 - Generic reasoning vocabulary lives in a downstream product repository.
-- Executor authority, port contract meaning, and pattern shape are not named as
-  separate concepts.
-- Shared contracts are copied as strings across executors, ports, workflows, and
-  runtime prompts rather than being composed from a catalog.
+- Executor authority, port contract meaning, and pattern shape are not named as separate concepts.
+- Shared contracts are copied as strings across executors, ports, workflows, and runtime prompts
+  rather than being composed from a catalog.
 
-The current Cortex root namespace also carries implementation-era roots:
-`Cortex.Graph`, `Cortex.Circuit`, `Cortex.Event`, `Cortex.Document`,
-`Cortex.Memory`, `Cortex.Agent`, `Cortex.Task`, `Cortex.Research`,
-`Cortex.Run`, and `Cortex.Provider`. Several of those roots describe the wrong
-abstraction level. `Graph` is the law-bearing algebra, `Circuit` is the compiled
-form of Wire, events are Pulse execution records, document-like outputs are
-artifacts, memory is cognitive context construction, and agent/task/research/run
-modules are mostly model-mediated reasoning machinery.
+The current Cortex root namespace also carries implementation-era roots: `Cortex.Graph`,
+`Cortex.Circuit`, `Cortex.Event`, `Cortex.Document`, `Cortex.Memory`, `Cortex.Agent`, `Cortex.Task`,
+`Cortex.Research`, `Cortex.Run`, and `Cortex.Provider`. Several of those roots describe the wrong
+abstraction level. `Graph` is the law-bearing algebra, `Circuit` is the compiled form of Wire,
+events are Pulse execution records, document-like outputs are artifacts, memory is cognitive context
+construction, and agent/task/research/run modules are mostly model-mediated reasoning machinery.
 
-ADR 0016 establishes `Cortex.Nous.Archetypes` and reserves
-`Cortex.Nous.Thought`, `Cortex.Nous.Memory`, and `Cortex.Nous.Patterns`. This
-ADR defines the root taxonomy target, the pending DeepReport extraction, and the
-contract/executor model needed to make that extraction disciplined.
+ADR 0016 establishes `Cortex.Nous.Archetypes` and reserves `Cortex.Nous.Thought`,
+`Cortex.Nous.Memory`, and `Cortex.Nous.Patterns`. This ADR defines the root taxonomy target, the
+pending DeepReport extraction, and the contract/executor model needed to make that extraction
+disciplined.
 
 ## Decision
 
@@ -89,20 +84,19 @@ Cortex
 
 Root responsibilities:
 
-| Root | Owns | Does not own |
-|---|---|---|
-| `Cortex.Algebra` | Graph/relation algebra, Mokhov laws, validation, rewrite laws. | Durable execution, language parsing, model cognition. |
-| `Cortex.Wire` | Wire source language, contracts, compiled circuit form, runtime envelopes. | Durable scheduling, host tool authority, reasoning patterns. |
-| `Cortex.Pulse` | Durable execution, frontier, checkpoints, persistence, signals, run events. | Cognitive memory shaping, model/tool loops, artifact semantics. |
-| `Cortex.Capability` | External authority surfaces: model clients, tool definitions, tool-call records, provider adapters. | Archetype activations, prompt discipline, reasoning memory, patterns. |
-| `Cortex.Artifact` | Generic durable outputs, artifact IR, metadata, provenance, rendering/host boundary. | LLM report/research semantics. |
-| `Cortex.Nous` | Model-mediated cognition: archetypes, thoughts, cognitive memory, reasoning patterns. | Provider mechanics, Wire compiler, Pulse durability, generic artifact substrate. |
+| Root                | Owns                                                                                                | Does not own                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `Cortex.Algebra`    | Graph/relation algebra, Mokhov laws, validation, rewrite laws.                                      | Durable execution, language parsing, model cognition.                            |
+| `Cortex.Wire`       | Wire source language, contracts, compiled circuit form, runtime envelopes.                          | Durable scheduling, host tool authority, reasoning patterns.                     |
+| `Cortex.Pulse`      | Durable execution, frontier, checkpoints, persistence, signals, run events.                         | Cognitive memory shaping, model/tool loops, artifact semantics.                  |
+| `Cortex.Capability` | External authority surfaces: model clients, tool definitions, tool-call records, provider adapters. | Archetype activations, prompt discipline, reasoning memory, patterns.            |
+| `Cortex.Artifact`   | Generic durable outputs, artifact IR, metadata, provenance, rendering/host boundary.                | LLM report/research semantics.                                                   |
+| `Cortex.Nous`       | Model-mediated cognition: archetypes, thoughts, cognitive memory, reasoning patterns.               | Provider mechanics, Wire compiler, Pulse durability, generic artifact substrate. |
 
-`Cortex.Nous.Patterns` is the planned home for reusable LLM-shaped reasoning programs.
-A pattern may ship contract catalogs, port catalogs, prompt families, memory
-presets, evaluation rules, and Wire templates. A pattern does not introduce a
-new runtime registry and does not grant host, tool, provider, or artifact
-authority by itself.
+`Cortex.Nous.Patterns` is the planned home for reusable LLM-shaped reasoning programs. A pattern may
+ship contract catalogs, port catalogs, prompt families, memory presets, evaluation rules, and Wire
+templates. A pattern does not introduce a new runtime registry and does not grant host, tool,
+provider, or artifact authority by itself.
 
 The first planned extraction target is `Cortex.Nous.Patterns.DeepReport`.
 
@@ -110,71 +104,64 @@ The first planned extraction target is `Cortex.Nous.Patterns.DeepReport`.
 
 ### Thought
 
-`Thought` replaces `Agent` as the canonical Nous execution word. An agent sounds
-like a durable persona. Cortex's wavefront model is different: a graph node is
-evaluated as one bounded cognitive act. A thought is one model-mediated
-cognitive evaluation bound to a Wire/Pulse node, with a frame, policy,
-prompt/context, memory surface, tool surface, and output contract.
+`Thought` replaces `Agent` as the canonical Nous execution word. An agent sounds like a durable
+persona. Cortex's wavefront model is different: a graph node is evaluated as one bounded cognitive
+act. A thought is one model-mediated cognitive evaluation bound to a Wire/Pulse node, with a frame,
+policy, prompt/context, memory surface, tool surface, and output contract.
 
-`Cortex.Nous.Thought` should own the generic model-mediated task host, tool host,
-tool loop, structured-output decoder, thought frame/policy, and thought event
-surface. Durable identity and product persona remain downstream concepts.
+`Cortex.Nous.Thought` should own the generic model-mediated task host, tool host, tool loop,
+structured-output decoder, thought frame/policy, and thought event surface. Durable identity and
+product persona remain downstream concepts.
 
 ### Memory
 
-Memory is Nous when it shapes cognitive context. `Cortex.Nous.Memory` should own
-retrieval, ranking, packing, compaction, source selection, topological context,
-and memory tools. Pulse may store run events, checkpoints, and settled node
-outputs, but an API that turns that state into model context belongs to Nous
-memory.
+Memory is Nous when it shapes cognitive context. `Cortex.Nous.Memory` should own retrieval, ranking,
+packing, compaction, source selection, topological context, and memory tools. Pulse may store run
+events, checkpoints, and settled node outputs, but an API that turns that state into model context
+belongs to Nous memory.
 
-This means `Cortex.Memory.*`, `Cortex.MemoryCompaction`, and the cognitive parts
-of `Cortex.Pulse.Memory.*` are migration candidates for `Cortex.Nous.Memory.*`.
-It is not a blanket rename: persistence-shaped, schema-shaped, or host-bound
-submodules must be resolved individually during Slice 0 and may stay under
-Pulse, move under Capability, or become internal helpers.
+This means `Cortex.Memory.*`, `Cortex.MemoryCompaction`, and the cognitive parts of
+`Cortex.Pulse.Memory.*` are migration candidates for `Cortex.Nous.Memory.*`. It is not a blanket
+rename: persistence-shaped, schema-shaped, or host-bound submodules must be resolved individually
+during Slice 0 and may stay under Pulse, move under Capability, or become internal helpers.
 
 ### Capability
 
-`Cortex.Capability` means external authority available to execution. It covers
-provider-neutral model calls, provider adapters, tool definitions, tool-call
-records, and generic host-side tool execution interfaces. It does not cover
-Nous archetype activations, prompt discipline, memory policy, or reasoning
-patterns.
+`Cortex.Capability` means external authority available to execution. It covers provider-neutral
+model calls, provider adapters, tool definitions, tool-call records, and generic host-side tool
+execution interfaces. It does not cover Nous archetype activations, prompt discipline, memory
+policy, or reasoning patterns.
 
-The boundary with `Cortex.Nous.Thought.ToolHost` is orchestration. Capability
-defines neutral tool surfaces, authority checks, request/response records, and
-host execution interfaces. Nous Thought binds those surfaces into one
-model-mediated thought's tool loop, prompt policy, and lifecycle events.
+The boundary with `Cortex.Nous.Thought.ToolHost` is orchestration. Capability defines neutral tool
+surfaces, authority checks, request/response records, and host execution interfaces. Nous Thought
+binds those surfaces into one model-mediated thought's tool loop, prompt policy, and lifecycle
+events.
 
 ### Executor
 
-An executor is registered runnable authority referenced from Wire as
-`@qualified.name`. It is not a contract and it does not own the meaning of a
-contract.
+An executor is registered runnable authority referenced from Wire as `@qualified.name`. It is not a
+contract and it does not own the meaning of a contract.
 
 An executor definition should eventually name:
 
 - executor id
 - config schema or decoder
-- accepted input contract refs and emitted output contract refs, or explicit
-  contract-polymorphic constraints
-- structural constraints over ports, such as required arity or exclusive output
-  groups
+- accepted input contract refs and emitted output contract refs, or explicit contract-polymorphic
+  constraints
+- structural constraints over ports, such as required arity or exclusive output groups
 - purity or effect class
 - tool-scope requirements
 - binder or runtime interpreter
 - model/provider selection policy when model-mediated
 
-Executors consume and emit contract references from shared contract catalogs.
-Many executors may use the same contract. One executor may support multiple
-contracts. Executor registration is authority over runnable behavior, not over
-contract semantics.
+Executors consume and emit contract references from shared contract catalogs. Many executors may use
+the same contract. One executor may support multiple contracts. Executor registration is authority
+over runnable behavior, not over contract semantics.
 
 ### Port contract
 
-A port contract is a named catalog entry describing the semantic obligation of a
-value crossing a Wire boundary.
+A port contract is a named catalog entry describing the semantic obligation of a value crossing a
+Wire boundary.
 
 The current Haskell shape is `WireContractSpec`:
 
@@ -184,47 +171,44 @@ The current Haskell shape is `WireContractSpec`:
 - optional schema
 - examples
 
-The contract catalog is the owner of payload meaning. Future extensions may add
-codecs, JSON Schema validation, content linting, rendering hints, evaluation
-criteria, and migration metadata, but those remain contract-catalog concerns.
+The contract catalog is the owner of payload meaning. Future extensions may add codecs, JSON Schema
+validation, content linting, rendering hints, evaluation criteria, and migration metadata, but those
+remain contract-catalog concerns.
 
-Contract-level evaluation answers: "is this payload well-formed for the named
-contract?" Archetype-activation evaluation answers: "did this thought produce
-the kind of reasoning its active archetype promised?" Pattern-level evaluation
-answers: "did the composed reasoning program satisfy its end-to-end obligations?"
+Contract-level evaluation answers: "is this payload well-formed for the named contract?"
+Archetype-activation evaluation answers: "did this thought produce the kind of reasoning its active
+archetype promised?" Pattern-level evaluation answers: "did the composed reasoning program satisfy
+its end-to-end obligations?"
 
-Contracts are not archetypes, executors, tools, prompts, or product permissions.
-They are shared data obligations that executors and patterns reference.
+Contracts are not archetypes, executors, tools, prompts, or product permissions. They are shared
+data obligations that executors and patterns reference.
 
 ### Contract enforcement
 
 Contract enforcement happens in layers:
 
-- **Compile time.** `WireCompileEnv` supplies a contract registry. The compiler
-  checks that referenced input and output contract names are known when a
-  registry is present. Wire then enforces port compatibility, labels, arity, and
-  graph topology through existing port-matching rules.
-- **Lowering/binding time.** Executor bindings decide whether a compiled node can
-  be interpreted by the host. This is where executor ids, config fields, tool
-  scopes, and product-specific authority are admitted.
-- **Runtime.** `wrapWireStageDefinition`, `wrapWireStageResult`, and
-  `wrapWireStageOutput` wrap values in `WireValue` envelopes, validate that
-  outputs match declared ports, apply the registered payload kind, and reject
-  shape mismatches.
-- **Future content validation.** Contract schemas, codecs, and lint/evaluation
-  rules should run after payload-kind checks and before downstream artifacts rely
-  on the payload.
+- **Compile time.** `WireCompileEnv` supplies a contract registry. The compiler checks that
+  referenced input and output contract names are known when a registry is present. Wire then
+  enforces port compatibility, labels, arity, and graph topology through existing port-matching
+  rules.
+- **Lowering/binding time.** Executor bindings decide whether a compiled node can be interpreted by
+  the host. This is where executor ids, config fields, tool scopes, and product-specific authority
+  are admitted.
+- **Runtime.** `wrapWireStageDefinition`, `wrapWireStageResult`, and `wrapWireStageOutput` wrap
+  values in `WireValue` envelopes, validate that outputs match declared ports, apply the registered
+  payload kind, and reject shape mismatches.
+- **Future content validation.** Contract schemas, codecs, and lint/evaluation rules should run
+  after payload-kind checks and before downstream artifacts rely on the payload.
 
-Current permissive behavior when no registry is provided is a development and
-compatibility mode, not the desired closed-authority semantics for Nous patterns.
-The behavior commitment is settled: Nous patterns should compile against
-explicit registries. The pending decision is only the API shape for expressing
-strict vs permissive mode without relying on `Maybe WireContractRegistry`.
+Current permissive behavior when no registry is provided is a development and compatibility mode,
+not the desired closed-authority semantics for Nous patterns. The behavior commitment is settled:
+Nous patterns should compile against explicit registries. The pending decision is only the API shape
+for expressing strict vs permissive mode without relying on `Maybe WireContractRegistry`.
 
 ### Sharing contracts between executors
 
-Contracts are shared by composing catalog values, not by making one executor the
-owner of another executor's vocabulary.
+Contracts are shared by composing catalog values, not by making one executor the owner of another
+executor's vocabulary.
 
 The intended sharing model is many-to-many:
 
@@ -232,17 +216,16 @@ The intended sharing model is many-to-many:
 - executors declare which obligations they can accept and emit
 - patterns declare which obligations their topology requires
 - consumers compose the required catalogs into a `WireCompileEnv`
-- downstream bindings may add domain-specific contracts without changing the
-  generic pattern catalog
+- downstream bindings may add domain-specific contracts without changing the generic pattern catalog
 
-For DeepReport, a planner, gatherer, analyst, section compiler, reviewer,
-rewriter, auditor, and artifact publisher can all reference the same shared
-contract IDs while retaining separate executor behavior and authority.
+For DeepReport, a planner, gatherer, analyst, section compiler, reviewer, rewriter, auditor, and
+artifact publisher can all reference the same shared contract IDs while retaining separate executor
+behavior and authority.
 
 ## DeepReport extraction target
 
-`Cortex.Nous.Patterns.DeepReport` is the planned module target for extracting the
-generic reasoning shape now scattered through Portman. The target structure is:
+`Cortex.Nous.Patterns.DeepReport` is the planned module target for extracting the generic reasoning
+shape now scattered through Portman. The target structure is:
 
 ```text
 Cortex.Nous.Patterns.DeepReport
@@ -255,15 +238,14 @@ Cortex.Nous.Patterns.DeepReport
 `-- PatternContract  -- later
 ```
 
-`PatternContract` is the end-to-end contract for the reusable pattern. It is
-distinct from an archetype activation's runtime contract, which constrains one
-thought operating under one archetype. Its concrete fields and schema are
-deferred until DeepReport slices 5-7 produce the first real template,
-artifact-ref, and evaluation candidates.
+`PatternContract` is the end-to-end contract for the reusable pattern. It is distinct from an
+archetype activation's runtime contract, which constrains one thought operating under one archetype.
+Its concrete fields and schema are deferred until DeepReport slices 5-7 produce the first real
+template, artifact-ref, and evaluation candidates.
 
-The initial generic contract catalog should cover contracts whose meaning is not
-finance-specific. This list is derived from Portman as of 2026-04-27 and should
-be revised during slices 1-4 as schemas and port ownership are formalized:
+The initial generic contract catalog should cover contracts whose meaning is not finance-specific.
+This list is derived from Portman as of 2026-04-27 and should be revised during slices 1-4 as
+schemas and port ownership are formalized:
 
 - `PlannerOutput`
 - `PlannerRewriteNeeded`
@@ -278,16 +260,15 @@ be revised during slices 1-4 as schemas and port ownership are formalized:
 - `WorkflowAudit`
 - `AwaitSignal`
 
-`ReportArtifactRef` is likely a substrate or artifact contract rather
-than a DeepReport-only contract, but its final home remains pending. DeepReport
-may depend on or re-export it until a generic artifact contract catalog exists.
+`ReportArtifactRef` is likely a substrate or artifact contract rather than a DeepReport-only
+contract, but its final home remains pending. DeepReport may depend on or re-export it until a
+generic artifact contract catalog exists.
 
-Contract evolution policy for the extraction is conservative: existing contract
-ids are additive-only. Breaking payload changes require a new contract id or an
-explicit versioned id such as `EvidenceBundleV2`; compatibility adapters may live
-in the pattern or downstream binding. Future registry metadata may record schema
-versions and migrations, but migration metadata does not make a breaking change
-safe under the same id.
+Contract evolution policy for the extraction is conservative: existing contract ids are
+additive-only. Breaking payload changes require a new contract id or an explicit versioned id such
+as `EvidenceBundleV2`; compatibility adapters may live in the pattern or downstream binding. Future
+registry metadata may record schema versions and migrations, but migration metadata does not make a
+breaking change safe under the same id.
 
 The initial generic port catalog should cover reusable reasoning slots:
 
@@ -315,169 +296,155 @@ Portman should keep ownership of:
 
 ## Migration slices
 
-The extraction should land in small slices. Slice 0 is namespace alignment: add
-new canonical modules and compatibility shims before moving implementation.
+The extraction should land in small slices. Slice 0 is namespace alignment: add new canonical
+modules and compatibility shims before moving implementation.
 
 ### Slice 0: root namespace alignment
 
-Target surfaces in this table are canonical planned homes. Some do not exist yet
-and should land with compatibility shims before implementation is moved.
+Target surfaces in this table are canonical planned homes. Some do not exist yet and should land
+with compatibility shims before implementation is moved.
 
-| Current surface | Target surface | Notes |
-|---|---|---|
-| `Cortex.Graph.*` | `Cortex.Algebra.Graph.*` | Root name should describe the law-bearing algebra. |
-| `Cortex.Circuit.*` | `Cortex.Wire.Circuit.*` | Circuit is Wire's compiled executable form. Keep shims while direct Circuit consumers migrate. |
-| `Cortex.Nous.<Archetype>` | `Cortex.Nous.Archetypes.<Archetype>` | Archetypes live under the `Archetypes` catalog. |
-| `Cortex.Nous.<Archetype>.Capability` | `Cortex.Nous.Archetypes.<Archetype>.Activation` | Avoid collision with root `Cortex.Capability`, which means external authority. |
-| `Cortex.Event` and `Cortex.Events` | `Cortex.Pulse.Event` for run events; `Cortex.Nous.Thought.Events` for thought events | Execution events are Pulse; model-mediated thought lifecycle events are Nous. |
-| `Cortex.Document.IR`, `Metadata`, `Host` | `Cortex.Artifact.*` | Generic durable output/provenance substrate. |
-| `Cortex.Document.Report`, `Cortex.Document.Section` | `Cortex.Nous.Patterns.DeepReport.*` | LLM report/research semantics are Nous pattern semantics. |
-| `Cortex.Memory.Score`, `Conflict`, `Source`, `Topological`, and other cognitive-context modules | `Cortex.Nous.Memory.*` | Resolved per submodule during Slice 0; only context-shaping code moves here. |
-| `Cortex.Memory.Persist`, `Schema`, `Host`, and other persistence-shaped modules | `Cortex.Pulse.*`, `Cortex.Capability.*`, or internal helpers | Not a blanket move; final homes depend on whether the module stores Pulse state, defines host authority, or is merely implementation support. |
-| `Cortex.MemoryCompaction` | `Cortex.Nous.Memory.Compact` | Keep compatibility shim only if needed. |
-| `Cortex.Pulse.Memory.*` | `Cortex.Nous.Memory.Topological.*` where it shapes model context | Pulse keeps persisted run state; Nous owns context construction. |
-| `Cortex.Agent.Config` | `Cortex.Nous.Thought.Frame` | Model/budget/prompt appendix are thought-frame concerns. |
-| `Cortex.Agent.Policy` | `Cortex.Nous.Thought.Policy` | Tool scope and approval policy for thoughts. |
-| `Cortex.Agent.Definition` | `Cortex.Nous.Thought.Frame` or remove | Avoid durable persona semantics unless a downstream product defines one. |
-| `Cortex.Task.Host` | `Cortex.Nous.Thought.Host` | Host for one model-mediated thought. |
-| `Cortex.Task.ToolHost` | `Cortex.Nous.Thought.ToolHost` | Host-side tool execution for a thought. |
-| `Cortex.Task.ToolLoop` | `Cortex.Nous.Thought.ToolLoop` | ReAct-style model/tool loop. |
-| `Cortex.Task.Runtime` | `Cortex.Nous.Thought.Runtime` | Thin thought runner and lifecycle event helpers. |
-| `Cortex.Task.StructuredOutput` | `Cortex.Nous.Thought.StructuredOutput` | Structured model-output decoding and fallback policy. |
-| `Cortex.Task.Plan` | `Cortex.Nous.Patterns.PlanReview` | Planner/reviewer pattern. |
-| `Cortex.Task.Gather` | `Cortex.Nous.Patterns.DeepReport.Gather` | DeepReport evidence-gathering stage. |
-| `Cortex.Task.Report` | `Cortex.Nous.Patterns.DeepReport.LegacyReportTask` initially | Decompose after contracts and ports stabilize. |
-| `Cortex.Research.Section` | `Cortex.Nous.Patterns.DeepReport.Section` | Section/chunk schema for model-generated research reports. |
-| `Cortex.Research.Runtime` | `Cortex.Nous.Patterns.DeepReport.Section.Runtime` | Section-output parsing and validation. |
-| `Cortex.Run.Types` | split between `Cortex.Pulse.Run` and `Cortex.Nous.Thought.Stage` | Durable run ids are Pulse; thought stage descriptors are Nous. |
-| `Cortex.Run.Engine` | `Cortex.Nous.Thought.Events` | Emits thought lifecycle events. |
-| `Cortex.Provider.OpenRouter.*` | `Cortex.Capability.Provider.OpenRouter.*` | Provider adapters belong under Capability; the target home is decided, deletion timing is deferred. |
-| `Cortex.Json.*` | `Platform.Serde.Json.*` or internal modules | Generic serde helpers should not be canonical Cortex roots. |
-| `Cortex.Text` | `Platform.Text` or internal module | Generic text helpers should not be canonical Cortex roots. |
+| Current surface                                                                                 | Target surface                                                                       | Notes                                                                                                                                         |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Cortex.Graph.*`                                                                                | `Cortex.Algebra.Graph.*`                                                             | Root name should describe the law-bearing algebra.                                                                                            |
+| `Cortex.Circuit.*`                                                                              | `Cortex.Wire.Circuit.*`                                                              | Circuit is Wire's compiled executable form. Keep shims while direct Circuit consumers migrate.                                                |
+| `Cortex.Nous.<Archetype>`                                                                       | `Cortex.Nous.Archetypes.<Archetype>`                                                 | Archetypes live under the `Archetypes` catalog.                                                                                               |
+| `Cortex.Nous.<Archetype>.Capability`                                                            | `Cortex.Nous.Archetypes.<Archetype>.Activation`                                      | Avoid collision with root `Cortex.Capability`, which means external authority.                                                                |
+| `Cortex.Event` and `Cortex.Events`                                                              | `Cortex.Pulse.Event` for run events; `Cortex.Nous.Thought.Events` for thought events | Execution events are Pulse; model-mediated thought lifecycle events are Nous.                                                                 |
+| `Cortex.Document.IR`, `Metadata`, `Host`                                                        | `Cortex.Artifact.*`                                                                  | Generic durable output/provenance substrate.                                                                                                  |
+| `Cortex.Document.Report`, `Cortex.Document.Section`                                             | `Cortex.Nous.Patterns.DeepReport.*`                                                  | LLM report/research semantics are Nous pattern semantics.                                                                                     |
+| `Cortex.Memory.Score`, `Conflict`, `Source`, `Topological`, and other cognitive-context modules | `Cortex.Nous.Memory.*`                                                               | Resolved per submodule during Slice 0; only context-shaping code moves here.                                                                  |
+| `Cortex.Memory.Persist`, `Schema`, `Host`, and other persistence-shaped modules                 | `Cortex.Pulse.*`, `Cortex.Capability.*`, or internal helpers                         | Not a blanket move; final homes depend on whether the module stores Pulse state, defines host authority, or is merely implementation support. |
+| `Cortex.MemoryCompaction`                                                                       | `Cortex.Nous.Memory.Compact`                                                         | Keep compatibility shim only if needed.                                                                                                       |
+| `Cortex.Pulse.Memory.*`                                                                         | `Cortex.Nous.Memory.Topological.*` where it shapes model context                     | Pulse keeps persisted run state; Nous owns context construction.                                                                              |
+| `Cortex.Agent.Config`                                                                           | `Cortex.Nous.Thought.Frame`                                                          | Model/budget/prompt appendix are thought-frame concerns.                                                                                      |
+| `Cortex.Agent.Policy`                                                                           | `Cortex.Nous.Thought.Policy`                                                         | Tool scope and approval policy for thoughts.                                                                                                  |
+| `Cortex.Agent.Definition`                                                                       | `Cortex.Nous.Thought.Frame` or remove                                                | Avoid durable persona semantics unless a downstream product defines one.                                                                      |
+| `Cortex.Task.Host`                                                                              | `Cortex.Nous.Thought.Host`                                                           | Host for one model-mediated thought.                                                                                                          |
+| `Cortex.Task.ToolHost`                                                                          | `Cortex.Nous.Thought.ToolHost`                                                       | Host-side tool execution for a thought.                                                                                                       |
+| `Cortex.Task.ToolLoop`                                                                          | `Cortex.Nous.Thought.ToolLoop`                                                       | ReAct-style model/tool loop.                                                                                                                  |
+| `Cortex.Task.Runtime`                                                                           | `Cortex.Nous.Thought.Runtime`                                                        | Thin thought runner and lifecycle event helpers.                                                                                              |
+| `Cortex.Task.StructuredOutput`                                                                  | `Cortex.Nous.Thought.StructuredOutput`                                               | Structured model-output decoding and fallback policy.                                                                                         |
+| `Cortex.Task.Plan`                                                                              | `Cortex.Nous.Patterns.PlanReview`                                                    | Planner/reviewer pattern.                                                                                                                     |
+| `Cortex.Task.Gather`                                                                            | `Cortex.Nous.Patterns.DeepReport.Gather`                                             | DeepReport evidence-gathering stage.                                                                                                          |
+| `Cortex.Task.Report`                                                                            | `Cortex.Nous.Patterns.DeepReport.LegacyReportTask` initially                         | Decompose after contracts and ports stabilize.                                                                                                |
+| `Cortex.Research.Section`                                                                       | `Cortex.Nous.Patterns.DeepReport.Section`                                            | Section/chunk schema for model-generated research reports.                                                                                    |
+| `Cortex.Research.Runtime`                                                                       | `Cortex.Nous.Patterns.DeepReport.Section.Runtime`                                    | Section-output parsing and validation.                                                                                                        |
+| `Cortex.Run.Types`                                                                              | split between `Cortex.Pulse.Run` and `Cortex.Nous.Thought.Stage`                     | Durable run ids are Pulse; thought stage descriptors are Nous.                                                                                |
+| `Cortex.Run.Engine`                                                                             | `Cortex.Nous.Thought.Events`                                                         | Emits thought lifecycle events.                                                                                                               |
+| `Cortex.Provider.OpenRouter.*`                                                                  | `Cortex.Capability.Provider.OpenRouter.*`                                            | Provider adapters belong under Capability; the target home is decided, deletion timing is deferred.                                           |
+| `Cortex.Json.*`                                                                                 | `Platform.Serde.Json.*` or internal modules                                          | Generic serde helpers should not be canonical Cortex roots.                                                                                   |
+| `Cortex.Text`                                                                                   | `Platform.Text` or internal module                                                   | Generic text helpers should not be canonical Cortex roots.                                                                                    |
 
-Compatibility modules may remain temporarily, but the canonical public root list
-is `Algebra`, `Wire`, `Pulse`, `Capability`, `Artifact`, and `Nous`.
+Compatibility modules may remain temporarily, but the canonical public root list is `Algebra`,
+`Wire`, `Pulse`, `Capability`, `Artifact`, and `Nous`.
 
 ### DeepReport extraction slices
 
-1. Add `Cortex.Nous.Patterns.DeepReport.Contracts` with the generic contract
-   catalog and tests for registry contents.
-2. Update Portman to import the Nous contract catalog instead of defining the
-   generic contracts locally.
-3. Add `Cortex.Nous.Patterns.DeepReport.Ports` for generic port maps, leaving
-   Portman to extend or override product-specific executor bindings.
+1. Add `Cortex.Nous.Patterns.DeepReport.Contracts` with the generic contract catalog and tests for
+   registry contents.
+2. Update Portman to import the Nous contract catalog instead of defining the generic contracts
+   locally.
+3. Add `Cortex.Nous.Patterns.DeepReport.Ports` for generic port maps, leaving Portman to extend or
+   override product-specific executor bindings.
 4. Update Portman to compose the Nous port catalog with product-specific ports.
-5. Add minimal generic DeepReport Wire templates only after contracts and ports
-   have stable names.
-6. Move reusable prompt, memory, and evaluation policy into Nous only after the
-   product-specific finance instructions are separated.
-7. Decide the final home for `ReportArtifactRef` and remove any temporary
-   DeepReport re-export.
-8. High-risk compiler slice: parameterize or replace the current
-   `@cortex.deep_report` compiler special case so runtime wrappers are not
-   hardcoded to one downstream workflow shape. This touches the Wire compiler hot
-   path and should land separately with focused compiler/runtime regression
+5. Add minimal generic DeepReport Wire templates only after contracts and ports have stable names.
+6. Move reusable prompt, memory, and evaluation policy into Nous only after the product-specific
+   finance instructions are separated.
+7. Decide the final home for `ReportArtifactRef` and remove any temporary DeepReport re-export.
+8. High-risk compiler slice: parameterize or replace the current `@cortex.deep_report` compiler
+   special case so runtime wrappers are not hardcoded to one downstream workflow shape. This touches
+   the Wire compiler hot path and should land separately with focused compiler/runtime regression
    tests.
 
 ## Pending decisions
 
-- Whether `.wire` `contract X;` declarations should admit local contract names,
-  remain documentation-only, or become importable declaration files. Current
-  compiler behavior parses them but does not use them for registry membership.
-  Tracked by GitHub #50.
-- The API surface for explicit strict/permissive contract-registry mode. The
-  behavior is settled: Nous patterns compile against explicit registries.
-- The exact schemas and content validation rules for generic DeepReport
-  contracts.
-- The concrete executor-definition data type and whether it belongs under
-  `Cortex.Capability`, `Cortex.Wire`, or `Cortex.Nous.Patterns`.
+- Whether `.wire` `contract X;` declarations should admit local contract names, remain
+  documentation-only, or become importable declaration files. Current compiler behavior parses them
+  but does not use them for registry membership. Tracked by GitHub #50.
+- The API surface for explicit strict/permissive contract-registry mode. The behavior is settled:
+  Nous patterns compile against explicit registries.
+- The exact schemas and content validation rules for generic DeepReport contracts.
+- The concrete executor-definition data type and whether it belongs under `Cortex.Capability`,
+  `Cortex.Wire`, or `Cortex.Nous.Patterns`.
 - The final home for generic artifact contracts such as `ReportArtifactRef`.
-- Which compatibility shims should remain exposed after the root migration and
-  for how many releases.
-- How to delete or shim `Cortex.Provider.OpenRouter.*` after moving the canonical
-  provider home to `Cortex.Capability.Provider.OpenRouter.*`.
+- Which compatibility shims should remain exposed after the root migration and for how many
+  releases.
+- How to delete or shim `Cortex.Provider.OpenRouter.*` after moving the canonical provider home to
+  `Cortex.Capability.Provider.OpenRouter.*`.
 
 ## Alternatives considered
 
-- **Keep current root names.** Rejected because `Graph`, `Circuit`, `Event`,
-  `Document`, `Memory`, `Agent`, `Task`, `Research`, `Run`, and `Provider` mix
-  substrate forms, implementation surfaces, and reasoning-layer concepts at the
-  same level.
-- **Keep `Graph` as the root instead of `Algebra`.** Rejected because the root
-  should name the law-bearing substrate; graph is one algebraic representation.
-- **Keep `Circuit` as a peer root beside Wire.** Rejected as the canonical target
-  because Circuit is the compiled executable form produced by Wire. Compatibility
-  shims may remain while direct Circuit consumers migrate.
-- **Keep `Document` as the root.** Rejected because the generic substrate concept
-  is artifact/provenance. LLM report and research-section semantics belong under
-  Nous patterns.
-- **Keep `Memory` as a root.** Rejected because Cortex memory is primarily
-  cognitive context construction. Pulse durable state remains Pulse; context
-  shaping belongs in Nous memory.
-- **Keep `Agent` as the reasoning word.** Rejected because agent implies durable
-  persona identity. Cortex evaluates graph nodes as bounded thoughts in a
-  wavefront, not as long-lived personas.
+- **Keep current root names.** Rejected because `Graph`, `Circuit`, `Event`, `Document`, `Memory`,
+  `Agent`, `Task`, `Research`, `Run`, and `Provider` mix substrate forms, implementation surfaces,
+  and reasoning-layer concepts at the same level.
+- **Keep `Graph` as the root instead of `Algebra`.** Rejected because the root should name the
+  law-bearing substrate; graph is one algebraic representation.
+- **Keep `Circuit` as a peer root beside Wire.** Rejected as the canonical target because Circuit is
+  the compiled executable form produced by Wire. Compatibility shims may remain while direct Circuit
+  consumers migrate.
+- **Keep `Document` as the root.** Rejected because the generic substrate concept is
+  artifact/provenance. LLM report and research-section semantics belong under Nous patterns.
+- **Keep `Memory` as a root.** Rejected because Cortex memory is primarily cognitive context
+  construction. Pulse durable state remains Pulse; context shaping belongs in Nous memory.
+- **Keep `Agent` as the reasoning word.** Rejected because agent implies durable persona identity.
+  Cortex evaluates graph nodes as bounded thoughts in a wavefront, not as long-lived personas.
 
-- **Keep DeepReport entirely in Portman.** Rejected because generic reasoning
-  contracts and workflow shape are reusable Cortex assets, not finance-product
-  assets.
-- **Move the whole Portman DeepReport runtime into Cortex.** Rejected because it
-  would pull user, portfolio, DB, workspace, tool-auth, and product-artifact
-  policy into the substrate.
-- **Let executors own contract definitions.** Rejected because the same contract
-  must be shared by multiple executors and patterns. Executors should reference
-  contract ids, not define their meaning.
-- **Create a new Nous runtime registry.** Rejected because ADR 0016 preserves the
-  existing authority boundaries. Nous publishes catalogs interpreted by Wire,
-  Pulse, capability, memory, and artifact substrate APIs.
-- **Ship `.wire` inline contract declarations as the sharing mechanism now.**
-  Deferred because the current compiler ignores `TopContract`, imports are not
-  compiled, and the registry-backed Haskell catalog is the safer first step.
+- **Keep DeepReport entirely in Portman.** Rejected because generic reasoning contracts and workflow
+  shape are reusable Cortex assets, not finance-product assets.
+- **Move the whole Portman DeepReport runtime into Cortex.** Rejected because it would pull user,
+  portfolio, DB, workspace, tool-auth, and product-artifact policy into the substrate.
+- **Let executors own contract definitions.** Rejected because the same contract must be shared by
+  multiple executors and patterns. Executors should reference contract ids, not define their
+  meaning.
+- **Create a new Nous runtime registry.** Rejected because ADR 0016 preserves the existing authority
+  boundaries. Nous publishes catalogs interpreted by Wire, Pulse, capability, memory, and artifact
+  substrate APIs.
+- **Ship `.wire` inline contract declarations as the sharing mechanism now.** Deferred because the
+  current compiler ignores `TopContract`, imports are not compiled, and the registry-backed Haskell
+  catalog is the safer first step.
 
 ## Consequences
 
 ### Positive
 
 - Generic DeepReport reasoning vocabulary can be reused by other consumers.
-- The Cortex public root becomes small enough to explain: algebra, language,
-  durable execution, external capability, artifacts, and cognition.
+- The Cortex public root becomes small enough to explain: algebra, language, durable execution,
+  external capability, artifacts, and cognition.
 - Executors, contracts, and patterns become separately nameable and testable.
-- Portman keeps product authority while deleting duplicated generic contract
-  definitions.
+- Portman keeps product authority while deleting duplicated generic contract definitions.
 - Contract sharing becomes explicit through catalog composition.
 
 ### Negative
 
-- The transition creates a temporary split between generic catalog modules and
-  Portman runtime execution.
+- The transition creates a temporary split between generic catalog modules and Portman runtime
+  execution.
 - Root migration creates compatibility-shim work and downstream import churn.
-- Existing `.wire` docs overstate `contract X;` behavior until the pending
-  declaration semantics are resolved.
-- DeepReport schemas are currently broad object schemas; formalizing them will
-  expose shape debt.
+- Existing `.wire` docs overstate `contract X;` behavior until the pending declaration semantics are
+  resolved.
+- DeepReport schemas are currently broad object schemas; formalizing them will expose shape debt.
 
 ### Obligations
 
 - Add tests proving the Nous DeepReport contract catalog is stable and complete.
 - Add compatibility modules or migration notes for every moved root-level module.
-- Audit Architecture chapters 03-08 for stale top-level Graph, Circuit, Document,
-  and Memory framing during Slice 0.
-- Update public-prelude drift assertions when archetype paths move from
-  `Cortex.Nous.<Archetype>` to `Cortex.Nous.Archetypes.<Archetype>`.
+- Audit Architecture chapters 03-08 for stale top-level Graph, Circuit, Document, and Memory framing
+  during Slice 0.
+- Update public-prelude drift assertions when archetype paths move from `Cortex.Nous.<Archetype>` to
+  `Cortex.Nous.Archetypes.<Archetype>`.
 - Keep Portman product tools and authorization downstream.
 - Avoid moving provider or host authority into Nous pattern modules.
 - Replace stringly duplicated contract names with catalog exports where possible.
-- Update Wire documentation once `.wire` contract declaration semantics are
-  decided and implemented.
+- Update Wire documentation once `.wire` contract declaration semantics are decided and implemented.
 
 ## Related
 
 - [0016-canonical-cortex-epistemological-archetypes.md](./0016-canonical-cortex-epistemological-archetypes.md)
-  defines `Cortex.Nous.Archetypes` and reserves `Cortex.Nous.Thought`,
-  `Cortex.Nous.Memory`, and `Cortex.Nous.Patterns`.
+  defines `Cortex.Nous.Archetypes` and reserves `Cortex.Nous.Thought`, `Cortex.Nous.Memory`, and
+  `Cortex.Nous.Patterns`.
 - [../Architecture/09-nous-reasoning-library.md](../Architecture/09-nous-reasoning-library.md)
   describes the Nous/runtime boundary.
-- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md)
-  describes Wire's closed-authority composition model.
+- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md) describes Wire's
+  closed-authority composition model.
 - [../Architecture/08-artifacts-and-provenance.md](../Architecture/08-artifacts-and-provenance.md)
   describes contract-owned meaning and runtime envelopes.

--- a/docs/ADRs/0018-wire-executor-and-port-catalog-boundary.md
+++ b/docs/ADRs/0018-wire-executor-and-port-catalog-boundary.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0018 — Wire Executor and Port Catalog Boundary"
-description: "Wire separates value-level contracts, id-referencing port profiles, compile-time projections, runtime payload validation, Pulse framing, and host codecs."
+description:
+  "Wire separates value-level contracts, id-referencing port profiles, compile-time projections,
+  runtime payload validation, Pulse framing, and host codecs."
 sidebar:
   label: "0018. Executor and ports"
   order: 18
@@ -22,54 +24,50 @@ related:
 
 ## Status
 
-Proposed - names the central seam exposed by the first DeepReport contract
-extraction: `WireCompileEnv` currently conflates executor authority projection,
-executor-port projection, and contract catalog projection. The target
-architecture splits those responsibilities before extracting more DeepReport
-structure from Portman.
+Proposed - names the central seam exposed by the first DeepReport contract extraction:
+`WireCompileEnv` currently conflates executor authority projection, executor-port projection, and
+contract catalog projection. The target architecture splits those responsibilities before extracting
+more DeepReport structure from Portman.
 
 ## Context
 
 PR #54 moved the generic DeepReport contract catalog from Portman into
-`Cortex.Nous.Patterns.DeepReport.Contracts`. That removed duplicated contract
-meaning, but it also exposed the next conflation. Portman still declares generic
-DeepReport port maps in `Portman.Workflow.WireEnv`, binds executor ids to
-runnable Haskell actions in `Portman.Task.DeepReportWorkflow`, and owns concrete
-payload records, codecs, prompts, persistence, and product semantics.
+`Cortex.Nous.Patterns.DeepReport.Contracts`. That removed duplicated contract meaning, but it also
+exposed the next conflation. Portman still declares generic DeepReport port maps in
+`Portman.Workflow.WireEnv`, binds executor ids to runnable Haskell actions in
+`Portman.Task.DeepReportWorkflow`, and owns concrete payload records, codecs, prompts, persistence,
+and product semantics.
 
-The problem is vocabulary drift. In Wire discussions, "contract" and "port" are
-often used for three different things:
+The problem is vocabulary drift. In Wire discussions, "contract" and "port" are often used for three
+different things:
 
 - value-level payload meaning
 - structural boundary slots on nodes
 - host/runtime code that marshals Haskell values and grants executor authority
 
-Those are different architecture artifacts. Folding them together makes it hard
-to extract reusable Nous pattern structure without accidentally moving product
-authority into `Cortex.Nous`.
+Those are different architecture artifacts. Folding them together makes it hard to extract reusable
+Nous pattern structure without accidentally moving product authority into `Cortex.Nous`.
 
-The current Haskell staging surface also blurs the seam. `WireCompileEnv` carries
-at least three distinct projections in one record:
+The current Haskell staging surface also blurs the seam. `WireCompileEnv` carries at least three
+distinct projections in one record:
 
 - the set of known executor ids, which is an authority projection from the host
 - the port shape each executor exposes, which is a catalog projection
 - the contract registry, which is the value-level catalog
 
-Wire does not need all host authority metadata to compile. It needs a projection:
-known contract ids and port shapes for the executor ids that source mentions.
+Wire does not need all host authority metadata to compile. It needs a projection: known contract ids
+and port shapes for the executor ids that source mentions.
 
 ## Decision
 
-Cortex separates value-level contracts, id-referencing port profiles,
-compile-time projections, runtime payload validation, Pulse framing, and host
-application codecs.
+Cortex separates value-level contracts, id-referencing port profiles, compile-time projections,
+runtime payload validation, Pulse framing, and host application codecs.
 
 ### Contracts are values, not Haskell types
 
-A Wire contract is a value-level descriptor of what a payload means at a Wire
-boundary. It is pure data: enumerable, serializable, shippable as JSON,
-comparable by id, and usable across process and language boundaries. It is not a
-Haskell type, and it is not parameterized over one.
+A Wire contract is a value-level descriptor of what a payload means at a Wire boundary. It is pure
+data: enumerable, serializable, shippable as JSON, comparable by id, and usable across process and
+language boundaries. It is not a Haskell type, and it is not parameterized over one.
 
 Current Haskell shape:
 
@@ -96,26 +94,22 @@ data WireValue = WireValue
   }
 ```
 
-`WirePayloadKind` is a closed Wire enum. Adding a payload kind is a Wire change,
-not a downstream extension point. The current runtime is JSON-value centered:
-markdown and text payloads are JSON strings, table payloads are JSON objects or
-arrays, and artifact refs are JSON objects. A contract catalog must survive
-documentation generation, JSON export, Pulse replay logs, and future
-cross-language clients. Making contracts phantom-typed Haskell values would make
-that catalog property depend on every consumer sharing the same Haskell type
-definitions.
+`WirePayloadKind` is a closed Wire enum. Adding a payload kind is a Wire change, not a downstream
+extension point. The current runtime is JSON-value centered: markdown and text payloads are JSON
+strings, table payloads are JSON objects or arrays, and artifact refs are JSON objects. A contract
+catalog must survive documentation generation, JSON export, Pulse replay logs, and future
+cross-language clients. Making contracts phantom-typed Haskell values would make that catalog
+property depend on every consumer sharing the same Haskell type definitions.
 
-Haskell payload types are a binding-layer concern. A downstream binder may decide
-that `ResearchPlan` corresponds to contract
-`cortex.deepreport.research-plan/v1`, but the contract catalog does not know the
-`ResearchPlan` type exists.
+Haskell payload types are a binding-layer concern. A downstream binder may decide that
+`ResearchPlan` corresponds to contract `cortex.deepreport.research-plan/v1`, but the contract
+catalog does not know the `ResearchPlan` type exists.
 
 ### Ports reference contracts by id
 
-A port is the structural shape of one boundary slot on a node. It references a
-contract by id and adds positional metadata: local label, cardinality,
-requiredness, and exclusive-output grouping. A port never carries the full
-contract spec inline.
+A port is the structural shape of one boundary slot on a node. It references a contract by id and
+adds positional metadata: local label, cardinality, requiredness, and exclusive-output grouping. A
+port never carries the full contract spec inline.
 
 Illustrative target shape:
 
@@ -142,37 +136,32 @@ data WirePorts = WirePorts
   }
 ```
 
-A port profile is a named `WirePorts` value published in a catalog. The name is
-what makes it shareable. Many executors can declare that they conform to a
-profile such as `deepreport.gatherer/v1`, and Wire can check that the executor's
-projected ports match the profile structurally. Port profiles carry no runnable
-authority.
+A port profile is a named `WirePorts` value published in a catalog. The name is what makes it
+shareable. Many executors can declare that they conform to a profile such as
+`deepreport.gatherer/v1`, and Wire can check that the executor's projected ports match the profile
+structurally. Port profiles carry no runnable authority.
 
-Labels are not the reason to extract DeepReport ports. The current DeepReport
-shape can be expressed with contract-only routing: each node input has a distinct
-contract, so no node needs two same-contract slots. Extracting
-`Cortex.Nous.Patterns.DeepReport.Ports` is therefore a module-boundary cleanup,
-not a new expressiveness requirement.
+Labels are not the reason to extract DeepReport ports. The current DeepReport shape can be expressed
+with contract-only routing: each node input has a distinct contract, so no node needs two
+same-contract slots. Extracting `Cortex.Nous.Patterns.DeepReport.Ports` is therefore a
+module-boundary cleanup, not a new expressiveness requirement.
 
-Labels become mandatory when a node needs distinct roles for the same contract,
-for example a comparative rewriter with `previous: ReportSection` and
-`reference: ReportSection`, an analysis diff with `baseline: Analysis` and
-`candidate: Analysis`, or a pure scoring node with several `Float` inputs. Those
-cases motivate pure nodes and structural primitives, not the first DeepReport
-port extraction. ADR 0019 owns that sequencing.
+Labels become mandatory when a node needs distinct roles for the same contract, for example a
+comparative rewriter with `previous: ReportSection` and `reference: ReportSection`, an analysis diff
+with `baseline: Analysis` and `candidate: Analysis`, or a pure scoring node with several `Float`
+inputs. Those cases motivate pure nodes and structural primitives, not the first DeepReport port
+extraction. ADR 0019 owns that sequencing.
 
 ### Executors grant authority through bindings
 
-An executor definition is not a contract and not merely a port shape. It names a
-runnable authority and should eventually include executor id, production kind from
-ADR 0014, config schema or decoder, port profile reference or explicit port
-constraints, replay and side-effect metadata, tool-scope requirements, provider
-policy when model-mediated, and the host binder or interpreter.
+An executor definition is not a contract and not merely a port shape. It names a runnable authority
+and should eventually include executor id, production kind from ADR 0014, config schema or decoder,
+port profile reference or explicit port constraints, replay and side-effect metadata, tool-scope
+requirements, provider policy when model-mediated, and the host binder or interpreter.
 
-The binder is where Haskell type identity matters. Executors are implemented over
-real application types such as `ResearchPlan` or `EvidenceBundle`. The binder
-bridges those values into `WirePayload` and binds the Haskell type to a contract
-id under host authority.
+The binder is where Haskell type identity matters. Executors are implemented over real application
+types such as `ResearchPlan` or `EvidenceBundle`. The binder bridges those values into `WirePayload`
+and binds the Haskell type to a contract id under host authority.
 
 Illustrative downstream shape:
 
@@ -185,61 +174,55 @@ class HasContract a => WireCodec a where
   decodeWire :: WirePayload -> Either DecodeError a
 ```
 
-These instances live with the application type or downstream pattern binding, not
-inside the value-level contract catalog. The catalog remains serializable and
-language-neutral.
+These instances live with the application type or downstream pattern binding, not inside the
+value-level contract catalog. The catalog remains serializable and language-neutral.
 
 ## Layer Split
 
 The architecture has two distinct serialization layers.
 
-**Layer 1: Pulse wire framing.** Pulse owns deterministic framing from
-`WireValue` to bytes. The framing table is closed and indexed by
-`WirePayloadKind`, but the current representation is JSON-centered: JSON payloads
-are framed as canonical JSON, markdown and text payloads are JSON strings, table
-payloads are JSON objects or arrays, and artifact refs are JSON objects.
-Downstream consumers must not plug arbitrary codecs into this layer because
-durable replay depends on stable framing.
+**Layer 1: Pulse wire framing.** Pulse owns deterministic framing from `WireValue` to bytes. The
+framing table is closed and indexed by `WirePayloadKind`, but the current representation is
+JSON-centered: JSON payloads are framed as canonical JSON, markdown and text payloads are JSON
+strings, table payloads are JSON objects or arrays, and artifact refs are JSON objects. Downstream
+consumers must not plug arbitrary codecs into this layer because durable replay depends on stable
+framing.
 
-**Layer 2: application codecs.** The host binder owns mappings between Haskell
-types and `WireValue`. This is where an executor returning `ResearchPlan` is
-encoded into a JSON-valued payload carrying the research-plan contract id. Replay
-decodes the persisted `WireValue` through the same host codec when a runnable
-stage needs the application type again.
+**Layer 2: application codecs.** The host binder owns mappings between Haskell types and
+`WireValue`. This is where an executor returning `ResearchPlan` is encoded into a JSON-valued
+payload carrying the research-plan contract id. Replay decodes the persisted `WireValue` through the
+same host codec when a runnable stage needs the application type again.
 
 The enforcement responsibilities are also separate.
 
-**Compile time.** Wire checks only structural facts: known contract ids, port
-shapes per mentioned executor id, labels, cardinality, exclusive output groups,
-and graph topology. It does not need schemas, codecs, or Haskell payload types.
+**Compile time.** Wire checks only structural facts: known contract ids, port shapes per mentioned
+executor id, labels, cardinality, exclusive output groups, and graph topology. It does not need
+schemas, codecs, or Haskell payload types.
 
-**Wire runtime.** Wire runtime currently validates that emitted `WireValue`
-values match the declared output contract's payload kind and coarse shape. Future
-schema and content validation belongs in this layer after payload-kind checks. It
-still does not know Haskell application types.
+**Wire runtime.** Wire runtime currently validates that emitted `WireValue` values match the
+declared output contract's payload kind and coarse shape. Future schema and content validation
+belongs in this layer after payload-kind checks. It still does not know Haskell application types.
 
-**Pulse persistence.** Pulse persists framed `WireValue` bytes according to the
-closed `WirePayloadKind` table. Contract schemas do not affect framing.
+**Pulse persistence.** Pulse persists framed `WireValue` bytes according to the closed
+`WirePayloadKind` table. Contract schemas do not affect framing.
 
-**Host binding.** The binder admits executor ids, config, tools, provider policy,
-artifact destinations, product permissions, and application codecs. It is the
-place where authority and Haskell type identity enter.
+**Host binding.** The binder admits executor ids, config, tools, provider policy, artifact
+destinations, product permissions, and application codecs. It is the place where authority and
+Haskell type identity enter.
 
-**Executor.** The executor is ordinary host code over host types. It is downstream
-of the binding decision and does not define Wire contract semantics.
+**Executor.** The executor is ordinary host code over host types. It is downstream of the binding
+decision and does not define Wire contract semantics.
 
-The dependency rule is: lower substrate layers know less. Contract catalogs do
-not know Haskell types. Wire knows contract ids, port profiles, payload kinds,
-and schemas, but not application codecs. Pulse knows payload kinds and framing,
-but not schemas or Haskell types. Host codecs know Haskell types and contract ids,
-but do not define Pulse framing.
+The dependency rule is: lower substrate layers know less. Contract catalogs do not know Haskell
+types. Wire knows contract ids, port profiles, payload kinds, and schemas, but not application
+codecs. Pulse knows payload kinds and framing, but not schemas or Haskell types. Host codecs know
+Haskell types and contract ids, but do not define Pulse framing.
 
 ## `WireCompileEnv` Target Shape
 
-`WireCompileEnv` should become an explicit compile-time projection rather than a
-mixed authority and catalog record. This is the central seam: executor admission
-is a host decision, while executor port shape is the structural projection Wire
-uses for checking.
+`WireCompileEnv` should become an explicit compile-time projection rather than a mixed authority and
+catalog record. This is the central seam: executor admission is a host decision, while executor port
+shape is the structural projection Wire uses for checking.
 
 Current staging shape:
 
@@ -250,42 +233,37 @@ Current staging shape:
 Target shape:
 
 - richer `ExecutorSpec` or host registration records live outside Wire compile
-- each executor spec references a port profile or declares explicit port
-  constraints
-- Wire receives only the projection it needs: `Map ExecutorId WirePorts` plus the
-  contract registry, in strict or explicitly permissive mode
+- each executor spec references a port profile or declares explicit port constraints
+- Wire receives only the projection it needs: `Map ExecutorId WirePorts` plus the contract registry,
+  in strict or explicitly permissive mode
 - host authority metadata no longer leaks into the compile-time API
 
-Port extraction should be designed around this projection. It can publish inert
-profile values now while leaving executor authority downstream. Pure nodes and
-structural primitives should wait until same-contract labeled slots are tested as
-part of their implementation, because those features actually require labels for
-expressiveness.
+Port extraction should be designed around this projection. It can publish inert profile values now
+while leaving executor authority downstream. Pure nodes and structural primitives should wait until
+same-contract labeled slots are tested as part of their implementation, because those features
+actually require labels for expressiveness.
 
 ## DeepReport Migration Implications
 
-For DeepReport, `Cortex.Nous.Patterns.DeepReport.Ports` should publish named port
-profiles such as planner, gatherer, required-evidence gate, analyst, section
-compiler, reviewer, rewriter, publish gate, workflow audit, and artifact emitter
-profiles. Portman may import those profiles, override or extend them for
-product-specific executors, and keep the runtime binder and payload records
+For DeepReport, `Cortex.Nous.Patterns.DeepReport.Ports` should publish named port profiles such as
+planner, gatherer, required-evidence gate, analyst, section compiler, reviewer, rewriter, publish
+gate, workflow audit, and artifact emitter profiles. Portman may import those profiles, override or
+extend them for product-specific executors, and keep the runtime binder and payload records
 downstream.
 
-This extraction should preserve today's DeepReport graph language. It should not
-introduce new port-label semantics, pure-node syntax, or structural primitive
-syntax. Current DeepReport gains cleaner module boundaries and less duplicated
-catalog data, not new expressiveness.
+This extraction should preserve today's DeepReport graph language. It should not introduce new
+port-label semantics, pure-node syntax, or structural primitive syntax. Current DeepReport gains
+cleaner module boundaries and less duplicated catalog data, not new expressiveness.
 
-Portman can remove duplicate generic contract definitions after PR #54 by
-importing `deepReportWireContractRegistry`. The next removal target is duplicate
-generic DeepReport port profiles, not executor dispatch or payload types.
+Portman can remove duplicate generic contract definitions after PR #54 by importing
+`deepReportWireContractRegistry`. The next removal target is duplicate generic DeepReport port
+profiles, not executor dispatch or payload types.
 
 Portman should keep ownership of:
 
 - executor dispatch and Haskell stage implementations
 - product prompts until finance-specific instructions are separated
-- runtime payload records and host codecs until generic schemas/codecs are
-  deliberately designed
+- runtime payload records and host codecs until generic schemas/codecs are deliberately designed
 - product tools, tool authorization, provider keys, and model defaults
 - DB-backed workflow loading and bundled-template sync
 - workspace artifact destinations and report UX policy
@@ -294,30 +272,27 @@ The clean next sequence is:
 
 1. Add `Cortex.Nous.Patterns.DeepReport.Ports` with generic port profiles.
 2. Update Portman to compose those port profiles with product-specific additions.
-3. Introduce explicit executor-definition types after the port profile shape is
-   stable enough to avoid encoding Portman assumptions into Cortex.
-4. Decide the final home for generic artifact contracts such as
-   `ReportArtifactRef` before making artifact-emitter profiles canonical.
+3. Introduce explicit executor-definition types after the port profile shape is stable enough to
+   avoid encoding Portman assumptions into Cortex.
+4. Decide the final home for generic artifact contracts such as `ReportArtifactRef` before making
+   artifact-emitter profiles canonical.
 
 ## Alternatives considered
 
-- **Make contracts phantom-typed Haskell values.** Rejected because contracts must
-  be serializable catalog values usable by docs, logs, cross-process replay, and
-  non-Haskell clients.
-- **Let ports carry contract specs inline.** Rejected because ports are endpoint
-  structure. Inlining specs would duplicate catalog data and make contract
-  identity harder to compare.
-- **Let executors own contracts.** Rejected because contracts are shared across
-  planners, gatherers, analysts, reviewers, emitters, and future patterns.
-- **Let downstream code plug Pulse framing codecs.** Rejected because durable
-  replay requires a closed, deterministic, kind-indexed framing table.
-- **Move Portman's runtime binder into Cortex.Nous.** Rejected because the binder
-  grants tool, provider, artifact, DB, and product authority. Nous patterns may
-  publish inert catalogs and templates, not host authority.
-- **Delay port extraction until a full `ExecutorSpec` exists.** Rejected because
-  the current duplicate `WirePorts` maps are already extractable as inert catalog
-  values. A full executor-definition API can follow once the profile boundary is
-  proven.
+- **Make contracts phantom-typed Haskell values.** Rejected because contracts must be serializable
+  catalog values usable by docs, logs, cross-process replay, and non-Haskell clients.
+- **Let ports carry contract specs inline.** Rejected because ports are endpoint structure. Inlining
+  specs would duplicate catalog data and make contract identity harder to compare.
+- **Let executors own contracts.** Rejected because contracts are shared across planners, gatherers,
+  analysts, reviewers, emitters, and future patterns.
+- **Let downstream code plug Pulse framing codecs.** Rejected because durable replay requires a
+  closed, deterministic, kind-indexed framing table.
+- **Move Portman's runtime binder into Cortex.Nous.** Rejected because the binder grants tool,
+  provider, artifact, DB, and product authority. Nous patterns may publish inert catalogs and
+  templates, not host authority.
+- **Delay port extraction until a full `ExecutorSpec` exists.** Rejected because the current
+  duplicate `WirePorts` maps are already extractable as inert catalog values. A full
+  executor-definition API can follow once the profile boundary is proven.
 
 ## Consequences
 
@@ -327,35 +302,33 @@ The clean next sequence is:
 - DeepReport ports can move to Cortex without moving Portman runtime authority.
 - Executors can share contract vocabulary and port profiles explicitly.
 - Pulse replay has a closed framing story independent of application codecs.
-- Future executor-definition work has a target shape rather than being inferred
-  from `WireCompileEnv` maps.
+- Future executor-definition work has a target shape rather than being inferred from
+  `WireCompileEnv` maps.
 
 ### Negative
 
-- The transition keeps a staged API where `WireCompileEnv` still mixes compile
-  projection and temporary executor-port maps.
-- Port catalogs introduce another named artifact that must be documented and kept
-  in sync with templates.
-- Broad object schemas in the current contract catalog still defer real content
-  validation.
+- The transition keeps a staged API where `WireCompileEnv` still mixes compile projection and
+  temporary executor-port maps.
+- Port catalogs introduce another named artifact that must be documented and kept in sync with
+  templates.
+- Broad object schemas in the current contract catalog still defer real content validation.
 - Application codec ownership must be documented for each downstream binding.
 
 ### Obligations
 
-- Add tests when extracting `Cortex.Nous.Patterns.DeepReport.Ports` to prove the
-  profile names, accepted contracts, output contracts, labels, and cardinalities.
-- Keep generated or materialized build metadata with source changes that expose
-  new Haskell modules.
-- Document downstream override rules when Portman composes generic profiles with
-  product-specific executors.
+- Add tests when extracting `Cortex.Nous.Patterns.DeepReport.Ports` to prove the profile names,
+  accepted contracts, output contracts, labels, and cardinalities.
+- Keep generated or materialized build metadata with source changes that expose new Haskell modules.
+- Document downstream override rules when Portman composes generic profiles with product-specific
+  executors.
 - Keep Pulse framing closed and deterministic; do not make it a user codec hook.
-- Add schema/content validation after the current payload-kind and coarse-shape
-  runtime checks before relying on schemas as enforced contracts.
-- Keep application `WireCodec` instances out of contract catalogs unless a future
-  ADR deliberately introduces a language-specific binding package.
+- Add schema/content validation after the current payload-kind and coarse-shape runtime checks
+  before relying on schemas as enforced contracts.
+- Keep application `WireCodec` instances out of contract catalogs unless a future ADR deliberately
+  introduces a language-specific binding package.
 - Do not let a Nous pattern module import Portman or grant product authority.
-- Replace `Maybe WireContractRegistry` with an explicit strict/permissive mode
-  before claiming closed authority for imported Nous templates.
+- Replace `Maybe WireContractRegistry` with an explicit strict/permissive mode before claiming
+  closed authority for imported Nous templates.
 
 ## Related
 

--- a/docs/ADRs/0019-wire-pure-nodes.md
+++ b/docs/ADRs/0019-wire-pure-nodes.md
@@ -1,6 +1,8 @@
 ---
 title: "ADR 0019 — Wire Pure Nodes"
-description: "Pure nodes are deterministic Wire-authored computations interpreted by registered pure executors; they require labeled same-contract slots but do not add a third executor kind."
+description:
+  "Pure nodes are deterministic Wire-authored computations interpreted by registered pure executors;
+  they require labeled same-contract slots but do not add a third executor kind."
 sidebar:
   label: "0019. Pure nodes"
   order: 19
@@ -20,20 +22,19 @@ related:
 
 ## Status
 
-Proposed - records the target semantics for pure nodes before implementation.
-Pure nodes are the first planned feature family that makes same-contract labeled
-inputs unavoidable; they are not needed for the current DeepReport port-profile
-extraction.
+Proposed - records the target semantics for pure nodes before implementation. Pure nodes are the
+first planned feature family that makes same-contract labeled inputs unavoidable; they are not
+needed for the current DeepReport port-profile extraction.
 
 ## Context
 
-Wire already has the vocabulary for registered executors, explicit ports, labels,
-and contract-polymorphic utility executors in the reference grammar. The current
-DeepReport shape does not force that machinery very hard: each node input uses a
-distinct contract, so contract-only routing is enough.
+Wire already has the vocabulary for registered executors, explicit ports, labels, and
+contract-polymorphic utility executors in the reference grammar. The current DeepReport shape does
+not force that machinery very hard: each node input uses a distinct contract, so contract-only
+routing is enough.
 
-Pure computations change the pressure. A simple weighted score needs several
-inputs with the same primitive contract but different roles:
+Pure computations change the pressure. A simple weighted score needs several inputs with the same
+primitive contract but different roles:
 
 ```wire
 node weighted_score :
@@ -44,10 +45,9 @@ node weighted_score :
 = @pure { expr = "0.5 * evidence_score + 0.3 * recency_score + 0.2 * authority_score"; };
 ```
 
-Without labels, the structural roles would have to be encoded as distinct
-contracts such as `EvidenceScore`, `RecencyScore`, and `AuthorityScore`. That
-would put graph-local slot identity into the contract catalog, which is exactly
-the conflation ADR 0018 rejects.
+Without labels, the structural roles would have to be encoded as distinct contracts such as
+`EvidenceScore`, `RecencyScore`, and `AuthorityScore`. That would put graph-local slot identity into
+the contract catalog, which is exactly the conflation ADR 0018 rejects.
 
 The same pressure appears in structural primitives:
 
@@ -65,21 +65,18 @@ node merge_evidence :
 = @pure { expr = "merge(primary, secondary)"; };
 ```
 
-These examples are not blockers for extracting current DeepReport ports. They are
-the reason pure nodes and structural primitives should land with tested label
-semantics.
+These examples are not blockers for extracting current DeepReport ports. They are the reason pure
+nodes and structural primitives should land with tested label semantics.
 
 ## Decision
 
-Wire pure nodes are deterministic, side-effect-free computations authored in Wire
-and interpreted by registered pure executors. They do not create a third
-node-level executor kind. Under ADR 0014, a pure evaluator is a registered
-`ExternalCallExecutor` variant with purity, replay-safety, and side-effect
-metadata set to the pure/no-effect class.
+Wire pure nodes are deterministic, side-effect-free computations authored in Wire and interpreted by
+registered pure executors. They do not create a third node-level executor kind. Under ADR 0014, a
+pure evaluator is a registered `ExternalCallExecutor` variant with purity, replay-safety, and
+side-effect metadata set to the pure/no-effect class.
 
-The expression body is executor config or sugar for executor config, not executor
-definition. Wire still does not let source files define new executor authority.
-For example, this surface:
+The expression body is executor config or sugar for executor config, not executor definition. Wire
+still does not let source files define new executor authority. For example, this surface:
 
 ```wire
 node weighted_score :
@@ -90,121 +87,109 @@ node weighted_score :
 = @pure { expr = "0.5 * evidence_score + 0.3 * recency_score + 0.2 * authority_score"; };
 ```
 
-means: use the host-registered `@pure` evaluator with explicit ports and an
-expression config. The host decides whether `@pure` is registered, which pure
-functions are available, which contracts are admitted, and how expression errors
-are reported.
+means: use the host-registered `@pure` evaluator with explicit ports and an expression config. The
+host decides whether `@pure` is registered, which pure functions are available, which contracts are
+admitted, and how expression errors are reported.
 
 Initial pure-node implementation should obey these constraints:
 
-- Ports are explicit. The compiler should not infer ports from expression
-  variables in the first slice.
-- Same-contract sibling inputs require explicit labels. Expression variable names
-  bind to labels. A single unlabeled input may be exposed as `in`; otherwise
-  pure-node inputs should be labeled to bind expression variables explicitly.
-- The pure evaluator operates on `WirePayload`-level values, not downstream
-  Haskell application types.
-- The expression language is closed and deterministic: no IO, time, randomness,
-  model calls, tool calls, memory queries, durable-state reads, or host callbacks
-  other than registered pure functions.
-- Pulse persistence still uses the closed `PayloadKind` framing table from ADR
-  0018. Pure nodes do not install Pulse codecs.
-- Runtime output is wrapped and validated through the declared output contract in
-  the normal Wire runtime path.
+- Ports are explicit. The compiler should not infer ports from expression variables in the first
+  slice.
+- Same-contract sibling inputs require explicit labels. Expression variable names bind to labels. A
+  single unlabeled input may be exposed as `in`; otherwise pure-node inputs should be labeled to
+  bind expression variables explicitly.
+- The pure evaluator operates on `WirePayload`-level values, not downstream Haskell application
+  types.
+- The expression language is closed and deterministic: no IO, time, randomness, model calls, tool
+  calls, memory queries, durable-state reads, or host callbacks other than registered pure
+  functions.
+- Pulse persistence still uses the closed `PayloadKind` framing table from ADR 0018. Pure nodes do
+  not install Pulse codecs.
+- Runtime output is wrapped and validated through the declared output contract in the normal Wire
+  runtime path.
 
 ## Boundary With Contracts And Codecs
 
 Pure nodes make the ADR 0018 split concrete.
 
-- Contract catalogs define value meaning such as `Float`, `Analysis`, or
-  `Evidence`.
-- Port labels define graph-local roles such as `baseline`, `candidate`,
-  `primary`, or `secondary`.
-- The pure evaluator sees decoded `WirePayload` values according to payload kind
-  and schema, not Haskell types such as `ResearchPlan`.
-- Host application codecs remain for host executors that work over Haskell types.
-  They are not used to make pure expressions type-check.
+- Contract catalogs define value meaning such as `Float`, `Analysis`, or `Evidence`.
+- Port labels define graph-local roles such as `baseline`, `candidate`, `primary`, or `secondary`.
+- The pure evaluator sees decoded `WirePayload` values according to payload kind and schema, not
+  Haskell types such as `ResearchPlan`.
+- Host application codecs remain for host executors that work over Haskell types. They are not used
+  to make pure expressions type-check.
 
-This keeps pure nodes portable. A future cross-language executor can evaluate the
-same pure expression over the same contract and schema catalog without importing
-Portman Haskell types.
+This keeps pure nodes portable. A future cross-language executor can evaluate the same pure
+expression over the same contract and schema catalog without importing Portman Haskell types.
 
 ## Relationship To Structural Primitives
 
-Pure nodes and structural primitives should share the same label discipline, but
-they do not have to ship in one implementation PR.
+Pure nodes and structural primitives should share the same label discipline, but they do not have to
+ship in one implementation PR.
 
 - `@pure` evaluates deterministic expressions.
-- `@identity`, `@const`, `@pack`, `@unpack`, `@merge`, and `@compare` are
-  registered pure utility executors or sugar over the same pure-evaluator family.
-- Contract-polymorphic utilities must still compile through explicit port
-  declarations and known contract ids.
-- Utilities that combine several values of the same contract must use labels to
-  distinguish roles.
+- `@identity`, `@const`, `@pack`, `@unpack`, `@merge`, and `@compare` are registered pure utility
+  executors or sugar over the same pure-evaluator family.
+- Contract-polymorphic utilities must still compile through explicit port declarations and known
+  contract ids.
+- Utilities that combine several values of the same contract must use labels to distinguish roles.
 
-This is why label testing belongs with pure/structural utility work, not with the
-current DeepReport port extraction.
+This is why label testing belongs with pure/structural utility work, not with the current DeepReport
+port extraction.
 
 ## Implementation Sequence
 
-1. Keep current DeepReport port extraction simple: move existing generic
-   `WirePorts` values into `Cortex.Nous.Patterns.DeepReport.Ports` without new
-   syntax or label semantics.
-2. Add pure-node reference tests for same-contract labeled inputs, expression
-   variable binding, deterministic evaluation, output wrapping, and schema/kind
-   validation.
-3. Register the first `@pure` evaluator through the normal executor-registration
-   path as a pure `ExternalCallExecutor` variant.
-4. Add structural primitives only after the pure evaluator and same-contract label
-   tests are stable.
+1. Keep current DeepReport port extraction simple: move existing generic `WirePorts` values into
+   `Cortex.Nous.Patterns.DeepReport.Ports` without new syntax or label semantics.
+2. Add pure-node reference tests for same-contract labeled inputs, expression variable binding,
+   deterministic evaluation, output wrapping, and schema/kind validation.
+3. Register the first `@pure` evaluator through the normal executor-registration path as a pure
+   `ExternalCallExecutor` variant.
+4. Add structural primitives only after the pure evaluator and same-contract label tests are stable.
 
 ## Alternatives considered
 
-- **Make pure nodes a third executor kind.** Rejected because ADR 0014 already
-  splits node executors by production mode. A pure evaluator is non-model host
-  execution with stronger replay and side-effect metadata.
-- **Infer contracts and ports from expression variables.** Rejected for the first
-  slice because it hides boundary shape. Explicit ports keep Wire's structural
-  type-checking visible.
-- **Invent role-specific contracts for every primitive input.** Rejected because
-  `EvidenceScore`, `RecencyScore`, and `AuthorityScore` are graph-local roles over
-  the same value shape. Labels, not contracts, should distinguish them.
-- **Evaluate pure expressions over downstream Haskell types.** Rejected because it
-  makes pure Wire programs language-specific and collapses the catalog/binder
-  split from ADR 0018.
-- **Allow host callbacks inside pure expressions.** Rejected because it turns pure
-  nodes into hidden tool calls and breaks deterministic replay expectations.
+- **Make pure nodes a third executor kind.** Rejected because ADR 0014 already splits node executors
+  by production mode. A pure evaluator is non-model host execution with stronger replay and
+  side-effect metadata.
+- **Infer contracts and ports from expression variables.** Rejected for the first slice because it
+  hides boundary shape. Explicit ports keep Wire's structural type-checking visible.
+- **Invent role-specific contracts for every primitive input.** Rejected because `EvidenceScore`,
+  `RecencyScore`, and `AuthorityScore` are graph-local roles over the same value shape. Labels, not
+  contracts, should distinguish them.
+- **Evaluate pure expressions over downstream Haskell types.** Rejected because it makes pure Wire
+  programs language-specific and collapses the catalog/binder split from ADR 0018.
+- **Allow host callbacks inside pure expressions.** Rejected because it turns pure nodes into hidden
+  tool calls and breaks deterministic replay expectations.
 
 ## Consequences
 
 ### Positive
 
-- Pure scoring, comparison, thresholding, and structural plumbing can be authored
-  without introducing product host actions for every small computation.
-- Labels get a concrete motivating feature: same-contract slots with distinct
-  structural roles.
+- Pure scoring, comparison, thresholding, and structural plumbing can be authored without
+  introducing product host actions for every small computation.
+- Labels get a concrete motivating feature: same-contract slots with distinct structural roles.
 - Pure nodes preserve ADR 0014 by staying inside the registered executor model.
-- Pure expressions remain portable because they operate over `WirePayload` and
-  contract/schema catalogs rather than Haskell application types.
+- Pure expressions remain portable because they operate over `WirePayload` and contract/schema
+  catalogs rather than Haskell application types.
 
 ### Negative
 
-- The pure expression language needs its own syntax, static checks, evaluator,
-  and determinism tests.
-- Schema access for JSON contracts must be specified carefully, or pure nodes will
-  become ad hoc JSON-path scripts.
-- The feature can grow into a general programming language if the evaluator is
-  not kept small.
+- The pure expression language needs its own syntax, static checks, evaluator, and determinism
+  tests.
+- Schema access for JSON contracts must be specified carefully, or pure nodes will become ad hoc
+  JSON-path scripts.
+- The feature can grow into a general programming language if the evaluator is not kept small.
 
 ### Obligations
 
 - Specify the pure expression grammar before implementation.
 - Add conformance tests for same-contract labeled inputs.
 - Add replay determinism tests for every built-in pure function.
-- Keep `@pure` registration outside `.wire` source; Wire source may configure the
-  registered evaluator but must not define new executor authority.
-- Keep pure-node runtime failures observable through the existing executor error
-  path rather than inventing a separate failure channel.
+- Keep `@pure` registration outside `.wire` source; Wire source may configure the registered
+  evaluator but must not define new executor authority.
+- Keep pure-node runtime failures observable through the existing executor error path rather than
+  inventing a separate failure channel.
 
 ## Related
 

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -1,6 +1,8 @@
 ---
 title: Architecture Decision Records
-description: Numbered ADRs capturing committed Cortex design decisions. Each ADR states one decision with context, alternatives considered, and consequences.
+description:
+  Numbered ADRs capturing committed Cortex design decisions. Each ADR states one decision with
+  context, alternatives considered, and consequences.
 sidebar:
   label: ADRs
   order: 3
@@ -8,40 +10,43 @@ sidebar:
 
 # Architecture Decision Records
 
-Each ADR captures one committed design decision. Files use `NNNN-kebab-slug.md` naming. Status values: `proposed`, `accepted`, `superseded`, `deprecated`.
+Each ADR captures one committed design decision. Files use `NNNN-kebab-slug.md` naming. Status
+values: `proposed`, `accepted`, `superseded`, `deprecated`.
 
 ## Current ADRs
 
-| # | Title | Status |
-|---|---|---|
-| [0001](0001-structured-report-ir.md) | Structured Document IR | accepted |
-| [0002](0002-cortex-downstream-ownership-boundary.md) | Cortex and Downstream Ownership Boundary | accepted |
-| [0003](0003-pulse-service-and-host-action-boundary.md) | Pulse Service and Host-Action Boundary | accepted |
-| [0004](0004-graph-native-pulse-execution.md) | Graph-Native Pulse Execution | accepted |
-| [0005](0005-budgeted-rewrite-admission-and-materialization.md) | Budgeted Rewrite Admission and Materialization | accepted |
-| [0006](0006-compiled-workflow-artifact-boundary.md) | Compiled Workflow Artifact Boundary | accepted |
-| [0007](0007-latent-branch-conditional-lowering.md) | Latent-Branch Conditional Lowering | accepted |
-| [0008](0008-pulse-operator-visibility-surfaces.md) | Pulse Operator Visibility Surfaces | accepted |
-| [0009](0009-rewrite-provenance-and-topology-integrity.md) | Rewrite Provenance and Topology Integrity | accepted |
-| [0010](0010-wire-closed-authority-and-three-layer-stack.md) | Wire as Closed-Authority Language over the Graph/Circuit/Wire Stack | accepted |
-| [0011](0011-compatibility-barriers-and-fresh-run-recovery.md) | Compatibility Barriers and Fresh-Run Recovery | accepted |
-| [0012](0012-topological-memory-as-deterministic-graph-query.md) | Topological Memory as Deterministic Graph Query | accepted |
-| [0013](0013-report-provenance-artifact-contract.md) | Artifact Provenance Contract | accepted |
-| [0014](0014-executor-taxonomy-model-vs-external-call.md) | Model vs External Call | proposed |
-| [0015](0015-cortex-logoi-reasoning-layer.md) | Structured Reasoning Above the Cortex Substrate | superseded |
-| [0016](0016-canonical-cortex-epistemological-archetypes.md) | Canonical Cortex Nous Archetypes | proposed |
-| [0017](0017-cortex-roots-and-nous-pattern-extraction.md) | Cortex Roots and Nous Pattern Extraction | proposed |
-| [0018](0018-wire-executor-and-port-catalog-boundary.md) | Wire Executor and Port Catalog Boundary | proposed |
-| [0019](0019-wire-pure-nodes.md) | Wire Pure Nodes | proposed |
+| #                                                               | Title                                                               | Status     |
+| --------------------------------------------------------------- | ------------------------------------------------------------------- | ---------- |
+| [0001](0001-structured-report-ir.md)                            | Structured Document IR                                              | accepted   |
+| [0002](0002-cortex-downstream-ownership-boundary.md)            | Cortex and Downstream Ownership Boundary                            | accepted   |
+| [0003](0003-pulse-service-and-host-action-boundary.md)          | Pulse Service and Host-Action Boundary                              | accepted   |
+| [0004](0004-graph-native-pulse-execution.md)                    | Graph-Native Pulse Execution                                        | accepted   |
+| [0005](0005-budgeted-rewrite-admission-and-materialization.md)  | Budgeted Rewrite Admission and Materialization                      | accepted   |
+| [0006](0006-compiled-workflow-artifact-boundary.md)             | Compiled Workflow Artifact Boundary                                 | accepted   |
+| [0007](0007-latent-branch-conditional-lowering.md)              | Latent-Branch Conditional Lowering                                  | accepted   |
+| [0008](0008-pulse-operator-visibility-surfaces.md)              | Pulse Operator Visibility Surfaces                                  | accepted   |
+| [0009](0009-rewrite-provenance-and-topology-integrity.md)       | Rewrite Provenance and Topology Integrity                           | accepted   |
+| [0010](0010-wire-closed-authority-and-three-layer-stack.md)     | Wire as Closed-Authority Language over the Graph/Circuit/Wire Stack | accepted   |
+| [0011](0011-compatibility-barriers-and-fresh-run-recovery.md)   | Compatibility Barriers and Fresh-Run Recovery                       | accepted   |
+| [0012](0012-topological-memory-as-deterministic-graph-query.md) | Topological Memory as Deterministic Graph Query                     | accepted   |
+| [0013](0013-report-provenance-artifact-contract.md)             | Artifact Provenance Contract                                        | accepted   |
+| [0014](0014-executor-taxonomy-model-vs-external-call.md)        | Model vs External Call                                              | proposed   |
+| [0015](0015-cortex-logoi-reasoning-layer.md)                    | Structured Reasoning Above the Cortex Substrate                     | superseded |
+| [0016](0016-canonical-cortex-epistemological-archetypes.md)     | Canonical Cortex Nous Archetypes                                    | proposed   |
+| [0017](0017-cortex-roots-and-nous-pattern-extraction.md)        | Cortex Roots and Nous Pattern Extraction                            | proposed   |
+| [0018](0018-wire-executor-and-port-catalog-boundary.md)         | Wire Executor and Port Catalog Boundary                             | proposed   |
+| [0019](0019-wire-pure-nodes.md)                                 | Wire Pure Nodes                                                     | proposed   |
 
 ## Writing a new ADR
 
 Use the [template](../Templates/adr.md). Key discipline:
 
-- Each ADR is about **one** decision. If you find yourself writing two decisions in one ADR, split them.
+- Each ADR is about **one** decision. If you find yourself writing two decisions in one ADR, split
+  them.
 - Frontmatter lists `status`, `date`, and `related` issues.
 - Body has `Context`, `Decision`, `Consequences` sections at minimum.
-- An accepted ADR is canon — supersede it with a new numbered ADR rather than editing the original, except to update `status` and add a forward-pointer.
+- An accepted ADR is canon — supersede it with a new numbered ADR rather than editing the original,
+  except to update `status` and add a forward-pointer.
 
 ## Related
 

--- a/docs/Architecture/01-overview.md
+++ b/docs/Architecture/01-overview.md
@@ -1,6 +1,8 @@
 ---
 title: "Chapter 01 — Overview"
-description: "Overview of Cortex as a three-layer AI substrate. Sets the Graph/Circuit/Wire model, the downstream integration boundary, and where detailed subsystem docs live."
+description:
+  "Overview of Cortex as a three-layer AI substrate. Sets the Graph/Circuit/Wire model, the
+  downstream integration boundary, and where detailed subsystem docs live."
 sidebar:
   label: "01. Overview"
   order: 1
@@ -9,47 +11,42 @@ status: active
 
 # Chapter 01 — Overview
 
-Cortex is a standalone AI substrate. This chapter sets the core architectural
-frame: Graph, Circuit, and Wire are separate layers; Cortex owns reusable
-substrate concerns; downstream products own domain semantics and the operator
-edge. Use this page to orient yourself. Use the later chapters for subsystem
-detail and the ADRs for settled decisions.
+Cortex is a standalone AI substrate. This chapter sets the core architectural frame: Graph, Circuit,
+and Wire are separate layers; Cortex owns reusable substrate concerns; downstream products own
+domain semantics and the operator edge. Use this page to orient yourself. Use the later chapters for
+subsystem detail and the ADRs for settled decisions.
 
 ## Three Layers
 
 Cortex separates three concerns that typed-dataflow programs depend on:
 
-| Layer | Responsibility | Primary artifact |
-|---|---|---|
-| **Graph** | Pure topology: vertices, edges, overlay, connect, DAG validation. | Graph topology |
-| **Circuit** | Validated executable topology: nodes plus compatible wires, ready for execution. | Circuit |
-| **Wire** | Source language and rewrite language that authors circuit topology. | `.wire` source |
+| Layer       | Responsibility                                                                   | Primary artifact |
+| ----------- | -------------------------------------------------------------------------------- | ---------------- |
+| **Graph**   | Pure topology: vertices, edges, overlay, connect, DAG validation.                | Graph topology   |
+| **Circuit** | Validated executable topology: nodes plus compatible wires, ready for execution. | Circuit          |
+| **Wire**    | Source language and rewrite language that authors circuit topology.              | `.wire` source   |
 
-The design rule: **Wire composes registered authority; implementations own what
-that authority means.** Wire source references registered nodes, contract IDs,
-prompts, and wiring. It does not invent executors, tools, payload types, or
-domain authority; those are defined outside the source language and referenced
-by name.
+The design rule: **Wire composes registered authority; implementations own what that authority
+means.** Wire source references registered nodes, contract IDs, prompts, and wiring. It does not
+invent executors, tools, payload types, or domain authority; those are defined outside the source
+language and referenced by name.
 
 For Wire-specific detail:
 
-- [Chapter 05 — Wire language](05-wire-language.md) for Wire architecture and
-  substrate concerns
-- [Wire Grammar](../Reference/Wire/grammar.md) for the normative grammar
-  and type-checking rules
+- [Chapter 05 — Wire language](05-wire-language.md) for Wire architecture and substrate concerns
+- [Wire Grammar](../Reference/Wire/grammar.md) for the normative grammar and type-checking rules
 
 ## System Boundary
 
 The core architectural split is:
 
-- Cortex owns reusable substrate concerns: authoring and typing, topology and
-  compilation, durable execution, capability abstractions, and provider
-  adapters.
-- A downstream product owns domain semantics, product policy, operator
-  surfaces, transport, and persistence.
+- Cortex owns reusable substrate concerns: authoring and typing, topology and compilation, durable
+  execution, capability abstractions, and provider adapters.
+- A downstream product owns domain semantics, product policy, operator surfaces, transport, and
+  persistence.
 
-Chapter 02 turns this into concrete ownership rules. This overview keeps the
-boundary at the architectural level.
+Chapter 02 turns this into concrete ownership rules. This overview keeps the boundary at the
+architectural level.
 
 ## Layer Boundary
 
@@ -57,8 +54,8 @@ The dependency direction is conceptual rather than repo-specific:
 
 `transport edge` → `product binding` → `Cortex substrate`
 
-Runtime calls may cross back into host-provided actions, but ownership and
-dependency direction still follow the boundary above.
+Runtime calls may cross back into host-provided actions, but ownership and dependency direction
+still follow the boundary above.
 
 ```mermaid
 flowchart LR
@@ -71,32 +68,30 @@ flowchart LR
 
 Ownership rules:
 
-- if a concern should be reusable across host applications as generic AI
-  infrastructure, it belongs in Cortex
-- if a concern encodes domain policy, artifact meaning, approval rules, or
-  product-specific tools, it stays downstream
-- if a concern owns transport, auth, delivery, storage, or API translation, it
-  stays at the host edge
+- if a concern should be reusable across host applications as generic AI infrastructure, it belongs
+  in Cortex
+- if a concern encodes domain policy, artifact meaning, approval rules, or product-specific tools,
+  it stays downstream
+- if a concern owns transport, auth, delivery, storage, or API translation, it stays at the host
+  edge
 
 ## What Cortex Owns
 
-Cortex is not a thin provider wrapper. It owns the reusable substrate end to
-end:
+Cortex is not a thin provider wrapper. It owns the reusable substrate end to end:
 
-- **Authoring and typing** — Wire as the source language for authoring circuits;
-  see [Chapter 05 — Wire language](05-wire-language.md) and
+- **Authoring and typing** — Wire as the source language for authoring circuits; see
+  [Chapter 05 — Wire language](05-wire-language.md) and
   [Wire Grammar](../Reference/Wire/grammar.md).
-- **Topology and compilation** — Graph and Circuit as the formal and executable
-  layers below Wire; see [Chapter 04 — Graph and Circuit](04-graph-and-circuit.md).
-- **Durable execution** — Pulse as the runtime that executes compiled circuits;
-  see [Chapter 06 — Pulse runtime](06-pulse-runtime.md).
-- **Runtime evolution** — admitted rewrites, materialization, and graph-native
-  execution; see
+- **Topology and compilation** — Graph and Circuit as the formal and executable layers below Wire;
+  see [Chapter 04 — Graph and Circuit](04-graph-and-circuit.md).
+- **Durable execution** — Pulse as the runtime that executes compiled circuits; see
+  [Chapter 06 — Pulse runtime](06-pulse-runtime.md).
+- **Runtime evolution** — admitted rewrites, materialization, and graph-native execution; see
   [Chapter 07 — Rewrites and materialization](07-rewrites-and-materialization.md).
-- **Capability substrate** — provider-neutral capability surfaces, provider
-  adapters, and reusable policy hooks.
-- **Artifact and memory primitives** — reusable provenance, document, memory,
-  and artifact-building surfaces that are not product-specific.
+- **Capability substrate** — provider-neutral capability surfaces, provider adapters, and reusable
+  policy hooks.
+- **Artifact and memory primitives** — reusable provenance, document, memory, and artifact-building
+  surfaces that are not product-specific.
 
 ## What Stays Downstream
 
@@ -110,17 +105,17 @@ Downstream ownership includes:
 - approval behavior and operator choices tied to a specific product UX
 - transport, auth, delivery, persistence, and edge error translation
 
-These are valid and important concerns. They are downstream concerns rather
-than Cortex substrate concerns.
+These are valid and important concerns. They are downstream concerns rather than Cortex substrate
+concerns.
 
 ## Boundary In Brief
 
-- Cortex may define substrate contracts and runtime mechanics, but it should not
-  own product semantics.
-- A downstream product binding may specialize Cortex, but it should not become
-  the long-term home of reusable provider or runtime code.
-- The transport edge should adapt requests, persistence, and delivery around
-  the product binding, not absorb generic orchestration.
+- Cortex may define substrate contracts and runtime mechanics, but it should not own product
+  semantics.
+- A downstream product binding may specialize Cortex, but it should not become the long-term home of
+  reusable provider or runtime code.
+- The transport edge should adapt requests, persistence, and delivery around the product binding,
+  not absorb generic orchestration.
 
 For the detailed ownership matrix, see
 [Chapter 02 — Ownership and boundaries](02-ownership-and-boundaries.md).
@@ -130,19 +125,18 @@ For the detailed ownership matrix, see
 Read in order:
 
 1. **This page** — three-layer model and ownership boundary.
-2. [Chapter 02 — Ownership and boundaries](02-ownership-and-boundaries.md) —
-   the detailed ownership matrix and dependency direction.
-3. [Chapter 03 — Algebraic foundations](03-formalism-stack.md) — the algebraic basis
-   for the substrate layers.
-4. [Chapter 04 — Graph and Circuit](04-graph-and-circuit.md) — the topology and
-   executable layers below Wire.
-5. [Chapter 05 — Wire language](05-wire-language.md) — source-language and
-   rewrite architecture.
+2. [Chapter 02 — Ownership and boundaries](02-ownership-and-boundaries.md) — the detailed ownership
+   matrix and dependency direction.
+3. [Chapter 03 — Algebraic foundations](03-formalism-stack.md) — the algebraic basis for the
+   substrate layers.
+4. [Chapter 04 — Graph and Circuit](04-graph-and-circuit.md) — the topology and executable layers
+   below Wire.
+5. [Chapter 05 — Wire language](05-wire-language.md) — source-language and rewrite architecture.
 6. [Chapter 06 — Pulse runtime](06-pulse-runtime.md) — durable execution.
-7. [Chapter 07 — Rewrites and materialization](07-rewrites-and-materialization.md) —
-   admitted runtime graph evolution.
-8. [Chapter 08 — Artifacts and provenance](08-artifacts-and-provenance.md) —
-   reusable artifact and provenance surfaces.
+7. [Chapter 07 — Rewrites and materialization](07-rewrites-and-materialization.md) — admitted
+   runtime graph evolution.
+8. [Chapter 08 — Artifacts and provenance](08-artifacts-and-provenance.md) — reusable artifact and
+   provenance surfaces.
 
 ## Related
 
@@ -159,10 +153,7 @@ Read in order:
 The Cortex architecture is structurally correct when:
 
 - Cortex concepts stand on their own without downstream-product framing
-- reusable authoring, topology, runtime, and capability concerns live in
-  Cortex
-- downstream products own domain policy, artifact meaning, and operator
-  surfaces
+- reusable authoring, topology, runtime, and capability concerns live in Cortex
+- downstream products own domain policy, artifact meaning, and operator surfaces
 - transport and persistence remain at the edge
-- a second downstream product could adopt Cortex without semantic boundary
-  cleanup first
+- a second downstream product could adopt Cortex without semantic boundary cleanup first

--- a/docs/Architecture/02-ownership-and-boundaries.md
+++ b/docs/Architecture/02-ownership-and-boundaries.md
@@ -1,6 +1,8 @@
 ---
 title: "Chapter 02 — Ownership and Boundaries"
-description: "Subsystem ownership, dependency direction, and the contract between the Cortex substrate and a host application."
+description:
+  "Subsystem ownership, dependency direction, and the contract between the Cortex substrate and a
+  host application."
 sidebar:
   label: "02. Ownership and boundaries"
   order: 2
@@ -9,22 +11,21 @@ status: active
 
 # Chapter 02 — Ownership and Boundaries
 
-Cortex is a generic AI substrate. A host application embeds Cortex and supplies
-domain semantics, transport, and persistence. The boundary described here is
-meant to survive any particular host.
+Cortex is a generic AI substrate. A host application embeds Cortex and supplies domain semantics,
+transport, and persistence. The boundary described here is meant to survive any particular host.
 
-This chapter states which subsystems own which responsibilities, which
-direction dependencies run, and what may and may not cross each boundary.
+This chapter states which subsystems own which responsibilities, which direction dependencies run,
+and what may and may not cross each boundary.
 
 ## Core model
 
 Three subsystems carry the bulk of the weight on either side of the boundary:
 
-| Subsystem | Role |
-|---|---|
+| Subsystem            | Role                                                                                                                             |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | **Cortex substrate** | Reusable AI substrate: provider integrations, capability abstractions, the Graph / Circuit / Wire layers, and the Pulse runtime. |
-| **Product binding** | Host-specific configuration of Cortex: prompts, grounding policy, tool registries, artifact assembly, and product policy. |
-| **Server edge** | Transport and persistence: HTTP, auth, streaming, request/response conversion, and persistence wiring. |
+| **Product binding**  | Host-specific configuration of Cortex: prompts, grounding policy, tool registries, artifact assembly, and product policy.        |
+| **Server edge**      | Transport and persistence: HTTP, auth, streaming, request/response conversion, and persistence wiring.                           |
 
 Two further subsystems are host-internal and do not interact with Cortex directly:
 
@@ -35,7 +36,10 @@ Dependency direction is fixed:
 
 `Server edge` → `Product binding` → `Cortex substrate`
 
-Runtime flow may invert — Cortex calls back into host-provided handlers, and Pulse receives callbacks from host-registered executors — but module imports must follow the arrow above. A module in the Cortex substrate that imports anything host-specific is a boundary violation, regardless of what the runtime does.
+Runtime flow may invert — Cortex calls back into host-provided handlers, and Pulse receives
+callbacks from host-registered executors — but module imports must follow the arrow above. A module
+in the Cortex substrate that imports anything host-specific is a boundary violation, regardless of
+what the runtime does.
 
 ```mermaid
 flowchart LR
@@ -46,7 +50,10 @@ flowchart LR
     S --> D[Persistence<br/>schemas + storage]
 ```
 
-The placement rule: if a module would be reusable outside the host as generic AI infrastructure, it belongs in the Cortex substrate, even when the product binding is currently the only caller. If it knows about host domain semantics, product-specific artifacts, truth policy, or host tool authority, it stays downstream.
+The placement rule: if a module would be reusable outside the host as generic AI infrastructure, it
+belongs in the Cortex substrate, even when the product binding is currently the only caller. If it
+knows about host domain semantics, product-specific artifacts, truth policy, or host tool authority,
+it stays downstream.
 
 ## Public import boundary
 
@@ -57,34 +64,37 @@ import Cortex
 import Platform
 ```
 
-Those modules are the supported public API boundary. They re-export the
-stable Cortex substrate surface, the public reasoning/workflow surface, and
-the generic Platform runtime utilities that downstream products are expected
-to use directly.
+Those modules are the supported public API boundary. They re-export the stable Cortex substrate
+surface, the public reasoning/workflow surface, and the generic Platform runtime utilities that
+downstream products are expected to use directly.
 
 Area modules such as `Cortex.Wire`, `Cortex.Pulse`, `Cortex.Nous.Memory`, or
-`Platform.Observability` remain available for advanced imports, examples, and
-focused tests. Implementation-era roots are not the downstream contract. A
-consumer that reaches past the umbrella modules should do so deliberately and
-expect that import to be reviewed when Cortex tightens its internal module
-layout.
+`Platform.Observability` remain available for advanced imports, examples, and focused tests.
+Implementation-era roots are not the downstream contract. A consumer that reaches past the umbrella
+modules should do so deliberately and expect that import to be reviewed when Cortex tightens its
+internal module layout.
 
 ## Ownership breakdown
 
 ### Cortex substrate
 
-Cortex is not a thin provider wrapper. It owns the generic substrate end to end, grouped into three layers:
+Cortex is not a thin provider wrapper. It owns the generic substrate end to end, grouped into three
+layers:
 
-- **Source language and graph layer.** Algebraic graph primitives (`Empty | Vertex | Overlay | Connect`), DAG validation, the validated executable Circuit, and the Wire source language that authors circuits. Normative Wire grammar lives at [`../Reference/Wire/grammar.md`](../Reference/Wire/grammar.md).
-- **Runtime and agent layer.** The Pulse runtime — durable stage execution,
-  checkpointing, rewrite hydration, and frontier scheduling — ships as its own
-  service. Run lifecycle and stage events sit alongside it, with generic agent
-  definitions and capability policies above.
-- **Provider and capability layer.** Provider-specific HTTP clients and wire decoding, provider-neutral request/response types and tool-call records, generic JSON and text helpers.
+- **Source language and graph layer.** Algebraic graph primitives
+  (`Empty | Vertex | Overlay | Connect`), DAG validation, the validated executable Circuit, and the
+  Wire source language that authors circuits. Normative Wire grammar lives at
+  [`../Reference/Wire/grammar.md`](../Reference/Wire/grammar.md).
+- **Runtime and agent layer.** The Pulse runtime — durable stage execution, checkpointing, rewrite
+  hydration, and frontier scheduling — ships as its own service. Run lifecycle and stage events sit
+  alongside it, with generic agent definitions and capability policies above.
+- **Provider and capability layer.** Provider-specific HTTP clients and wire decoding,
+  provider-neutral request/response types and tool-call records, generic JSON and text helpers.
 
 ### Product binding
 
-The product binding is host-specific behavior. It configures Cortex for one product's use case and nothing more:
+The product binding is host-specific behavior. It configures Cortex for one product's use case and
+nothing more:
 
 - prompts and model-catalog policy
 - domain-specific grounding and truth policy
@@ -94,55 +104,67 @@ The product binding is host-specific behavior. It configures Cortex for one prod
 
 ### Server edge
 
-The server edge is the transport and persistence boundary: HTTP routing, auth, SSE/poll, request/response conversion, persistence wiring, usage logging, edge error translation. Nothing else.
+The server edge is the transport and persistence boundary: HTTP routing, auth, SSE/poll,
+request/response conversion, persistence wiring, usage logging, edge error translation. Nothing
+else.
 
 ## Boundaries and invariants
 
-Each boundary has a closed allow-list and an explicit forbid-list. Violations are caught in review today; mechanical enforcement is a direction-of-travel goal.
+Each boundary has a closed allow-list and an explicit forbid-list. Violations are caught in review
+today; mechanical enforcement is a direction-of-travel goal.
 
 ### Cortex substrate
 
-Allowed: generic provider integrations; provider-neutral capability abstractions; Wire / Graph / Circuit / Pulse primitives; generic JSON, text, time, and runtime helpers; generic AI observability hooks.
+Allowed: generic provider integrations; provider-neutral capability abstractions; Wire / Graph /
+Circuit / Pulse primitives; generic JSON, text, time, and runtime helpers; generic AI observability
+hooks.
 
-Forbidden: any host-specific import; server transport types; host durable-task scheduling; database queries and schemas; domain-specific imports; host artifact contracts.
+Forbidden: any host-specific import; server transport types; host durable-task scheduling; database
+queries and schemas; domain-specific imports; host artifact contracts.
 
-The graph layer has a tighter rule than the rest of Cortex: it must contain no Pulse node identity, no rewrite lineage, no task scheduler coupling, no run-outcome semantics. It is pure graph algebra.
+The graph layer has a tighter rule than the rest of Cortex: it must contain no Pulse node identity,
+no rewrite lineage, no task scheduler coupling, no run-outcome semantics. It is pure graph algebra.
 
 ### Product binding
 
 Allowed: the Cortex substrate, host domain core, host product code.
 
-Forbidden as a long-term home: provider wire details, generic runtime helpers, or any utility that should be reusable by another host. If such code lands in the product binding during migration, it is a migration aid, not a durable boundary.
+Forbidden as a long-term home: provider wire details, generic runtime helpers, or any utility that
+should be reusable by another host. If such code lands in the product binding during migration, it
+is a migration aid, not a durable boundary.
 
 ### Server edge
 
 Allowed: the product binding, the host's transport API surface, auth, persistence, and route wiring.
 
-Forbidden as a long-term home: provider clients, generic capability types, report or runtime orchestration that is not transport-specific, product-agnostic utility helpers. Edge handlers are thin adapters.
+Forbidden as a long-term home: provider clients, generic capability types, report or runtime
+orchestration that is not transport-specific, product-agnostic utility helpers. Edge handlers are
+thin adapters.
 
 ## Why this boundary matters
 
-This split is not just cleanup discipline. It is what makes Cortex usable as a
-real substrate:
+This split is not just cleanup discipline. It is what makes Cortex usable as a real substrate:
 
-- Cortex can evolve as a reusable system rather than as one product's internal
-  helper layer.
-- A second host can adopt Cortex by supplying its own bindings rather than by
-  forking Cortex semantics.
-- Product-specific meaning stays where product teams can change it without
-  destabilizing the substrate.
-- Transport and persistence concerns stay at the edge instead of leaking into
-  the execution model.
+- Cortex can evolve as a reusable system rather than as one product's internal helper layer.
+- A second host can adopt Cortex by supplying its own bindings rather than by forking Cortex
+  semantics.
+- Product-specific meaning stays where product teams can change it without destabilizing the
+  substrate.
+- Transport and persistence concerns stay at the edge instead of leaking into the execution model.
 
 ## Extensibility
 
-Downstream consumers extend Cortex by registering into closed alphabets, not by modifying Cortex modules:
+Downstream consumers extend Cortex by registering into closed alphabets, not by modifying Cortex
+modules:
 
-- executors register under the `@qualified.name` namespace with declared vocabulary, structural constraints, and purity.
+- executors register under the `@qualified.name` namespace with declared vocabulary, structural
+  constraints, and purity.
 - contracts register with a payload kind and codec in the contract registry.
 - tools register in the ambient tool namespace referenced from executor config records.
 
-The boundary is preserved because Wire source only references names in these registries; it does not invent executor authority, contract semantics, or tool behavior. A second host stands up its own registrations and consumes Cortex unchanged.
+The boundary is preserved because Wire source only references names in these registries; it does not
+invent executor authority, contract semantics, or tool behavior. A second host stands up its own
+registrations and consumes Cortex unchanged.
 
 ## Related
 

--- a/docs/Architecture/03-formalism-stack.md
+++ b/docs/Architecture/03-formalism-stack.md
@@ -1,6 +1,8 @@
 ---
 title: "Chapter 03 — Algebraic Foundations"
-description: "Why the Cortex topology model is algebraic, what laws it preserves, and why rewrites can stay structural rather than ad hoc."
+description:
+  "Why the Cortex topology model is algebraic, what laws it preserves, and why rewrites can stay
+  structural rather than ad hoc."
 sidebar:
   label: "03. Algebraic foundations"
   order: 3
@@ -9,163 +11,145 @@ status: active
 
 # Chapter 03 — Algebraic Foundations
 
-Cortex is a stack of algebras chosen so that each layer adds exactly one
-kind of authority. The Graph layer contributes pure topology. The Circuit
-layer adds validation. Wire adds a surface syntax whose operators refine the
-algebraic primitives one level below. Rewrites are structural edits stated
-over the same algebra that authored the topology. This chapter records the
-formal basis of that stack and the laws it preserves; proofs live in the
-publications and are only referenced here.
+Cortex is a stack of algebras chosen so that each layer adds exactly one kind of authority. The
+Graph layer contributes pure topology. The Circuit layer adds validation. Wire adds a surface syntax
+whose operators refine the algebraic primitives one level below. Rewrites are structural edits
+stated over the same algebra that authored the topology. This chapter records the formal basis of
+that stack and the laws it preserves; proofs live in the publications and are only referenced here.
 
-If you are evaluating Cortex rather than studying the foundations in detail,
-the core model below is the important part. The later sections explain why the
-rewrite story and topology model stay coherent under that surface.
+If you are evaluating Cortex rather than studying the foundations in detail, the core model below is
+the important part. The later sections explain why the rewrite story and topology model stay
+coherent under that surface.
 
 ## Core model
 
 Three layers, each defined over the previous:
 
-| Layer   | Object                                                | Algebra                                                              |
-|---------|-------------------------------------------------------|----------------------------------------------------------------------|
-| Graph   | Pure topology: vertices and edges over a carrier set. | `Empty \| Vertex \| Overlay \| Connect`, per Mokhov.                 |
-| Circuit | Validated executable topology: nodes plus wires.      | Graph plus DAG invariant plus port-contract compatibility.           |
-| Wire    | Source language that authors Circuits.                | `<>` (overlay) and `=>` (port-key-matched connect), plus value ops.  |
+| Layer   | Object                                                | Algebra                                                             |
+| ------- | ----------------------------------------------------- | ------------------------------------------------------------------- |
+| Graph   | Pure topology: vertices and edges over a carrier set. | `Empty \| Vertex \| Overlay \| Connect`, per Mokhov.                |
+| Circuit | Validated executable topology: nodes plus wires.      | Graph plus DAG invariant plus port-contract compatibility.          |
+| Wire    | Source language that authors Circuits.                | `<>` (overlay) and `=>` (port-key-matched connect), plus value ops. |
 
-Pulse is the durable runtime that executes Circuits. It is not a new algebra;
-it interprets the Circuit object and applies admitted rewrites at runtime. The
-algebraic stack itself ends at Circuit — Pulse is the mechanical realization
-of its semantics.
+Pulse is the durable runtime that executes Circuits. It is not a new algebra; it interprets the
+Circuit object and applies admitted rewrites at runtime. The algebraic stack itself ends at Circuit
+— Pulse is the mechanical realization of its semantics.
 
-The load-bearing property across these layers is **composition closure**. A
-wire value composed with another wire value under `<>` or `=>` is itself a
-wire value. The class is closed under its own operators. This is what makes
-partial authorship, template reuse, and rewriting tractable: authors and
-rewrites manipulate the same kind of object the compiler consumes.
+The load-bearing property across these layers is **composition closure**. A wire value composed with
+another wire value under `<>` or `=>` is itself a wire value. The class is closed under its own
+operators. This is what makes partial authorship, template reuse, and rewriting tractable: authors
+and rewrites manipulate the same kind of object the compiler consumes.
 
 ## Detailed structure
 
 ### Mokhov's algebraic graph model
 
-Wire's graph expressions inherit their primitive constructor set from Mokhov's
-*Algebraic Graphs with Class* (2017): `Empty | Vertex | Overlay | Connect`.
-Any finite directed graph can be constructed from these four constructors, and
-the denotational object (vertex set plus edge set) is determined by the laws
-of overlay (commutative monoid with `Empty` as identity) and connect
-(associative, distributes over overlay, decomposes into overlay plus the edge
-fringe).
+Wire's graph expressions inherit their primitive constructor set from Mokhov's _Algebraic Graphs
+with Class_ (2017): `Empty | Vertex | Overlay | Connect`. Any finite directed graph can be
+constructed from these four constructors, and the denotational object (vertex set plus edge set) is
+determined by the laws of overlay (commutative monoid with `Empty` as identity) and connect
+(associative, distributes over overlay, decomposes into overlay plus the edge fringe).
 
-Cortex treats this algebra as axiomatic at the Graph layer. `Cortex.Graph`
-lowers the four-constructor expression to a `Relation` carrier via `foldg`;
-every downstream layer operates on that denotation. The laws hold by
-construction because the interpretation is the standard one. For their
-algebraic statement and the proof obligations they carry into the
-staged-execution setting, see [`paper 2`](../Publications/Paper-2-algebraic-foundations/manuscript.md).
+Cortex treats this algebra as axiomatic at the Graph layer. `Cortex.Graph` lowers the
+four-constructor expression to a `Relation` carrier via `foldg`; every downstream layer operates on
+that denotation. The laws hold by construction because the interpretation is the standard one. For
+their algebraic statement and the proof obligations they carry into the staged-execution setting,
+see [`paper 2`](../Publications/Paper-2-algebraic-foundations/manuscript.md).
 
 ### Wire's `<>` and `=>` as refinements
 
-Wire's two graph operators correspond directly to Mokhov's primitives, but
-refine them:
+Wire's two graph operators correspond directly to Mokhov's primitives, but refine them:
 
-- **`<>` (overlay)** is exactly Mokhov's Overlay. Set-union of vertices and
-  edges across two wires. It inherits the Mokhov laws unchanged:
-  commutative monoid with `Empty` as identity, idempotent when the operands
-  share vertices.
+- **`<>` (overlay)** is exactly Mokhov's Overlay. Set-union of vertices and edges across two wires.
+  It inherits the Mokhov laws unchanged: commutative monoid with `Empty` as identity, idempotent
+  when the operands share vertices.
 
-- **`=>` (connect)** is a *refinement* of Mokhov's Connect, not an instance
-  of it. Mokhov's Connect takes the cross product of left outputs against
-  right inputs and unions the resulting edges. Wire's `=>` is
-  **port-key-matched**: an edge is added between a left-hand boundary output
-  and a right-hand boundary input only when their port keys agree on
-  `(direction, contract, label)`. An absent label is itself a key, not a
-  wildcard. The result is a deterministic cross-product with a filter: fewer
-  edges than Mokhov's Connect for the same endpoints, never more.
+- **`=>` (connect)** is a _refinement_ of Mokhov's Connect, not an instance of it. Mokhov's Connect
+  takes the cross product of left outputs against right inputs and unions the resulting edges.
+  Wire's `=>` is **port-key-matched**: an edge is added between a left-hand boundary output and a
+  right-hand boundary input only when their port keys agree on `(direction, contract, label)`. An
+  absent label is itself a key, not a wildcard. The result is a deterministic cross-product with a
+  filter: fewer edges than Mokhov's Connect for the same endpoints, never more.
 
-This refinement is why `=>` lands usable edges instead of a combinatorial
-mesh of unchecked connections. It also preserves the Mokhov laws where they
-matter: overlay's associativity and commutativity hold on Wire values;
-connect remains associative under port-key matching; `Empty <> w = w` and
-`Empty => w = w`. The laws that involve the cross-product shape of Connect
-(full distributivity over Overlay) hold only on the port-matched projection,
-which is the only form Wire ever exposes. See
-[`terminology.md`](../Reference/terminology.md) for the normative definitions
+This refinement is why `=>` lands usable edges instead of a combinatorial mesh of unchecked
+connections. It also preserves the Mokhov laws where they matter: overlay's associativity and
+commutativity hold on Wire values; connect remains associative under port-key matching;
+`Empty <> w = w` and `Empty => w = w`. The laws that involve the cross-product shape of Connect
+(full distributivity over Overlay) hold only on the port-matched projection, which is the only form
+Wire ever exposes. See [`terminology.md`](../Reference/terminology.md) for the normative definitions
 of port key and the composition algebra.
 
 ### DAG semantics as a Circuit-layer invariant
 
-The pure Graph layer is acyclic-agnostic. Mokhov's algebra constructs
-arbitrary directed graphs, not DAGs. Cortex does not collapse this
-distinction: acyclicity is a **Circuit-layer invariant**, not a Graph-layer
-one. The Graph algebra stays maximally permissive so that intermediate
-fragments, rewrite templates, and partial authorship can use the full
-algebraic surface. Cycles are rejected when a graph is promoted to a Circuit
-— the point at which the topology becomes an executable artifact.
+The pure Graph layer is acyclic-agnostic. Mokhov's algebra constructs arbitrary directed graphs, not
+DAGs. Cortex does not collapse this distinction: acyclicity is a **Circuit-layer invariant**, not a
+Graph-layer one. The Graph algebra stays maximally permissive so that intermediate fragments,
+rewrite templates, and partial authorship can use the full algebraic surface. Cycles are rejected
+when a graph is promoted to a Circuit — the point at which the topology becomes an executable
+artifact.
 
-This placement matters because rewrite fragments may be algebraically
-simpler than their insertion target; forcing them to be acyclic in isolation
-would over-constrain the algebra. The Circuit validator is also the natural
-place to pair acyclicity with the other executable invariants: port-contract
-compatibility, runnable-wire boundary checks, and payload-kind admission.
-The full list lives in [`chapter 04`](./04-graph-and-circuit.md); the
-formalism only requires that they attach at the Circuit boundary.
+This placement matters because rewrite fragments may be algebraically simpler than their insertion
+target; forcing them to be acyclic in isolation would over-constrain the algebra. The Circuit
+validator is also the natural place to pair acyclicity with the other executable invariants:
+port-contract compatibility, runnable-wire boundary checks, and payload-kind admission. The full
+list lives in [`chapter 04`](./04-graph-and-circuit.md); the formalism only requires that they
+attach at the Circuit boundary.
 
 ### Rewrite algebra
 
-A rewrite is a structural edit: a function from a Circuit to a Circuit whose
-effect is expressible as a composition of Mokhov operators applied at an
-anchor. In Wire terms, a rewrite fragment is itself a wire value, and
-admitting a rewrite is overlaying that fragment into the live topology and
-re-connecting endpoints under `=>`. Because the fragment and the target
-belong to the same algebraic class, admission is law-preserving by
-construction: the post-rewrite object satisfies exactly the same overlay and
-connect laws as the pre-rewrite object.
+A rewrite is a structural edit: a function from a Circuit to a Circuit whose effect is expressible
+as a composition of Mokhov operators applied at an anchor. In Wire terms, a rewrite fragment is
+itself a wire value, and admitting a rewrite is overlaying that fragment into the live topology and
+re-connecting endpoints under `=>`. Because the fragment and the target belong to the same algebraic
+class, admission is law-preserving by construction: the post-rewrite object satisfies exactly the
+same overlay and connect laws as the pre-rewrite object.
 
-The rewrite algebra is stated as vertex-anchored substitution: a fragment is
-spliced at a designated vertex through a typed interface, preserving causal
-structure outside the interface. This is the substitution semantics developed
-in [`paper 3`](../Publications/Paper-3-graph-substitution-semantics/manuscript.md).
-The operational side — gas, admission, materialization, replay contracts — is
-the subject of [`chapter 07`](./07-rewrites-and-materialization.md). The
-formalism only records that rewrites are algebraic operations over the same
-object class, not a separate mutation layer.
+The rewrite algebra is stated as vertex-anchored substitution: a fragment is spliced at a designated
+vertex through a typed interface, preserving causal structure outside the interface. This is the
+substitution semantics developed in
+[`paper 3`](../Publications/Paper-3-graph-substitution-semantics/manuscript.md). The operational
+side — gas, admission, materialization, replay contracts — is the subject of
+[`chapter 07`](./07-rewrites-and-materialization.md). The formalism only records that rewrites are
+algebraic operations over the same object class, not a separate mutation layer.
 
 ## Boundaries and invariants
 
 What this stack enforces:
 
-- **Composition closure.** Wire values are closed under `<>` and `=>`.
-  Partial authorship and rewriting share the same object class as finished
-  circuits.
-- **Law preservation through refinement.** `<>` inherits Mokhov overlay
-  laws. `=>` preserves those laws on the port-key-matched projection.
-- **Layered invariants.** Acyclicity and port-contract compatibility attach
-  at the Circuit boundary, not at Graph. Fragments remain algebraically
-  first-class below that line.
-- **Rewrites as algebraic operations.** Structural edits are expressible in
-  the same algebra that authored the topology; admission preserves the laws.
+- **Composition closure.** Wire values are closed under `<>` and `=>`. Partial authorship and
+  rewriting share the same object class as finished circuits.
+- **Law preservation through refinement.** `<>` inherits Mokhov overlay laws. `=>` preserves those
+  laws on the port-key-matched projection.
+- **Layered invariants.** Acyclicity and port-contract compatibility attach at the Circuit boundary,
+  not at Graph. Fragments remain algebraically first-class below that line.
+- **Rewrites as algebraic operations.** Structural edits are expressible in the same algebra that
+  authored the topology; admission preserves the laws.
 
-What the stack does not enforce: executor semantics, payload-kind
-validation, runtime scheduling, provenance — all delegated to Circuit, Pulse,
-or the contract registry.
+What the stack does not enforce: executor semantics, payload-kind validation, runtime scheduling,
+provenance — all delegated to Circuit, Pulse, or the contract registry.
 
 ## Extensibility
 
-The Mokhov alphabet is fixed at four constructors. Cortex does not extend it.
-New authoring convenience enters Wire as derived value operators (`//`, `++`,
-`let`, partial-node merge) that reduce to existing graph operators when the
-expression reaches the Graph layer. New semantic categories — payload kinds,
-structural-authority classes, parameterized latent branches explored in the
-foundation synthesis note — attach as registry metadata on the Circuit
-layer, not as new graph primitives. The algebra stays small on purpose; the
-ecosystem grows by registering authority into a closed alphabet, not by
-mutating the alphabet.
+The Mokhov alphabet is fixed at four constructors. Cortex does not extend it. New authoring
+convenience enters Wire as derived value operators (`//`, `++`, `let`, partial-node merge) that
+reduce to existing graph operators when the expression reaches the Graph layer. New semantic
+categories — payload kinds, structural-authority classes, parameterized latent branches explored in
+the foundation synthesis note — attach as registry metadata on the Circuit layer, not as new graph
+primitives. The algebra stays small on purpose; the ecosystem grows by registering authority into a
+closed alphabet, not by mutating the alphabet.
 
 ## Related
 
 - [`../Reference/terminology.md`](../Reference/terminology.md) — normative vocabulary.
 - [`./01-overview.md`](./01-overview.md) — three-layer model and ownership.
 - [`./04-graph-and-circuit.md`](./04-graph-and-circuit.md) — Graph and Circuit mechanics.
-- [`./05-wire-language.md`](./05-wire-language.md) — Wire substrate; grammar at [`../Reference/Wire/grammar.md`](../Reference/Wire/grammar.md).
-- [`./07-rewrites-and-materialization.md`](./07-rewrites-and-materialization.md) — rewrite admission mechanics.
-- [`../Publications/Paper-2-algebraic-foundations/manuscript.md`](../Publications/Paper-2-algebraic-foundations/manuscript.md) — algebraic foundations of staged durable execution.
-- [`../Publications/Paper-3-graph-substitution-semantics/manuscript.md`](../Publications/Paper-3-graph-substitution-semantics/manuscript.md) — vertex-anchored substitution semantics.
-- [`../Research-notes/Foundation/2026-04-11-formalism-stack-synthesis.md`](../Research-notes/Foundation/2026-04-11-formalism-stack-synthesis.md) — live research on topology/intent/authority split.
+- [`./05-wire-language.md`](./05-wire-language.md) — Wire substrate; grammar at
+  [`../Reference/Wire/grammar.md`](../Reference/Wire/grammar.md).
+- [`./07-rewrites-and-materialization.md`](./07-rewrites-and-materialization.md) — rewrite admission
+  mechanics.
+- [`../Publications/Paper-2-algebraic-foundations/manuscript.md`](../Publications/Paper-2-algebraic-foundations/manuscript.md)
+  — algebraic foundations of staged durable execution.
+- [`../Publications/Paper-3-graph-substitution-semantics/manuscript.md`](../Publications/Paper-3-graph-substitution-semantics/manuscript.md)
+  — vertex-anchored substitution semantics.
+- [`../Research-notes/Foundation/2026-04-11-formalism-stack-synthesis.md`](../Research-notes/Foundation/2026-04-11-formalism-stack-synthesis.md)
+  — live research on topology/intent/authority split.

--- a/docs/Architecture/04-graph-and-circuit.md
+++ b/docs/Architecture/04-graph-and-circuit.md
@@ -1,6 +1,8 @@
 ---
 title: "Chapter 04 — Graph and Circuit"
-description: "Pure topology vs validated executable topology. The two substrate layers that sit below Wire and above Pulse."
+description:
+  "Pure topology vs validated executable topology. The two substrate layers that sit below Wire and
+  above Pulse."
 sidebar:
   label: "04. Graph and Circuit"
   order: 4
@@ -9,24 +11,22 @@ status: active
 
 # Chapter 04 — Graph and Circuit
 
-Chapter 03 establishes the algebraic basis. This chapter picks up one level
-later and defines the two artifacts that matter operationally: Graph as pure
-topology, and Circuit as validated executable topology. Graph keeps the
-formalism maximally reusable. Circuit is the point where a topology becomes an
-artifact that Pulse can execute, persist, and re-validate after
-admitted rewrites.
+Chapter 03 establishes the algebraic basis. This chapter picks up one level later and defines the
+two artifacts that matter operationally: Graph as pure topology, and Circuit as validated executable
+topology. Graph keeps the formalism maximally reusable. Circuit is the point where a topology
+becomes an artifact that Pulse can execute, persist, and re-validate after admitted rewrites.
 
 ## Core Model
 
 The distinction is simple:
 
-| Layer | Role | Excludes |
-|---|---|---|
-| **Graph** | Pure topology: vertices, edges, overlay, connect, traversal, decomposition. | Ports, contracts, executors, payloads, runtime state |
-| **Circuit** | Executable topology: stable nodes, compatible endpoints, boundary markers, runtime-facing metadata. | Scheduling, persistence policy, operator APIs |
+| Layer       | Role                                                                                                | Excludes                                             |
+| ----------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| **Graph**   | Pure topology: vertices, edges, overlay, connect, traversal, decomposition.                         | Ports, contracts, executors, payloads, runtime state |
+| **Circuit** | Executable topology: stable nodes, compatible endpoints, boundary markers, runtime-facing metadata. | Scheduling, persistence policy, operator APIs        |
 
-Wire authors topology using the Graph layer's composition laws. Pulse executes
-Circuits. The boundary looks like this:
+Wire authors topology using the Graph layer's composition laws. Pulse executes Circuits. The
+boundary looks like this:
 
 ```mermaid
 flowchart LR
@@ -42,14 +42,14 @@ Each boundary narrows freedom:
 - Graph carries only denotational topology.
 - Circuit checks that the topology is executable.
 - Pulse schedules and persists the resulting executable object over time.
-- Run state is the durable record of that execution, owned by Pulse and read by
-  downstream artifact and provenance surfaces.
+- Run state is the durable record of that execution, owned by Pulse and read by downstream artifact
+  and provenance surfaces.
 
 ## Graph
 
 Graph is the pure topology layer defined formally in
-[Chapter 03 — Algebraic foundations](./03-formalism-stack.md). It is responsible for
-structure, not meaning.
+[Chapter 03 — Algebraic foundations](./03-formalism-stack.md). It is responsible for structure, not
+meaning.
 
 Graph owns:
 
@@ -65,19 +65,18 @@ Graph does not own:
 - payload semantics
 - runtime state or scheduling
 
-A graph may be cyclic or acyclic. That distinction matters only when a topology
-is promoted into an executable artifact. Keeping Graph permissive is what makes
-fragments, templates, and rewrite proposals cheap to construct and analyze
-before execution is considered.
+A graph may be cyclic or acyclic. That distinction matters only when a topology is promoted into an
+executable artifact. Keeping Graph permissive is what makes fragments, templates, and rewrite
+proposals cheap to construct and analyze before execution is considered.
 
-In practice, topology algorithms often run over a lowered relation or adjacency
-view rather than over the authoring expression itself. That does not add new
-semantics; it is just the executable denotation of the same topology.
+In practice, topology algorithms often run over a lowered relation or adjacency view rather than
+over the authoring expression itself. That does not add new semantics; it is just the executable
+denotation of the same topology.
 
 ## Circuit
 
-Circuit is the executable topology artifact. It takes a graph-shaped structure
-and adds the facts that execution needs but pure topology does not:
+Circuit is the executable topology artifact. It takes a graph-shaped structure and adds the facts
+that execution needs but pure topology does not:
 
 - stable node identity
 - compatible endpoints between connected nodes
@@ -85,14 +84,12 @@ and adds the facts that execution needs but pure topology does not:
 - enough metadata for Pulse to lower and resume the topology safely
 - a compatibility witness that downstream durable state can key against
 
-Circuit is where executable invariants become mandatory. A topology that is
-perfectly valid as Graph structure may still fail to become a Circuit if it is
-cyclic, references incompatible endpoints, or does not preserve the required
-boundary information.
+Circuit is where executable invariants become mandatory. A topology that is perfectly valid as Graph
+structure may still fail to become a Circuit if it is cyclic, references incompatible endpoints, or
+does not preserve the required boundary information.
 
-Circuit still does not own runtime behavior. It does not schedule work, store
-checkpoints, admit rewrites, or decide operator policy. It defines the object
-those mechanisms operate on.
+Circuit still does not own runtime behavior. It does not schedule work, store checkpoints, admit
+rewrites, or decide operator policy. It defines the object those mechanisms operate on.
 
 ## The Compilation Boundary
 
@@ -102,64 +99,62 @@ Wire contributes three things to the Circuit boundary:
 - a composed topology over those nodes
 - endpoint compatibility information already resolved at the authoring layer
 
-Circuit compilation does not re-interpret domain semantics. Its job is narrower
-and more mechanical: materialize the topology into an executable form, enforce
-the executable invariants, and emit an artifact that Pulse can lower without
-re-parsing Wire.
+Circuit compilation does not re-interpret domain semantics. Its job is narrower and more mechanical:
+materialize the topology into an executable form, enforce the executable invariants, and emit an
+artifact that Pulse can lower without re-parsing Wire.
 
 Stated as seam contracts:
 
-| Seam | What comes in | What must come out |
-|---|---|---|
-| Wire → Circuit | Registered nodes, composed topology, endpoint-compatible connections | Executable topology with stable identity and preserved boundaries |
-| Circuit → Pulse | Executable topology plus compatibility witness | Runtime plan that preserves topology up to runtime naming |
+| Seam            | What comes in                                                        | What must come out                                                |
+| --------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Wire → Circuit  | Registered nodes, composed topology, endpoint-compatible connections | Executable topology with stable identity and preserved boundaries |
+| Circuit → Pulse | Executable topology plus compatibility witness                       | Runtime plan that preserves topology up to runtime naming         |
 
 ## Boundaries and Invariants
 
-**Graph guarantees upward.** Structural algorithms operate over a coherent
-topology. Relation-style views, adjacency, and decomposition must agree with
-the underlying edge set. Graph updates are purely structural.
+**Graph guarantees upward.** Structural algorithms operate over a coherent topology. Relation-style
+views, adjacency, and decomposition must agree with the underlying edge set. Graph updates are
+purely structural.
 
-**Circuit guarantees upward.** A Circuit carries executable topology rather than
-merely possible topology: acyclic structure, stable node identity, preserved
-boundaries, and a compatibility witness suitable for durable consumers.
+**Circuit guarantees upward.** A Circuit carries executable topology rather than merely possible
+topology: acyclic structure, stable node identity, preserved boundaries, and a compatibility witness
+suitable for durable consumers.
 
-**Circuit guarantees downward.** Lowering preserves topology up to runtime
-renaming. Rewrite, signal, and artifact boundaries remain explicit; Circuit
-does not collapse them into opaque generic tasks.
+**Circuit guarantees downward.** Lowering preserves topology up to runtime renaming. Rewrite,
+signal, and artifact boundaries remain explicit; Circuit does not collapse them into opaque generic
+tasks.
 
-**Delegated concerns.** The algebra and its laws live in Chapter 03. Wire
-owns source-language composition and endpoint typing. Pulse owns scheduling,
-durability, and resume behavior. Chapter 08 owns value and artifact semantics.
-Graph and Circuit are the structural seam that lets those concerns meet
-cleanly.
+**Delegated concerns.** The algebra and its laws live in Chapter 03. Wire owns source-language
+composition and endpoint typing. Pulse owns scheduling, durability, and resume behavior. Chapter 08
+owns value and artifact semantics. Graph and Circuit are the structural seam that lets those
+concerns meet cleanly.
 
-**Shared invariant: edges are opaque.** In both layers, an edge only means that
-one node feeds another. Meaning lives at the endpoints, not on the edge
-itself. That is what keeps rewrites tractable: topology changes can be checked
-mechanically without inventing edge-local semantics.
+**Shared invariant: edges are opaque.** In both layers, an edge only means that one node feeds
+another. Meaning lives at the endpoints, not on the edge itself. That is what keeps rewrites
+tractable: topology changes can be checked mechanically without inventing edge-local semantics.
 
 ## Why the split matters
 
 - It keeps the algebraic layer reusable and small.
 - It puts executable checks exactly once, at the Circuit boundary.
-- It lets rewrites propose structural edits without also re-defining runtime
-  semantics.
-- It gives downstream systems a clear extension point: register nodes,
-  contracts, and host actions around the substrate instead of modifying the
-  topology model itself.
+- It lets rewrites propose structural edits without also re-defining runtime semantics.
+- It gives downstream systems a clear extension point: register nodes, contracts, and host actions
+  around the substrate instead of modifying the topology model itself.
 
-The extension rule is correspondingly strict: host systems extend by supplying
-registered authority around the substrate. They do not fork Graph semantics,
-and they should not use Circuit as a hiding place for product policy.
+The extension rule is correspondingly strict: host systems extend by supplying registered authority
+around the substrate. They do not fork Graph semantics, and they should not use Circuit as a hiding
+place for product policy.
 
 ## Related
 
 - [./03-formalism-stack.md](./03-formalism-stack.md) — the algebra, Mokhov's laws, proofs.
 - [./05-wire-language.md](./05-wire-language.md) — Wire as source language; contract registry.
-- [./06-pulse-runtime.md](./06-pulse-runtime.md) — durable scheduling and execution over a compiled Circuit.
-- [./07-rewrites-and-materialization.md](./07-rewrites-and-materialization.md) — dynamic rewrites admitted during execution.
-- [./08-artifacts-and-provenance.md](./08-artifacts-and-provenance.md) — envelopes and payload kinds on edges.
+- [./06-pulse-runtime.md](./06-pulse-runtime.md) — durable scheduling and execution over a compiled
+  Circuit.
+- [./07-rewrites-and-materialization.md](./07-rewrites-and-materialization.md) — dynamic rewrites
+  admitted during execution.
+- [./08-artifacts-and-provenance.md](./08-artifacts-and-provenance.md) — envelopes and payload kinds
+  on edges.
 - [./02-ownership-and-boundaries.md](./02-ownership-and-boundaries.md) — Cortex ↔ host boundary.
 - [../Reference/terminology.md](../Reference/terminology.md) — normative vocabulary.
 - [../Reference/Wire/grammar.md](../Reference/Wire/grammar.md) — Wire normative grammar.

--- a/docs/Architecture/05-wire-language.md
+++ b/docs/Architecture/05-wire-language.md
@@ -1,6 +1,8 @@
 ---
 title: "Chapter 05 — Wire Language"
-description: "Source-language architecture for Wire. Explains what Wire adds above Graph and Circuit, how it composes registered authority, and how it hands executable topology to Circuit and Pulse."
+description:
+  "Source-language architecture for Wire. Explains what Wire adds above Graph and Circuit, how it
+  composes registered authority, and how it hands executable topology to Circuit and Pulse."
 sidebar:
   label: "05. Wire language"
   order: 5
@@ -9,31 +11,29 @@ status: active
 
 # Chapter 05 — Wire Language
 
-Chapters 03 and 04 establish the algebraic and structural substrate. This
-chapter explains what Wire adds on top: an author-facing language for composing
-registered authority into executable topology, and a rewrite surface for
-proposing bounded structural change over the same model.
+Chapters 03 and 04 establish the algebraic and structural substrate. This chapter explains what Wire
+adds on top: an author-facing language for composing registered authority into executable topology,
+and a rewrite surface for proposing bounded structural change over the same model.
 
-Wire is not where Cortex defines new runtime authority. It is where authors and
-agents compose authority that has already been registered elsewhere.
+Wire is not where Cortex defines new runtime authority. It is where authors and agents compose
+authority that has already been registered elsewhere.
 
 ## Relationship to the reference
 
-This chapter is architectural. It explains what Wire is for and how it fits
-into Cortex.
+This chapter is architectural. It explains what Wire is for and how it fits into Cortex.
 
 The normative rules live in the reference:
 
-- [Wire Grammar](../Reference/Wire/grammar.md) — grammar, precedence,
-  type surface, composition semantics
-- [Contracts, ports, and matching](../Reference/Wire/contracts-ports-and-matching.md) —
-  contract namespace, port declarations, `=>` matching
-- [Partials and execution boundary](../Reference/Wire/partials-and-execution-boundary.md) —
-  partial nodes, port-determined rule, runnable-wire boundary
-- [Rewrites](../Reference/rewrites.md) — bounded dynamic rewrite algebra,
-  budget, admission, materialization, provenance
-- [Modules, imports, and file returns](../Reference/Wire/modules-imports-and-file-returns.md) —
-  file structure and import model
+- [Wire Grammar](../Reference/Wire/grammar.md) — grammar, precedence, type surface, composition
+  semantics
+- [Contracts, ports, and matching](../Reference/Wire/contracts-ports-and-matching.md) — contract
+  namespace, port declarations, `=>` matching
+- [Partials and execution boundary](../Reference/Wire/partials-and-execution-boundary.md) — partial
+  nodes, port-determined rule, runnable-wire boundary
+- [Rewrites](../Reference/rewrites.md) — bounded dynamic rewrite algebra, budget, admission,
+  materialization, provenance
+- [Modules, imports, and file returns](../Reference/Wire/modules-imports-and-file-returns.md) — file
+  structure and import model
 
 This chapter intentionally does not restate those rules in full.
 
@@ -44,12 +44,12 @@ Wire adds four things above the Graph and Circuit layers:
 - an authoring surface for naming nodes, declarations, and reusable values
 - endpoint-typed composition over registered contracts and ports
 - partial-node reuse and configuration layering
-- a rewrite surface that lets topology changes be proposed in the same
-  composition model used for initial authoring
+- a rewrite surface that lets topology changes be proposed in the same composition model used for
+  initial authoring
 
-Wire does not replace Graph or Circuit. It authors them. Graph remains the pure
-topology layer. Circuit remains the validated executable artifact. Wire is the
-surface that turns registered vocabulary into those artifacts.
+Wire does not replace Graph or Circuit. It authors them. Graph remains the pure topology layer.
+Circuit remains the validated executable artifact. Wire is the surface that turns registered
+vocabulary into those artifacts.
 
 ```mermaid
 flowchart LR
@@ -70,56 +70,52 @@ The implementation owns what that authority means.
 
 That yields three important consequences:
 
-- Wire may reference executors, contracts, prompts, tools, and config
-  constructors by name, but it does not define those authorities itself.
-- Composition meaning lives at endpoints, not on edges. Edges stay structurally
-  simple; contracts and ports determine whether a connection is valid.
-- Domain semantics stay downstream. Cortex provides the language and substrate;
-  host systems supply domain-specific vocabularies and policy.
+- Wire may reference executors, contracts, prompts, tools, and config constructors by name, but it
+  does not define those authorities itself.
+- Composition meaning lives at endpoints, not on edges. Edges stay structurally simple; contracts
+  and ports determine whether a connection is valid.
+- Domain semantics stay downstream. Cortex provides the language and substrate; host systems supply
+  domain-specific vocabularies and policy.
 
 ## Registered authority
 
-Wire is deliberately closed over authority. The language assumes an external
-registry surface for:
+Wire is deliberately closed over authority. The language assumes an external registry surface for:
 
 - executors
 - contracts
 - tool names and config constructors
 - payload codecs, validation, and rendering rules
 
-That closure is what keeps autonomous authoring and rewrites tractable. A Wire
-program can only compose within a known vocabulary. It cannot invent a new
-executor, contract, or tool at compile time.
+That closure is what keeps autonomous authoring and rewrites tractable. A Wire program can only
+compose within a known vocabulary. It cannot invent a new executor, contract, or tool at compile
+time.
 
-This is also where the downstream boundary stays clean. A host system extends
-Cortex by registering its own domain vocabulary around Wire rather than by
-changing Wire semantics.
+This is also where the downstream boundary stays clean. A host system extends Cortex by registering
+its own domain vocabulary around Wire rather than by changing Wire semantics.
 
 ## Boundary typing
 
-Wire composes through endpoint compatibility rather than through semantic edge
-labels.
+Wire composes through endpoint compatibility rather than through semantic edge labels.
 
 - ports declare what a node can accept or produce
 - contracts name the semantic interface flowing through those ports
 - `=>` connects compatible boundary ports
-- payload validation and rendering happen in the contract registry and runtime
-  surfaces, not in the graph operator itself
+- payload validation and rendering happen in the contract registry and runtime surfaces, not in the
+  graph operator itself
 
-This is why Wire can stay structurally simple while still carrying meaningful
-types. The language reasons about compatibility at the boundary. Rich payload
-meaning lives outside the composition algebra.
+This is why Wire can stay structurally simple while still carrying meaningful types. The language
+reasons about compatibility at the boundary. Rich payload meaning lives outside the composition
+algebra.
 
-One practical design rule follows from this split: use ports for stable
-structural roles, not for encoding graph-discovered collections. When a node
-aggregates a variable number of homogeneous fragments, the structural shape
-should usually be "many fragments of one contract" rather than "one separately
-named port per expected fragment."
+One practical design rule follows from this split: use ports for stable structural roles, not for
+encoding graph-discovered collections. When a node aggregates a variable number of homogeneous
+fragments, the structural shape should usually be "many fragments of one contract" rather than "one
+separately named port per expected fragment."
 
 ## Partial nodes and reuse
 
-Wire's reuse surface is the partial node: a configured executor value whose
-remaining structural choices are pinned later.
+Wire's reuse surface is the partial node: a configured executor value whose remaining structural
+choices are pinned later.
 
 The canonical authored unit is:
 
@@ -127,9 +123,9 @@ The canonical authored unit is:
 node = ports + executor(config)
 ```
 
-Ports stay first-class because the graph type-checker reasons about them.
-Everything behavioral belongs in executor config: prompt, tools, memory, model
-choice, timeouts, budgets, and domain-specific fields.
+Ports stay first-class because the graph type-checker reasons about them. Everything behavioral
+belongs in executor config: prompt, tools, memory, model choice, timeouts, budgets, and
+domain-specific fields.
 
 ```wire
 let section_writer_base = @native.report_section_writer {
@@ -146,29 +142,27 @@ node valuation_writer :
 };
 ```
 
-Rewrite producers use the same explicit `node ... = @executor { ... };` form as
-authored workflows. There is no separate template-use syntax in the Wire
-surface.
+Rewrite producers use the same explicit `node ... = @executor { ... };` form as authored workflows.
+There is no separate template-use syntax in the Wire surface.
 
 Architecturally, this matters for two reasons:
 
 - it keeps reuse inside the same value algebra as the rest of the language
-- it lets rewrites instantiate new nodes by authoring bounded executor configs
-  against already-registered authority
+- it lets rewrites instantiate new nodes by authoring bounded executor configs against
+  already-registered authority
 
-The precise typing rules for partial nodes belong in the reference. The
-architectural point is that reuse is compositional rather than template-like.
+The precise typing rules for partial nodes belong in the reference. The architectural point is that
+reuse is compositional rather than template-like.
 
-Workflow-level config may also provide defaults for executor config, for
-example default models or per-executor model policy on a runtime wrapper.
-Those defaults only fill gaps; an explicit field authored on a node remains
-authoritative.
+Workflow-level config may also provide defaults for executor config, for example default models or
+per-executor model policy on a runtime wrapper. Those defaults only fill gaps; an explicit field
+authored on a node remains authoritative.
 
 ## Rewrites and runtime handoff
 
-Wire is also the authoring surface for runtime topology evolution. A rewrite is
-not a different kind of object from the initial graph; it is another
-composition over the same registered vocabulary and compatibility rules.
+Wire is also the authoring surface for runtime topology evolution. A rewrite is not a different kind
+of object from the initial graph; it is another composition over the same registered vocabulary and
+compatibility rules.
 
 The generic pattern is:
 
@@ -176,9 +170,8 @@ The generic pattern is:
 Plan -> WorkItem* -> Fragment* -> Aggregate
 ```
 
-The mutable part is the realized topology and the node configuration, not the
-core composition law. That is why dynamic decomposition can stay bounded and
-checkable.
+The mutable part is the realized topology and the node configuration, not the core composition law.
+That is why dynamic decomposition can stay bounded and checkable.
 
 Wire does not admit rewrites by itself. The handoff is:
 
@@ -186,13 +179,13 @@ Wire does not admit rewrites by itself. The handoff is:
 - Circuit validates that the structure is still executable
 - Pulse decides admission, budgeting, materialization, and resume behavior
 
-That boundary keeps the language small. Wire describes candidate topology.
-Pulse owns runtime policy.
+That boundary keeps the language small. Wire describes candidate topology. Pulse owns runtime
+policy.
 
 ## Downstream bindings
 
-A consumer may register its own vocabulary around Wire, but it should not make
-Wire itself product-specific.
+A consumer may register its own vocabulary around Wire, but it should not make Wire itself
+product-specific.
 
 Downstream bindings own:
 
@@ -204,20 +197,17 @@ Cortex still owns the source language, composition rules, and substrate runtime.
 
 ## Related
 
-- [Chapter 01 — Overview](01-overview.md) — system overview and high-level
-  boundary
-- [Chapter 04 — Graph and Circuit](04-graph-and-circuit.md) — the structural
-  layers Wire authors
-- [Chapter 06 — Pulse runtime](06-pulse-runtime.md) — durable execution over
-  Circuits
-- [Chapter 07 — Rewrites and materialization](07-rewrites-and-materialization.md) —
-  runtime admission and realized topology
-- [Chapter 08 — Artifacts and provenance](08-artifacts-and-provenance.md) —
-  payload, artifact, and provenance surfaces
-- [ADR 0018 — Wire Executor and Port Catalog Boundary](../ADRs/0018-wire-executor-and-port-catalog-boundary.md) —
-  contract, port, executor, and binding separation
-- [ADR 0019 — Wire Pure Nodes](../ADRs/0019-wire-pure-nodes.md) —
-  deterministic expression nodes and same-contract labels
+- [Chapter 01 — Overview](01-overview.md) — system overview and high-level boundary
+- [Chapter 04 — Graph and Circuit](04-graph-and-circuit.md) — the structural layers Wire authors
+- [Chapter 06 — Pulse runtime](06-pulse-runtime.md) — durable execution over Circuits
+- [Chapter 07 — Rewrites and materialization](07-rewrites-and-materialization.md) — runtime
+  admission and realized topology
+- [Chapter 08 — Artifacts and provenance](08-artifacts-and-provenance.md) — payload, artifact, and
+  provenance surfaces
+- [ADR 0018 — Wire Executor and Port Catalog Boundary](../ADRs/0018-wire-executor-and-port-catalog-boundary.md)
+  — contract, port, executor, and binding separation
+- [ADR 0019 — Wire Pure Nodes](../ADRs/0019-wire-pure-nodes.md) — deterministic expression nodes and
+  same-contract labels
 - [Wire Grammar](../Reference/Wire/grammar.md) — normative grammar
 - [Cortex Terminology](../Reference/terminology.md) — accepted vocabulary
 - [Consumer examples](../Consumers/) — downstream binding examples

--- a/docs/Architecture/06-pulse-runtime.md
+++ b/docs/Architecture/06-pulse-runtime.md
@@ -1,6 +1,8 @@
 ---
 title: "Chapter 06 — Pulse Runtime"
-description: "The durable runtime that executes Circuits. Service boundary, runtime model, Pulse-owned state, stage execution mechanics, and the host-action contract consumers use to extend Pulse."
+description:
+  "The durable runtime that executes Circuits. Service boundary, runtime model, Pulse-owned state,
+  stage execution mechanics, and the host-action contract consumers use to extend Pulse."
 sidebar:
   label: "06. Pulse runtime"
   order: 6
@@ -9,49 +11,44 @@ status: active
 
 # Chapter 06 — Pulse Runtime
 
-Pulse is the durable runtime that executes Circuits. It is the mechanical
-realization of the Circuit semantics laid out in chapters 03 and 04: a
-standalone service that owns scheduling, stage execution, checkpoint
-persistence, cancellation, lease recovery, and rewrite materialization for
-long-lived Cortex runs. This chapter covers the runtime model, Pulse-owned
-state, stage execution, the memory surface, and the contract Pulse presents
-to downstream consumers. The contract is generic; consumer-specific bindings
-live outside the substrate.
+Pulse is the durable runtime that executes Circuits. It is the mechanical realization of the Circuit
+semantics laid out in chapters 03 and 04: a standalone service that owns scheduling, stage
+execution, checkpoint persistence, cancellation, lease recovery, and rewrite materialization for
+long-lived Cortex runs. This chapter covers the runtime model, Pulse-owned state, stage execution,
+the memory surface, and the contract Pulse presents to downstream consumers. The contract is
+generic; consumer-specific bindings live outside the substrate.
 
-If you are evaluating Cortex rather than implementing against Pulse directly,
-the core model and service boundary are the key sections. The later sections
-spell out the runtime mechanics in detail.
+If you are evaluating Cortex rather than implementing against Pulse directly, the core model and
+service boundary are the key sections. The later sections spell out the runtime mechanics in detail.
 
 Wire source examples on this page use the canonical grammar. The normative grammar is
-[`../Reference/Wire/grammar.md`](../Reference/Wire/grammar.md); the
-substrate story is [`./05-wire-language.md`](./05-wire-language.md).
+[`../Reference/Wire/grammar.md`](../Reference/Wire/grammar.md); the substrate story is
+[`./05-wire-language.md`](./05-wire-language.md).
 
 ## Core model
 
-Pulse is a runtime, not an algebra. It interprets a compiled Circuit as a
-sequence of stage transitions and records each transition durably. Every
-stage boundary has a persisted checkpoint; every resume is a pure function
-of persisted state. The service owns six concerns:
+Pulse is a runtime, not an algebra. It interprets a compiled Circuit as a sequence of stage
+transitions and records each transition durably. Every stage boundary has a persisted checkpoint;
+every resume is a pure function of persisted state. The service owns six concerns:
 
-| Concern                         | Role                                                                       |
-|---------------------------------|----------------------------------------------------------------------------|
-| Scheduling                      | Own due-task discovery, CAS claim, cron advancement, lease recovery.       |
-| Stage execution                 | Drive a Circuit's stage plan forward, one admitted transition at a time.   |
-| Checkpoint persistence          | Write a versioned envelope at every stage boundary. Validate on resume.    |
-| Cancellation                    | Propagate a cancel request to the executor and finalize at safe boundaries.|
-| Rewrite materialization         | Atomically admit, apply, and record structural rewrites during a run.      |
-| Observability                   | Emit lifecycle and per-stage events; expose run detail through a service API. |
+| Concern                 | Role                                                                          |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| Scheduling              | Own due-task discovery, CAS claim, cron advancement, lease recovery.          |
+| Stage execution         | Drive a Circuit's stage plan forward, one admitted transition at a time.      |
+| Checkpoint persistence  | Write a versioned envelope at every stage boundary. Validate on resume.       |
+| Cancellation            | Propagate a cancel request to the executor and finalize at safe boundaries.   |
+| Rewrite materialization | Atomically admit, apply, and record structural rewrites during a run.         |
+| Observability           | Emit lifecycle and per-stage events; expose run detail through a service API. |
 
-Pulse does not define task semantics. Consumers register task types and
-provide the stage actions; Pulse executes them. The generic contract is
-captured in [`../Reference/Pulse/`](../Reference/Pulse/). Consumer-specific
-bindings live under [`../Consumers/`](../Consumers/).
+Pulse does not define task semantics. Consumers register task types and provide the stage actions;
+Pulse executes them. The generic contract is captured in
+[`../Reference/Pulse/`](../Reference/Pulse/). Consumer-specific bindings live under
+[`../Consumers/`](../Consumers/).
 
 ## Service boundary
 
-Pulse runs as its own service with its own DB schema. Consumers talk to
-Pulse through HTTP. When Pulse needs domain work, it calls the consumer
-back through a host-action API the consumer provides.
+Pulse runs as its own service with its own DB schema. Consumers talk to Pulse through HTTP. When
+Pulse needs domain work, it calls the consumer back through a host-action API the consumer provides.
 
 ```mermaid
 flowchart LR
@@ -74,226 +71,200 @@ flowchart LR
 
 The boundary is strict:
 
-- **Pulse owns** task definitions, runs, checkpoints, stage log, stage attempt log, scheduling, leases, cancellation flags, and run lifecycle.
-- **The consumer owns** domain state and operator surfaces. It writes its own tables only through its own APIs.
-- **Neither side reads the other's tables.** Pulse fetches domain context through host actions; consumers fetch run state through Pulse's API.
+- **Pulse owns** task definitions, runs, checkpoints, stage log, stage attempt log, scheduling,
+  leases, cancellation flags, and run lifecycle.
+- **The consumer owns** domain state and operator surfaces. It writes its own tables only through
+  its own APIs.
+- **Neither side reads the other's tables.** Pulse fetches domain context through host actions;
+  consumers fetch run state through Pulse's API.
 
-Co-locating both schemas in a single PostgreSQL cluster is an operational shortcut. The service-API-first contract means migrating to separate databases is cheap.
+Co-locating both schemas in a single PostgreSQL cluster is an operational shortcut. The
+service-API-first contract means migrating to separate databases is cheap.
 
-Endpoint shapes, authentication, and idempotency rules live in [`../Reference/Pulse/service-api.md`](../Reference/Pulse/service-api.md).
+Endpoint shapes, authentication, and idempotency rules live in
+[`../Reference/Pulse/service-api.md`](../Reference/Pulse/service-api.md).
 
 ## Runtime model
 
 ### Process
 
-Pulse runs as a standalone daemon under a process supervisor. It exposes a
-health endpoint, recovers stale leases on startup, and restarts without
-affecting the consumer's own processes.
+Pulse runs as a standalone daemon under a process supervisor. It exposes a health endpoint, recovers
+stale leases on startup, and restarts without affecting the consumer's own processes.
 
 ### Scheduling
 
-Pulse owns its scheduler. The poll loop discovers due tasks, claims them
-with a CAS flag on the task row, creates a run, and advances the schedule
-— all within Pulse-owned storage. No consumer table participates in
-scheduling. The claim flag prevents double-claiming without overloading
+Pulse owns its scheduler. The poll loop discovers due tasks, claims them with a CAS flag on the task
+row, creates a run, and advances the schedule — all within Pulse-owned storage. No consumer table
+participates in scheduling. The claim flag prevents double-claiming without overloading
 `next_run_at` semantics; see
 [`../Reference/Pulse/schema.md`](../Reference/Pulse/schema.md#2-task-definitions).
 
 ### Concurrent execution
 
-Pulse runs up to N concurrent task runs per process, bounded by a shared
-pool. Each cycle of the poll loop reaps finished runs, fills remaining
-slots, and updates health counters. Per-task-type caps prevent any one
-task type from starving others; unconfigured types share the remaining
-global capacity.
+Pulse runs up to N concurrent task runs per process, bounded by a shared pool. Each cycle of the
+poll loop reaps finished runs, fills remaining slots, and updates health counters. Per-task-type
+caps prevent any one task type from starving others; unconfigured types share the remaining global
+capacity.
 
-Ordinary-node execution runs concurrently across the frontier. Rewrite
-proposals may also arise from multiple frontier nodes in the same wave, but
-rewrite admission is still deterministic rather than fully concurrent in the
-strong semantic sense: proposals are admitted through a shared admission gate
-and shared remaining-budget state, then materialized in deterministic order
-after frontier classification. See
-[chapter 07](./07-rewrites-and-materialization.md) for the admission contract.
+Ordinary-node execution runs concurrently across the frontier. Rewrite proposals may also arise from
+multiple frontier nodes in the same wave, but rewrite admission is still deterministic rather than
+fully concurrent in the strong semantic sense: proposals are admitted through a shared admission
+gate and shared remaining-budget state, then materialized in deterministic order after frontier
+classification. See [chapter 07](./07-rewrites-and-materialization.md) for the admission contract.
 
 ### Lifecycle
 
-- **Startup.** Connect to the database, verify schema, recover stale runs
-  by resuming from their last completed checkpoint, start the scheduler
-  and the health endpoint.
-- **Shutdown.** On SIGTERM, stop claiming new work, drain in-flight runs
-  at a tight poll interval, finalize each completed run, and exit.
-- **Unclean exit.** On SIGKILL or crash, the next startup re-reads the
-  last completed checkpoint and re-executes the incomplete stage.
+- **Startup.** Connect to the database, verify schema, recover stale runs by resuming from their
+  last completed checkpoint, start the scheduler and the health endpoint.
+- **Shutdown.** On SIGTERM, stop claiming new work, drain in-flight runs at a tight poll interval,
+  finalize each completed run, and exit.
+- **Unclean exit.** On SIGKILL or crash, the next startup re-reads the last completed checkpoint and
+  re-executes the incomplete stage.
 
 ### Run identity and operator verbs
 
-A run is the unit of durable execution identity. Checkpoints belong to a
-run. This principle determines the semantics of every operator action:
+A run is the unit of durable execution identity. Checkpoints belong to a run. This principle
+determines the semantics of every operator action:
 
-| Verb       | Meaning                                         | Implementation                                                                       |
-|------------|-------------------------------------------------|--------------------------------------------------------------------------------------|
-| **Resume** | Continue the same run after crash or lease loss.| Scheduler reclaim path — same `run_id`, same checkpoint lineage.                     |
-| **Retry**  | Start a fresh execution.                        | New `run_id`, links to parent via `parent_run_id`, no checkpoint inheritance.        |
-| **Cancel** | Request graceful termination.                   | Sets `cancel_requested_at`; executor checks at stage boundaries.                     |
+| Verb       | Meaning                                          | Implementation                                                                |
+| ---------- | ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| **Resume** | Continue the same run after crash or lease loss. | Scheduler reclaim path — same `run_id`, same checkpoint lineage.              |
+| **Retry**  | Start a fresh execution.                         | New `run_id`, links to parent via `parent_run_id`, no checkpoint inheritance. |
+| **Cancel** | Request graceful termination.                    | Sets `cancel_requested_at`; executor checks at stage boundaries.              |
 
-Resume is not an operator action — it happens automatically when the
-scheduler reclaims a run whose lease has expired. Any future
-"restart from checkpoint" or "branch from run" capability would be modeled
-as a distinct Tier 2 operation with explicit version compatibility checks
-and side-effect fencing, not as a variant of retry.
+Resume is not an operator action — it happens automatically when the scheduler reclaims a run whose
+lease has expired. Any future "restart from checkpoint" or "branch from run" capability would be
+modeled as a distinct Tier 2 operation with explicit version compatibility checks and side-effect
+fencing, not as a variant of retry.
 
 ## Stage execution
 
 ### Typed stage identity
 
-Each stage in a Pulse run has a stable text identity. For linear plans,
-the stage kind and the durable identity coincide. For rewrite-capable
-runs, identity splits into four typed ids — `NodeId`, `stageId`,
-`StageTemplateId`, `StageActionId` — so that rewritten nodes bind to the
-intended runtime action on resume. The split is specified in
+Each stage in a Pulse run has a stable text identity. For linear plans, the stage kind and the
+durable identity coincide. For rewrite-capable runs, identity splits into four typed ids — `NodeId`,
+`stageId`, `StageTemplateId`, `StageActionId` — so that rewritten nodes bind to the intended runtime
+action on resume. The split is specified in
 [`../Reference/Pulse/types.md`](../Reference/Pulse/types.md#3-stage-identity).
 
 ### Stage plans
 
-The executor operates on a `StagePlan`: a typed container for a task's
-executable dependency graph, its initial state, the replay policy, the
-runtime version, and the initial rewrite budget. Each node carries a
-`StageDefinition` that names the stage kind, its template, its action, its
-replay safety, and optional per-stage timeout and retry policy. Shapes are
-in [`../Reference/Pulse/types.md`](../Reference/Pulse/types.md#4-stage-plan).
+The executor operates on a `StagePlan`: a typed container for a task's executable dependency graph,
+its initial state, the replay policy, the runtime version, and the initial rewrite budget. Each node
+carries a `StageDefinition` that names the stage kind, its template, its action, its replay safety,
+and optional per-stage timeout and retry policy. Shapes are in
+[`../Reference/Pulse/types.md`](../Reference/Pulse/types.md#4-stage-plan).
 
-`spCheckpointRuntimeVersion` is embedded in checkpoint envelopes and
-validated on resume. Bumping it after a breaking stage-plan change causes
-in-flight runs to fail cleanly instead of resuming against incompatible
-code.
+`spCheckpointRuntimeVersion` is embedded in checkpoint envelopes and validated on resume. Bumping it
+after a breaking stage-plan change causes in-flight runs to fail cleanly instead of resuming against
+incompatible code.
 
 ### Replay safety
 
-Each stage declares its replay safety: `SafeToReplay` or `Irreversible`.
-Irreversible stages (persistence writes, external trade execution) have
-side effects that cannot be undone. The executor emits a warning event if
-it detects a prior stage-log entry for an `Irreversible` stage during
+Each stage declares its replay safety: `SafeToReplay` or `Irreversible`. Irreversible stages
+(persistence writes, external trade execution) have side effects that cannot be undone. The executor
+emits a warning event if it detects a prior stage-log entry for an `Irreversible` stage during
 resume, since the side effect may have partially completed.
 
 ### Retry
 
-Per-stage retry policies name a serialized retryability predicate, a max
-attempt count, a backoff schedule (fixed or exponential, capped), and an
-exhaustion policy (fail the run, or skip the stage). Each attempt is
-recorded in `pulse.stage_attempt_log`. Cancellation and shutdown checks
-run between retries.
+Per-stage retry policies name a serialized retryability predicate, a max attempt count, a backoff
+schedule (fixed or exponential, capped), and an exhaustion policy (fail the run, or skip the stage).
+Each attempt is recorded in `pulse.stage_attempt_log`. Cancellation and shutdown checks run between
+retries.
 
-Per-stage `sdTimeoutSeconds` takes precedence over the task-level timeout
-when set.
+Per-stage `sdTimeoutSeconds` takes precedence over the task-level timeout when set.
 
 ### Mandatory checkpoints
 
-The executor rejects a stage transition that does not include a
-checkpoint write. Every stage boundary has a persisted
-`CheckpointEnvelope`, even when the task completes successfully without
+The executor rejects a stage transition that does not include a checkpoint write. Every stage
+boundary has a persisted `CheckpointEnvelope`, even when the task completes successfully without
 needing resume. This enforces serialization discipline from day one.
 
 ### Resume
 
-On resume, Pulse parses the raw checkpoint payload into a
-`CheckpointEnvelope` and validates format, task type, task version, and
-runtime version against the current code. A mismatch produces a
-`checkpoint_incompatible` failure — the run fails non-retryably rather
-than silently resuming against changed code. The executor then extracts
-the last completed stage and its state, skips up to that stage, warns if
-the next stage is `Irreversible` with a prior entry, and resumes from
-the next stage. Host-action results needed for remaining stages come
-from the checkpoint state, not by re-calling the host action.
+On resume, Pulse parses the raw checkpoint payload into a `CheckpointEnvelope` and validates format,
+task type, task version, and runtime version against the current code. A mismatch produces a
+`checkpoint_incompatible` failure — the run fails non-retryably rather than silently resuming
+against changed code. The executor then extracts the last completed stage and its state, skips up to
+that stage, warns if the next stage is `Irreversible` with a prior entry, and resumes from the next
+stage. Host-action results needed for remaining stages come from the checkpoint state, not by
+re-calling the host action.
 
 ### Current rewrite contract
 
-Pulse owns where rewrite admission happens in the runtime loop, but it does not
-own the rewrite contract in full. The current runtime admits bounded,
-fail-fast rewrites during execution and persists enough anchor state to resume
-correctly after admission. The full contract — rewrite forms, gas, admission
-policy, materialization, and structural provenance — belongs to
+Pulse owns where rewrite admission happens in the runtime loop, but it does not own the rewrite
+contract in full. The current runtime admits bounded, fail-fast rewrites during execution and
+persists enough anchor state to resume correctly after admission. The full contract — rewrite forms,
+gas, admission policy, materialization, and structural provenance — belongs to
 [Chapter 07](./07-rewrites-and-materialization.md).
 
 ## Topological memory
 
-Topological memory currently lives near Pulse because it queries Pulse event
-state. ADR 0017 makes the canonical target `Cortex.Nous.Memory.Topological`:
-Pulse remains the durable event/checkpoint substrate, while Nous owns the API
-that shapes settled graph state into model context.
+Topological memory currently lives near Pulse because it queries Pulse event state. ADR 0017 makes
+the canonical target `Cortex.Nous.Memory.Topological`: Pulse remains the durable event/checkpoint
+substrate, while Nous owns the API that shapes settled graph state into model context.
 
-The split is **Pulse stores, Nous shapes**. Pulse persists the event substrate,
-frontier, checkpoints, materialized outputs, and snapshots that make the query
-deterministic. Nous owns the context-construction API that walks those settled
-outputs, scores them, packs them, and exposes them to a model-mediated thought.
+The split is **Pulse stores, Nous shapes**. Pulse persists the event substrate, frontier,
+checkpoints, materialized outputs, and snapshots that make the query deterministic. Nous owns the
+context-construction API that walks those settled outputs, scores them, packs them, and exposes them
+to a model-mediated thought.
 
-Memory is a query, not a store. A stage's view of upstream context is derived
-from the Pulse event substrate, scored by a composite of graph influence,
-wall-clock distance, and a pluggable semantic score. There is no parallel
-claim-assertion table; the substrate is already indexed by node, by completion
-time, and by output schema, and it is already append-only.
+Memory is a query, not a store. A stage's view of upstream context is derived from the Pulse event
+substrate, scored by a composite of graph influence, wall-clock distance, and a pluggable semantic
+score. There is no parallel claim-assertion table; the substrate is already indexed by node, by
+completion time, and by output schema, and it is already append-only.
 
 ### Three graphs
 
 A running Circuit at any moment contains three graphs:
 
-- **Past** — settled nodes (`NodeCompleted`, `NodeSkipped`, `NodeRewritten`)
-  with materialized outputs. This is the Pulse-owned source state that Nous
-  memory may surface for domain queries.
-- **Present** — the current frontier. Running and waiting nodes are
-  deliberately excluded from memory: there is no observable artifact yet,
-  and including them would leak sibling context into a stage that is
-  supposed to run blind of its peers.
-- **Future** — not-yet-materialized descendants and latent rewrites.
-  Absent from memory by construction.
+- **Past** — settled nodes (`NodeCompleted`, `NodeSkipped`, `NodeRewritten`) with materialized
+  outputs. This is the Pulse-owned source state that Nous memory may surface for domain queries.
+- **Present** — the current frontier. Running and waiting nodes are deliberately excluded from
+  memory: there is no observable artifact yet, and including them would leak sibling context into a
+  stage that is supposed to run blind of its peers.
+- **Future** — not-yet-materialized descendants and latent rewrites. Absent from memory by
+  construction.
 
-The `WalkScope` type reflects this split: `SettledOnly` for domain code;
-`DebugAllStatuses` for operator inspection surfaces. Even when widened, the Nous
-scoring stage drops nodes without materialized payloads, so widening never
-surfaces live-only statuses as memory matches.
+The `WalkScope` type reflects this split: `SettledOnly` for domain code; `DebugAllStatuses` for
+operator inspection surfaces. Even when widened, the Nous scoring stage drops nodes without
+materialized payloads, so widening never surfaces live-only statuses as memory matches.
 
 ### Stage-entry snapshot binding
 
-The past/present split is enforced by binding one snapshot per stage
-attempt. At stage entry the executor captures a `MemorySnapshot` over the
-graph state, completion timestamps, and topology in one STM transaction,
-and every `queryMemory` call on that stage's handle returns results
-computed against that bound snapshot. Mid-attempt writes — a sibling
-settling while this stage is still executing — are invisible to the bound
-handle. The next stage's entry fires a new capture that does observe
-them. Re-execution after a rejected rewrite is treated as a fresh stage
-entry: a new handle is bound.
+The past/present split is enforced by binding one snapshot per stage attempt. At stage entry the
+executor captures a `MemorySnapshot` over the graph state, completion timestamps, and topology in
+one STM transaction, and every `queryMemory` call on that stage's handle returns results computed
+against that bound snapshot. Mid-attempt writes — a sibling settling while this stage is still
+executing — are invisible to the bound handle. The next stage's entry fires a new capture that does
+observe them. Re-execution after a rejected rewrite is treated as a fresh stage entry: a new handle
+is bound.
 
 ### Query pipeline
 
 `queryMemory` uses a fixed, deterministic pipeline:
 
-1. Enumerate reachable candidates by walk direction with BFS hop
-   distance.
-2. Compute DAG random-walk influence from the origin over the same
-   direction relation. Bidirectional walks evaluate both directions and
-   merge the influence maps with `max`.
+1. Enumerate reachable candidates by walk direction with BFS hop distance.
+2. Compute DAG random-walk influence from the origin over the same direction relation. Bidirectional
+   walks evaluate both directions and merge the influence maps with `max`.
 3. Apply the hard graph-distance cutoff as a pre-filter only.
 4. Drop candidates without materialized payloads.
 5. Apply the query extractor and routing-key filter.
-6. Score each survivor by graph influence, temporal distance, and the
-   configured semantic scorer.
+6. Score each survivor by graph influence, temporal distance, and the configured semantic scorer.
 7. Sort by `(score DESC, graphDistance ASC, NodeId ASC)`.
 8. Apply `limit` after sort.
 
-Graph influence replaced the older `1 / (1 + hops)` graph axis because
-hop count treats a node reached through many short paths the same as one
-reached through a single chain. Influence rewards merges and shared
-upstream structure without introducing an iterative fixed-point
-procedure.
+Graph influence replaced the older `1 / (1 + hops)` graph axis because hop count treats a node
+reached through many short paths the same as one reached through a single chain. Influence rewards
+merges and shared upstream structure without introducing an iterative fixed-point procedure.
 
 ### Per-node declaration
 
-Memory is a per-node property declared on the wire, not a global run
-setting. The `MemoryStrategy` ADT is the surface:
-`MemoryClassic` (the executor hands the stage exactly what its declared
-upstream produced) or `MemoryTopological cfg` (the stage runs a
-`queryMemory` walk at entry with the preset, routing-key filter, and
-top-N limit from `cfg`). Wire grammar:
+Memory is a per-node property declared on the wire, not a global run setting. The `MemoryStrategy`
+ADT is the surface: `MemoryClassic` (the executor hands the stage exactly what its declared upstream
+produced) or `MemoryTopological cfg` (the stage runs a `queryMemory` walk at entry with the preset,
+routing-key filter, and top-N limit from `cfg`). Wire grammar:
 
 ```wire
 node reviewer :
@@ -308,23 +279,19 @@ node reviewer :
 };
 ```
 
-Short form `memory = classic;` is equivalent to omitting the field.
-Changing strategy does not subsume classic — it remains a legitimate
-choice, and its local-causality guarantee is the reason many stages
-should keep it.
+Short form `memory = classic;` is equivalent to omitting the field. Changing strategy does not
+subsume classic — it remains a legitimate choice, and its local-causality guarantee is the reason
+many stages should keep it.
 
 ### Reviewer retrieval
 
-The current reviewer contract is pull-based. Under `MemoryClassic`, the
-reviewer sees only its direct inputs and runs as a normal single-shot
-stage. Under `MemoryTopological`, the prompt is still prefilled only
-with the direct-predecessor Markov boundary and the stage gets
-`cortex_memory_query` as an on-demand retrieval tool. This keeps the
-default prompt bounded while preserving access to sibling analysts and
-distant ancestors when the model explicitly asks for them.
+The current reviewer contract is pull-based. Under `MemoryClassic`, the reviewer sees only its
+direct inputs and runs as a normal single-shot stage. Under `MemoryTopological`, the prompt is still
+prefilled only with the direct-predecessor Markov boundary and the stage gets `cortex_memory_query`
+as an on-demand retrieval tool. This keeps the default prompt bounded while preserving access to
+sibling analysts and distant ancestors when the model explicitly asks for them.
 
-The full `MemoryStrategy` type, the scoring pipeline, and the
-determinism contract are in
+The full `MemoryStrategy` type, the scoring pipeline, and the determinism contract are in
 [`../Reference/Pulse/types.md`](../Reference/Pulse/types.md#6-memory-strategy).
 
 ## Cancellation
@@ -333,74 +300,67 @@ Cancellation is Pulse-owned state. The protocol:
 
 1. The consumer's operator surface calls Pulse's cancel endpoint.
 2. Pulse sets `cancel_requested_at` on the run row.
-3. The executor checks the flag at every stage transition, between
-   tool-loop steps within a stage, and before any irreversible host
-   action.
-4. On cancel, the current stage completes or is abandoned at the next
-   safe boundary, a checkpoint is written at the last completed stage,
-   the run is transitioned to `cancelled` with a reason, and the
-   schedule advances normally.
+3. The executor checks the flag at every stage transition, between tool-loop steps within a stage,
+   and before any irreversible host action.
+4. On cancel, the current stage completes or is abandoned at the next safe boundary, a checkpoint is
+   written at the last completed stage, the run is transitioned to `cancelled` with a reason, and
+   the schedule advances normally.
 
-Only Pulse transitions runs to terminal states. Consumers never write
-Pulse run state directly.
+Only Pulse transitions runs to terminal states. Consumers never write Pulse run state directly.
 
 ## Observability
 
-Pulse emits structured events on lifecycle transitions: run start, run
-complete, run fail, lease loss, schedule advance, and per-stage
-completion. Event fields include `run_id`, `task_id`, `task_type`,
-`trigger_source`, `checkpoint_name`, per-stage `duration_ms`, and on
-failure the `error_type` and `retryable` flag. Model-call and tool-call
-cost is tracked in Pulse's own usage records. The generic error taxonomy
-is in [`../Reference/Pulse/service-api.md`](../Reference/Pulse/service-api.md#6-error-taxonomy);
+Pulse emits structured events on lifecycle transitions: run start, run complete, run fail, lease
+loss, schedule advance, and per-stage completion. Event fields include `run_id`, `task_id`,
+`task_type`, `trigger_source`, `checkpoint_name`, per-stage `duration_ms`, and on failure the
+`error_type` and `retryable` flag. Model-call and tool-call cost is tracked in Pulse's own usage
+records. The generic error taxonomy is in
+[`../Reference/Pulse/service-api.md`](../Reference/Pulse/service-api.md#6-error-taxonomy);
 consumer-specific categories live with the consumer.
 
-The admin run-detail response surfaces the persisted node-state summary,
-remaining rewrite budget, applied rewrite watermark, rewrite history,
-per-rewrite structural delta, and for supported graph tasks the
-structured blocked and waiting sets.
+The admin run-detail response surfaces the persisted node-state summary, remaining rewrite budget,
+applied rewrite watermark, rewrite history, per-rewrite structural delta, and for supported graph
+tasks the structured blocked and waiting sets.
 
 ## Boundaries and invariants
 
 What this runtime enforces:
 
-- **Durability at every stage boundary.** No stage transition is admitted
-  without a checkpoint write. Resume is a pure function of persisted
-  state.
-- **Version compatibility.** Format, task, task-config, and runtime
-  versions on the checkpoint envelope must all match on resume. Mismatch
-  fails the run non-retryably.
-- **Clean service boundary.** Neither side reads the other's tables.
-  Pulse fetches domain context through the host-action contract;
-  consumers fetch run state through Pulse's service API.
-- **Single terminal-state writer.** Only Pulse transitions runs to
-  terminal states. Cancel is a request, not a mutation.
-- **Past/present isolation in memory.** Mid-stage frontier writes are
-  invisible to a stage's bound memory handle.
+- **Durability at every stage boundary.** No stage transition is admitted without a checkpoint
+  write. Resume is a pure function of persisted state.
+- **Version compatibility.** Format, task, task-config, and runtime versions on the checkpoint
+  envelope must all match on resume. Mismatch fails the run non-retryably.
+- **Clean service boundary.** Neither side reads the other's tables. Pulse fetches domain context
+  through the host-action contract; consumers fetch run state through Pulse's service API.
+- **Single terminal-state writer.** Only Pulse transitions runs to terminal states. Cancel is a
+  request, not a mutation.
+- **Past/present isolation in memory.** Mid-stage frontier writes are invisible to a stage's bound
+  memory handle.
 
-What Pulse does not enforce: task semantics, domain validation, payload
-kinds, and rewrite algebra — delegated to the Circuit layer, the
-contract registry, and the consumer's host actions.
+What Pulse does not enforce: task semantics, domain validation, payload kinds, and rewrite algebra —
+delegated to the Circuit layer, the contract registry, and the consumer's host actions.
 
 ## Extensibility
 
-New task kinds enter host-side: the host registers a handler and a
-versioned config decoder under a new `TaskKind` tag. New stage-plan features enter by bumping
-`spCheckpointRuntimeVersion` alongside a decoder migration. New memory
-strategies attach as additional `MemoryStrategy` constructors with their
-own wire syntax and executor dispatch. New error categories are added to
-the taxonomy with an explicit retryability classification. None of these
-require changes to the service boundary or the checkpoint envelope
-format.
+New task kinds enter host-side: the host registers a handler and a versioned config decoder under a
+new `TaskKind` tag. New stage-plan features enter by bumping `spCheckpointRuntimeVersion` alongside
+a decoder migration. New memory strategies attach as additional `MemoryStrategy` constructors with
+their own wire syntax and executor dispatch. New error categories are added to the taxonomy with an
+explicit retryability classification. None of these require changes to the service boundary or the
+checkpoint envelope format.
 
-Child workflows (spawn sub-runs, await completion) and true concurrent
-rewrite admission are the largest deferred extensions; the retained theory
-thread is the rewrite materialization and recovery plan.
+Child workflows (spawn sub-runs, await completion) and true concurrent rewrite admission are the
+largest deferred extensions; the retained theory thread is the rewrite materialization and recovery
+plan.
 
 ## Related
 
-- [./01-overview.md](./01-overview.md), [./03-formalism-stack.md](./03-formalism-stack.md), [./04-graph-and-circuit.md](./04-graph-and-circuit.md), [./07-rewrites-and-materialization.md](./07-rewrites-and-materialization.md), [./08-artifacts-and-provenance.md](./08-artifacts-and-provenance.md)
+- [./01-overview.md](./01-overview.md), [./03-formalism-stack.md](./03-formalism-stack.md),
+  [./04-graph-and-circuit.md](./04-graph-and-circuit.md),
+  [./07-rewrites-and-materialization.md](./07-rewrites-and-materialization.md),
+  [./08-artifacts-and-provenance.md](./08-artifacts-and-provenance.md)
 - [../Reference/Pulse/](../Reference/Pulse/) — schema, types, service API.
 - [../Reference/terminology.md](../Reference/terminology.md) — normative vocabulary.
 - [../Consumers/](../Consumers/) — downstream binding examples.
-- [../Roadmap/Plans/rewrite-materialization-and-recovery.md](../Roadmap/Plans/rewrite-materialization-and-recovery.md) — rewrite and recovery research plan.
+- [../Roadmap/Plans/rewrite-materialization-and-recovery.md](../Roadmap/Plans/rewrite-materialization-and-recovery.md)
+  — rewrite and recovery research plan.

--- a/docs/Architecture/07-rewrites-and-materialization.md
+++ b/docs/Architecture/07-rewrites-and-materialization.md
@@ -1,6 +1,8 @@
 ---
 title: "Chapter 07 — Rewrites and Materialization"
-description: "Bounded dynamic graph evolution during execution. Rewrite algebra, gas budgets, admission policy, materialization into durable state, provenance of rewrite events."
+description:
+  "Bounded dynamic graph evolution during execution. Rewrite algebra, gas budgets, admission policy,
+  materialization into durable state, provenance of rewrite events."
 sidebar:
   label: "07. Rewrites and materialization"
   order: 7
@@ -9,25 +11,36 @@ status: active
 
 # Chapter 07 — Rewrites and Materialization
 
-A static Circuit is enough only when the work is known at compile time. Planners discover a missing dimension; reviewers expand a node into validation branches; gatherers choose a retrieval strategy after seeing intermediate output. This chapter specifies how Cortex admits topology change without dissolving into arbitrary mutation. The answer is a **rewire**: a bounded runtime topology modification over an existing Circuit, drawn from a closed algebra, metered in gas, admitted by the runtime, and materialized into durable state with an explicit audit trail. Rewires obey the same vocabulary, endpoint-compatibility, and validity rules a compiled Wire source must satisfy, plus a structural resource budget the runtime enforces at admission time.
+A static Circuit is enough only when the work is known at compile time. Planners discover a missing
+dimension; reviewers expand a node into validation branches; gatherers choose a retrieval strategy
+after seeing intermediate output. This chapter specifies how Cortex admits topology change without
+dissolving into arbitrary mutation. The answer is a **rewire**: a bounded runtime topology
+modification over an existing Circuit, drawn from a closed algebra, metered in gas, admitted by the
+runtime, and materialized into durable state with an explicit audit trail. Rewires obey the same
+vocabulary, endpoint-compatibility, and validity rules a compiled Wire source must satisfy, plus a
+structural resource budget the runtime enforces at admission time.
 
 ## Core model
 
-A rewire is a structured proposal, not a mutation. A stage produces its ordinary output **and** a rewrite value from a closed algebra; the runtime validates, checks against the remaining budget, and admits or rejects with a structured reason. No stage writes to the graph directly.
+A rewire is a structured proposal, not a mutation. A stage produces its ordinary output **and** a
+rewrite value from a closed algebra; the runtime validates, checks against the remaining budget, and
+admits or rejects with a structured reason. No stage writes to the graph directly.
 
-| Concept | Role |
-|---|---|
-| Plan graph | Initial Circuit compiled from Wire source. |
-| Materialized graph | Plan graph plus all admitted rewires. |
-| Rewrite log | Append-only provenance of proposals and admission decisions. |
-| Gas | Five-dimensional structural-change budget. |
-| Watermark | Monotone id up to which rewires have been materialized. |
+| Concept            | Role                                                         |
+| ------------------ | ------------------------------------------------------------ |
+| Plan graph         | Initial Circuit compiled from Wire source.                   |
+| Materialized graph | Plan graph plus all admitted rewires.                        |
+| Rewrite log        | Append-only provenance of proposals and admission decisions. |
+| Gas                | Five-dimensional structural-change budget.                   |
+| Watermark          | Monotone id up to which rewires have been materialized.      |
 
-Authorship is split: stages and planners **propose**; the runtime **admits**. Only the runtime mutates durable graph state, and only through the narrow algebra below.
+Authorship is split: stages and planners **propose**; the runtime **admits**. Only the runtime
+mutates durable graph state, and only through the narrow algebra below.
 
 ## Rewrite algebra
 
-The algebra is intentionally narrow. Two constructors cover the highest-value dynamic patterns; additional forms are deferred until a real task requires them.
+The algebra is intentionally narrow. Two constructors cover the highest-value dynamic patterns;
+additional forms are deferred until a real task requires them.
 
 ```haskell
 data GraphRewrite
@@ -39,9 +52,16 @@ data ExpansionMode
   | ExpandRetainNodeAsEnvelope
 ```
 
-`ExpandNode` replaces a node with a subgraph — a planner turns a single step into a repair or evidence-gathering branch. `AppendAfter` inserts a subgraph downstream of a node — a reviewer queues validation once the anchor finishes. `InsertBefore`, `PruneSubgraph`, `AddJoin`, and `ReplaceNode` are recognized future forms but not part of the admitted alphabet.
+`ExpandNode` replaces a node with a subgraph — a planner turns a single step into a repair or
+evidence-gathering branch. `AppendAfter` inserts a subgraph downstream of a node — a reviewer queues
+validation once the anchor finishes. `InsertBefore`, `PruneSubgraph`, `AddJoin`, and `ReplaceNode`
+are recognized future forms but not part of the admitted alphabet.
 
-A `SubgraphSpec` is a self-contained fragment: local topology, stage definitions for every local node, explicit entry nodes where inbound edges attach, explicit exit nodes where outbound edges continue. Validation rejects missing definitions, orphan nodes, definitions outside the fragment, and any cycle in the resulting materialized graph. New nodes receive deterministic ids namespaced by their parent (`planner:repair_branch_1:step_1`), keeping identity stable across replay.
+A `SubgraphSpec` is a self-contained fragment: local topology, stage definitions for every local
+node, explicit entry nodes where inbound edges attach, explicit exit nodes where outbound edges
+continue. Validation rejects missing definitions, orphan nodes, definitions outside the fragment,
+and any cycle in the resulting materialized graph. New nodes receive deterministic ids namespaced by
+their parent (`planner:repair_branch_1:step_1`), keeping identity stable across replay.
 
 Stages signal rewrites via a richer outcome:
 
@@ -52,11 +72,16 @@ data StageResult
   | StageRewrite  Aeson.Value GraphRewrite
 ```
 
-`StageRewrite` carries both the node's durable output and the proposed edit; retained or appended subgraphs insert entry nodes that depend on that output, so a rewire is "output and rewrite," not "output or rewrite." See [Paper 3](../Publications/Paper-3-graph-substitution-semantics/manuscript.md) for the formal substitution treatment.
+`StageRewrite` carries both the node's durable output and the proposed edit; retained or appended
+subgraphs insert entry nodes that depend on that output, so a rewire is "output and rewrite," not
+"output or rewrite." See
+[Paper 3](../Publications/Paper-3-graph-substitution-semantics/manuscript.md) for the formal
+substitution treatment.
 
 ## Gas accounting
 
-Gas is a **structural-change budget**, structural only; semantic weighting (latency, cost class, effect class) is deferred. The five dimensions:
+Gas is a **structural-change budget**, structural only; semantic weighting (latency, cost class,
+effect class) is deferred. The five dimensions:
 
 ```haskell
 data RewriteBudget = RewriteBudget
@@ -68,61 +93,122 @@ data RewriteBudget = RewriteBudget
   }
 ```
 
-Each admitted rewire consumes a `RewriteCost` computed statically from its `SubgraphSpec`; admission draws only against remaining budget. Runaway planner elaboration becomes a runtime impossibility rather than a prompt-discipline problem. Gas is visible in run history: operators can inspect remaining budget, each rewrite's cost, and the rewire that exhausted a dimension.
+Each admitted rewire consumes a `RewriteCost` computed statically from its `SubgraphSpec`; admission
+draws only against remaining budget. Runaway planner elaboration becomes a runtime impossibility
+rather than a prompt-discipline problem. Gas is visible in run history: operators can inspect
+remaining budget, each rewrite's cost, and the rewire that exhausted a dimension.
 
 ## Admission policy
 
 Admission is the runtime's gate. A proposal is admitted only when every check passes:
 
-1. **Vocabulary bounds.** Every node instance references a registered executor; every port contract is a registered `ContractId`. No executors or contracts outside the closed alphabet.
-2. **Endpoint compatibility.** Every new edge connects ports whose contracts are compatible under the port-semantic rules of [Chapter 05](./05-wire-language.md). Singular and list-valued inputs obey the same arity rules at the rewire boundary as at compile time.
-3. **Topology validity.** The post-application materialized graph remains a DAG. The anchor exists in the current topology and definition map. Entry/exit sets are non-empty where the rewrite form requires them. No orphans, no dangling references.
+1. **Vocabulary bounds.** Every node instance references a registered executor; every port contract
+   is a registered `ContractId`. No executors or contracts outside the closed alphabet.
+2. **Endpoint compatibility.** Every new edge connects ports whose contracts are compatible under
+   the port-semantic rules of [Chapter 05](./05-wire-language.md). Singular and list-valued inputs
+   obey the same arity rules at the rewire boundary as at compile time.
+3. **Topology validity.** The post-application materialized graph remains a DAG. The anchor exists
+   in the current topology and definition map. Entry/exit sets are non-empty where the rewrite form
+   requires them. No orphans, no dangling references.
 4. **Resource bounds.** Estimated `RewriteCost` fits within the remaining budget on every dimension.
-5. **Runtime policy.** The anchor, the run, and the task type permit rewrites of this form. Planner nodes may be restricted to a subset of the algebra.
+5. **Runtime policy.** The anchor, the run, and the task type permit rewrites of this form. Planner
+   nodes may be restricted to a subset of the algebra.
 
-A proposal that fails any check is rejected with a structured reason (`invalid_rewrite`, `rewrite_budget_exceeded`, `vocabulary_violation`, `cycle_introduced`, …). Default policy is fail-fast: the node and run fail with a legible error. Task-specific fallback modes — structured-output-only continuation, operator escalation — are deferred.
+A proposal that fails any check is rejected with a structured reason (`invalid_rewrite`,
+`rewrite_budget_exceeded`, `vocabulary_violation`, `cycle_introduced`, …). Default policy is
+fail-fast: the node and run fail with a legible error. Task-specific fallback modes —
+structured-output-only continuation, operator escalation — are deferred.
 
-Admission is deterministic per frontier wave. Multiple frontier nodes may emit proposals in the same wave. The runtime serializes admission through a shared admission gate and shared remaining budget, persists admitted rewrite rows individually with monotone rewrite ids, and materializes admitted rows in rewrite-id order after frontier classification. This is deterministic ordered admission, not a proof that same-wave rewrites commute or can be treated as one concurrent semantic step. See [Chapter 06](./06-pulse-runtime.md) for scheduler-loop placement and blocked-graph diagnostics.
+Admission is deterministic per frontier wave. Multiple frontier nodes may emit proposals in the same
+wave. The runtime serializes admission through a shared admission gate and shared remaining budget,
+persists admitted rewrite rows individually with monotone rewrite ids, and materializes admitted
+rows in rewrite-id order after frontier classification. This is deterministic ordered admission, not
+a proof that same-wave rewrites commute or can be treated as one concurrent semantic step. See
+[Chapter 06](./06-pulse-runtime.md) for scheduler-loop placement and blocked-graph diagnostics.
 
-This boundary is architectural, not just procedural. Within one materialized topology, Pulse can reduce node-local facts concurrently over the current frontier. Rewrite admission is different: it is the coordinated phase where topology-changing proposals are checked against the ambient graph, the remaining budget, and the other proposals in flight. The phase boundary therefore separates coordination-friendly fact reduction from coordinated topology change.
+This boundary is architectural, not just procedural. Within one materialized topology, Pulse can
+reduce node-local facts concurrently over the current frontier. Rewrite admission is different: it
+is the coordinated phase where topology-changing proposals are checked against the ambient graph,
+the remaining budget, and the other proposals in flight. The phase boundary therefore separates
+coordination-friendly fact reduction from coordinated topology change.
 
 ## Materialization
 
-Admission and application are separate events with crash-safety obligations between them. The normative durability contract:
+Admission and application are separate events with crash-safety obligations between them. The
+normative durability contract:
 
-- The **rewrite log** is append-only. Each entry carries the accepted rewrite specification, the anchor's output needed to replay into inserted entry nodes, the static cost, and a monotone rewrite id.
-- The **graph state** carries the watermark (highest rewrite id materialized) and the remaining budget. Materialization applies node-state changes, budget consumption, and watermark advance in one atomic commit.
-- Admitted lineage may exist beyond the watermark. That means "admitted but not yet applied to the materialized graph", not "applied and omitted".
-- Resume reconstructs the materialized graph only through the watermark. If lineage exists beyond it, resume deterministically finishes materialization before any scheduling decision.
+- The **rewrite log** is append-only. Each entry carries the accepted rewrite specification, the
+  anchor's output needed to replay into inserted entry nodes, the static cost, and a monotone
+  rewrite id.
+- The **graph state** carries the watermark (highest rewrite id materialized) and the remaining
+  budget. Materialization applies node-state changes, budget consumption, and watermark advance in
+  one atomic commit.
+- Admitted lineage may exist beyond the watermark. That means "admitted but not yet applied to the
+  materialized graph", not "applied and omitted".
+- Resume reconstructs the materialized graph only through the watermark. If lineage exists beyond
+  it, resume deterministically finishes materialization before any scheduling decision.
 
-The watermark makes crash recovery explicit at the rewrite boundary: without it, raw lineage replay cannot distinguish "persisted but not yet applied" from "applied and reflected." Watermark-based materialization requires a Runtime/checkpoint version bump; pre-watermark rewrite-capable runs are legacy and not guaranteed resumable.
+The watermark makes crash recovery explicit at the rewrite boundary: without it, raw lineage replay
+cannot distinguish "persisted but not yet applied" from "applied and reflected." Watermark-based
+materialization requires a Runtime/checkpoint version bump; pre-watermark rewrite-capable runs are
+legacy and not guaranteed resumable.
 
-Hydration of rewritten stages is keyed by stage-template identity (durable executable identity) and verified against stage-action identity, not by scanning ad-hoc stage ids. Duplicate template ids in a materialized plan are rejected unless they map to the same action and identical policy metadata. See the [rewrite materialization and recovery plan](../Roadmap/Plans/rewrite-materialization-and-recovery.md) for the formal treatment of the materialization boundary and recovery invariants.
+Hydration of rewritten stages is keyed by stage-template identity (durable executable identity) and
+verified against stage-action identity, not by scanning ad-hoc stage ids. Duplicate template ids in
+a materialized plan are rejected unless they map to the same action and identical policy metadata.
+See the
+[rewrite materialization and recovery plan](../Roadmap/Plans/rewrite-materialization-and-recovery.md)
+for the formal treatment of the materialization boundary and recovery invariants.
 
 ## Provenance of rewrite events
 
-This chapter covers provenance of **structural events**; provenance of **values** flowing through edges belongs to [Chapter 08](./08-artifacts-and-provenance.md).
+This chapter covers provenance of **structural events**; provenance of **values** flowing through
+edges belongs to [Chapter 08](./08-artifacts-and-provenance.md).
 
-Every material graph evolution event is explainable after the fact. For each rewrite the runtime persists: the proposing node id and stage result, the raw `GraphRewrite` proposal, the admission decision (admitted, or rejected-with-reason), the cost and post-admission remaining budget, the structural diff applied, and any operator override. Rejected rewrites are not silently discarded — rejection rows are part of the audit trail. Operator surfaces expose the current materialized graph, rewrite history per run, and any blocked or waiting reasons introduced by rewrites.
+Every material graph evolution event is explainable after the fact. For each rewrite the runtime
+persists: the proposing node id and stage result, the raw `GraphRewrite` proposal, the admission
+decision (admitted, or rejected-with-reason), the cost and post-admission remaining budget, the
+structural diff applied, and any operator override. Rejected rewrites are not silently discarded —
+rejection rows are part of the audit trail. Operator surfaces expose the current materialized graph,
+rewrite history per run, and any blocked or waiting reasons introduced by rewrites.
 
 ## Boundaries and invariants
 
 This layer enforces:
 
 - stages and planners propose; only the runtime admits.
-- rewrites stay inside the closed executor alphabet, contract registry, endpoint compatibility, DAG validity, and the five-dimensional gas budget.
-- same-wave rewrite proposals are admitted in deterministic order against shared remaining budget; ordinary node execution across the frontier is still concurrent.
-- the rewrite log is append-only, and watermark and remaining budget update atomically with the node-state changes they imply.
-- static DAGs and linear stage paths remain valid programs — a run with no rewrites is a degenerate case, not a special mode.
+- rewrites stay inside the closed executor alphabet, contract registry, endpoint compatibility, DAG
+  validity, and the five-dimensional gas budget.
+- same-wave rewrite proposals are admitted in deterministic order against shared remaining budget;
+  ordinary node execution across the frontier is still concurrent.
+- the rewrite log is append-only, and watermark and remaining budget update atomically with the
+  node-state changes they imply.
+- static DAGs and linear stage paths remain valid programs — a run with no rewrites is a degenerate
+  case, not a special mode.
 
-It delegates graph algebra to [Chapter 04](./04-graph-and-circuit.md), scheduling and checkpointing to [Chapter 06](./06-pulse-runtime.md), value-envelope provenance to [Chapter 08](./08-artifacts-and-provenance.md), and Wire grammar and partial-node rules to [Chapter 05](./05-wire-language.md).
+It delegates graph algebra to [Chapter 04](./04-graph-and-circuit.md), scheduling and checkpointing
+to [Chapter 06](./06-pulse-runtime.md), value-envelope provenance to
+[Chapter 08](./08-artifacts-and-provenance.md), and Wire grammar and partial-node rules to
+[Chapter 05](./05-wire-language.md).
 
 ## Extensibility
 
-New rewrite forms enter by adding constructors to `GraphRewrite` and extending the validator — not by letting stages emit arbitrary edits. `InsertBefore`, `PruneSubgraph`, `AddJoin`, and `ReplaceNode` lie along this path. Richer gas dimensions (semantic weighting, effect classes, irreversibility boundaries) enter by extending `RewriteBudget` and the static cost estimator with a matching durability migration. Hierarchical subgraphs — composite nodes owning nested budgets — are the planned composition extension once the flat algebra has been proven on a real task. Planner integration proceeds by registering planner-capable nodes with a policy-gated, budget-aware contract, not by loosening admission checks.
+New rewrite forms enter by adding constructors to `GraphRewrite` and extending the validator — not
+by letting stages emit arbitrary edits. `InsertBefore`, `PruneSubgraph`, `AddJoin`, and
+`ReplaceNode` lie along this path. Richer gas dimensions (semantic weighting, effect classes,
+irreversibility boundaries) enter by extending `RewriteBudget` and the static cost estimator with a
+matching durability migration. Hierarchical subgraphs — composite nodes owning nested budgets — are
+the planned composition extension once the flat algebra has been proven on a real task. Planner
+integration proceeds by registering planner-capable nodes with a policy-gated, budget-aware
+contract, not by loosening admission checks.
 
 ## Related
 
-- [./03-formalism-stack.md](./03-formalism-stack.md), [./04-graph-and-circuit.md](./04-graph-and-circuit.md), [./05-wire-language.md](./05-wire-language.md), [./06-pulse-runtime.md](./06-pulse-runtime.md), [./08-artifacts-and-provenance.md](./08-artifacts-and-provenance.md)
+- [./03-formalism-stack.md](./03-formalism-stack.md),
+  [./04-graph-and-circuit.md](./04-graph-and-circuit.md),
+  [./05-wire-language.md](./05-wire-language.md), [./06-pulse-runtime.md](./06-pulse-runtime.md),
+  [./08-artifacts-and-provenance.md](./08-artifacts-and-provenance.md)
 - [../Reference/terminology.md](../Reference/terminology.md) — normative vocabulary.
-- [../Roadmap/Plans/rewrite-materialization-and-recovery.md](../Roadmap/Plans/rewrite-materialization-and-recovery.md), [../Publications/Paper-3-graph-substitution-semantics/manuscript.md](../Publications/Paper-3-graph-substitution-semantics/manuscript.md) — formal treatment.
+- [../Roadmap/Plans/rewrite-materialization-and-recovery.md](../Roadmap/Plans/rewrite-materialization-and-recovery.md),
+  [../Publications/Paper-3-graph-substitution-semantics/manuscript.md](../Publications/Paper-3-graph-substitution-semantics/manuscript.md)
+  — formal treatment.

--- a/docs/Architecture/08-artifacts-and-provenance.md
+++ b/docs/Architecture/08-artifacts-and-provenance.md
@@ -1,6 +1,8 @@
 ---
 title: "Chapter 08 — Artifacts and Provenance"
-description: "Artifact architecture for Cortex. Explains runtime envelopes, contract-owned payload meaning, value provenance, and how downstream systems build richer artifact surfaces on top."
+description:
+  "Artifact architecture for Cortex. Explains runtime envelopes, contract-owned payload meaning,
+  value provenance, and how downstream systems build richer artifact surfaces on top."
 sidebar:
   label: "08. Artifacts and provenance"
   order: 8
@@ -9,20 +11,17 @@ status: active
 
 # Chapter 08 — Artifacts and Provenance
 
-Chapter 07 covers structural provenance: how live topology changes over a run.
-This chapter covers value and artifact provenance: what crosses an edge at
-runtime, how payload meaning is defined, and how a downstream system can answer
-"where did this value come from?" without changing the substrate's topology
-model.
+Chapter 07 covers structural provenance: how live topology changes over a run. This chapter covers
+value and artifact provenance: what crosses an edge at runtime, how payload meaning is defined, and
+how a downstream system can answer "where did this value come from?" without changing the
+substrate's topology model.
 
-The central idea is simple: runtime values travel as typed envelopes, while
-their semantic meaning lives in the contract registry rather than in Wire
-syntax or edge-local labels.
+The central idea is simple: runtime values travel as typed envelopes, while their semantic meaning
+lives in the contract registry rather than in Wire syntax or edge-local labels.
 
 ## What this layer owns
 
-This layer sits between executable topology and downstream artifact surfaces.
-It owns:
+This layer sits between executable topology and downstream artifact surfaces. It owns:
 
 - the runtime envelope that carries values across edges
 - the contract-owned interpretation of payloads
@@ -33,8 +32,7 @@ It does not own:
 
 - graph structure or rewrite provenance
 - source-language typing rules
-- downstream artifact presentation such as report-specific HTML, spans, or UI
-  affordances
+- downstream artifact presentation such as report-specific HTML, spans, or UI affordances
 
 ```mermaid
 flowchart LR
@@ -47,8 +45,8 @@ flowchart LR
 
 ## Runtime envelopes
 
-At runtime, Cortex moves envelopes rather than bare payloads. The envelope is a
-uniform carrier with four responsibilities:
+At runtime, Cortex moves envelopes rather than bare payloads. The envelope is a uniform carrier with
+four responsibilities:
 
 - identify what semantic contract the value claims to satisfy
 - identify which node produced it
@@ -73,8 +71,7 @@ Illustrative shape:
 }
 ```
 
-The important architectural point is not the field spelling. It is the split of
-responsibility:
+The important architectural point is not the field spelling. It is the split of responsibility:
 
 - the runtime stamps envelope metadata
 - the contract registry defines what the payload means
@@ -82,8 +79,8 @@ responsibility:
 
 ## Contract-owned meaning
 
-The envelope carries a contract ID, but the ID alone is not the semantic type.
-Meaning lives in the contract registry.
+The envelope carries a contract ID, but the ID alone is not the semantic type. Meaning lives in the
+contract registry.
 
 The registry is the authority for:
 
@@ -93,19 +90,17 @@ The registry is the authority for:
 - examples and rendering hints
 - content-level lint or normalization rules
 
-This keeps the composition layer small. Wire and Circuit only need stable
-contract identity and compatibility. Rich payload meaning stays in the registry
-surface that implementations and downstream consumers can evolve deliberately.
+This keeps the composition layer small. Wire and Circuit only need stable contract identity and
+compatibility. Rich payload meaning stays in the registry surface that implementations and
+downstream consumers can evolve deliberately.
 
-That is also what keeps the downstream boundary clean: a host system can define
-its own domain contracts without changing the substrate's composition or
-topology model.
+That is also what keeps the downstream boundary clean: a host system can define its own domain
+contracts without changing the substrate's composition or topology model.
 
 ## Payload kinds
 
-Payload kinds are the substrate's coarse runtime categories for payload
-handling. They are not the full semantic type. They select which validation and
-rendering pipeline applies.
+Payload kinds are the substrate's coarse runtime categories for payload handling. They are not the
+full semantic type. They select which validation and rendering pipeline applies.
 
 Typical kinds include:
 
@@ -126,38 +121,36 @@ Contract-level check:
   Does the payload satisfy the validation and rendering rules for that contract?
 ```
 
-That split is important because it lets Cortex keep routing and composition
-mechanical while still supporting rich payload semantics.
+That split is important because it lets Cortex keep routing and composition mechanical while still
+supporting rich payload semantics.
 
 ## Value provenance
 
-Value provenance answers where a specific runtime value came from. It is not the
-same as graph provenance.
+Value provenance answers where a specific runtime value came from. It is not the same as graph
+provenance.
 
 Value provenance tracks facts such as:
 
 - which run produced the value
 - which node emitted it
 - which upstream producers informed it
-- which tool or external actions shaped it when the execution model exposes
-  that detail
+- which tool or external actions shaped it when the execution model exposes that detail
 
-Graph provenance, by contrast, tracks how the executable topology changed over
-time. That belongs to Chapter 07.
+Graph provenance, by contrast, tracks how the executable topology changed over time. That belongs to
+Chapter 07.
 
 The separation matters because the two questions are different:
 
 - "Which rewrites were admitted?" is a graph question.
-- "Where did this output number or document fragment come from?" is a value
-  question.
+- "Where did this output number or document fragment come from?" is a value question.
 
-Keeping the records separate lets Cortex answer both without overloading one
-structure with two kinds of meaning.
+Keeping the records separate lets Cortex answer both without overloading one structure with two
+kinds of meaning.
 
 ## Artifact surfaces
 
-An envelope is not yet a user-facing artifact. It is the substrate unit from
-which artifacts are built.
+An envelope is not yet a user-facing artifact. It is the substrate unit from which artifacts are
+built.
 
 Downstream systems build richer artifact surfaces by layering on top of:
 
@@ -165,53 +158,49 @@ Downstream systems build richer artifact surfaces by layering on top of:
 - the contract registry
 - the runtime provenance chain
 
-That layered design is what allows the substrate to stay generic. Cortex does
-not need to know about a particular consumer's report layout, annotation model,
-HTML rendering, or consumer presentation UX in order to provide trustworthy provenance.
+That layered design is what allows the substrate to stay generic. Cortex does not need to know about
+a particular consumer's report layout, annotation model, HTML rendering, or consumer presentation UX
+in order to provide trustworthy provenance.
 
 ## Artifact references
 
-One special case matters architecturally: some values are references to durable
-artifacts rather than inline payloads.
+One special case matters architecturally: some values are references to durable artifacts rather
+than inline payloads.
 
-`artifact_ref`-style contracts let the substrate move a stable reference through
-the graph while leaving blob storage, large document rendering, or binary
-retrieval to the consumer boundary. This prevents the graph runtime from having
-to copy large artifacts through every edge while still keeping provenance and
-contract identity attached.
+`artifact_ref`-style contracts let the substrate move a stable reference through the graph while
+leaving blob storage, large document rendering, or binary retrieval to the consumer boundary. This
+prevents the graph runtime from having to copy large artifacts through every edge while still
+keeping provenance and contract identity attached.
 
 ## Downstream bindings
 
-Consumer-specific artifact surfaces are downstream bindings on top of the
-generic envelope and provenance surfaces described here. Those bindings belong
-in consumer docs and ADRs, not in the substrate chapter itself.
+Consumer-specific artifact surfaces are downstream bindings on top of the generic envelope and
+provenance surfaces described here. Those bindings belong in consumer docs and ADRs, not in the
+substrate chapter itself.
 
 The pattern is:
 
 - Cortex owns the generic runtime envelope and provenance model
-- the consumer owns its presentation model, audit UX, and domain-specific
-  artifact contracts
+- the consumer owns its presentation model, audit UX, and domain-specific artifact contracts
 
 ## Why this split matters
 
 - It keeps runtime transport and composition generic.
-- It lets provenance travel with values without hard-coding a particular UI or
-  artifact format into Cortex.
-- It gives downstream systems enough structure to build trustworthy audit and
-  inspection surfaces.
-- It prevents product-specific artifact meaning from leaking into the substrate
-  layer.
+- It lets provenance travel with values without hard-coding a particular UI or artifact format into
+  Cortex.
+- It gives downstream systems enough structure to build trustworthy audit and inspection surfaces.
+- It prevents product-specific artifact meaning from leaking into the substrate layer.
 
 ## Related
 
-- [Chapter 05 — Wire language](05-wire-language.md) — source-language view of
-  contracts and registered authority
-- [Chapter 06 — Pulse runtime](06-pulse-runtime.md) — runtime that emits and
-  propagates envelopes during execution
-- [Chapter 07 — Rewrites and materialization](07-rewrites-and-materialization.md) —
-  structural provenance and realized topology
-- [Cortex Terminology](../Reference/terminology.md) — normative definitions of
-  envelope, payload kind, contract registry, and provenance
+- [Chapter 05 — Wire language](05-wire-language.md) — source-language view of contracts and
+  registered authority
+- [Chapter 06 — Pulse runtime](06-pulse-runtime.md) — runtime that emits and propagates envelopes
+  during execution
+- [Chapter 07 — Rewrites and materialization](07-rewrites-and-materialization.md) — structural
+  provenance and realized topology
+- [Cortex Terminology](../Reference/terminology.md) — normative definitions of envelope, payload
+  kind, contract registry, and provenance
 - [ADR 0013 — Artifact Provenance Contract](../ADRs/0013-report-provenance-artifact-contract.md) —
   artifact provenance contract decision
 - [Consumer examples](../Consumers/) — downstream binding examples

--- a/docs/Architecture/09-nous-reasoning-library.md
+++ b/docs/Architecture/09-nous-reasoning-library.md
@@ -1,6 +1,8 @@
 ---
 title: "Chapter 09 — Nous Reasoning Library"
-description: "How Cortex.Nous sits above the substrate, defines canonical archetypes and reusable patterns, and preserves runtime authority boundaries."
+description:
+  "How Cortex.Nous sits above the substrate, defines canonical archetypes and reusable patterns, and
+  preserves runtime authority boundaries."
 sidebar:
   label: "09. Nous reasoning"
   order: 9
@@ -9,28 +11,27 @@ status: active
 
 # Chapter 09 — Nous Reasoning Library
 
-`Cortex.Nous` is the structured reasoning library above the Cortex substrate. It
-names reusable epistemological modes under `Cortex.Nous.Archetypes`, one bounded
-model-mediated node evaluation under `Cortex.Nous.Thought`, cognitive memory
-under `Cortex.Nous.Memory`, and reusable reasoning programs under
-`Cortex.Nous.Patterns`. It does not extend the runtime alphabet. Algebra, Wire,
-Pulse, Capability, and Artifact mechanics remain the substrate. Nous composes
-those mechanics into reusable reasoning programs.
+`Cortex.Nous` is the structured reasoning library above the Cortex substrate. It names reusable
+epistemological modes under `Cortex.Nous.Archetypes`, one bounded model-mediated node evaluation
+under `Cortex.Nous.Thought`, cognitive memory under `Cortex.Nous.Memory`, and reusable reasoning
+programs under `Cortex.Nous.Patterns`. It does not extend the runtime alphabet. Algebra, Wire,
+Pulse, Capability, and Artifact mechanics remain the substrate. Nous composes those mechanics into
+reusable reasoning programs.
 
-> **Implementation staging.** Current Haskell modules still use staging paths such
-> as `Cortex.Nous.Logos` and `Cortex.Nous.Logos.Capability`. Canonical paths such
-> as `Cortex.Nous.Archetypes.Logos` and planned pattern modules such as
+> **Implementation staging.** Current Haskell modules still use staging paths such as
+> `Cortex.Nous.Logos` and `Cortex.Nous.Logos.Capability`. Canonical paths such as
+> `Cortex.Nous.Archetypes.Logos` and planned pattern modules such as
 > `Cortex.Nous.Patterns.DeepReport` land through ADR 0017 migration slices.
 
 ## Core model
 
 The split is vertical:
 
-| Layer | Owns | Does not own |
-|---|---|---|
-| Cortex runtime substrate | Algebra, Wire language and compiled circuit form, Pulse execution, Capability authority, Artifact provenance. | Product persona, domain policy, concrete reasoning templates. |
-| `Cortex.Nous` | Archetype taxonomy, thoughts, cognitive memory, reusable pattern catalogs, `.wire` templates, prompt families, memory presets, contract-entry conventions. | Runtime authority, new executor kinds, new contract registry, host tools. |
-| Downstream product binding | Domain prompts, product policy, domain tools, approval behavior, product artifact semantics. | Generic substrate mechanics or generic Nous archetype definitions. |
+| Layer                      | Owns                                                                                                                                                       | Does not own                                                              |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Cortex runtime substrate   | Algebra, Wire language and compiled circuit form, Pulse execution, Capability authority, Artifact provenance.                                              | Product persona, domain policy, concrete reasoning templates.             |
+| `Cortex.Nous`              | Archetype taxonomy, thoughts, cognitive memory, reusable pattern catalogs, `.wire` templates, prompt families, memory presets, contract-entry conventions. | Runtime authority, new executor kinds, new contract registry, host tools. |
+| Downstream product binding | Domain prompts, product policy, domain tools, approval behavior, product artifact semantics.                                                               | Generic substrate mechanics or generic Nous archetype definitions.        |
 
 The dependency direction is strict:
 
@@ -40,8 +41,8 @@ flowchart LR
     Nous --> Runtime[Cortex substrate<br/>Algebra, Wire, Pulse, Capability, Artifact]
 ```
 
-Substrate code must not import Nous. Nous may import runtime types and publish
-catalog values or source templates that consumers opt into.
+Substrate code must not import Nous. Nous may import runtime types and publish catalog values or
+source templates that consumers opt into.
 
 ## Detailed structure
 
@@ -76,19 +77,18 @@ Cortex.Nous
 
 The first catalog contains seven archetypes:
 
-| Archetype | Role | Typical responsibility | Literature-backed pattern |
-|---|---|---|---|
-| `Cortex.Nous.Archetypes.Logos` | Discursive reason, argument, symbolic reasoning | Make reasoning explicit as structured claims, premises, inference, and explanation. | Self-consistency, Tree of Thoughts |
-| `Cortex.Nous.Archetypes.Sophia` | Wisdom, judgment, synthesis | Weigh competing goods, recognize context, identify salience, and synthesize under uncertainty. | LLM-as-a-judge, multi-agent debate |
-| `Cortex.Nous.Archetypes.Techne` | Craft, engineering, implementation | Turn understanding into working artifacts, executable plans, interfaces, tests, and systems. | SWE-agent, CodeAct, tool-use frameworks |
-| `Cortex.Nous.Archetypes.Episteme` | Knowledge, evidence, research | Ground cognition in what is known, observed, measured, cited, or otherwise supported. | ReAct, tool-use agents, information retrieval |
-| `Cortex.Nous.Archetypes.Kritikos` | Criticism, adversarial review | Apply constructive severity to expose weak claims, hidden assumptions, contradictions, and failure modes. | Constitutional AI, red-teaming |
-| `Cortex.Nous.Archetypes.Themis` | Audit, law, correctness, constraints | Ensure reasoning and action remain within defined bounds, contracts, policies, and invariants. | AI safety, Constitutional AI, alignment |
-| `Cortex.Nous.Archetypes.Poiesis` | Creative generation, composition | Bring forth new forms, alternatives, narratives, designs, and generative possibilities. | Creative generation, story-telling agents |
+| Archetype                         | Role                                            | Typical responsibility                                                                                    | Literature-backed pattern                     |
+| --------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `Cortex.Nous.Archetypes.Logos`    | Discursive reason, argument, symbolic reasoning | Make reasoning explicit as structured claims, premises, inference, and explanation.                       | Self-consistency, Tree of Thoughts            |
+| `Cortex.Nous.Archetypes.Sophia`   | Wisdom, judgment, synthesis                     | Weigh competing goods, recognize context, identify salience, and synthesize under uncertainty.            | LLM-as-a-judge, multi-agent debate            |
+| `Cortex.Nous.Archetypes.Techne`   | Craft, engineering, implementation              | Turn understanding into working artifacts, executable plans, interfaces, tests, and systems.              | SWE-agent, CodeAct, tool-use frameworks       |
+| `Cortex.Nous.Archetypes.Episteme` | Knowledge, evidence, research                   | Ground cognition in what is known, observed, measured, cited, or otherwise supported.                     | ReAct, tool-use agents, information retrieval |
+| `Cortex.Nous.Archetypes.Kritikos` | Criticism, adversarial review                   | Apply constructive severity to expose weak claims, hidden assumptions, contradictions, and failure modes. | Constitutional AI, red-teaming                |
+| `Cortex.Nous.Archetypes.Themis`   | Audit, law, correctness, constraints            | Ensure reasoning and action remain within defined bounds, contracts, policies, and invariants.            | AI safety, Constitutional AI, alignment       |
+| `Cortex.Nous.Archetypes.Poiesis`  | Creative generation, composition                | Bring forth new forms, alternatives, narratives, designs, and generative possibilities.                   | Creative generation, story-telling agents     |
 
-The catalog describes reusable modes of cognition. It does not prescribe a
-specific provider, model, prompt, tool list, or domain ontology. Those are later
-library presets or downstream bindings.
+The catalog describes reusable modes of cognition. It does not prescribe a specific provider, model,
+prompt, tool list, or domain ontology. Those are later library presets or downstream bindings.
 
 ### Activation bundles
 
@@ -105,79 +105,70 @@ Cortex.Nous.Archetypes.<Archetype>.Activation
   + runtime contract
 ```
 
-The archetype is the semantic definition. The activation is the concrete bundle
-of assets and policies that implement that mode. A thought frame composes one or
-more archetype activations into a single cognitive evaluation.
+The archetype is the semantic definition. The activation is the concrete bundle of assets and
+policies that implement that mode. A thought frame composes one or more archetype activations into a
+single cognitive evaluation.
 
-Current implementation status: this first PR lands the type shape and module
-slots only. Current `Cortex.Nous.<Archetype>.Capability` modules are staging
-stubs. The canonical target is
-`Cortex.Nous.Archetypes.<Archetype>.Activation`, populated by later PRs with real
-prompts, corpora, embedding indexes, tool surfaces, memory policies, evaluation
-checks, and runtime contracts.
+Current implementation status: this first PR lands the type shape and module slots only. Current
+`Cortex.Nous.<Archetype>.Capability` modules are staging stubs. The canonical target is
+`Cortex.Nous.Archetypes.<Archetype>.Activation`, populated by later PRs with real prompts, corpora,
+embedding indexes, tool surfaces, memory policies, evaluation checks, and runtime contracts.
 
-For example, `Cortex.Nous.Archetypes.Episteme.Activation` is the home for
-evidence-grounded prompts, source-quality rules, retrieval strategies,
-source-ranking heuristics, uncertainty policy, citation discipline, and
-validation tests. A `Cortex.Nous.Archetypes.Kritikos.Activation` bundle is the
-home for adversarial-review prompts, failure-mode corpora, contradiction checks,
-falsification discipline, and red-team evaluation. A
-`Cortex.Nous.Archetypes.Techne.Activation` bundle is the home for codebase-local
-implementation memory, architecture conventions, build and test patterns, and
+For example, `Cortex.Nous.Archetypes.Episteme.Activation` is the home for evidence-grounded prompts,
+source-quality rules, retrieval strategies, source-ranking heuristics, uncertainty policy, citation
+discipline, and validation tests. A `Cortex.Nous.Archetypes.Kritikos.Activation` bundle is the home
+for adversarial-review prompts, failure-mode corpora, contradiction checks, falsification
+discipline, and red-team evaluation. A `Cortex.Nous.Archetypes.Techne.Activation` bundle is the home
+for codebase-local implementation memory, architecture conventions, build and test patterns, and
 implementation checks.
 
-This makes the vocabulary operational. A node is not just tagged with
-`Episteme`; it runs with the Episteme activation active. The activation shapes what
-context is retrieved, which tools are available, which prompt discipline is
-applied, which memory policy is used, and how the result is evaluated.
+This makes the vocabulary operational. A node is not just tagged with `Episteme`; it runs with the
+Episteme activation active. The activation shapes what context is retrieved, which tools are
+available, which prompt discipline is applied, which memory policy is used, and how the result is
+evaluated.
 
-The stub activations in this PR are not yet operational substrates. They are public
-slots and expected component lists for follow-up implementation.
+The stub activations in this PR are not yet operational substrates. They are public slots and
+expected component lists for follow-up implementation.
 
-Retrieval is thought-frame-aware rather than a single global index per archetype. An
-activation can combine canonical corpus, local project corpus, examples, failures,
-contracts, and tool docs with task-specific weights. A `Techne` activation for
-Cortex code and a `Techne` activation for another domain share the archetype but
-activate different local corpora and tool surfaces.
+Retrieval is thought-frame-aware rather than a single global index per archetype. An activation can
+combine canonical corpus, local project corpus, examples, failures, contracts, and tool docs with
+task-specific weights. A `Techne` activation for Cortex code and a `Techne` activation for another
+domain share the archetype but activate different local corpora and tool surfaces.
 
 ### Catalog artifacts
 
 Nous can expose the following catalog artifacts:
 
-| Artifact | Shape | Runtime relationship |
-|---|---|---|
-| Archetype definitions | Haskell data values under `Cortex.Nous.Archetypes` | Metadata only. No runtime registration. |
+| Artifact                | Shape                                                                                     | Runtime relationship                                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Archetype definitions   | Haskell data values under `Cortex.Nous.Archetypes`                                        | Metadata only. No runtime registration.                                                                |
 | Activation bundle slots | Prompts, corpus selectors, embeddings, tools, memory policy, evaluation, runtime contract | Stubbed in this PR; later activated by thought frames and interpreted through existing substrate APIs. |
-| Thought runtime | Frame, policy, host, tool loop, structured output, thought events | Uses model and tool capabilities without owning provider or tool authority. |
-| Cognitive memory | Retrieval, ranking, packing, compaction, source selection, topological context | Builds model context over substrate state; Pulse remains durable execution state. |
-| Pattern catalogs | `Cortex.Nous.Patterns.<Name>` modules | Library-owned reasoning programs interpreted by existing substrate APIs. |
-| Template programs | `.wire` modules shipped by Nous patterns | Imported by consumers and compiled by the normal Wire compiler. |
-| Memory presets | Haskell values naming query and walk strategy defaults | Passed through `Cortex.Nous.Memory` APIs over substrate state. |
-| Contract conventions | Stable contract entries and documentation | Implemented through the existing contract registry. |
-| Prompt families | Text builders or source artifacts | Bound to executors by consumers or library templates. |
+| Thought runtime         | Frame, policy, host, tool loop, structured output, thought events                         | Uses model and tool capabilities without owning provider or tool authority.                            |
+| Cognitive memory        | Retrieval, ranking, packing, compaction, source selection, topological context            | Builds model context over substrate state; Pulse remains durable execution state.                      |
+| Pattern catalogs        | `Cortex.Nous.Patterns.<Name>` modules                                                     | Library-owned reasoning programs interpreted by existing substrate APIs.                               |
+| Template programs       | `.wire` modules shipped by Nous patterns                                                  | Imported by consumers and compiled by the normal Wire compiler.                                        |
+| Memory presets          | Haskell values naming query and walk strategy defaults                                    | Passed through `Cortex.Nous.Memory` APIs over substrate state.                                         |
+| Contract conventions    | Stable contract entries and documentation                                                 | Implemented through the existing contract registry.                                                    |
+| Prompt families         | Text builders or source artifacts                                                         | Bound to executors by consumers or library templates.                                                  |
 
-The important rule is that each artifact is interpreted by an existing
-substrate mechanism. Nous catalogs do not add a hidden resolver.
+The important rule is that each artifact is interpreted by an existing substrate mechanism. Nous
+catalogs do not add a hidden resolver.
 
 ## Boundaries and invariants
 
 Nous is correct when these invariants hold:
 
 - Substrate modules do not import `Cortex.Nous` modules.
-- Archetype names never grant tool access, model access, side effects, or host
-  authority.
-- Archetype activations can request tool surfaces and runtime contracts, but those
-  requests are still admitted through existing executor, contract, and host
-  authority boundaries.
-- Patterns can ship contracts, ports, prompts, and templates, but executable
-  authority still comes from consumer-selected executors and host bindings.
-- A node's executable authority still comes from its registered executor and its
-  configured tool scope.
-- A node's payload obligations still come from its contracts and runtime
-  validation.
-- Archetypes classify epistemic function and reusable program shape; contracts
-  define data obligations; activations bundle operational assets; executors
-  define runnable authority.
+- Archetype names never grant tool access, model access, side effects, or host authority.
+- Archetype activations can request tool surfaces and runtime contracts, but those requests are
+  still admitted through existing executor, contract, and host authority boundaries.
+- Patterns can ship contracts, ports, prompts, and templates, but executable authority still comes
+  from consumer-selected executors and host bindings.
+- A node's executable authority still comes from its registered executor and its configured tool
+  scope.
+- A node's payload obligations still come from its contracts and runtime validation.
+- Archetypes classify epistemic function and reusable program shape; contracts define data
+  obligations; activations bundle operational assets; executors define runnable authority.
 
 What Nous intentionally does not enforce in this first slice:
 
@@ -186,15 +177,13 @@ What Nous intentionally does not enforce in this first slice:
 - full canonical `.wire` program set
 - downstream domain semantics
 
-Those are follow-up decisions and implementation work, not prerequisites for the
-taxonomy to exist.
+Those are follow-up decisions and implementation work, not prerequisites for the taxonomy to exist.
 
 ## Extensibility
 
-New archetypes require an ADR because they change the public epistemological
-vocabulary. Downstream products do not need an ADR to create product-specific
-roles; they should map those roles to the nearest Nous archetype when using
-generic templates.
+New archetypes require an ADR because they change the public epistemological vocabulary. Downstream
+products do not need an ADR to create product-specific roles; they should map those roles to the
+nearest Nous archetype when using generic templates.
 
 Program templates extend the library by composing existing runtime authority:
 
@@ -204,10 +193,9 @@ Program templates extend the library by composing existing runtime authority:
 - attach memory presets through `Cortex.Nous.Memory`
 - compile through Wire and run through Pulse unchanged
 
-The planned target for reusable LLM-shaped workflow extraction is
-`Cortex.Nous.Patterns.DeepReport`. Its first slices should extract generic
-contract and port catalogs; downstream bindings keep product tools, artifact
-semantics, DB loading, and authorization.
+The planned target for reusable LLM-shaped workflow extraction is `Cortex.Nous.Patterns.DeepReport`.
+Its first slices should extract generic contract and port catalogs; downstream bindings keep product
+tools, artifact semantics, DB loading, and authorization.
 
 ## Related
 
@@ -219,5 +207,4 @@ semantics, DB loading, and authorization.
 - [Chapter 02 — Ownership and boundaries](02-ownership-and-boundaries.md)
 - [Chapter 05 — Wire language](05-wire-language.md)
 - [Chapter 08 — Artifacts and provenance](08-artifacts-and-provenance.md)
-- GitHub #14, #31, and #32 for the first role-contract, debate, and critique
-  workflows that need this vocabulary.
+- Initial role-contract, debate, and critique workflows that need this vocabulary.

--- a/docs/Architecture/index.md
+++ b/docs/Architecture/index.md
@@ -1,6 +1,8 @@
 ---
 title: Cortex Architecture
-description: Canonical architecture chapters for Cortex. Read top-to-bottom for the full story, or follow the evaluator path for a fast first pass.
+description:
+  Canonical architecture chapters for Cortex. Read top-to-bottom for the full story, or follow the
+  evaluator path for a fast first pass.
 sidebar:
   label: Architecture
   order: 1
@@ -8,8 +10,8 @@ sidebar:
 
 # Cortex Architecture
 
-Canonical chapters. Enumerated `NN-` for reading order. Each chapter explains
-how the system fits together at its layer and what its design commitments are.
+Canonical chapters. Enumerated `NN-` for reading order. Each chapter explains how the system fits
+together at its layer and what its design commitments are.
 
 ## Reading paths
 
@@ -27,19 +29,21 @@ Then read these for the deeper rationale and host-boundary contract:
 1. [02-ownership-and-boundaries.md](02-ownership-and-boundaries.md)
 2. [03-formalism-stack.md](03-formalism-stack.md)
 
-| # | Chapter | Topic |
-|---|---|---|
-| 01 | [Overview](01-overview.md) | Three-layer model, ownership boundary, what Cortex owns. |
-| 02 | [Ownership and boundaries](02-ownership-and-boundaries.md) | Substrate/host boundary, dependency direction, and what stays downstream. |
-| 03 | [Algebraic foundations](03-formalism-stack.md) | Why the topology model is algebraic and why rewrites can stay law-preserving. |
-| 04 | [Graph and Circuit](04-graph-and-circuit.md) | Pure topology vs validated executable topology. |
-| 05 | [Wire language](05-wire-language.md) | Source-language architecture: registered authority, boundary typing, partial-node reuse, runtime handoff. |
-| 06 | [Pulse runtime](06-pulse-runtime.md) | Durable execution service, service boundary, task types, checkpoints. |
-| 07 | [Rewrites and materialization](07-rewrites-and-materialization.md) | Bounded dynamic graph evolution, gas, admission policy. |
-| 08 | [Artifacts and provenance](08-artifacts-and-provenance.md) | Runtime outputs, contract envelopes, provenance chains. |
-| 09 | [Nous reasoning library](09-nous-reasoning-library.md) | Archetypes and reasoning patterns above the runtime substrate. |
+| #   | Chapter                                                            | Topic                                                                                                     |
+| --- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| 01  | [Overview](01-overview.md)                                         | Three-layer model, ownership boundary, what Cortex owns.                                                  |
+| 02  | [Ownership and boundaries](02-ownership-and-boundaries.md)         | Substrate/host boundary, dependency direction, and what stays downstream.                                 |
+| 03  | [Algebraic foundations](03-formalism-stack.md)                     | Why the topology model is algebraic and why rewrites can stay law-preserving.                             |
+| 04  | [Graph and Circuit](04-graph-and-circuit.md)                       | Pure topology vs validated executable topology.                                                           |
+| 05  | [Wire language](05-wire-language.md)                               | Source-language architecture: registered authority, boundary typing, partial-node reuse, runtime handoff. |
+| 06  | [Pulse runtime](06-pulse-runtime.md)                               | Durable execution service, service boundary, task types, checkpoints.                                     |
+| 07  | [Rewrites and materialization](07-rewrites-and-materialization.md) | Bounded dynamic graph evolution, gas, admission policy.                                                   |
+| 08  | [Artifacts and provenance](08-artifacts-and-provenance.md)         | Runtime outputs, contract envelopes, provenance chains.                                                   |
+| 09  | [Nous reasoning library](09-nous-reasoning-library.md)             | Archetypes and reasoning patterns above the runtime substrate.                                            |
 
-Normative grammar details (operators, port signatures, type-checking) live in [Reference/Wire/](../Reference/Wire/), not here. Chapters point into references where precision is needed.
+Normative grammar details (operators, port signatures, type-checking) live in
+[Reference/Wire/](../Reference/Wire/), not here. Chapters point into references where precision is
+needed.
 
 ## Related
 

--- a/docs/Consumers/Portman.md
+++ b/docs/Consumers/Portman.md
@@ -1,6 +1,7 @@
 ---
 title: Portman Consumer Example
-description: Compact example of how a private downstream product binds Cortex without defining Cortex itself.
+description:
+  Compact example of how a private downstream product binds Cortex without defining Cortex itself.
 sidebar:
   label: Portman
   order: 1
@@ -8,36 +9,34 @@ sidebar:
 
 # Portman Consumer Example
 
-Portman is a private downstream product that uses Cortex as an upstream
-substrate. This page is an example of a consumer binding, not a specification
-for Cortex and not the full Portman system design.
+Portman is a private downstream product that uses Cortex as an upstream substrate. This page is an
+example of a consumer binding, not a specification for Cortex and not the full Portman system
+design.
 
-The useful pattern is the ownership boundary: Cortex owns reusable substrate
-mechanics, while the consumer owns product semantics, policy, persistence, and
-operator experience.
+The useful pattern is the ownership boundary: Cortex owns reusable substrate mechanics, while the
+consumer owns product semantics, policy, persistence, and operator experience.
 
 ## Boundary
 
-| Cortex owns | Portman owns |
-|---|---|
-| Wire authoring, graph composition, Circuit validation, and Pulse execution. | Product skills, finance policy, prompts, tool allowlists, report shape, and UI language. |
+| Cortex owns                                                                                 | Portman owns                                                                                    |
+| ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Wire authoring, graph composition, Circuit validation, and Pulse execution.                 | Product skills, finance policy, prompts, tool allowlists, report shape, and UI language.        |
 | Generic run state, retries, cancellation, host-action boundaries, and provenance mechanics. | Product persistence, admin APIs, workspace surfaces, scorecards, and customer-facing artifacts. |
-| Structured document and artifact contracts that can be reused by other consumers. | Mapping those contracts into Portman report artifacts and private product workflows. |
+| Structured document and artifact contracts that can be reused by other consumers.           | Mapping those contracts into Portman report artifacts and private product workflows.            |
 
-If another consumer could reuse the rule unchanged, it belongs in Cortex canon.
-If the rule depends on Portman's product surface, storage model, or private
-domain policy, it belongs downstream.
+If another consumer could reuse the rule unchanged, it belongs in Cortex canon. If the rule depends
+on Portman's product surface, storage model, or private domain policy, it belongs downstream.
 
 ## Binding Shape
 
 Portman's current Cortex usage can be summarized as four binding points.
 
-| Binding point | Cortex role | Portman role |
-|---|---|---|
-| Deep research reports | Run a bounded research workflow and return structured research/document outputs. | Bind the workflow to the `/deep-report` product skill, finance prompts, section ordering, and report UX. |
-| Report provenance | Provide reusable structured document and provenance mechanics. | Resolve tool-call evidence into product-facing report inspection, freshness indicators, and workspace artifacts. |
-| Pulse host actions | Execute durable runs and call host-owned actions for domain side effects. | Implement authenticated, idempotent host actions and expose product-specific operator controls. |
-| Evaluation runs | Exercise the Pulse lifecycle with typed outcomes, checkpoints, cancellation, and partial progress. | Persist eval rows, scorecards, and admin read models in the private product database. |
+| Binding point         | Cortex role                                                                                        | Portman role                                                                                                     |
+| --------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Deep research reports | Run a bounded research workflow and return structured research/document outputs.                   | Bind the workflow to the `/deep-report` product skill, finance prompts, section ordering, and report UX.         |
+| Report provenance     | Provide reusable structured document and provenance mechanics.                                     | Resolve tool-call evidence into product-facing report inspection, freshness indicators, and workspace artifacts. |
+| Pulse host actions    | Execute durable runs and call host-owned actions for domain side effects.                          | Implement authenticated, idempotent host actions and expose product-specific operator controls.                  |
+| Evaluation runs       | Exercise the Pulse lifecycle with typed outcomes, checkpoints, cancellation, and partial progress. | Persist eval rows, scorecards, and admin read models in the private product database.                            |
 
 ```mermaid
 flowchart LR
@@ -61,27 +60,32 @@ flowchart LR
     D -. host actions .-> H
 ```
 
-The diagram is intentionally high level. Private endpoint names, table names,
-CLI commands, issue IDs, and product rollout plans are Portman implementation
-details and should live in the Portman repository.
+The diagram is intentionally high level. Private endpoint names, table names, CLI commands, issue
+IDs, and product rollout plans are Portman implementation details and should live in the Portman
+repository.
 
 ## Why This Example Stays Here
 
-Portman is useful in the Cortex docs because it shows how a real downstream
-consumer binds the substrate:
+Portman is useful in the Cortex docs because it shows how a real downstream consumer binds the
+substrate:
 
 - product skills sit above Wire and Pulse rather than inside them
 - durable execution crosses into the host only through explicit host actions
 - structured artifacts are reusable, but product rendering and storage are not
 - provenance is substrate-supported, then presented through product policy
 
-The example should stay compact. It should help a new consumer understand where
-to attach their own semantics without making Portman the frame for Cortex.
+The example should stay compact. It should help a new consumer understand where to attach their own
+semantics without making Portman the frame for Cortex.
 
 ## Related
 
-- [../Architecture/02-ownership-and-boundaries.md](../Architecture/02-ownership-and-boundaries.md) - Cortex and downstream ownership rules.
-- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md) - Wire authoring and registered authority.
-- [../Architecture/06-pulse-runtime.md](../Architecture/06-pulse-runtime.md) - durable execution and host-action boundary.
-- [../Architecture/08-artifacts-and-provenance.md](../Architecture/08-artifacts-and-provenance.md) - artifact and provenance substrate.
-- [../ADRs/0002-cortex-downstream-ownership-boundary.md](../ADRs/0002-cortex-downstream-ownership-boundary.md) - decision record for keeping downstream examples out of the Cortex frame.
+- [../Architecture/02-ownership-and-boundaries.md](../Architecture/02-ownership-and-boundaries.md) -
+  Cortex and downstream ownership rules.
+- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md) - Wire authoring and
+  registered authority.
+- [../Architecture/06-pulse-runtime.md](../Architecture/06-pulse-runtime.md) - durable execution and
+  host-action boundary.
+- [../Architecture/08-artifacts-and-provenance.md](../Architecture/08-artifacts-and-provenance.md) -
+  artifact and provenance substrate.
+- [../ADRs/0002-cortex-downstream-ownership-boundary.md](../ADRs/0002-cortex-downstream-ownership-boundary.md) -
+  decision record for keeping downstream examples out of the Cortex frame.

--- a/docs/Consumers/index.md
+++ b/docs/Consumers/index.md
@@ -1,6 +1,8 @@
 ---
 title: Cortex Consumers
-description: Downstream bindings of Cortex. Consumer docs show how products attach domain semantics, policy, tools, persistence, and operator surfaces to the substrate.
+description:
+  Downstream bindings of Cortex. Consumer docs show how products attach domain semantics, policy,
+  tools, persistence, and operator surfaces to the substrate.
 sidebar:
   label: Consumers
   order: 5
@@ -8,37 +10,33 @@ sidebar:
 
 # Cortex Consumers
 
-Cortex is a generic AI substrate; consumers bind it into product-specific
-runtimes. These pages show binding patterns without making any consumer the
-frame for Cortex itself.
+Cortex is a generic AI substrate; consumers bind it into product-specific runtimes. These pages show
+binding patterns without making any consumer the frame for Cortex itself.
 
 ## Documented consumers
 
-- **[Portman](Portman.md)** - private downstream example. Shows how one product
-  binds Cortex to product policy, artifacts, persistence, and Pulse host
-  actions.
+- **[Portman](Portman.md)** - private downstream example. Shows how one product binds Cortex to
+  product policy, artifacts, persistence, and Pulse host actions.
 
 ## What belongs here
 
 Consumer-specific design docs that describe:
 
 - How the consumer binds Cortex's runtime seams.
-- Product-domain extensions, such as host-specific contracts, tools, and report
-  shapes.
-- Domain-specific decisions, such as how host policy attaches to Cortex
-  actions.
+- Product-domain extensions, such as host-specific contracts, tools, and report shapes.
+- Domain-specific decisions, such as how host policy attaches to Cortex actions.
 - Consumer-side workflow specs built on Cortex primitives.
 
-What does **not** belong here: generic Cortex substrate concerns, which stay in
-`Architecture/` or `Reference/`.
+What does **not** belong here: generic Cortex substrate concerns, which stay in `Architecture/` or
+`Reference/`.
 
 ## Adding a consumer
 
-Start with one page under `Consumers/{Name}.md`. Create a subdirectory only
-when the consumer is public enough and broad enough to justify a multi-page
-binding reference.
+Start with one page under `Consumers/{Name}.md`. Create a subdirectory only when the consumer is
+public enough and broad enough to justify a multi-page binding reference.
 
 ## Related
 
-- [../Architecture/02-ownership-and-boundaries.md](../Architecture/02-ownership-and-boundaries.md) - Cortex and consumer boundary rules.
+- [../Architecture/02-ownership-and-boundaries.md](../Architecture/02-ownership-and-boundaries.md) -
+  Cortex and consumer boundary rules.
 - [../ADRs/](../ADRs/) - substrate-level decisions that affect all consumers.

--- a/docs/Experiments/Wire/2026-04-15-wire-organic-rewrite-smoke.md
+++ b/docs/Experiments/Wire/2026-04-15-wire-organic-rewrite-smoke.md
@@ -1,6 +1,8 @@
 ---
 title: "Wire Organic Rewrite Smoke"
-description: Canonical dogfood prompt and inspection checklist for live LLM-generated Wire append rewrites in thesis_stress_test
+description:
+  Canonical dogfood prompt and inspection checklist for live LLM-generated Wire append rewrites in
+  thesis_stress_test
 date: 2026-04-15
 status: accepted
 related:
@@ -11,13 +13,18 @@ related:
 
 Date: 2026-04-15
 
-This is the canonical small dogfood case for the first live LLM-generated Wire rewrite smoke. It is intentionally smaller than the semiconductor equipment thesis so failures are easy to attribute to rewrite context, grammar, template discovery, or gas handling.
+This is the canonical small dogfood case for the first live LLM-generated Wire rewrite smoke. It is
+intentionally smaller than the semiconductor equipment thesis so failures are easy to attribute to
+rewrite context, grammar, template discovery, or gas handling.
 
 ## Goal
 
-Run `thesis_stress_test` with one obvious thesis that should cause the analyst adaptation node to add focused `Analyst` node instances.
+Run `thesis_stress_test` with one obvious thesis that should cause the analyst adaptation node to
+add focused `Analyst` node instances.
 
-The deterministic test suite already covers raw Wire proposal compilation, append-hole validation, Pulse admission, over-budget rejection, materialization, and successor fan-in. This smoke covers the remaining live behavior: whether the model chooses a valid rewrite from the context it receives.
+The deterministic test suite already covers raw Wire proposal compilation, append-hole validation,
+Pulse admission, over-budget rejection, materialization, and successor fan-in. This smoke covers the
+remaining live behavior: whether the model chooses a valid rewrite from the context it receives.
 
 ## Workflow
 
@@ -83,9 +90,12 @@ In this proposal scope:
 
 - `@analyst` is the registered executor target for these proposal-local nodes.
 - `cuda_moat`, `custom_silicon`, and `valuation_break` are fresh proposal-local node instances.
-- `analyst` is the append anchor and `reviewer` is the original successor. They are supplied by the runtime and should not appear in the proposal graph.
-- `prompt = "..."` is ordinary executor config on the materialized node instance, for example `analyst:cuda_moat`.
-- Because `thesis_stress_test` sets `propagateRewriteAuthority = true`, materialized `Analyst` nodes may also propose follow-on local fragments when remaining rewrite gas allows it.
+- `analyst` is the append anchor and `reviewer` is the original successor. They are supplied by the
+  runtime and should not appear in the proposal graph.
+- `prompt = "..."` is ordinary executor config on the materialized node instance, for example
+  `analyst:cuda_moat`.
+- Because `thesis_stress_test` sets `propagateRewriteAuthority = true`, materialized `Analyst` nodes
+  may also propose follow-on local fragments when remaining rewrite gas allows it.
 
 ## Context The Node Must Receive
 
@@ -111,7 +121,8 @@ In the run UI or DB-backed admin view, inspect:
 - `pulse.graph_rewrites.budget_before` and `budget_after`.
 - Materialized node IDs, expected to be namespaced under `analyst:`.
 - Reviewer inputs, expected to include the rewritten stress nodes rather than only `analyst`.
-- Later rewrite rows whose `source_node_id` is a generated node such as `analyst:software_moat`; these prove recursive bounded rewriting beyond the initial analyst node.
+- Later rewrite rows whose `source_node_id` is a generated node such as `analyst:software_moat`;
+  these prove recursive bounded rewriting beyond the initial analyst node.
 
 ## Failure Diagnosis
 
@@ -123,9 +134,11 @@ If no rewrite happens:
 If the rewrite is rejected:
 
 - `proposal_parse_rejected` means the model did not return raw Wire.
-- `wire_scope_rejected` means the proposal referenced existing workflow nodes such as `analyst` or `reviewer`; append proposals may only reference proposal-local nodes.
+- `wire_scope_rejected` means the proposal referenced existing workflow nodes such as `analyst` or
+  `reviewer`; append proposals may only reference proposal-local nodes.
 - `wire_shape_rejected` means the proposal shape violates the workflow's current shape policy.
-- `wire_*_rejected` means the proposal parsed but failed template, port, hole, shape, or lowering validation.
+- `wire_*_rejected` means the proposal parsed but failed template, port, hole, shape, or lowering
+  validation.
 - `rewrite_budget_exceeded` means the proposal was valid but too large for remaining gas.
 
 If the rewritten nodes run but produce poor content:

--- a/docs/Experiments/Wire/2026-04-16-thesis-stress-test-analyst-dogfood.md
+++ b/docs/Experiments/Wire/2026-04-16-thesis-stress-test-analyst-dogfood.md
@@ -33,7 +33,9 @@ Stress-test this thesis. Focus on where it would break: CUDA/software moat durab
 
 ## Expected Rewrite
 
-`analyst_adaptation` should return raw Wire that declares focused `@analyst` nodes. It should not use `@stress_dimension`, and it should not reference outer workflow node instances such as `analyst` or `reviewer`.
+`analyst_adaptation` should return raw Wire that declares focused `@analyst` nodes. It should not
+use `@stress_dimension`, and it should not reference outer workflow node instances such as `analyst`
+or `reviewer`.
 
 Example shape:
 
@@ -68,5 +70,7 @@ node valuation_break :
 - `pulse.graph_rewrites.status` is `admitted`.
 - Materialized node ids include names like `analyst:cuda_moat`.
 - Reviewer inputs include spawned analyst nodes, not only the original `analyst`.
-- Generated analyst nodes can propose follow-on rewrites if gas remains. The stress-test workflow currently allows up to 16 added nodes, 40 added edges, depth 8, frontier delta 12, and 8 rewrite ops so the run can expose a dozen-ish materialized analysts without unbounded growth.
+- Generated analyst nodes can propose follow-on rewrites if gas remains. The stress-test workflow
+  currently allows up to 16 added nodes, 40 added edges, depth 8, frontier delta 12, and 8 rewrite
+  ops so the run can expose a dozen-ish materialized analysts without unbounded growth.
 - Console `Feed`, `Model`, `Tools`, and `Thoughts` tabs filter correctly when clicking each node.

--- a/docs/Experiments/Wire/index.md
+++ b/docs/Experiments/Wire/index.md
@@ -10,9 +10,9 @@ sidebar:
 
 Dated Wire-specific experiments.
 
-| Date | Title |
-|---|---|
-| 2026-04-15 | [Wire organic rewrite smoke](2026-04-15-wire-organic-rewrite-smoke.md) |
+| Date       | Title                                                                                  |
+| ---------- | -------------------------------------------------------------------------------------- |
+| 2026-04-15 | [Wire organic rewrite smoke](2026-04-15-wire-organic-rewrite-smoke.md)                 |
 | 2026-04-16 | [Thesis stress-test analyst dogfood](2026-04-16-thesis-stress-test-analyst-dogfood.md) |
 
 ## Related

--- a/docs/Experiments/index.md
+++ b/docs/Experiments/index.md
@@ -1,6 +1,8 @@
 ---
 title: Cortex Experiments
-description: Dated smoke tests, dogfood runs, and exploratory trials. Lightweight record of what was tried and what came of it.
+description:
+  Dated smoke tests, dogfood runs, and exploratory trials. Lightweight record of what was tried and
+  what came of it.
 sidebar:
   label: Experiments
   order: 8
@@ -8,7 +10,8 @@ sidebar:
 
 # Cortex Experiments
 
-Dated exploratory runs. Each experiment captures what was tried, under what conditions, and what was learned. Lower bar than a research note — a successful or failed smoke test counts.
+Dated exploratory runs. Each experiment captures what was tried, under what conditions, and what was
+learned. Lower bar than a research note — a successful or failed smoke test counts.
 
 ## Scope subdirectories
 

--- a/docs/Handoffs/index.md
+++ b/docs/Handoffs/index.md
@@ -10,10 +10,9 @@ sidebar:
 
 No handoff notes are currently retained.
 
-Use this directory for temporary work-transition records: contributor
-handoffs, PR-to-PR continuation notes, or phase-transition summaries. Remove a
-handoff once its surviving decisions have moved into ADRs, architecture,
-reference, or roadmap docs.
+Use this directory for temporary work-transition records: contributor handoffs, PR-to-PR
+continuation notes, or phase-transition summaries. Remove a handoff once its surviving decisions
+have moved into ADRs, architecture, reference, or roadmap docs.
 
 ## Template
 

--- a/docs/Publications/Notes/deterministic-multi-rewrite-admission.md
+++ b/docs/Publications/Notes/deterministic-multi-rewrite-admission.md
@@ -1,6 +1,8 @@
 ---
 title: "Deterministic Multi-Rewrite Admission"
-description: Current Cortex runtime semantics for same-wave rewrite proposals, plus validation questions for a future paper direction.
+description:
+  Current Cortex runtime semantics for same-wave rewrite proposals, plus validation questions for a
+  future paper direction.
 status: draft
 related:
   - docs/Architecture/07-rewrites-and-materialization.md
@@ -10,7 +12,8 @@ related:
 
 # Deterministic Multi-Rewrite Admission
 
-This note records the current runtime semantics for multiple rewrite proposals arising from one frontier wave and sketches why that seam may justify a future paper.
+This note records the current runtime semantics for multiple rewrite proposals arising from one
+frontier wave and sketches why that seam may justify a future paper.
 
 ## Current Runtime Semantics
 
@@ -21,11 +24,13 @@ It is closer to:
 1. frontier nodes execute concurrently from the same settled snapshot
 2. any frontier node may emit `StageRewrite`
 3. rewrite admission is serialized through a shared admission gate and shared remaining-budget state
-4. each admitted proposal is persisted immediately as an admitted rewrite row with a monotone `rewrite_id`
+4. each admitted proposal is persisted immediately as an admitted rewrite row with a monotone
+   `rewrite_id`
 5. after the frontier completes, admitted rows from that wave are materialized in `rewrite_id` order
 6. the loop then recurses on the new topology
 
-That gives Cortex a real same-wave multi-proposal story, but the semantics are still **ordered admission and ordered materialization**, not an order-insensitive concurrent substitution law.
+That gives Cortex a real same-wave multi-proposal story, but the semantics are still **ordered
+admission and ordered materialization**, not an order-insensitive concurrent substitution law.
 
 ## Important Boundary Cases
 
@@ -33,7 +38,8 @@ Two cases matter especially.
 
 ### Admitted but Not Yet Materialized
 
-Admission and materialization are separate. A rewrite row may already exist in lineage while the graph watermark still points to an earlier materialized topology.
+Admission and materialization are separate. A rewrite row may already exist in lineage while the
+graph watermark still points to an earlier materialized topology.
 
 That means:
 
@@ -45,13 +51,15 @@ This is not a corner case. It is part of the intended durability boundary.
 
 ### Terminal Frontier Outcomes
 
-A frontier can still terminate the run before admitted rewrite rows from that wave are materialized. That gives a second important state:
+A frontier can still terminate the run before admitted rewrite rows from that wave are materialized.
+That gives a second important state:
 
 - a rewrite was admitted
 - a sibling failure or other terminal outcome won the frontier
 - the run ended before the admitted rewrite affected the materialized topology
 
-This is one reason the seam is interesting. The rewrite log and the materialized graph are not redundant views of the same thing.
+This is one reason the seam is interesting. The rewrite log and the materialized graph are not
+redundant views of the same thing.
 
 ## Why This Might Be a Paper
 
@@ -59,29 +67,40 @@ The interesting question is not "can multiple rewrites happen?" They already can
 
 The interesting question is:
 
-> What semantic law justifies deterministic ordered admission of multiple structural proposals from one frontier wave, and what stronger law would be needed to treat those proposals as truly concurrent?
+> What semantic law justifies deterministic ordered admission of multiple structural proposals from
+> one frontier wave, and what stronger law would be needed to treat those proposals as truly
+> concurrent?
 
 That splits the design space cleanly:
 
 - **current Cortex machine:** concurrent proposal, serialized admission, ordered materialization
-- **stronger future machine:** explicit independence relation and commutation law for same-wave rewrites
+- **stronger future machine:** explicit independence relation and commutation law for same-wave
+  rewrites
 
 The first is already real. The second is still theory debt.
 
 ## Validation Program
 
-If this becomes a paper direction, "complex end shapes looked good" is not enough. A serious validation program would need at least:
+If this becomes a paper direction, "complex end shapes looked good" is not enough. A serious
+validation program would need at least:
 
-1. **Order sensitivity tests.** Force different admission orders for same-wave proposals and compare resulting topology, budget, provenance, and run outcome.
-2. **Independence candidates.** Define a local criterion over anchors, interfaces, and budget effects that predicts when two proposals should commute.
-3. **Counterexample suite.** Construct non-commuting siblings on purpose: overlapping anchors, interface collisions, budget races, and terminal sibling outcomes.
-4. **Watermark invariants.** Show that admitted-but-unmaterialized lineage is always distinguishable from applied topology through watermark discipline.
-5. **Replay and resume checks.** Validate that resume reconstructs the same materialized topology and frontier from the same admitted lineage prefix and watermark.
-6. **Admin-surface clarity.** Confirm that operator surfaces can explain the difference between admitted lineage and applied topology without ambiguity.
+1. **Order sensitivity tests.** Force different admission orders for same-wave proposals and compare
+   resulting topology, budget, provenance, and run outcome.
+2. **Independence candidates.** Define a local criterion over anchors, interfaces, and budget
+   effects that predicts when two proposals should commute.
+3. **Counterexample suite.** Construct non-commuting siblings on purpose: overlapping anchors,
+   interface collisions, budget races, and terminal sibling outcomes.
+4. **Watermark invariants.** Show that admitted-but-unmaterialized lineage is always distinguishable
+   from applied topology through watermark discipline.
+5. **Replay and resume checks.** Validate that resume reconstructs the same materialized topology
+   and frontier from the same admitted lineage prefix and watermark.
+6. **Admin-surface clarity.** Confirm that operator surfaces can explain the difference between
+   admitted lineage and applied topology without ambiguity.
 
 ## Likely Paper Shape
 
-If pursued, the strongest framing is probably not "concurrent graph rewriting" in the broadest categorical sense.
+If pursued, the strongest framing is probably not "concurrent graph rewriting" in the broadest
+categorical sense.
 
 A more Cortex-shaped framing would be:
 
@@ -89,10 +108,13 @@ A more Cortex-shaped framing would be:
 - ordered materialization over durable lineage
 - minimal independence law for stronger concurrency
 
-That would stay close to the real machine instead of overclaiming a stronger concurrency model than Cortex currently has.
+That would stay close to the real machine instead of overclaiming a stronger concurrency model than
+Cortex currently has.
 
 ## Related
 
-- [../Paper-3-graph-substitution-semantics/](../Paper-3-graph-substitution-semantics/) — current substitution paper.
-- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md) — updated architecture contract.
+- [../Paper-3-graph-substitution-semantics/](../Paper-3-graph-substitution-semantics/) — current
+  substitution paper.
+- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md)
+  — updated architecture contract.
 - [../../Reference/rewrites.md](../../Reference/rewrites.md) — updated normative rewrite reference.

--- a/docs/Publications/Notes/frontier-ideas.md
+++ b/docs/Publications/Notes/frontier-ideas.md
@@ -7,158 +7,155 @@ description: Research ideas surfacing from paper iterations on the frontier alge
 
 ## Idea 1: Closed states as a Boolean algebra
 
-The set of closed states (where `propagateFailure gs = gs`) is closed under
-the accumulate operation: if gs is closed and we accumulate a new fact and
-re-close, the result is still closed. This means closed states form a
-sub-monoid of GraphState under accumulation+closure. Is there additional
-algebraic structure (meet, complement) that would make this a Boolean algebra
-or a Heyting algebra? If so, it would give us a logic over graph states.
+The set of closed states (where `propagateFailure gs = gs`) is closed under the accumulate
+operation: if gs is closed and we accumulate a new fact and re-close, the result is still closed.
+This means closed states form a sub-monoid of GraphState under accumulation+closure. Is there
+additional algebraic structure (meet, complement) that would make this a Boolean algebra or a
+Heyting algebra? If so, it would give us a logic over graph states.
 
 ## Idea 2: The observation schedule as a refinement relation
 
-Sequential and concurrent execution produce the same final state but different
-intermediate observations. This is a refinement relation: the sequential path
-is a refinement of the concurrent path (it exposes more intermediate states).
-Could this be formalized as a simulation relation between two transition
-systems? That would give us a clean proof that sequential and concurrent
+Sequential and concurrent execution produce the same final state but different intermediate
+observations. This is a refinement relation: the sequential path is a refinement of the concurrent
+path (it exposes more intermediate states). Could this be formalized as a simulation relation
+between two transition systems? That would give us a clean proof that sequential and concurrent
 execution are observationally equivalent at frontier boundaries.
 
 ## Idea 3: The persistence safety theorem generalizes beyond failure
 
-The theorem says: "closure idempotency makes incremental persistence safe."
-But this isn't specific to failure propagation. Any closure operator on the
-graph state — not just failure propagation — would give the same safety
-property. What if we had multiple closure operators (failure propagation,
-signal resolution, resource accounting) composed? The composition of closure
-operators is a closure operator iff they commute. This gives a precise
-criterion for adding new "consequence derivation" phases.
+The theorem says: "closure idempotency makes incremental persistence safe." But this isn't specific
+to failure propagation. Any closure operator on the graph state — not just failure propagation —
+would give the same safety property. What if we had multiple closure operators (failure propagation,
+signal resolution, resource accounting) composed? The composition of closure operators is a closure
+operator iff they commute. This gives a precise criterion for adding new "consequence derivation"
+phases.
 
 ## Idea 4: The forward/reset partition suggests a session type
 
-Forward outcomes advance a node through a typed session:
-  Pending → Running → {Completed(v), Failed(e), Skipped, Waiting(s)}
+Forward outcomes advance a node through a typed session: Pending → Running → {Completed(v),
+Failed(e), Skipped, Waiting(s)}
 
-Reset outcomes break the session. If we modeled node execution as a session
-type, the forward/reset distinction would be enforced by the type system.
-Workers would be *unable* to produce reset outcomes — only the coordinator
-(via cancellation/shutdown) could. This would make the constitutional
-restriction on workers into a type-level guarantee.
+Reset outcomes break the session. If we modeled node execution as a session type, the forward/reset
+distinction would be enforced by the type system. Workers would be _unable_ to produce reset
+outcomes — only the coordinator (via cancellation/shutdown) could. This would make the
+constitutional restriction on workers into a type-level guarantee.
 
 ## Idea 5: classifyGraphState as a Brzozowski derivative
 
-The classification of a graph state is essentially: "given the current state,
-what language of future executions is possible?" Progressing = non-empty
-language. Settled = empty language (done). Suspended = blocked until input.
-Stuck = empty language (error). This is analogous to the Brzozowski derivative
-of a regular language: the derivative of a language L with respect to a
-symbol a is {w | aw ∈ L}. The frontier is the set of "next symbols."
+The classification of a graph state is essentially: "given the current state, what language of
+future executions is possible?" Progressing = non-empty language. Settled = empty language (done).
+Suspended = blocked until input. Stuck = empty language (error). This is analogous to the Brzozowski
+derivative of a regular language: the derivative of a language L with respect to a symbol a is {w |
+aw ∈ L}. The frontier is the set of "next symbols."
 
-This is probably too speculative for any of the three papers, but it suggests
-a connection to language theory that might be interesting for a deeper
-theoretical treatment.
+This is probably too speculative for any of the three papers, but it suggests a connection to
+language theory that might be interesting for a deeper theoretical treatment.
 
 ## Idea 6: The three-phase pattern as a design pattern for other systems
 
-The accumulate-close-classify pattern is not specific to workflow execution.
-It applies to any system where:
+The accumulate-close-classify pattern is not specific to workflow execution. It applies to any
+system where:
+
 1. Multiple independent agents produce local facts
 2. Those facts have global consequences that are computed centrally
 3. The system needs to make a lifecycle decision based on the closed state
 
 Examples:
+
 - Distributed consensus (votes are facts, quorum is closure, decision is classification)
-- Build systems (compilation results are facts, dependency propagation is closure, build status is classification)
-- Game state (player actions are facts, physics resolution is closure, game state classification is classification)
+- Build systems (compilation results are facts, dependency propagation is closure, build status is
+  classification)
+- Game state (player actions are facts, physics resolution is closure, game state classification is
+  classification)
 
 This could be a separate short paper or blog post — "the accumulate-close-classify pattern."
 
 ## Idea 7: simulateRun as a test oracle and specification
 
-simulateRun is a pure function that runs the entire runtime lifecycle
-with no IO. It takes a WorkerOracle (NodeId → Inputs → NodeOutcome) and
-produces the complete wave history + final StepResult.
+simulateRun is a pure function that runs the entire runtime lifecycle with no IO. It takes a
+WorkerOracle (NodeId → Inputs → NodeOutcome) and produces the complete wave history + final
+StepResult.
 
 This has several implications:
 
-a) It's a **test oracle**: any behavior observed in the real IO executor
-   should match what simulateRun produces given the same oracle. We could
-   property-test this: run simulateRun with a deterministic oracle, then
-   run the real executor with the same stage actions, and compare final
-   graph states.
+a) It's a **test oracle**: any behavior observed in the real IO executor should match what
+simulateRun produces given the same oracle. We could property-test this: run simulateRun with a
+deterministic oracle, then run the real executor with the same stage actions, and compare final
+graph states.
 
-b) It's a **specification**: the Lean 4 mechanization can target
-   simulateRun directly as the executable specification. The Haskell
-   code is the implementation; simulateRun is the spec; Lean proves
-   properties of the spec.
+b) It's a **specification**: the Lean 4 mechanization can target simulateRun directly as the
+executable specification. The Haskell code is the implementation; simulateRun is the spec; Lean
+proves properties of the spec.
 
-c) It enables **what-if analysis**: before executing a real graph, run
-   simulateRun with various failure scenarios to predict behavior.
-   "If node B fails, what happens?" becomes a pure function call.
+c) It enables **what-if analysis**: before executing a real graph, run simulateRun with various
+failure scenarios to predict behavior. "If node B fails, what happens?" becomes a pure function
+call.
 
-d) It's a **fuzzer target**: generate random oracles (with random
-   success/failure/suspension per node) and verify that simulateRun
-   always terminates and produces a consistent final state.
+d) It's a **fuzzer target**: generate random oracles (with random success/failure/suspension per
+node) and verify that simulateRun always terminates and produces a consistent final state.
 
 ## Idea 8: The algebra surface area is now measurable
 
-The pure algebra kernel is exactly 5 named functions:
-  readyNodes → reduceFacts → propagateFailure → classifyGraphState
-  (composed as applyFrontierResults)
+The pure algebra kernel is exactly 5 named functions: readyNodes → reduceFacts → propagateFailure →
+classifyGraphState (composed as applyFrontierResults)
 
 Plus the simulation: simulateRun.
 
 Everything else is IO glue. This ratio is measurable:
+
 - Graph.hs: ~1100 lines, 0 IO types, 60 pure functions
 - Executor.hs: ~1700 lines, the IO coordinator
 
-The "purity ratio" of the runtime is ~40% pure algebra by line count.
-The semantic ratio is higher: all lifecycle decisions live in the pure
-layer. The IO layer is persistence, logging, and concurrency machinery.
+The "purity ratio" of the runtime is ~40% pure algebra by line count. The semantic ratio is higher:
+all lifecycle decisions live in the pure layer. The IO layer is persistence, logging, and
+concurrency machinery.
 
-This metric could be tracked over time. As extensions are added (graph
-rewriting, quorum dependencies), the purity ratio should stay high or
-increase — if it drops, the extension is leaking IO into the algebra.
+This metric could be tracked over time. As extensions are added (graph rewriting, quorum
+dependencies), the purity ratio should stay high or increase — if it drops, the extension is leaking
+IO into the algebra.
 
 ## Idea 9: Rewrite materialization watermark as a projection checkpoint
 
 This idea is now large enough to justify a dedicated plan:
 `../../Roadmap/Plans/rewrite-materialization-and-recovery.md`.
 
-The rewrite-capable runtime now persists append-only rewrite lineage plus a
-monotone materialization watermark (`applied_rewrite_id`) on graph state.
-This is a useful abstraction boundary:
+The rewrite-capable runtime now persists append-only rewrite lineage plus a monotone materialization
+watermark (`applied_rewrite_id`) on graph state. This is a useful abstraction boundary:
 
 - lineage = immutable structural history
 - watermark = "all rewrites up to here are reflected in the current materialized graph"
 
-That is more precise than saying the system "just replays the log", and it is
-lighter than full graph snapshots after every accepted rewrite. The concept
-looks a lot like a projection checkpoint in event-sourced systems, where the
-read model is rebuilt from an append-only stream up to a known durable offset.
+That is more precise than saying the system "just replays the log", and it is lighter than full
+graph snapshots after every accepted rewrite. The concept looks a lot like a projection checkpoint
+in event-sourced systems, where the read model is rebuilt from an append-only stream up to a known
+durable offset.
 
 Possible write-up directions:
+
 - Rewrite materialization and recovery plan: recovery semantics and determinism burden
-- a shorter design note comparing rewrite-watermark recovery with event-sourced
-  projection rebuilds
+- a shorter design note comparing rewrite-watermark recovery with event-sourced projection rebuilds
 
 ## Idea 10: Local graph substitution and process migration are different extension classes
 
 This boundary is also now part of the rewrite-materialization track, not just a parked note.
 
 The current rewrite model is still local graph substitution:
+
 - rewrite a node boundary
 - materialize the new local topology
 - resume deterministically from the new boundary
 
-Future planner/operator rewrites may want broader structural changes that move
-or reinterpret already-executed regions. That is no longer "just another
-rewrite constructor"; it starts to look like dynamic process migration with an
-explicit state-mapping or history-equivalence problem.
+Future planner/operator rewrites may want broader structural changes that move or reinterpret
+already-executed regions. That is no longer "just another rewrite constructor"; it starts to look
+like dynamic process migration with an explicit state-mapping or history-equivalence problem.
 
 This suggests a useful research boundary:
+
 - local rewrites can be handled by substitution + lineage + watermark
 - non-local rewrites may require migration semantics, not just replay
 
 Possible write-up directions:
+
 - Paper 2: extension boundary of the algebra
-- Rewrite materialization and recovery plan: recovery and migration semantics for broader graph changes
+- Rewrite materialization and recovery plan: recovery and migration semantics for broader graph
+  changes

--- a/docs/Publications/Notes/index.md
+++ b/docs/Publications/Notes/index.md
@@ -1,0 +1,21 @@
+---
+title: Publication Notes
+description: Working notes and idea memos that feed the Cortex publication corpus.
+status: research
+date: 2026-04-28
+updated: 2026-04-28
+related:
+  - docs/Publications/roadmap.md
+  - docs/Publications/index.md
+---
+
+# Publication Notes
+
+Working-stage material for the publication corpus. These notes are not canonical paper claims;
+mature material moves into the relevant manuscript, artifact note, or roadmap plan.
+
+## Notes
+
+- [frontier-ideas.md](frontier-ideas.md) — raw idea bank for paper and plan development.
+- [deterministic-multi-rewrite-admission.md](deterministic-multi-rewrite-admission.md) — runtime
+  semantics and validation questions for same-wave multi-proposal admission.

--- a/docs/Publications/Paper-1-staged-reduction/Figures/index.md
+++ b/docs/Publications/Paper-1-staged-reduction/Figures/index.md
@@ -4,6 +4,9 @@ description: Figure inventory and source notes for Paper 1.
 date: 2026-04-28
 updated: 2026-04-28
 status: draft
+related:
+  - docs/Publications/Paper-1-staged-reduction/manuscript.md
+  - docs/Publications/Paper-1-staged-reduction/index.md
 ---
 
 # Paper 1 Figures
@@ -12,8 +15,10 @@ This directory holds figure sources and exported assets for the staged-reduction
 
 ## Inventory
 
-- `staged-reduction-overview.mmd` — Mermaid source for the manuscript's staged-reduction overview figure.
+- `staged-reduction-overview.mmd` — Mermaid source for the manuscript's staged-reduction overview
+  figure.
 
 ## Status
 
-The current draft keeps Figure 1 inline in the manuscript. Publication-exported vector figures are not checked in yet.
+The current draft keeps Figure 1 inline in the manuscript. Publication-exported vector figures are
+not checked in yet.

--- a/docs/Publications/Paper-1-staged-reduction/Figures/staged-reduction-overview.mmd
+++ b/docs/Publications/Paper-1-staged-reduction/Figures/staged-reduction-overview.mmd
@@ -1,25 +1,20 @@
 flowchart TB
   subgraph Pure["Pure Graph Reduction"]
     A["Node results"]
-    B["Accumulate<br/>commutative point updates"]
-    C["Close<br/>idempotent failure closure"]
-    D["Classify<br/>lifecycle decision"]
+    B["Accumulate"]
+    C["Close"]
+    D["Classify"]
     A --> B --> C --> D
   end
 
   subgraph Runtime["Runtime Coordinator"]
-    E["Dispatch ready frontier"]
-    F["Mark run complete or failed"]
+    E["Dispatch frontier"]
+    F["Mark run done"]
     G["Persist and suspend"]
-    H["Emit diagnostic and fail run"]
+    H["Diagnose and fail"]
   end
 
   D -->|Progressing| E
   D -->|Settled| F
   D -->|Suspended| G
   D -->|Stuck| H
-
-  classDef pure fill:#eef6ff,stroke:#1d4ed8,color:#0f172a,stroke-width:1.5px;
-  classDef runtime fill:#f8fafc,stroke:#475569,color:#0f172a,stroke-width:1.5px;
-  class A,B,C,D pure;
-  class E,F,G,H runtime;

--- a/docs/Publications/Paper-1-staged-reduction/index.md
+++ b/docs/Publications/Paper-1-staged-reduction/index.md
@@ -1,38 +1,56 @@
 ---
 title: "Paper 1 — Staged Reduction"
-description: Landing page for the Staged Reduction paper. Abstract, status, figures, and related material.
+description:
+  Landing page for the Staged Reduction paper. Abstract, status, figures, and related material.
 sidebar:
   label: Paper 1
   order: 1
 status: draft
 date: 2026-04-28
 updated: 2026-04-28
+related:
+  - docs/Publications/Paper-1-staged-reduction/manuscript.md
+  - docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md
+  - docs/Publications/Paper-1-staged-reduction/lean-mechanization.md
 ---
 
 # Paper 1 — Staged Reduction
 
-Staged reduction for durable workflow execution over fixed DAG topology. The paper argues that incremental persistence is structurally safe because recovery normalizes partially persisted state and reapplies failure closure before lifecycle classification.
+Staged reduction for durable workflow execution over fixed DAG topology. The paper argues that
+incremental persistence is structurally safe because recovery normalizes partially persisted state
+and reapplies failure closure before lifecycle classification.
 
 ## Status
 
 Draft manuscript. See [manuscript.md](manuscript.md) for the full text.
 
-The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`, including the structural recovery theorem (`persistence_safety`), frontier antichain, disjoint-key accumulation commutativity, fold permutation invariance, classification exhaustiveness, and the extensiveness, monotonicity, and idempotence closure laws. The Lean-Haskell modeling boundary is documented in [lean-haskell-boundary.md](lean-haskell-boundary.md).
+The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`, including the
+structural recovery theorem (`persistence_safety`), frontier antichain, disjoint-key accumulation
+commutativity, fold permutation invariance, classification exhaustiveness, and the extensiveness,
+monotonicity, and idempotence closure laws. The Lean-Haskell modeling boundary is documented in
+[lean-haskell-boundary.md](lean-haskell-boundary.md).
 
 ## Abstract
 
-The manuscript presents a durable workflow runtime organized as a staged pure reduction over fixed algebraic graph topology. Its central claim is deliberately narrow: crash recovery after partial persistence remains structurally safe because normalization and failure closure restore a valid schedulable state before classification resumes.
+The manuscript presents a durable workflow runtime organized as a staged pure reduction over fixed
+algebraic graph topology. Its central claim is deliberately narrow: crash recovery after partial
+persistence remains structurally safe because normalization and failure closure restore a valid
+schedulable state before classification resumes.
 
 ## Figures
 
 - [Figures/index.md](Figures/index.md) — figure inventory and export notes.
-- [staged-reduction-overview.mmd](Figures/staged-reduction-overview.mmd) — source for the staged-reduction overview figure used in the manuscript.
+- [staged-reduction-overview.mmd](Figures/staged-reduction-overview.mmd) — source for the
+  staged-reduction overview figure used in the manuscript.
 - Publication-exported figures are not checked in yet.
 
 ## Related
 
 - [manuscript.md](manuscript.md) — full manuscript.
 - [lean-mechanization.md](lean-mechanization.md) — paper-local Lean 4 plan and draft exit criteria.
-- [lean-haskell-boundary.md](lean-haskell-boundary.md) — companion note on the Lean model and Haskell runtime boundary.
-- [../../Roadmap/Plans/lean-mechanization.md](../../Roadmap/Plans/lean-mechanization.md) — program-level mechanization plan shared with Paper 2.
-- [../Paper-2-algebraic-foundations/](../Paper-2-algebraic-foundations/) — companion algebraic foundations paper.
+- [lean-haskell-boundary.md](lean-haskell-boundary.md) — companion note on the Lean model and
+  Haskell runtime boundary.
+- [../../Roadmap/Plans/lean-mechanization.md](../../Roadmap/Plans/lean-mechanization.md) —
+  program-level mechanization plan shared with Paper 2.
+- [../Paper-2-algebraic-foundations/](../Paper-2-algebraic-foundations/) — companion algebraic
+  foundations paper.

--- a/docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md
+++ b/docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md
@@ -1,6 +1,8 @@
 ---
 title: "Paper 1 — Lean-Haskell Pulse Boundary"
-description: "Companion artifact note for the Staged Reduction paper: what the Lean Pulse kernel models, what the Haskell runtime must establish, and where assumptions remain."
+description:
+  "Companion artifact note for the Staged Reduction paper: what the Lean Pulse kernel models, what
+  the Haskell runtime must establish, and where assumptions remain."
 date: 2026-04-28
 updated: 2026-04-28
 status: draft
@@ -12,48 +14,41 @@ related:
 
 # Paper 1 — Lean-Haskell Pulse Boundary
 
-This note states the boundary between the fixed-topology Pulse kernel
-mechanized in Lean and the live Haskell Pulse runtime.
-It is the artifact note for the Staged Reduction manuscript's
+This note states the boundary between the fixed-topology Pulse kernel mechanized in Lean and the
+live Haskell Pulse runtime. It is the artifact note for the Staged Reduction manuscript's
 implementation claim.
 
 ## Boundary Summary
 
-Lean proves structural safety for a finite DAG and an extensional graph
-state after recovery normalization and failure closure. The Haskell
-runtime is responsible for decoding, validating, and persisting concrete
-state; running node executors; and admitting only topology-valid node
-results. The Lean theorem begins once the runtime has supplied a
-candidate graph state and the stated persisted preconditions hold.
+Lean proves structural safety for a finite DAG and an extensional graph state after recovery
+normalization and failure closure. The Haskell runtime is responsible for decoding, validating, and
+persisting concrete state; running node executors; and admitting only topology-valid node results.
+The Lean theorem begins once the runtime has supplied a candidate graph state and the stated
+persisted preconditions hold.
 
-The mechanization is intentionally structural. It does not model worker
-I/O, JSON schemas, database transactions, retry policy, signal delivery,
-or the semantic correctness of a node's payload.
+The mechanization is intentionally structural. It does not model worker I/O, JSON schemas, database
+transactions, retry policy, signal delivery, or the semantic correctness of a node's payload.
 
 ## Lean Kernel Model
 
 The Lean model under `theory/Cortex/Pulse/` uses these abstractions:
 
-- `DAG`: a finite node set with an edge relation whose endpoints are in
-  the node set. Reachability is the edge-path transitive closure, not a
-  free relation supplied by callers.
-- `GraphState`: total functions from nodes to statuses and optional
-  outputs. The `topologyDomain` predicate makes off-topology state
-  inert: off-topology statuses are pending and off-topology outputs are
-  absent.
-- `NodeStatus`: the eight runtime lifecycle statuses, with operational
-  payloads erased. `NodeInterrupted reason` becomes `interrupted`;
-  `NodeWaiting signal` becomes `waiting`.
-- `payload`: an abstract type. Lean tracks whether an output exists and
-  whether its status may own it; it does not inspect JSON values.
-- `NodeOutcome` and `NodeResult`: abstract worker results used for the
-  pure accumulation phase. The admissibility predicate requires the
-  target node to be in the topology and executable from the direct
-  runtime frontier.
+- `DAG`: a finite node set with an edge relation whose endpoints are in the node set. Reachability
+  is the edge-path transitive closure, not a free relation supplied by callers.
+- `GraphState`: total functions from nodes to statuses and optional outputs. The `topologyDomain`
+  predicate makes off-topology state inert: off-topology statuses are pending and off-topology
+  outputs are absent.
+- `NodeStatus`: the eight runtime lifecycle statuses, with operational payloads erased.
+  `NodeInterrupted reason` becomes `interrupted`; `NodeWaiting signal` becomes `waiting`.
+- `payload`: an abstract type. Lean tracks whether an output exists and whether its status may own
+  it; it does not inspect JSON values.
+- `NodeOutcome` and `NodeResult`: abstract worker results used for the pure accumulation phase. The
+  admissibility predicate requires the target node to be in the topology and executable from the
+  direct runtime frontier.
 
-The public recovered-state structure is `WellFormedGraphState`, exposed
-through the stable `wellFormedGraphState` predicate name. Its fields are
-the proof-side version of the runtime boundary:
+The public recovered-state structure is `WellFormedGraphState`, exposed through the stable
+`wellFormedGraphState` predicate name. Its fields are the proof-side version of the runtime
+boundary:
 
 - `topologyDomain`
 - `outputsRespectStatuses`
@@ -64,78 +59,67 @@ the proof-side version of the runtime boundary:
 - `causalHistoryClosed`
 - `frontierBridge`
 
-`frontierBridge` states that proof-level reachability readiness and the
-runtime's direct-predecessor frontier coincide. Lean proves this bridge
-from failure closure plus causal-history closure.
+`frontierBridge` states that proof-level reachability readiness and the runtime's direct-predecessor
+frontier coincide. Lean proves this bridge from failure closure plus causal-history closure.
 
-`causalHistoryClosed` is the structure field for the standalone
-predicate `CausalHistoryClosed`; the two names denote the same
-conceptual obligation at different levels of the Lean API.
+`causalHistoryClosed` is the structure field for the standalone predicate `CausalHistoryClosed`; the
+two names denote the same conceptual obligation at different levels of the Lean API.
 
 ## Runtime Responsibilities
 
-The Haskell runtime carries concrete identifiers, maps, JSON payloads,
-durable storage, and executor effects. To use the Lean theorem as the
-structural justification for recovery, the runtime side must establish
-or preserve the following obligations.
+The Haskell runtime carries concrete identifiers, maps, JSON payloads, durable storage, and executor
+effects. To use the Lean theorem as the structural justification for recovery, the runtime side must
+establish or preserve the following obligations.
 
-| Runtime obligation | Lean boundary predicate |
-|---|---|
-| Build a finite acyclic topology and reject persisted status keys outside the rebuilt topology. | `DAG` well-formedness and `topologyDomain` |
-| Insert missing topology statuses as pending during reconciliation. | `topologyDomain` |
-| Normalize in-flight execution state before resumption. | `resetRunningToPending`, `noRunningNodes`, `noInterruptedNodes` |
-| Keep outputs only on payload-owning statuses. | `outputsRespectStatuses` |
-| Ensure payload-owning terminal statuses have outputs. | `outputsCompleteForStatuses` |
-| Persist only node facts produced for topology nodes admitted by the executable frontier. | `NodeResult.Admissible` preservation lemmas |
-| Preserve the causal history of successor-unblocking statuses. | `CausalHistoryClosed` |
-| Re-run failure propagation before authoritative classification. | `failureClosureComplete`, closure idempotence |
+| Runtime obligation                                                                             | Lean boundary predicate                                         |
+| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Build a finite acyclic topology and reject persisted status keys outside the rebuilt topology. | `DAG` well-formedness and `topologyDomain`                      |
+| Insert missing topology statuses as pending during reconciliation.                             | `topologyDomain`                                                |
+| Normalize in-flight execution state before resumption.                                         | `resetRunningToPending`, `noRunningNodes`, `noInterruptedNodes` |
+| Keep outputs only on payload-owning statuses.                                                  | `outputsRespectStatuses`                                        |
+| Ensure payload-owning terminal statuses have outputs.                                          | `outputsCompleteForStatuses`                                    |
+| Persist only node facts produced for topology nodes admitted by the executable frontier.       | `NodeResult.Admissible` preservation lemmas                     |
+| Preserve the causal history of successor-unblocking statuses.                                  | `CausalHistoryClosed`                                           |
+| Re-run failure propagation before authoritative classification.                                | `failureClosureComplete`, closure idempotence                   |
 
-Some of these are local runtime mechanisms: `initialGraphState` creates
-pending statuses for topology nodes, `reconcileGraphState` rejects
-unknown status nodes and fills missing topology statuses as pending, and
-`normalizeForResume` maps running and interrupted nodes back to
-pending. Others are end-to-end contracts on the execution path: node
-results must come from the ready frontier, persisted outputs must match
-their statuses, and persisted state must not acquire stray topology
-identifiers.
+Some of these are local runtime mechanisms: `initialGraphState` creates pending statuses for
+topology nodes, `reconcileGraphState` rejects unknown status nodes and fills missing topology
+statuses as pending, and `normalizeForResume` maps running and interrupted nodes back to pending.
+Others are end-to-end contracts on the execution path: node results must come from the ready
+frontier, persisted outputs must match their statuses, and persisted state must not acquire stray
+topology identifiers.
 
 ## Status And Output Correspondence
 
-| Haskell status | Lean status | Boundary meaning |
-|---|---|---|
-| `NodePending` | `pending` | Waiting to run; no output. |
-| `NodeRunning` | `running` | Volatile in-flight state; reset to pending on recovery. |
-| `NodeCompleted` | `completed` | Terminal success; owns and requires an output. |
-| `NodeFailed` | `failed` | Terminal failure; owns no output and drives failure closure. |
-| `NodeSkipped` | `skipped` | Terminal non-output status; unblocks successors and contributes no input payload. |
-| `NodeInterrupted reason` | `interrupted` | Volatile interruption; the reason is operational and erased by Lean. |
-| `NodeWaiting signal` | `waiting` | Suspended on an external signal; the signal name is operational and erased by Lean. |
-| `NodeRewritten` | `rewritten` | Terminal rewrite marker; Lean treats well-formed rewritten nodes as payload-owning. Rewrite correctness itself belongs to the rewrite-materialization proof path, not the fixed-topology Paper 1 claim. |
+| Haskell status           | Lean status   | Boundary meaning                                                                                                                                                                                        |
+| ------------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NodePending`            | `pending`     | Waiting to run; no output.                                                                                                                                                                              |
+| `NodeRunning`            | `running`     | Volatile in-flight state; reset to pending on recovery.                                                                                                                                                 |
+| `NodeCompleted`          | `completed`   | Terminal success; owns and requires an output.                                                                                                                                                          |
+| `NodeFailed`             | `failed`      | Terminal failure; owns no output and drives failure closure.                                                                                                                                            |
+| `NodeSkipped`            | `skipped`     | Terminal non-output status; unblocks successors and contributes no input payload.                                                                                                                       |
+| `NodeInterrupted reason` | `interrupted` | Volatile interruption; the reason is operational and erased by Lean.                                                                                                                                    |
+| `NodeWaiting signal`     | `waiting`     | Suspended on an external signal; the signal name is operational and erased by Lean.                                                                                                                     |
+| `NodeRewritten`          | `rewritten`   | Terminal rewrite marker; Lean treats well-formed rewritten nodes as payload-owning. Rewrite correctness itself belongs to the rewrite-materialization proof path, not the fixed-topology Paper 1 claim. |
 
-The important invariant is negative as much as positive: failed,
-skipped, pending, running, interrupted, and waiting nodes must not carry
-durable outputs in a well-formed recovered state. This is what prevents
-stale payloads from being read after a skipped or failed dependency.
+The important invariant is negative as much as positive: failed, skipped, pending, running,
+interrupted, and waiting nodes must not carry durable outputs in a well-formed recovered state. This
+is what prevents stale payloads from being read after a skipped or failed dependency.
 
 ## Frontier And Classification Boundary
 
-The runtime computes readiness from direct predecessors. The Lean proof
-defines readiness over all strict ancestors because that is the natural
-shape for antichain and stuck-freeness arguments. These agree only under
-the recovered-state invariants:
+The runtime computes readiness from direct predecessors. The Lean proof defines readiness over all
+strict ancestors because that is the natural shape for antichain and stuck-freeness arguments. These
+agree only under the recovered-state invariants:
 
-- failure closure ensures failed ancestors have propagated through
-  propagatable descendants
-- causal-history closure ensures a successor-unblocking node has
-  terminal strict ancestors
-- topology-domain validity prevents off-topology statuses from affecting
-  the runtime-style scan
+- failure closure ensures failed ancestors have propagated through propagatable descendants
+- causal-history closure ensures a successor-unblocking node has terminal strict ancestors
+- topology-domain validity prevents off-topology statuses from affecting the runtime-style scan
 
-With those invariants, Lean proves `readyNodes_eq_directReadyNodes`.
-Classification then follows the runtime order: failure, progressing,
-completed, suspended, stuck. The theorem
-`classifyGraphState_not_stuck_of_wellFormed` states that well-formed
-states cannot reach the stuck branch after the runtime closure step.
+With those invariants, Lean proves `readyNodes_eq_directReadyNodes`. Classification then follows the
+runtime order: failure, progressing, completed, suspended, stuck. The theorem
+`classifyGraphState_not_stuck_of_wellFormed` states that well-formed states cannot reach the stuck
+branch after the runtime closure step.
 
 ## What Remains Outside Lean
 
@@ -146,12 +130,9 @@ The fixed-topology kernel does not prove these runtime properties:
 - database writes are atomic or ordered correctly
 - host cancellation and signal delivery are fair
 - dynamic rewrite materialization is sound
-- Haskell's concrete map representation is extensionally equal to the
-  Lean total-function model
+- Haskell's concrete map representation is extensionally equal to the Lean total-function model
 
-Those are separate runtime, registry, or rewrite-materialization
-obligations. Paper 1's Lean-backed claim is narrower: if the runtime
-supplies a finite topology-valid recovered state satisfying the
-persisted boundary preconditions, then normalization and failure closure
-produce a structurally well-formed state whose frontier and classifier
-are safe to use.
+Those are separate runtime, registry, or rewrite-materialization obligations. Paper 1's Lean-backed
+claim is narrower: if the runtime supplies a finite topology-valid recovered state satisfying the
+persisted boundary preconditions, then normalization and failure closure produce a structurally
+well-formed state whose frontier and classifier are safe to use.

--- a/docs/Publications/Paper-1-staged-reduction/lean-mechanization.md
+++ b/docs/Publications/Paper-1-staged-reduction/lean-mechanization.md
@@ -1,6 +1,8 @@
 ---
 title: "Paper 1 — Lean 4 Mechanization Plan"
-description: Paper-local Lean 4 plan for discharging the fixed-topology staged-reduction obligations used by the Staged Reduction manuscript.
+description:
+  Paper-local Lean 4 plan for discharging the fixed-topology staged-reduction obligations used by
+  the Staged Reduction manuscript.
 date: 2026-04-28
 updated: 2026-04-28
 status: draft
@@ -15,7 +17,10 @@ related:
 
 This note keeps the proof work for Paper 1 next to the manuscript.
 
-The program-level plan in [../../Roadmap/Plans/lean-mechanization.md](../../Roadmap/Plans/lean-mechanization.md) still matters, but this file is the paper-local contract: what must be mechanized before the manuscript should stop calling itself a draft.
+The program-level plan in
+[../../Roadmap/Plans/lean-mechanization.md](../../Roadmap/Plans/lean-mechanization.md) still
+matters, but this file is the paper-local contract: what must be mechanized before the manuscript
+should stop calling itself a draft.
 
 ## Goal
 
@@ -33,11 +38,19 @@ The target is structural safety, not end-to-end workflow correctness.
 
 Paper 1 should stay `draft` until all of the following exist in Lean 4:
 
-1. A machine-checked `wellFormedGraphState` predicate for normalized, closed recovered states. **Done** (`theory/Cortex/Pulse/Validity.lean`).
-2. Proofs of the three closure laws for `propagateFailure`: extensiveness, monotonicity, idempotence. **Done** — `propagateFailure_extensive`, `propagateFailure_monotone`, and `propagateFailure_idempotent` are discharged in `theory/Cortex/Pulse/Closure.lean`.
-3. A machine-checked structural recovery theorem matching Proposition 1 in the manuscript. **Done** (`persistence_safety` in `theory/Cortex/Pulse/Recovery.lean`), conditional on persisted topology-domain, output-ownership, output-completeness, and causal-history preconditions.
-4. A machine-checked classification exhaustiveness theorem for normalized, closed states. **Done** (`classifyClosedGraphState_exhaustive_of_wellFormed` and `classifyGraphState_not_stuck_of_wellFormed` in `theory/Cortex/Pulse/Classify.lean`).
-5. A short artifact note explaining the modeling boundary between the Lean kernel and the live Haskell runtime. **Done** ([lean-haskell-boundary.md](lean-haskell-boundary.md)).
+1. A machine-checked `wellFormedGraphState` predicate for normalized, closed recovered states.
+   **Done** (`theory/Cortex/Pulse/Validity.lean`).
+2. Proofs of the three closure laws for `propagateFailure`: extensiveness, monotonicity,
+   idempotence. **Done** — `propagateFailure_extensive`, `propagateFailure_monotone`, and
+   `propagateFailure_idempotent` are discharged in `theory/Cortex/Pulse/Closure.lean`.
+3. A machine-checked structural recovery theorem matching Proposition 1 in the manuscript. **Done**
+   (`persistence_safety` in `theory/Cortex/Pulse/Recovery.lean`), conditional on persisted
+   topology-domain, output-ownership, output-completeness, and causal-history preconditions.
+4. A machine-checked classification exhaustiveness theorem for normalized, closed states. **Done**
+   (`classifyClosedGraphState_exhaustive_of_wellFormed` and
+   `classifyGraphState_not_stuck_of_wellFormed` in `theory/Cortex/Pulse/Classify.lean`).
+5. A short artifact note explaining the modeling boundary between the Lean kernel and the live
+   Haskell runtime. **Done** ([lean-haskell-boundary.md](lean-haskell-boundary.md)).
 
 ## What Must Be Proved
 
@@ -49,10 +62,14 @@ Load-bearing theorems for the paper, with their current Lean status:
 - `propagateFailure_extensive` — done (`theory/Cortex/Pulse/Closure.lean`)
 - `propagateFailure_monotone` — done (`theory/Cortex/Pulse/Closure.lean`)
 - `propagateFailure_idempotent` — done (`theory/Cortex/Pulse/Closure.lean`)
-- normalization lemmas for `resetRunningToPending` — done (`theory/Cortex/Pulse/State.lean`, `Recovery.lean`)
-- `frontierBridge` on normalized, closed states — done (`theory/Cortex/Pulse/Validity.lean`); the non-trivial bridge `readyNodes_eq_directReadyNodes` lives in the same file
-- classification exhaustiveness on normalized, closed states — done (`theory/Cortex/Pulse/Classify.lean`)
-- structural persistence safety after persisted-prefix crashes — done (`persistence_safety` in `theory/Cortex/Pulse/Recovery.lean`)
+- normalization lemmas for `resetRunningToPending` — done (`theory/Cortex/Pulse/State.lean`,
+  `Recovery.lean`)
+- `frontierBridge` on normalized, closed states — done (`theory/Cortex/Pulse/Validity.lean`); the
+  non-trivial bridge `readyNodes_eq_directReadyNodes` lives in the same file
+- classification exhaustiveness on normalized, closed states — done
+  (`theory/Cortex/Pulse/Classify.lean`)
+- structural persistence safety after persisted-prefix crashes — done (`persistence_safety` in
+  `theory/Cortex/Pulse/Recovery.lean`)
 
 ## What May Stay Abstract
 
@@ -66,7 +83,8 @@ These should be parameterized or axiomatized so the mechanization stays focused:
 - scheduler fairness and timing
 - concrete map implementation details
 
-The Lean model should be extensional: finite vertex type, status function, optional output function, finite DAG relation.
+The Lean model should be extensional: finite vertex type, status function, optional output function,
+finite DAG relation.
 
 ## What Must Not Be Axiomatized
 
@@ -81,7 +99,8 @@ If these are assumed instead of proved, the mechanization adds too little:
 
 ## Lean Structure
 
-The mechanization lives under `theory/Cortex/Pulse/` (rather than a separate `Paper1/` subtree, so it can share the substrate's `theory/Cortex/Graph/` algebra with Paper 2):
+The mechanization lives under `theory/Cortex/Pulse/` (rather than a separate `Paper1/` subtree, so
+it can share the substrate's `theory/Cortex/Graph/` algebra with Paper 2):
 
 ```text
 theory/Cortex/Pulse/
@@ -107,29 +126,35 @@ Build order followed by the existing artifacts:
 
 ## Manuscript Mapping
 
-| Manuscript section | Lean artifact |
-|---|---|
-| Lemma 1: frontier antichain | `frontier_antichain` in `theory/Cortex/Pulse/Frontier.lean` |
-| Lemma 2: disjoint-key accumulation commutativity | `NodeResult.applyNodeFact_comm` and `NodeResult.applyNodeFacts_perm_invariant` in `theory/Cortex/Pulse/Fact.lean` |
-| Phase 2 closure laws | `propagateFailure_extensive`, `propagateFailure_monotone`, `propagateFailure_idempotent` in `theory/Cortex/Pulse/Closure.lean` |
-| Definition 1: valid recovered graph state | `wellFormedGraphState` in `theory/Cortex/Pulse/Validity.lean` |
-| Proposition 1: structural persistence safety | `persistence_safety` in `theory/Cortex/Pulse/Recovery.lean` |
-| Phase 3 classification split | `classifyClosedGraphState_exhaustive_of_wellFormed` and `classifyGraphState_not_stuck_of_wellFormed` in `theory/Cortex/Pulse/Classify.lean` |
+| Manuscript section                               | Lean artifact                                                                                                                               |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Lemma 1: frontier antichain                      | `frontier_antichain` in `theory/Cortex/Pulse/Frontier.lean`                                                                                 |
+| Lemma 2: disjoint-key accumulation commutativity | `NodeResult.applyNodeFact_comm` and `NodeResult.applyNodeFacts_perm_invariant` in `theory/Cortex/Pulse/Fact.lean`                           |
+| Phase 2 closure laws                             | `propagateFailure_extensive`, `propagateFailure_monotone`, `propagateFailure_idempotent` in `theory/Cortex/Pulse/Closure.lean`              |
+| Definition 1: valid recovered graph state        | `wellFormedGraphState` in `theory/Cortex/Pulse/Validity.lean`                                                                               |
+| Proposition 1: structural persistence safety     | `persistence_safety` in `theory/Cortex/Pulse/Recovery.lean`                                                                                 |
+| Phase 3 classification split                     | `classifyClosedGraphState_exhaustive_of_wellFormed` and `classifyGraphState_not_stuck_of_wellFormed` in `theory/Cortex/Pulse/Classify.lean` |
 
 ## Manuscript Notes
 
-The mechanized obligations now have direct Lean references in the manuscript body. Remaining manuscript-side guidance:
+The mechanized obligations now have direct Lean references in the manuscript body. Remaining
+manuscript-side guidance:
 
-- keep Proposition 1's preconditions explicit — the Lean theorem is conditional on persisted topology-domain, output-ownership, output-completeness, and causal-history invariants that the runtime must establish
-- keep the Lean-Haskell modeling boundary linked from the manuscript and synchronized with the Pulse runtime contract ([lean-haskell-boundary.md](lean-haskell-boundary.md))
+- keep Proposition 1's preconditions explicit — the Lean theorem is conditional on persisted
+  topology-domain, output-ownership, output-completeness, and causal-history invariants that the
+  runtime must establish
+- keep the Lean-Haskell modeling boundary linked from the manuscript and synchronized with the Pulse
+  runtime contract ([lean-haskell-boundary.md](lean-haskell-boundary.md))
 
 ## Immediate Next Steps
 
-1. Keep the boundary note synchronized when `wellFormedGraphState`, recovery normalization, or Pulse persisted-state handling changes.
+1. Keep the boundary note synchronized when `wellFormedGraphState`, recovery normalization, or Pulse
+   persisted-state handling changes.
 
 ## Related
 
 - [manuscript.md](manuscript.md) — Paper 1 manuscript.
 - [index.md](index.md) — paper landing page.
 - [lean-haskell-boundary.md](lean-haskell-boundary.md) — Lean-Haskell runtime boundary note.
-- [../../Roadmap/Plans/lean-mechanization.md](../../Roadmap/Plans/lean-mechanization.md) — program-level plan shared with Paper 2.
+- [../../Roadmap/Plans/lean-mechanization.md](../../Roadmap/Plans/lean-mechanization.md) —
+  program-level plan shared with Paper 2.

--- a/docs/Publications/Paper-1-staged-reduction/manuscript.md
+++ b/docs/Publications/Paper-1-staged-reduction/manuscript.md
@@ -1,6 +1,8 @@
 ---
 title: "Staged Reduction for Durable Workflow Execution"
-description: Draft manuscript on staged reduction, crash recovery, and structural persistence safety for durable workflow execution.
+description:
+  Draft manuscript on staged reduction, crash recovery, and structural persistence safety for
+  durable workflow execution.
 kind: publication
 status: draft
 authors:
@@ -17,33 +19,67 @@ related:
 
 ## Abstract
 
-We present a durable workflow execution runtime organized as a staged pure reduction over fixed algebraic graph topology. Workers produce node-local outcomes from an immutable predecessor-complete snapshot. The coordinator applies results through three phases with distinct algebraic roles: **accumulation** of commutative local facts, **closure** under an idempotent failure-propagation operator, and **classification** of the resulting state into a lifecycle decision. The central claim of the paper is intentionally narrow: incremental persistence is **structurally safe** at any point during accumulation because recovery normalizes partially persisted state and re-closes it before any authoritative lifecycle decision is taken. We define the recovered-state validity contract explicitly and show how the three-phase decomposition explains both normal execution and crash recovery. The paper reports the design as implemented in Cortex Pulse, contrasts it with the failure modes of an earlier imperative runtime, and supports the implementation claims with property-based validation plus a proof sketch of the core structural argument. We do not claim end-to-end workflow correctness, outcome reproducibility for nondeterministic stages, or topology-changing rewrite correctness in this paper.
-
----
+We present a durable workflow execution runtime organized as a staged pure reduction over fixed
+algebraic graph topology. Workers produce node-local outcomes from an immutable predecessor-complete
+snapshot. The coordinator applies results through three phases with distinct algebraic roles:
+**accumulation** of commutative local facts, **closure** under an idempotent failure-propagation
+operator, and **classification** of the resulting state into a lifecycle decision. The central claim
+of the paper is intentionally narrow: incremental persistence is **structurally safe** at any point
+during accumulation because recovery normalizes partially persisted state and re-closes it before
+any authoritative lifecycle decision is taken. We define the recovered-state validity contract
+explicitly and show how the three-phase decomposition explains both normal execution and crash
+recovery. The paper reports the design as implemented in the Pulse runtime, contrasts it with the
+failure modes of an earlier imperative runtime, and supports the implementation claims with
+property-based validation plus a proof sketch of the core structural argument. We do not claim
+end-to-end workflow correctness, outcome reproducibility for nondeterministic stages, or
+topology-changing rewrite correctness in this paper.
 
 ## Artifact Status
 
-The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`; see [lean-mechanization.md](lean-mechanization.md) for the artifact mapping. The boundary between the Lean model and the live Haskell runtime is documented in [lean-haskell-boundary.md](lean-haskell-boundary.md).
-
----
+The fixed-topology kernel is mechanized in Lean 4 under `theory/Cortex/Pulse/`; see
+[lean-mechanization.md](lean-mechanization.md) for the artifact mapping. The boundary between the
+Lean model and the live Haskell runtime is documented in
+[lean-haskell-boundary.md](lean-haskell-boundary.md).
 
 ## 1. Introduction
 
-Durable execution runtimes — systems that execute long-running workflows with crash recovery, signal suspension, and audit trails — must answer a fundamental question: when do you persist state, and what invariants does the persisted state satisfy?
+Durable execution runtimes — systems that execute long-running workflows with crash recovery, signal
+suspension, and audit trails — must answer a fundamental question: when do you persist state, and
+what invariants does the persisted state satisfy?
 
-Event-sourced runtimes (Temporal [1], Azure Durable Functions [2]) replay workflow code from a command journal on crash. This achieves determinism but constrains workflow code: no randomness, no direct I/O, no threading. Checkpoint-based systems (Flink [3], derived from Chandy-Lamport [4]) snapshot operator state at barriers. DAG-based orchestrators (Airflow [5], Dagster [6]) track task instance status but typically treat the graph as scheduling metadata rather than as the semantic object that defines state transitions.
+Event-sourced runtimes (Temporal [\[1\]](#ref-1), Azure Durable Functions [\[2\]](#ref-2)) replay
+workflow code from a command journal on crash. This achieves determinism but constrains workflow
+code: no randomness, no direct I/O, no threading. Checkpoint-based systems (Flink [\[3\]](#ref-3),
+derived from Chandy-Lamport [\[4\]](#ref-4)) snapshot operator state at barriers. DAG-based
+orchestrators (Airflow [\[5\]](#ref-5), Dagster [\[6\]](#ref-6)) track task instance status but
+typically treat the graph as scheduling metadata rather than as the semantic object that defines
+state transitions.
 
-We take a different approach. In our runtime, the algebraic graph topology is the source of the state-transition semantics. The execution frontier — the set of nodes ready to execute — is an antichain in the DAG's reachability order (Lemma 1). Workers execute from a common snapshot and produce pure result values. The coordinator applies results through a staged reduction:
+We take a different approach. In our runtime, the algebraic graph topology is the source of the
+state-transition semantics. The execution frontier — the set of nodes ready to execute — is an
+antichain in the DAG's reachability order (Lemma 1). Workers execute from a common snapshot and
+produce pure result values. The coordinator applies results through a staged reduction:
 
 1. **Accumulate:** apply each worker's result as a commutative point update to graph state.
-2. **Close:** propagate failure consequences through the topology via an idempotent closure operator.
+2. **Close:** propagate failure consequences through the topology via an idempotent closure
+   operator.
 3. **Classify:** determine whether the graph is progressing, settled, suspended, or stuck.
 
-The architectural insight is that persistence boundaries align with algebraic phase boundaries. Because the closure operator is idempotent, the coordinator can persist at any point during accumulation — even mid-frontier — and recovery can normalize the partial state and re-close it before resuming. This removes the need for frontier-atomic persistence and makes incremental per-node persistence in the concurrent path safe by construction rather than by careful synchronization.
+The architectural insight is that persistence boundaries align with algebraic phase boundaries.
+Because the closure operator is idempotent, the coordinator can persist at any point during
+accumulation — even mid-frontier — and recovery can normalize the partial state and re-close it
+before resuming. This removes the need for frontier-atomic persistence and makes incremental
+per-node persistence in the concurrent path safe by construction rather than by careful
+synchronization.
 
 ### 1.1 Context
 
-The model is implemented in Cortex Pulse, a durable execution runtime for graph-shaped AI and host-action workflows. Pulse manages workflows with 4-20 stages per plan, including stages that call external APIs, evaluate model responses, and execute multi-step host actions. The staged-reduction model replaced an earlier imperative design that used per-worker atomic state mutation and ad hoc recovery logic; that design produced persist races, duplicated failure propagation, and exception-handling ambiguity that motivated the redesign.
+The model is implemented in the Pulse runtime for graph-shaped AI and host-action workflows. Pulse
+manages workflows with 4-20 stages per plan, including stages that call external APIs, evaluate
+model responses, and execute multi-step host actions. The staged-reduction model replaced an earlier
+imperative design that used per-worker atomic state mutation and ad hoc recovery logic; that design
+produced persist races, duplicated failure propagation, and exception-handling ambiguity that
+motivated the redesign.
 
 ### 1.2 Assumptions and Scope
 
@@ -67,17 +103,18 @@ Model assumptions:
 Claim boundaries:
 
 - **Claimed in this paper:** structural persistence safety for fixed-topology execution
-- **Not claimed in this paper:** end-to-end workflow correctness, exact outcome reproducibility for nondeterministic stages, or rewrite-capable execution
+- **Not claimed in this paper:** end-to-end workflow correctness, exact outcome reproducibility for
+  nondeterministic stages, or rewrite-capable execution
 
-When outcome reproducibility is discussed, it is conditional on a standard piecewise-determinism assumption: re-executed nodes observe the same predecessor-complete inputs and produce compatible results. Structural safety does not require that assumption; only outcome identity does.
-
----
+When outcome reproducibility is discussed, it is conditional on a standard piecewise-determinism
+assumption: re-executed nodes observe the same predecessor-complete inputs and produce compatible
+results. Structural safety does not require that assumption; only outcome identity does.
 
 ## 2. Background
 
 ### 2.1 Algebraic Graphs
 
-Mokhov [7] introduces an algebraic graph with four constructors:
+Mokhov [\[7\]](#ref-7) introduces an algebraic graph with four constructors:
 
 ```haskell
 data Graph a
@@ -90,7 +127,10 @@ instance Semigroup (Graph a) where (<>) = Overlay
 instance Monoid (Graph a) where mempty = Empty
 ```
 
-Derived combinators build execution topologies declaratively (`edge`, `path`, `star`, `clique`). We lower graphs to a `Relation` with cached forward and reverse adjacency maps for efficient predecessor and successor queries. DAG validation runs at plan construction and again at execution entry.
+Derived combinators build execution topologies declaratively (`edge`, `path`, `star`, `clique`). We
+lower graphs to a `Relation` with cached forward and reverse adjacency maps for efficient
+predecessor and successor queries. DAG validation runs at plan construction and again at execution
+entry.
 
 ### 2.2 Graph State
 
@@ -113,9 +153,8 @@ A graph is:
 - **terminal** when settled and either some node is Failed or all nodes are Completed or Skipped
 - **suspended** when at least one node is Waiting and no node is ready
 
-The runtime also has rewrite-capable extensions, but they are intentionally out of scope for this paper's theorem path.
-
----
+The runtime also has rewrite-capable extensions, but they are intentionally out of scope for this
+paper's theorem path.
 
 ## 3. The Staged Reduction
 
@@ -123,35 +162,34 @@ The runtime also has rewrite-capable extensions, but they are intentionally out 
 flowchart TB
   subgraph Pure["Pure Graph Reduction"]
     A["Node results"]
-    B["Accumulate<br/>commutative point updates"]
-    C["Close<br/>idempotent failure closure"]
-    D["Classify<br/>lifecycle decision"]
+    B["Accumulate"]
+    C["Close"]
+    D["Classify"]
     A --> B --> C --> D
   end
 
   subgraph Runtime["Runtime Coordinator"]
-    E["Dispatch ready frontier"]
-    F["Mark run complete or failed"]
+    E["Dispatch frontier"]
+    F["Mark run done"]
     G["Persist and suspend"]
-    H["Emit diagnostic and fail run"]
+    H["Diagnose and fail"]
   end
 
   D -->|Progressing| E
   D -->|Settled| F
   D -->|Suspended| G
   D -->|Stuck| H
-
-  classDef pure fill:#eef6ff,stroke:#1d4ed8,color:#0f172a,stroke-width:1.5px;
-  classDef runtime fill:#f8fafc,stroke:#475569,color:#0f172a,stroke-width:1.5px;
-  class A,B,C,D pure;
-  class E,F,G,H runtime;
 ```
 
-*Figure 1.* The staged reduction separates a pure graph reduction from the runtime coordinator that dispatches frontier work and handles lifecycle transitions.
+_Figure 1._ The pure graph reduction (top) processes worker results through commutative
+accumulation, idempotent failure closure, and exhaustive lifecycle classification. The runtime
+coordinator (bottom) dispatches frontier work, persists state, and finalizes lifecycle outcomes from
+the classifier's verdict.
 
 ### 3.1 Frontier Computation
 
-The execution frontier is the set of Pending nodes whose predecessors are all Completed, Skipped, or Rewritten:
+The execution frontier is the set of Pending nodes whose predecessors are all Completed, Skipped, or
+Rewritten:
 
 ```haskell
 readyNodes :: Relation NodeId -> GraphState o -> [NodeId]
@@ -164,13 +202,18 @@ readyNodes rel state =
 
 **Lemma 1 (Frontier antichain).** The ready set forms an antichain under reachability.
 
-*Proof.* Suppose frontier nodes $A$ and $B$ are comparable, so there is a directed path
+_Proof._ Suppose frontier nodes $A$ and $B$ are comparable, so there is a directed path
+
 $$
 B = v_0 \to v_1 \to \cdots \to v_k = A.
 $$
-For $A$ to be ready, $v_{k-1}$ must be `Completed`, `Skipped`, or `Rewritten`. Inducting backward, each $v_i$ for $1 \le i < k$ must be `Completed`, `Skipped`, or `Rewritten`; in particular, $B$ must have one of those statuses. But frontier membership requires $B$ to be `Pending`. Contradiction.
 
-**Consequence.** Frontier nodes update disjoint keys. Workers execute from the same predecessor-complete snapshot without sibling ordering dependence.
+For $A$ to be ready, $v_{k-1}$ must be `Completed`, `Skipped`, or `Rewritten`. Inducting backward,
+each $v_i$ for $1 \le i < k$ must be `Completed`, `Skipped`, or `Rewritten`; in particular, $B$ must
+have one of those statuses. But frontier membership requires $B$ to be `Pending`. Contradiction.
+
+**Consequence.** Frontier nodes update disjoint keys. Workers execute from the same
+predecessor-complete snapshot without sibling ordering dependence.
 
 ### 3.2 Node Outcomes and the Forward/Reset Partition
 
@@ -193,7 +236,8 @@ The outcome type partitions into two classes with different algebraic roles:
 - **forward outcomes** advance the node's status monotonically on the status partial order
 - **reset outcomes** revert the node to Pending and are explicitly non-monotone
 
-Both classes commute for independent frontier nodes because they update disjoint keys. Only the forward fragment admits the stronger lattice-style monotonicity reading.
+Both classes commute for independent frontier nodes because they update disjoint keys. Only the
+forward fragment admits the stronger lattice-style monotonicity reading.
 
 ### 3.3 Phase 1: Accumulate
 
@@ -212,21 +256,26 @@ applyNodeFact (NodeResult nid outcome) gs = case outcome of
 
 `applyNodeFact` updates only the node's own status and output. It does not propagate consequences.
 
-**Lemma 2 (Disjoint-key accumulation commutativity).** For frontier results $r_A$ and $r_B$ from distinct frontier nodes $A$ and $B$,
+**Lemma 2 (Disjoint-key accumulation commutativity).** For frontier results $r_A$ and $r_B$ from
+distinct frontier nodes $A$ and $B$,
+
 $$
 \texttt{applyNodeFact}\, r_A \circ \texttt{applyNodeFact}\, r_B
 =
 \texttt{applyNodeFact}\, r_B \circ \texttt{applyNodeFact}\, r_A.
 $$
 
-*Proof.* `applyNodeFact` writes to `gsNodeStatuses` and `gsNodeOutputs` at key `nrNodeId` only. For distinct keys $k_1 \neq k_2$,
+_Proof._ `applyNodeFact` writes to `gsNodeStatuses` and `gsNodeOutputs` at key `nrNodeId` only. For
+distinct keys $k_1 \neq k_2$,
+
 $$
 \texttt{Map.insert}\,(k_1, v_1) \circ \texttt{Map.insert}\,(k_2, v_2)
 =
 \texttt{Map.insert}\,(k_2, v_2) \circ \texttt{Map.insert}\,(k_1, v_1).
 $$
 
-This lemma is deliberately weaker than the shared-state commutativity results studied in LVars or CRDTs. Here we exploit disjoint-key point updates, not conflict resolution on a shared key.
+This lemma is deliberately weaker than the shared-state commutativity results studied in LVars or
+CRDTs. Here we exploit disjoint-key point updates, not conflict resolution on a shared key.
 
 ### 3.4 Phase 2: Close
 
@@ -234,49 +283,69 @@ This lemma is deliberately weaker than the shared-state commutativity results st
 propagateFailure :: Relation NodeId -> GraphState o -> GraphState o
 ```
 
-`propagateFailure` marks all reachable Pending and Waiting descendants of Failed nodes as Failed. In the implementation, it behaves as a closure operator:
+`propagateFailure` marks all reachable Pending and Waiting descendants of Failed nodes as Failed. In
+the implementation, it behaves as a closure operator:
 
 - **monotone:** more failures in imply more failures out
 - **extensive:** failures are only added, never removed
 - **idempotent:** applying closure twice yields the same result as once
 
-Extensiveness, monotonicity, and idempotence are mechanized in Lean 4 as `propagateFailure_extensive`, `propagateFailure_monotone`, and `propagateFailure_idempotent` (see [lean-mechanization.md](lean-mechanization.md)).
+Extensiveness, monotonicity, and idempotence are mechanized in Lean 4 as
+`propagateFailure_extensive`, `propagateFailure_monotone`, and `propagateFailure_idempotent` (see
+[lean-mechanization.md](lean-mechanization.md)).
 
 #### Definition 1 (Valid recovered graph state)
 
-Let $G$ be a fixed DAG and $gs$ a graph state after recovery normalization and closure. We say $\operatorname{wellFormedGraphState}(G, gs)$ holds iff:
+Let $G$ be a fixed DAG and $gs$ a graph state after recovery normalization and closure. We say
+$\operatorname{wellFormedGraphState}(G, gs)$ holds iff:
 
 1. $\operatorname{dom}(gsNodeStatuses) = V(G)$
 2. $\operatorname{dom}(gsNodeOutputs) \subseteq V(G)$
 3. a node has an output iff its status is `NodeCompleted` or `NodeRewritten`
 4. no node is `NodeRunning` or `NodeInterrupted`
 5. every `Pending` or `Waiting` descendant of a `Failed` node is itself `Failed`
-6. $\texttt{readyNodes}(G, gs)$ is exactly the set of `Pending` nodes all of whose predecessors are `Completed`, `Skipped`, or `Rewritten`
+6. $\texttt{readyNodes}(G, gs)$ is exactly the set of `Pending` nodes all of whose predecessors are
+   `Completed`, `Skipped`, or `Rewritten`
 
-Items 5 and 6 are properties of the closed, normalized state used for classification and resume. Arbitrary mid-accumulation persisted snapshots need not satisfy them before normalization and closure.
+Items 5 and 6 are properties of the closed, normalized state used for classification and resume.
+Arbitrary mid-accumulation persisted snapshots need not satisfy them before normalization and
+closure.
 
 #### Proposition 1 (Structural persistence safety, conditional on closure laws)
 
-Assuming the closure laws above, let $S$ be a frontier result set and let $S' \subseteq S$ be the prefix whose facts were durably persisted before a crash. Define:
+Assuming the closure laws above, let $S$ be a frontier result set and let $S' \subseteq S$ be the
+prefix whose facts were durably persisted before a crash. Define:
 
 ```haskell
 gsPersisted  = foldl' (flip applyNodeFact) gs0 S'
 gsRecovered  = propagateFailure G (resetRunningToPending gsPersisted)
 ```
 
-Then `gsRecovered` is a valid recovered graph state. In particular, `readyNodes G gsRecovered` is a correct resume frontier from which execution may continue without corrupting graph structure.
+Then `gsRecovered` is a valid recovered graph state. In particular, `readyNodes G gsRecovered` is a
+correct resume frontier from which execution may continue without corrupting graph structure.
 
-*Proof sketch.* The proof obligation breaks into named parts:
+_Proof sketch._ The proof obligation breaks into named parts:
 
-1. **Domain preservation.** `applyNodeFact` only updates keys already present in the topology-indexed status and output maps, so accumulation never introduces out-of-topology node ids.
-2. **Normalization.** `resetRunningToPending` preserves domains and outputs while removing volatile `NodeRunning` and `NodeInterrupted` markers that may remain after a crash.
-3. **Closure completeness.** `propagateFailure` preserves domains and saturates all propagatable descendants of failed nodes, establishing item 5 of Definition 1.
-4. **Frontier correctness.** `readyNodes` is an extensional test of item 6: it selects exactly the Pending nodes whose predecessors are Completed or Skipped.
-5. **Resume safety under additional facts.** When unpersisted nodes re-execute, re-closing cannot invalidate already propagated failures because closure is idempotent and monotone.
+1. **Domain preservation.** `applyNodeFact` only updates keys already present in the
+   topology-indexed status and output maps, so accumulation never introduces out-of-topology node
+   ids.
+2. **Normalization.** `resetRunningToPending` preserves domains and outputs while removing volatile
+   `NodeRunning` and `NodeInterrupted` markers that may remain after a crash.
+3. **Closure completeness.** `propagateFailure` preserves domains and saturates all propagatable
+   descendants of failed nodes, establishing item 5 of Definition 1.
+4. **Frontier correctness.** `readyNodes` is an extensional test of item 6: it selects exactly the
+   Pending nodes whose predecessors are Completed or Skipped.
+5. **Resume safety under additional facts.** When unpersisted nodes re-execute, re-closing cannot
+   invalidate already propagated failures because closure is idempotent and monotone.
 
-The proposition is therefore a structural statement: the recovered graph state is normalized, closed, and schedulable. It does not prove that replayed worker I/O yields the same business result as the pre-crash execution.
+The proposition is therefore a structural statement: the recovered graph state is normalized,
+closed, and schedulable. It does not prove that replayed worker I/O yields the same business result
+as the pre-crash execution.
 
-Proposition 1 is mechanized in Lean 4 as `persistence_safety` in `theory/Cortex/Pulse/Recovery.lean` (see [lean-mechanization.md](lean-mechanization.md)). The Lean theorem is conditional on persisted topology-domain, output-ownership, output-completeness, and causal-history preconditions, which the runtime must establish at the persistence boundary.
+Proposition 1 is mechanized in Lean 4 as `persistence_safety` in `theory/Cortex/Pulse/Recovery.lean`
+(see [lean-mechanization.md](lean-mechanization.md)). The Lean theorem is conditional on persisted
+topology-domain, output-ownership, output-completeness, and causal-history preconditions, which the
+runtime must establish at the persistence boundary.
 
 ### 3.5 Phase 3: Classify
 
@@ -312,10 +381,13 @@ The coordinator is a thin I/O interpreter over this pure classification.
 
 The three phases compose differently in the two execution strategies:
 
-- **Sequential:** for each node in the frontier, accumulate one fact, close, classify, persist, observe, maybe continue
+- **Sequential:** for each node in the frontier, accumulate one fact, close, classify, persist,
+  observe, maybe continue
 - **Concurrent:** accumulate all facts, close once, classify once, observe once
 
-Both converge to the same closed final state given the same `NodeResult` values. They differ only in observation schedule: the sequential path may observe intermediate classifications and short-circuit earlier, while the concurrent path defers observation to the batch boundary.
+Both converge to the same closed final state given the same `NodeResult` values. They differ only in
+observation schedule: the sequential path may observe intermediate classifications and short-circuit
+earlier, while the concurrent path defers observation to the batch boundary.
 
 The formal composition is:
 
@@ -325,11 +397,15 @@ applyFrontierResults rel results gs =
   classifyGraphState rel (foldl' (flip applyNodeFact) gs results)
 ```
 
-**Proposition 2 (Permutation invariance).** `applyFrontierResults` is invariant under permutation of `results`.
+**Proposition 2 (Permutation invariance).** `applyFrontierResults` is invariant under permutation of
+`results`.
 
-*Proof.* By Lemma 2, the accumulation fold is permutation-invariant for distinct-key frontier results. `propagateFailure` and `classifyGraphState` are deterministic functions of the accumulated state. QED.
+_Proof._ By Lemma 2, the accumulation fold is permutation-invariant for distinct-key frontier
+results. `propagateFailure` and `classifyGraphState` are deterministic functions of the accumulated
+state. QED.
 
-The Lean theorem `NodeResult.applyNodeFacts_perm_invariant` mechanizes the fold-level accumulation claim for distinct node keys.
+The Lean theorem `NodeResult.applyNodeFacts_perm_invariant` mechanizes the fold-level accumulation
+claim for distinct node keys.
 
 ### 3.7 Crash Recovery
 
@@ -342,19 +418,28 @@ let gs2 = resetRunningToPending gs1
 let step = classifyGraphState topology gs2
 ```
 
-The persisted state may reflect a partially completed frontier: some nodes may already be Completed, some may still be Running, and some consequences of failure may not yet have been closed. Recovery normalizes this partial state and then re-enters the same pure reduction used during ordinary execution.
+The persisted state may reflect a partially completed frontier: some nodes may already be Completed,
+some may still be Running, and some consequences of failure may not yet have been closed. Recovery
+normalizes this partial state and then re-enters the same pure reduction used during ordinary
+execution.
 
 ### 3.8 Signal Suspension
 
-Suspension flows through the same staged reduction. `OutcomeSuspendedOn` maps to `NodeWaiting` via `applyNodeFact`. When `classifyGraphState` finds waiting nodes and no frontier, the result is `Suspended`. Signal delivery records the payload and conditionally wakes the run. On resume, `resolveDeliveredSignals` transitions delivered waits into completed nodes with the signal payload as output.
+Suspension flows through the same staged reduction. `OutcomeSuspendedOn` maps to `NodeWaiting` via
+`applyNodeFact`. When `classifyGraphState` finds waiting nodes and no frontier, the result is
+`Suspended`. Signal delivery records the payload and conditionally wakes the run. On resume,
+`resolveDeliveredSignals` transitions delivered waits into completed nodes with the signal payload
+as output.
 
-A run can have both waiting and progressing nodes simultaneously; suspension occurs only when no further progress is possible without signal delivery.
+A run can have both waiting and progressing nodes simultaneously; suspension occurs only when no
+further progress is possible without signal delivery.
 
 ### 3.9 Worked Examples
 
 #### 3.9.1 Normal completion on a diamond
 
 Consider the DAG
+
 $$
 \alpha \to \beta,\qquad
 \alpha \to \gamma,\qquad
@@ -392,7 +477,8 @@ Step 3:
 - close is a no-op
 - classify yields `Settled OutcomeCompleted`
 
-The example shows the main path of the staged reduction: local facts first, global consequences second, lifecycle decision last.
+The example shows the main path of the staged reduction: local facts first, global consequences
+second, lifecycle decision last.
 
 #### 3.9.2 Mid-frontier crash and recovery
 
@@ -423,15 +509,22 @@ Now $\beta$ re-executes and returns `OutcomeNodeFailed`. After accumulation and 
 - $\delta$ is `Failed` by failure propagation
 - classify yields `Settled OutcomeFailed`
 
-If the crash had happened after $\beta$'s failure was persisted but before global observation, recovery would simply close the already persisted failure and classify the same settled failed state. The important point is not that the pre-crash and post-crash histories are textually identical; it is that the recovered state remains structurally valid and resumes from a correct frontier.
-
----
+If the crash had happened after $\beta$'s failure was persisted but before global observation,
+recovery would simply close the already persisted failure and classify the same settled failed
+state. The important point is not that the pre-crash and post-crash histories are textually
+identical; it is that the recovered state remains structurally valid and resumes from a correct
+frontier.
 
 ## 4. Implementation
 
-The current prototype comprises approximately 1100 lines of pure graph-reduction code plus approximately 1700 lines of runtime coordination code. The pure layer implements graph algebra, frontier computation, failure closure, and classification. The coordinator handles persistence, logging, cancellation, and worker scheduling.
+The current prototype comprises approximately 1100 lines of pure graph-reduction code plus
+approximately 1700 lines of runtime coordination code. The pure layer implements graph algebra,
+frontier computation, failure closure, and classification. The coordinator handles persistence,
+logging, cancellation, and worker scheduling.
 
-The concurrent path dispatches workers with bounded parallelism. The theory permits persistence at any coordinator-chosen prefix of accumulation; the current implementation still centralizes close-and-classify at the frontier observation boundary.
+The concurrent path dispatches workers with bounded parallelism. The theory permits persistence at
+any coordinator-chosen prefix of accumulation; the current implementation still centralizes
+close-and-classify at the frontier observation boundary.
 
 Execution-entry DAG validation ensures cyclic topologies are rejected before any stage executes.
 
@@ -439,72 +532,96 @@ Execution-entry DAG validation ensures cyclic topologies are rejected before any
 
 The implementation-level claims are backed by QuickCheck property tests on randomly generated DAGs:
 
-| Property | Paper ref | Test evidence |
-|---|---|---|
-| Frontier antichain (Lemma 1) | §3.1 | No two `readyNodes` have a reachability relationship |
-| Disjoint-key commutativity (Lemma 2) | §3.3 | `applyNodeFact` commutes for pairs of distinct frontier nodes |
-| Permutation invariance | §3.6 | `applyFrontierResults` gives the same result under `shuffle` |
-| Closure idempotence | §3.4 | `propagateFailure` applied twice equals applied once |
-| Closure extensiveness | §3.4 | Failure count never decreases after propagation |
-| Closure monotonicity | §3.4 | More failures in yields more failures out |
-| Recovery normalization | §3.4, §3.7 | Partial frontier + `resetRunningToPending` + classify yields a valid closed state |
-| Sequential = batch | §3.6 | Fold of single-element `applyFrontierResults` matches batch application |
+| Property                             | Paper ref  | Test evidence                                                                     |
+| ------------------------------------ | ---------- | --------------------------------------------------------------------------------- |
+| Frontier antichain (Lemma 1)         | §3.1       | No two `readyNodes` have a reachability relationship                              |
+| Disjoint-key commutativity (Lemma 2) | §3.3       | `applyNodeFact` commutes for pairs of distinct frontier nodes                     |
+| Permutation invariance               | §3.6       | `applyFrontierResults` gives the same result under `shuffle`                      |
+| Closure idempotence                  | §3.4       | `propagateFailure` applied twice equals applied once                              |
+| Closure extensiveness                | §3.4       | Failure count never decreases after propagation                                   |
+| Closure monotonicity                 | §3.4       | More failures in yields more failures out                                         |
+| Recovery normalization               | §3.4, §3.7 | Partial frontier + `resetRunningToPending` + classify yields a valid closed state |
+| Sequential = batch                   | §3.6       | Fold of single-element `applyFrontierResults` matches batch application           |
 
-Several of these properties are now mechanized in Lean 4 — frontier antichain, disjoint-key commutativity and fold permutation, closure extensiveness, monotonicity, idempotence, recovery normalization, and classification exhaustiveness — and the artifacts are listed in [lean-mechanization.md](lean-mechanization.md). The QuickCheck tests remain runtime evidence on the live Haskell implementation; they are not a substitute for the Lean proof surface.
-
----
+Several of these properties are now mechanized in Lean 4 — frontier antichain, disjoint-key
+commutativity and fold permutation, closure extensiveness, monotonicity, idempotence, recovery
+normalization, and classification exhaustiveness — and the artifacts are listed in
+[lean-mechanization.md](lean-mechanization.md). The QuickCheck tests remain runtime evidence on the
+live Haskell implementation; they are not a substitute for the Lean proof surface.
 
 ## 5. Failure Modes Addressed by the Redesign
 
-The table below is a design-level comparison between the earlier imperative runtime and the staged-reduction model. It states which failure classes the redesign removes structurally; it is not a quantitative operational evaluation.
+The table below is a design-level comparison between the earlier imperative runtime and the
+staged-reduction model. It states which failure classes the redesign removes structurally; it is not
+a quantitative operational evaluation.
 
-| Failure mode | Prior design | Staged reduction |
-|---|---|---|
-| **Persist race** | Workers persist independently; stale snapshots overwrite | Coordinator-controlled partial persist; recovery re-closes state |
-| **Interleaved mutation** | Workers read and write shared coordinator state | Workers get immutable snapshots and return values |
-| **Cancellation complexity** | Monitor + terminal flags + exception discrimination | Cancelled workers produce `NodeResult`; algebra handles reset |
-| **Failure propagation drift** | Duplicated in worker paths and collector logic | Single `propagateFailure`, pure, tested independently |
-| **Recovery ambiguity** | Event log reconstruction or frontier-atomic persist | State normalization: `resetRunningToPending` + close + classify |
-
----
+| Failure mode                  | Prior design                                             | Staged reduction                                                 |
+| ----------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------- |
+| **Persist race**              | Workers persist independently; stale snapshots overwrite | Coordinator-controlled partial persist; recovery re-closes state |
+| **Interleaved mutation**      | Workers read and write shared coordinator state          | Workers get immutable snapshots and return values                |
+| **Cancellation complexity**   | Monitor + terminal flags + exception discrimination      | Cancelled workers produce `NodeResult`; algebra handles reset    |
+| **Failure propagation drift** | Duplicated in worker paths and collector logic           | Single `propagateFailure`, pure, tested independently            |
+| **Recovery ambiguity**        | Event log reconstruction or frontier-atomic persist      | State normalization: `resetRunningToPending` + close + classify  |
 
 ## 6. Related Work
 
-The accumulation lemma here is a disjoint-key commutativity result. It is related in spirit to lattice-based determinism (LVars [8]) and CRDTs [10], but substantially weaker: we do not solve shared-key merge semantics, only independent point updates. The analogy is architectural rather than technical identity.
+The accumulation lemma here is a disjoint-key commutativity result. It is related in spirit to
+lattice-based determinism (LVars [\[8\]](#ref-8)) and CRDTs [\[10\]](#ref-10), but substantially
+weaker: we do not solve shared-key merge semantics, only independent point updates. The analogy is
+architectural rather than technical identity.
 
-The CALM theorem [11] still provides a useful reading of the design. Accumulation is coordination-free, while lifecycle classification is a threshold observation that requires a barrier. The frontier boundary is therefore the coordination boundary.
+The CALM theorem [\[11\]](#ref-11) still provides a useful reading of the design. Accumulation is
+coordination-free, while lifecycle classification is a threshold observation that requires a
+barrier. The frontier boundary is therefore the coordination boundary.
 
-Petri-net work on concurrent processes [9] is relevant because the frontier is an antichain of concurrently enabled work, but again the correspondence is suggestive rather than complete. Our runtime uses a much narrower operational fragment.
+Petri-net work on concurrent processes [\[9\]](#ref-9) is relevant because the frontier is an
+antichain of concurrently enabled work, but again the correspondence is suggestive rather than
+complete. Our runtime uses a much narrower operational fragment.
 
-Henrio et al. [12] provide a recent mechanized account of layered confluence for actor systems. That is a useful comparison point for the worker-coordinator topology, but we do not derive our theorem from their framework here.
+Henrio et al. [\[12\]](#ref-12) provide a recent mechanized account of layered confluence for actor
+systems. That is a useful comparison point for the worker-coordinator topology, but we do not derive
+our theorem from their framework here.
 
-Temporal [1] constrains workflow code to be deterministic; we constrain only the coordinator's reduction. Within Elnozahy et al.'s recovery taxonomy [13], our approach is coordinated checkpointing at frontier barriers, justified by closure idempotence rather than by replay from a command log.
+Temporal [\[1\]](#ref-1) constrains workflow code to be deterministic; we constrain only the
+coordinator's reduction. Within Elnozahy et al.'s recovery taxonomy [\[13\]](#ref-13), our approach
+is coordinated checkpointing at frontier barriers, justified by closure idempotence rather than by
+replay from a command log.
 
-Haxl [14] and the Par monad [15] exploit independence for deterministic parallelism; our contribution extends that design pressure to long-running durable tasks with crash recovery and signal suspension.
-
----
+Haxl [\[14\]](#ref-14) and the Par monad [\[15\]](#ref-15) exploit independence for deterministic
+parallelism; our contribution extends that design pressure to long-running durable tasks with crash
+recovery and signal suspension.
 
 ## 7. Discussion
 
 ### 7.1 Structural Safety Versus End-to-End Correctness
 
-The main theorem is intentionally a structural theorem. It says the recovered graph state is well-formed, closed, and schedulable. It does not say the application-level result is identical across crashes, because that depends on stage I/O semantics that the algebra does not govern.
+The main theorem is intentionally a structural theorem. It says the recovered graph state is
+well-formed, closed, and schedulable. It does not say the application-level result is identical
+across crashes, because that depends on stage I/O semantics that the algebra does not govern.
 
-This is a deliberate design choice, not a hidden gap. The paper's contribution is to isolate the part of the system that can be reasoned about compositionally and test it against a precise contract.
+This is a deliberate design choice, not a hidden gap. The paper's contribution is to isolate the
+part of the system that can be reasoned about compositionally and test it against a precise
+contract.
 
 ### 7.2 Recovery Cost
 
-Frontier-wave replay may re-execute completed work on crash, which asynchronous snapshotting systems such as Flink can sometimes avoid. The trade-off is a much simpler coordinator model and a narrower persistence theorem. Incremental per-node persistence reduces the replay cost in practice because only work whose facts were not durably observed must re-run.
+Frontier-wave replay may re-execute completed work on crash, which asynchronous snapshotting systems
+such as Flink can sometimes avoid. The trade-off is a much simpler coordinator model and a narrower
+persistence theorem. Incremental per-node persistence reduces the replay cost in practice because
+only work whose facts were not durably observed must re-run.
 
 ### 7.3 The Forward/Reset Boundary
 
-The node-outcome type partitions into monotone forward outcomes and explicitly non-monotone reset outcomes. The monotone core admits the cleaner algebraic story. Reset outcomes commute only because they remain node-local. This boundary is the honest edge of the model and should remain explicit.
+The node-outcome type partitions into monotone forward outcomes and explicitly non-monotone reset
+outcomes. The monotone core admits the cleaner algebraic story. Reset outcomes commute only because
+they remain node-local. This boundary is the honest edge of the model and should remain explicit.
 
 ### 7.4 Boundary to Topology-Changing Execution
 
-Dynamic graph rewriting is no longer treated as part of this paper's theorem path. Once topology changes mid-run, the fixed-topology structural-safety theorem stated here is insufficient. Rewrite-capable execution needs an additional materialization boundary, durable identity story, and recovery theorem. That is now a separate paper track.
-
----
+Dynamic graph rewriting is no longer treated as part of this paper's theorem path. Once topology
+changes mid-run, the fixed-topology structural-safety theorem stated here is insufficient.
+Rewrite-capable execution needs an additional materialization boundary, durable identity story, and
+recovery theorem. That is now a separate paper track.
 
 ## 8. Conclusion
 
@@ -514,26 +631,36 @@ The central result is a staged pure reduction for fixed-topology durable workflo
 2. **Close** under an idempotent failure-propagation operator.
 3. **Classify** the resulting state into a lifecycle decision.
 
-The architectural insight is that persistence boundaries align with these algebraic phase boundaries. Incremental persistence during accumulation is structurally safe because recovery normalizes partial state and re-closes it before any authoritative lifecycle decision is taken.
+The architectural insight is that persistence boundaries align with these algebraic phase
+boundaries. Incremental persistence during accumulation is structurally safe because recovery
+normalizes partial state and re-closes it before any authoritative lifecycle decision is taken.
 
-The runtime is not claimed correct because every worker interleaving is directly controlled. It is claimed structurally safe because worker results accumulate into a state that is normalized, closed, and classified by a pure algebra with explicit assumptions and boundaries.
-
----
+The runtime is not claimed correct because every worker interleaving is directly controlled. It is
+claimed structurally safe because worker results accumulate into a state that is normalized, closed,
+and classified by a pure algebra with explicit assumptions and boundaries.
 
 ## References
 
-1. Temporal Technologies. *Temporal*. <https://temporal.io>
-2. Microsoft. *Azure Durable Functions*. <https://learn.microsoft.com/en-us/azure/azure-functions/durable/>
-3. Carbone, P. et al. (2015). *Lightweight Asynchronous Snapshots for Distributed Dataflows*. arXiv:[1506.08603](https://arxiv.org/abs/1506.08603).
-4. Chandy, K. M., Lamport, L. (1985). *Distributed Snapshots*. ACM TOCS 3(1):63–75.
-5. Apache Software Foundation. *Apache Airflow*. <https://airflow.apache.org>
-6. Dagster Labs. *Dagster*. <https://dagster.io>
-7. Mokhov, A. (2017). *Algebraic Graphs with Class*. Haskell 2017.
-8. Kuper, L., Newton, R. (2013). *LVars: Lattice-based Data Structures for Deterministic Parallelism*. FHPC 2013.
-9. Best, E., Devillers, R. (1987). *Sequential and Concurrent Behaviour in Petri Net Theory*. TCS 55:87–136.
-10. Shapiro, M. et al. (2011). *Conflict-free Replicated Data Types*. SSS 2011.
-11. Conway, N. et al. (2012). *Logic and Lattices for Distributed Programming*. SoCC 2012.
-12. Henrio, L. et al. (2026). *Layers of Confluence for Actors*. CPP 2026.
-13. Elnozahy, E. et al. (2002). *A Survey of Rollback-Recovery Protocols*. ACM Computing Surveys 34(3):375–408.
-14. Marlow, S. et al. (2014). *There is No Fork*. ICFP 2014.
-15. Marlow, S. et al. (2011). *A Monad for Deterministic Parallelism*. Haskell 2011.
+1. <a id="ref-1"></a>Temporal Technologies. _Temporal_. <https://temporal.io>
+2. <a id="ref-2"></a>Microsoft. _Azure Durable Functions_.
+   <https://learn.microsoft.com/en-us/azure/azure-functions/durable/>
+3. <a id="ref-3"></a>Carbone, P. et al. (2015). _Lightweight Asynchronous Snapshots for Distributed
+   Dataflows_. arXiv:[1506.08603](https://arxiv.org/abs/1506.08603).
+4. <a id="ref-4"></a>Chandy, K. M., Lamport, L. (1985). _Distributed Snapshots_. ACM TOCS
+   3(1):63–75.
+5. <a id="ref-5"></a>Apache Software Foundation. _Apache Airflow_. <https://airflow.apache.org>
+6. <a id="ref-6"></a>Dagster Labs. _Dagster_. <https://dagster.io>
+7. <a id="ref-7"></a>Mokhov, A. (2017). _Algebraic Graphs with Class_. Haskell 2017.
+8. <a id="ref-8"></a>Kuper, L., Newton, R. (2013). _LVars: Lattice-based Data Structures for
+   Deterministic Parallelism_. FHPC 2013.
+9. <a id="ref-9"></a>Best, E., Devillers, R. (1987). _Sequential and Concurrent Behaviour in Petri
+   Net Theory_. TCS 55:87–136.
+10. <a id="ref-10"></a>Shapiro, M. et al. (2011). _Conflict-free Replicated Data Types_. SSS 2011.
+11. <a id="ref-11"></a>Conway, N. et al. (2012). _Logic and Lattices for Distributed Programming_.
+    SoCC 2012.
+12. <a id="ref-12"></a>Henrio, L. et al. (2026). _Layers of Confluence for Actors_. CPP 2026.
+13. <a id="ref-13"></a>Elnozahy, E. et al. (2002). _A Survey of Rollback-Recovery Protocols_. ACM
+    Computing Surveys 34(3):375–408.
+14. <a id="ref-14"></a>Marlow, S. et al. (2014). _There is No Fork_. ICFP 2014.
+15. <a id="ref-15"></a>Marlow, S. et al. (2011). _A Monad for Deterministic Parallelism_.
+    Haskell 2011.

--- a/docs/Publications/Paper-2-algebraic-foundations/Figures/index.md
+++ b/docs/Publications/Paper-2-algebraic-foundations/Figures/index.md
@@ -4,6 +4,9 @@ description: Figure inventory and export status for the Algebraic Foundations pa
 date: 2026-04-28
 updated: 2026-04-28
 status: draft
+related:
+  - docs/Publications/Paper-2-algebraic-foundations/manuscript.md
+  - docs/Publications/Paper-2-algebraic-foundations/index.md
 ---
 
 # Paper 2 Figure Inventory

--- a/docs/Publications/Paper-2-algebraic-foundations/index.md
+++ b/docs/Publications/Paper-2-algebraic-foundations/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Paper 2 — Algebraic Foundations"
-description: Landing page for the Algebraic Foundations paper. Abstract, status, figures, and related material.
+description:
+  Landing page for the Algebraic Foundations paper. Abstract, status, figures, and related material.
 sidebar:
   label: Paper 2
   order: 2
@@ -16,7 +17,8 @@ related:
 
 # Paper 2 — Algebraic Foundations
 
-The keystone paper in the series: the algebraic calculus that the other papers refine, mechanize, and extend.
+The keystone paper in the series: the algebraic calculus that the other papers refine, mechanize,
+and extend.
 
 ## Status
 
@@ -24,11 +26,10 @@ Draft manuscript. See [manuscript.md](manuscript.md) for the full text.
 
 ## Abstract
 
-This paper isolates the fixed-topology algebraic kernel of Cortex durable
-execution: node-local fact accumulation, failure closure, deterministic
-classification, and structural recovery safety after partial persistence. It
-also marks the extension boundary where those results stop carrying over and a
-different machine is required.
+This paper isolates the fixed-topology algebraic kernel of Cortex durable execution: node-local fact
+accumulation, failure closure, deterministic classification, and structural recovery safety after
+partial persistence. It also marks the extension boundary where those results stop carrying over and
+a different machine is required.
 
 ## Figures
 
@@ -38,8 +39,13 @@ different machine is required.
 ## Related
 
 - [manuscript.md](manuscript.md) — full manuscript.
-- [../Paper-1-staged-reduction/](../Paper-1-staged-reduction/) — staged reduction refining this calculus.
-- [../../Roadmap/Plans/lean-mechanization.md](../../Roadmap/Plans/lean-mechanization.md) — supporting research plan for mechanized proofs.
-- [../../Roadmap/Plans/rewrite-materialization-and-recovery.md](../../Roadmap/Plans/rewrite-materialization-and-recovery.md) — runtime rewrite plan building on this extension boundary.
-- [../Paper-3-graph-substitution-semantics/](../Paper-3-graph-substitution-semantics/) — substitution extension of this.
-- [../../Architecture/03-formalism-stack.md](../../Architecture/03-formalism-stack.md) — architecture chapter citing this paper.
+- [../Paper-1-staged-reduction/](../Paper-1-staged-reduction/) — staged reduction refining this
+  calculus.
+- [../../Roadmap/Plans/lean-mechanization.md](../../Roadmap/Plans/lean-mechanization.md) —
+  supporting research plan for mechanized proofs.
+- [../../Roadmap/Plans/rewrite-materialization-and-recovery.md](../../Roadmap/Plans/rewrite-materialization-and-recovery.md)
+  — runtime rewrite plan building on this extension boundary.
+- [../Paper-3-graph-substitution-semantics/](../Paper-3-graph-substitution-semantics/) —
+  substitution extension of this.
+- [../../Architecture/03-formalism-stack.md](../../Architecture/03-formalism-stack.md) —
+  architecture chapter citing this paper.

--- a/docs/Publications/Paper-2-algebraic-foundations/manuscript.md
+++ b/docs/Publications/Paper-2-algebraic-foundations/manuscript.md
@@ -18,7 +18,16 @@ related:
 
 ## Abstract
 
-We develop an algebraic account of durable workflow execution organized as a staged reduction: commutative fact accumulation, idempotent failure closure, and deterministic state classification. The core object is not a workflow program trace but a topology-indexed graph state together with a validity predicate for normalized, closed states. We separate three layers of obligation: algebraic facts about accumulation, closure, and classification; structural recovery theorems for fixed-topology execution; and external assumptions about worker I/O reproducibility. The result is a sharper statement of what the runtime proves, what it merely assumes, and what is deferred to mechanization. We also characterize the extension boundary: which changes preserve the staged reduction and which require a different machine. Topology-changing graph rewriting is treated as one such boundary and is excluded from the core theory of this paper.
+We develop an algebraic account of durable workflow execution organized as a staged reduction:
+commutative fact accumulation, idempotent failure closure, and deterministic state classification.
+The core object is not a workflow program trace but a topology-indexed graph state together with a
+validity predicate for normalized, closed states. We separate three layers of obligation: algebraic
+facts about accumulation, closure, and classification; structural recovery theorems for
+fixed-topology execution; and external assumptions about worker I/O reproducibility. The result is a
+sharper statement of what the runtime proves, what it merely assumes, and what is deferred to
+mechanization. We also characterize the extension boundary: which changes preserve the staged
+reduction and which require a different machine. Topology-changing graph rewriting is treated as one
+such boundary and is excluded from the core theory of this paper.
 
 ---
 
@@ -53,11 +62,14 @@ The main validity predicate is defined only on normalized, closed states.
 2. $\operatorname{dom}(output) \subseteq V$
 3. outputs appear exactly on statuses that semantically carry outputs
 4. no node is $\text{Running}$ or $\text{Interrupted}$
-5. every $\text{Pending}$ or $\text{Waiting}$ descendant of a $\text{Failed}$ node is itself $\text{Failed}$
-6. $\operatorname{readyNodes}(G, s)$ is extensionally equal to the readiness predicate:
-   nodes that are $\text{Pending}$ and whose predecessors are all $\text{Completed}$, $\text{Skipped}$, or $\text{Rewritten}$
+5. every $\text{Pending}$ or $\text{Waiting}$ descendant of a $\text{Failed}$ node is itself
+   $\text{Failed}$
+6. $\operatorname{readyNodes}(G, s)$ is extensionally equal to the readiness predicate: nodes that
+   are $\text{Pending}$ and whose predecessors are all $\text{Completed}$, $\text{Skipped}$, or
+   $\text{Rewritten}$
 
-This definition is intentionally relative to fixed topology. Once topology changes, the validity contract must be enriched with materialization and identity invariants.
+This definition is intentionally relative to fixed topology. Once topology changes, the validity
+contract must be enriched with materialization and identity invariants.
 
 ### 1.2 The Staged Machine
 
@@ -74,7 +86,8 @@ Where:
 - `close = propagateFailure`
 - `classify = classifyGraphState`
 
-The execution model uses barriered frontier waves, but the algebraic core only sees a set of node-local facts and a topology-indexed state.
+The execution model uses barriered frontier waves, but the algebraic core only sees a set of
+node-local facts and a topology-indexed state.
 
 ---
 
@@ -82,7 +95,8 @@ The execution model uses barriered frontier waves, but the algebraic core only s
 
 ### 2.1 Accumulation as a Commutative Action
 
-Let `F` be the free commutative monoid of `NodeResult` values with distinct `NodeId`s. Distinctness is justified by the frontier antichain property.
+Let `F` be the free commutative monoid of `NodeResult` values with distinct `NodeId`s. Distinctness
+is justified by the frontier antichain property.
 
 `applyNodeFact` induces a monoid action:
 
@@ -94,7 +108,8 @@ $$
 \operatorname{act}(S, s) = \operatorname{foldl}(\operatorname{flip}\ applyNodeFact,\ s,\ S)
 $$
 
-The load-bearing property is not a deep join law on shared state. It is the more modest disjoint-key commutativity of point updates.
+The load-bearing property is not a deep join law on shared state. It is the more modest disjoint-key
+commutativity of point updates.
 
 **Lemma 1 (disjoint-key commutativity).** If $r_1.nid \neq r_2.nid$, then:
 
@@ -104,19 +119,20 @@ applyNodeFact\ r_1\ (applyNodeFact\ r_2\ s)
 applyNodeFact\ r_2\ (applyNodeFact\ r_1\ s)
 $$
 
-This is the precise theorem. References to LVars, CRDTs, and related work should be read as analogies in design style, not as direct reuse of their stronger shared-key commutativity results.
+This is the precise theorem. References to LVars, CRDTs, and related work should be read as
+analogies in design style, not as direct reuse of their stronger shared-key commutativity results.
 
 ### 2.2 Failure Closure
 
-`propagateFailure` is treated as a closure operator on the preorder "has at least as many failed consequences as":
+`propagateFailure` is treated as a closure operator on the preorder "has at least as many failed
+consequences as":
 
 - extensive
 - monotone
 - idempotent
 
-These laws are what make partial persistence structurally safe. In this draft
-they are stated as semantic obligations of the implementation and deferred to
-the Lean mechanization plan.
+These laws are what make partial persistence structurally safe. In this draft they are stated as
+semantic obligations of the implementation and deferred to the Lean mechanization plan.
 
 ### 2.3 Classification
 
@@ -138,7 +154,8 @@ $$
 \operatorname{reduce}(G, results, s)
 $$
 
-The theorem is conditional on the identity of `NodeResult` values. It is a theorem about reduction order, not about worker I/O behavior.
+The theorem is conditional on the identity of `NodeResult` values. It is a theorem about reduction
+order, not about worker I/O behavior.
 
 ---
 
@@ -146,7 +163,8 @@ The theorem is conditional on the identity of `NodeResult` values. It is a theor
 
 ### 3.1 Theorem Statement
 
-Let $S = S_1 \cup S_2$ be a frontier result set, where $S_1$ is the subset whose local facts were durably persisted before a crash and $S_2$ is the subset that must be replayed. Define:
+Let $S = S_1 \cup S_2$ be a frontier result set, where $S_1$ is the subset whose local facts were
+durably persisted before a crash and $S_2$ is the subset that must be replayed. Define:
 
 $$
 s_{persisted} = \operatorname{accumulate}(S_1, s_0)
@@ -157,7 +175,8 @@ s_{recovered} =
 \operatorname{close}(G, \operatorname{resetRunningToPending}(s_{persisted}))
 $$
 
-**Theorem 3 (structural recovery safety).** $s_{recovered}$ satisfies $\operatorname{wellFormedGraphState}(G, s_{recovered})$.
+**Theorem 3 (structural recovery safety).** $s_{recovered}$ satisfies
+$\operatorname{wellFormedGraphState}(G, s_{recovered})$.
 
 Moreover:
 
@@ -180,7 +199,8 @@ The theorem does **not** guarantee:
 - identical worker exceptions or timing
 - end-to-end correctness of the whole workflow system
 
-Those stronger properties require assumptions or proof obligations outside the staged reduction itself.
+Those stronger properties require assumptions or proof obligations outside the staged reduction
+itself.
 
 ### 3.3 Dependency Structure
 
@@ -195,15 +215,16 @@ Only after these are stated explicitly does the recovery theorem stop being circ
 
 ### 3.4 Proof Status
 
-| Claim | Status in this draft | Intended home |
-|---|---|---|
-| Frontier antichain | sketchable from DAG readiness | Paper 1 + Paper 2 |
-| Disjoint-key commutativity | direct proof | Paper 1 + Paper 2 |
-| Closure extensiveness / monotonicity / idempotence | stated as obligations, not fully proved here | Lean mechanization plan |
-| Structural recovery safety | stated sharply, proof outline only | Lean mechanization plan + Paper 2 |
-| Outcome reproducibility under replay | external assumption | outside the algebra |
+| Claim                                              | Status in this draft                         | Intended home                     |
+| -------------------------------------------------- | -------------------------------------------- | --------------------------------- |
+| Frontier antichain                                 | sketchable from DAG readiness                | Paper 1 + Paper 2                 |
+| Disjoint-key commutativity                         | direct proof                                 | Paper 1 + Paper 2                 |
+| Closure extensiveness / monotonicity / idempotence | stated as obligations, not fully proved here | Lean mechanization plan           |
+| Structural recovery safety                         | stated sharply, proof outline only           | Lean mechanization plan + Paper 2 |
+| Outcome reproducibility under replay               | external assumption                          | outside the algebra               |
 
-The point of the table is discipline: this paper should never silently upgrade "tested in implementation" into "proved in theory."
+The point of the table is discipline: this paper should never silently upgrade "tested in
+implementation" into "proved in theory."
 
 ---
 
@@ -222,11 +243,13 @@ $$
 \end{aligned}
 $$
 
-Forward outcomes move upward in this partial order. This fragment supports the cleanest algebraic reading.
+Forward outcomes move upward in this partial order. This fragment supports the cleanest algebraic
+reading.
 
 ### 4.2 Reset Boundary
 
-Cancellation, shutdown, and crash normalization are explicitly non-monotone. They do not invalidate the staged reduction, but they do invalidate any claim that the runtime is globally monotone.
+Cancellation, shutdown, and crash normalization are explicitly non-monotone. They do not invalidate
+the staged reduction, but they do invalidate any claim that the runtime is globally monotone.
 
 This separation should remain explicit:
 
@@ -245,23 +268,24 @@ The staged reduction has three load-bearing invariants:
 
 ### 5.1 Extensions That Preserve the Core
 
-| Extension | I | II | III | Reason |
-|---|---|---|---|---|
-| new node-local forward outcome | yes | yes | yes | still a point update |
-| richer classification output | yes | yes | yes | classification is observational |
-| additional closure commuting with failure closure | yes | conditionally | yes | composition of commuting closures |
-| edge annotations preserving DAG readiness semantics | yes | yes | conditionally | if readiness stays predecessor-based |
+| Extension                                           | I   | II            | III           | Reason                               |
+| --------------------------------------------------- | --- | ------------- | ------------- | ------------------------------------ |
+| new node-local forward outcome                      | yes | yes           | yes           | still a point update                 |
+| richer classification output                        | yes | yes           | yes           | classification is observational      |
+| additional closure commuting with failure closure   | yes | conditionally | yes           | composition of commuting closures    |
+| edge annotations preserving DAG readiness semantics | yes | yes           | conditionally | if readiness stays predecessor-based |
 
 ### 5.2 Extensions That Cross the Boundary
 
-| Extension | Broken invariant | Why |
-|---|---|---|
-| inter-node mutation in accumulation | I | facts no longer commute by disjoint key |
-| compensating or oscillating propagation | II | closure may stop being idempotent |
-| topology mutation during accumulation | III | frontier and closure are computed over moving topology |
-| shared-key accumulation without a merge algebra | I | update order becomes observable |
+| Extension                                       | Broken invariant | Why                                                    |
+| ----------------------------------------------- | ---------------- | ------------------------------------------------------ |
+| inter-node mutation in accumulation             | I                | facts no longer commute by disjoint key                |
+| compensating or oscillating propagation         | II               | closure may stop being idempotent                      |
+| topology mutation during accumulation           | III              | frontier and closure are computed over moving topology |
+| shared-key accumulation without a merge algebra | I                | update order becomes observable                        |
 
-Topology-changing execution is therefore not "just another extension." It requires a different machine and a different safety theorem.
+Topology-changing execution is therefore not "just another extension." It requires a different
+machine and a different safety theorem.
 
 ---
 
@@ -286,26 +310,36 @@ $$
 (\text{wave}_2\ \text{workers}) ; \text{close} ; \text{classify} ; \cdots
 $$
 
-This is useful for intuition about barriered parallel composition, but we do not claim a full CKA embedding here.
+This is useful for intuition about barriered parallel composition, but we do not claim a full CKA
+embedding here.
 
 ### 6.3 Actor Confluence Work
 
-Henrio et al.'s layered confluence results for actors are relevant because our system is also a worker-coordinator architecture. The key difference is that our workers are constitutionally restricted to node-local facts, which gives a narrower and stronger commutativity condition than arbitrary actor messaging.
+Henrio et al.'s layered confluence results for actors are relevant because our system is also a
+worker-coordinator architecture. The key difference is that our workers are constitutionally
+restricted to node-local facts, which gives a narrower and stronger commutativity condition than
+arbitrary actor messaging.
 
 ---
 
 ## 7. Open Problems
 
-1. **Mechanize the closure laws.** This is the main proof debt and the central purpose of the Lean mechanization plan.
-2. **Characterize the closed-state subspace.** The closure operator suggests a useful sub-poset of normalized states, but its exact algebraic structure is still only partly understood.
-3. **Weaken replay assumptions.** Structural safety needs less than outcome identity. The weakest useful replay-compatibility condition is still open.
-4. **Separate theory for topology-changing execution.** Rewrite-capable execution requires a materialization boundary, durable identity scheme, and different recovery theorem. That is the subject of the rewrite materialization and recovery plan.
+1. **Mechanize the closure laws.** This is the main proof debt and the central purpose of the Lean
+   mechanization plan.
+2. **Characterize the closed-state subspace.** The closure operator suggests a useful sub-poset of
+   normalized states, but its exact algebraic structure is still only partly understood.
+3. **Weaken replay assumptions.** Structural safety needs less than outcome identity. The weakest
+   useful replay-compatibility condition is still open.
+4. **Separate theory for topology-changing execution.** Rewrite-capable execution requires a
+   materialization boundary, durable identity scheme, and different recovery theorem. That is the
+   subject of the rewrite materialization and recovery plan.
 
 ---
 
 ## 8. Takeaway
 
-The point of the algebraic foundations paper is not to inflate an implementation sketch into a fake theorem. It is to isolate the exact mathematical kernel of the fixed-topology runtime:
+The point of the algebraic foundations paper is not to inflate an implementation sketch into a fake
+theorem. It is to isolate the exact mathematical kernel of the fixed-topology runtime:
 
 - node-local facts commute by disjoint key
 - failure closure is the load-bearing closure operator
@@ -316,9 +350,12 @@ Everything stronger must either be proved elsewhere, or named honestly as an ass
 
 ## References
 
-1. Kuper, L., Newton, R. (2013). *LVars: Lattice-based Data Structures for Deterministic Parallelism*. FHPC 2013.
-2. Shapiro, M. et al. (2011). *Conflict-free Replicated Data Types*. SSS 2011.
-3. Conway, N. et al. (2012). *Logic and Lattices for Distributed Programming*. SoCC 2012.
-4. Hoare, C. A. R., Möller, B., Struth, G., Wehrman, I. (2009). *Foundations of Concurrent Kleene Algebra*. RelMiCS 2009.
-5. Valiant, L. G. (1990). *A Bridging Model for Parallel Computation*. Communications of the ACM 33(8):103–111.
-6. Henrio, L. et al. (2026). *Layers of Confluence for Actors*. CPP 2026.
+1. Kuper, L., Newton, R. (2013). _LVars: Lattice-based Data Structures for Deterministic
+   Parallelism_. FHPC 2013.
+2. Shapiro, M. et al. (2011). _Conflict-free Replicated Data Types_. SSS 2011.
+3. Conway, N. et al. (2012). _Logic and Lattices for Distributed Programming_. SoCC 2012.
+4. Hoare, C. A. R., Möller, B., Struth, G., Wehrman, I. (2009). _Foundations of Concurrent Kleene
+   Algebra_. RelMiCS 2009.
+5. Valiant, L. G. (1990). _A Bridging Model for Parallel Computation_. Communications of the ACM
+   33(8):103–111.
+6. Henrio, L. et al. (2026). _Layers of Confluence for Actors_. CPP 2026.

--- a/docs/Publications/Paper-3-graph-substitution-semantics/Figures/index.md
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/Figures/index.md
@@ -4,16 +4,23 @@ description: Figure inventory and export status for the Graph Substitution Seman
 date: 2026-04-28
 updated: 2026-04-28
 status: draft
+related:
+  - docs/Publications/Paper-3-graph-substitution-semantics/manuscript.md
+  - docs/Publications/Paper-3-graph-substitution-semantics/index.md
 ---
 
 # Paper 3 Figure Inventory
 
 ## Checked-in figure sources
 
-- [layered-semantic-architecture.mmd](layered-semantic-architecture.mmd) — workflow meaning, compilation, execution, and recovery stack.
-- [phase-based-durable-execution.mmd](phase-based-durable-execution.mmd) — runtime control loop over a materialized graph state.
-- [substitution-example-before.mmd](substitution-example-before.mmd) — materialized shape before local substitution.
-- [substitution-example-after.mmd](substitution-example-after.mmd) — envelope substitution adding a new branch.
+- [layered-semantic-architecture.mmd](layered-semantic-architecture.mmd) — workflow meaning,
+  compilation, execution, and recovery stack.
+- [phase-based-durable-execution.mmd](phase-based-durable-execution.mmd) — runtime control loop over
+  a materialized graph state.
+- [substitution-example-before.mmd](substitution-example-before.mmd) — materialized shape before
+  local substitution.
+- [substitution-example-after.mmd](substitution-example-after.mmd) — envelope substitution adding a
+  new branch.
 
 ## Export status
 

--- a/docs/Publications/Paper-3-graph-substitution-semantics/Figures/layered-semantic-architecture.mmd
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/Figures/layered-semantic-architecture.mmd
@@ -4,13 +4,3 @@ flowchart TD
     C --> D["Phase-Based Durable Execution"]
     D --> E["Lineage and Materialization"]
     E --> F["Recovery and Explanation"]
-
-    classDef semantic fill:#eef7f2,stroke:#1f6b4f,color:#103827,stroke-width:1.5px;
-    classDef compiled fill:#f6f1e8,stroke:#8a5a00,color:#4b3200,stroke-width:1.5px;
-    classDef runtime fill:#eef2fb,stroke:#315ea8,color:#19325a,stroke-width:1.5px;
-    classDef durability fill:#f8ebf2,stroke:#9b3d6d,color:#5f2342,stroke-width:1.5px;
-
-    class A,B semantic;
-    class C compiled;
-    class D runtime;
-    class E,F durability;

--- a/docs/Publications/Paper-3-graph-substitution-semantics/Figures/phase-based-durable-execution.mmd
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/Figures/phase-based-durable-execution.mmd
@@ -8,13 +8,3 @@ flowchart TD
     E -- No --> G{"Ready frontier empty?"}
     G -- No --> A
     G -- Yes --> H["Terminal"]
-
-    classDef runtime fill:#eef2fb,stroke:#315ea8,color:#19325a,stroke-width:1.5px;
-    classDef substitution fill:#f8ebf2,stroke:#9b3d6d,color:#5f2342,stroke-width:1.5px;
-    classDef decision fill:#f6f1e8,stroke:#8a5a00,color:#4b3200,stroke-width:1.5px;
-    classDef terminal fill:#eef7f2,stroke:#1f6b4f,color:#103827,stroke-width:1.5px;
-
-    class A,B,C,D runtime;
-    class E,G decision;
-    class F substitution;
-    class H terminal;

--- a/docs/Publications/Paper-3-graph-substitution-semantics/Figures/substitution-example-after.mmd
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/Figures/substitution-example-after.mmd
@@ -8,11 +8,3 @@ flowchart TD
     FI --> A
     DER --> A
     CR2 --> A
-
-    classDef anchor fill:#f6f1e8,stroke:#8a5a00,color:#4b3200,stroke-width:2px;
-    classDef branch fill:#eef2fb,stroke:#315ea8,color:#19325a,stroke-width:1.5px;
-    classDef inserted fill:#eef7f2,stroke:#1f6b4f,color:#103827,stroke-width:1.5px;
-
-    class C anchor;
-    class EQ,FI,DER,A branch;
-    class CR1,CR2 inserted;

--- a/docs/Publications/Paper-3-graph-substitution-semantics/Figures/substitution-example-before.mmd
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/Figures/substitution-example-before.mmd
@@ -5,9 +5,3 @@ flowchart TD
     EQ --> A["aggregateExecutionPlan"]
     FI --> A
     DER --> A
-
-    classDef anchor fill:#f6f1e8,stroke:#8a5a00,color:#4b3200,stroke-width:2px;
-    classDef branch fill:#eef2fb,stroke:#315ea8,color:#19325a,stroke-width:1.5px;
-
-    class C anchor;
-    class EQ,FI,DER,A branch;

--- a/docs/Publications/Paper-3-graph-substitution-semantics/index.md
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/index.md
@@ -1,6 +1,8 @@
 ---
 title: "Paper 3 — Graph Substitution Semantics"
-description: Landing page for the Graph Substitution Semantics paper. Abstract, status, figures, and related material.
+description:
+  Landing page for the Graph Substitution Semantics paper. Abstract, status, figures, and related
+  material.
 sidebar:
   label: Paper 3
   order: 3
@@ -21,11 +23,10 @@ Draft manuscript. See [manuscript.md](manuscript.md) for the full text.
 
 ## Abstract
 
-This paper develops the implementation-independent theory of dynamic durable
-workflow execution by graph substitution. It separates workflow meaning,
-compiled executable structure, and phase-based durable execution, then shows
-how lineage, materialization, and interface admissibility give topology change
-an explicit semantic boundary.
+This paper develops the implementation-independent theory of dynamic durable workflow execution by
+graph substitution. It separates workflow meaning, compiled executable structure, and phase-based
+durable execution, then shows how lineage, materialization, and interface admissibility give
+topology change an explicit semantic boundary.
 
 ## Figures
 
@@ -36,6 +37,9 @@ an explicit semantic boundary.
 ## Related
 
 - [manuscript.md](manuscript.md) — full manuscript.
-- [../Paper-2-algebraic-foundations/](../Paper-2-algebraic-foundations/) — algebraic base extended here.
-- [../../Roadmap/Plans/rewrite-materialization-and-recovery.md](../../Roadmap/Plans/rewrite-materialization-and-recovery.md) — runtime-grounded rewrite plan realizing this substitution model.
-- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md) — architecture chapter.
+- [../Paper-2-algebraic-foundations/](../Paper-2-algebraic-foundations/) — algebraic base extended
+  here.
+- [../../Roadmap/Plans/rewrite-materialization-and-recovery.md](../../Roadmap/Plans/rewrite-materialization-and-recovery.md)
+  — runtime-grounded rewrite plan realizing this substitution model.
+- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md)
+  — architecture chapter.

--- a/docs/Publications/Paper-3-graph-substitution-semantics/manuscript.md
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/manuscript.md
@@ -1,6 +1,8 @@
 ---
 title: "Paper 3: Graph Substitution Semantics"
-description: Typed workflow compilation, vertex-anchored graph substitution, and durable materialization for dynamic workflow execution
+description:
+  Typed workflow compilation, vertex-anchored graph substitution, and durable materialization for
+  dynamic workflow execution
 kind: publication
 status: draft
 authors:
@@ -17,38 +19,33 @@ related:
 
 ## Abstract
 
-We present a semantics for dynamic durable workflows in which workflow meaning,
-durable execution, and topology evolution are separated into explicit layers.
-A workflow program is first interpreted into a typed workflow IR, then compiled
-into an executable graph artifact carrying topology, node definitions, typed
-interfaces, and a compatibility witness. The compiled artifact denotes the
-space of obligations that may arise during a run; the materialized run state
-records what has actually been reached after applying an admitted lineage of
-substitutions. Execution proceeds in phases over that materialized state.
-Dynamic change is modeled by **graph substitution**: an admitted operation
-replaces or refines a durable step by splicing in a fragment through an
-explicit interface while preserving causal structure and durable provenance.
+We present a semantics for dynamic durable workflows in which workflow meaning, durable execution,
+and topology evolution are separated into explicit layers. A workflow program is first interpreted
+into a typed workflow IR, then compiled into an executable graph artifact carrying topology, node
+definitions, typed interfaces, and a compatibility witness. The compiled artifact denotes the space
+of obligations that may arise during a run; the materialized run state records what has actually
+been reached after applying an admitted lineage of substitutions. Execution proceeds in phases over
+that materialized state. Dynamic change is modeled by **graph substitution**: an admitted operation
+replaces or refines a durable step by splicing in a fragment through an explicit interface while
+preserving causal structure and durable provenance.
 
-The paper makes four claims. First, workflow semantics should not be identified
-with runtime scheduling; lowering is a compilation boundary. Second, dynamic
-topology change is best modeled by vertex-anchored substitution rather than ad
-hoc mutation. Third, durable execution requires a lineage-plus-materialization
-semantics, not merely a replay story. Fourth, concurrency of node execution and
-concurrency of substitutions are distinct questions and should be treated by
-different laws.
+The paper makes four claims. First, workflow semantics should not be identified with runtime
+scheduling; lowering is a compilation boundary. Second, dynamic topology change is best modeled by
+vertex-anchored substitution rather than ad hoc mutation. Third, durable execution requires a
+lineage-plus-materialization semantics, not merely a replay story. Fourth, concurrency of node
+execution and concurrency of substitutions are distinct questions and should be treated by different
+laws.
 
-The running examples use Cortex and downstream host applications as motivating
-contexts, but the theory is stated independently of any particular
-implementation.
+The running examples use Cortex and downstream host applications as motivating contexts, but the
+theory is stated independently of any particular implementation.
 
 ---
 
 ## 1. Introduction
 
-Durable workflows must survive crashes, suspension, operator intervention, and
-long-running external work. Fixed-topology models explain a large class of
-workflow engines, but they are insufficient when execution may reveal that the
-remaining graph itself should change.
+Durable workflows must survive crashes, suspension, operator intervention, and long-running external
+work. Fixed-topology models explain a large class of workflow engines, but they are insufficient
+when execution may reveal that the remaining graph itself should change.
 
 Typical examples include:
 
@@ -59,53 +56,50 @@ Typical examples include:
 
 The central semantic problem is therefore:
 
-> How can a workflow evolve after partial execution while preserving durable
-> replay, causal correctness, and a stable explanation of what was executed?
+> How can a workflow evolve after partial execution while preserving durable replay, causal
+> correctness, and a stable explanation of what was executed?
 
-This paper presents the implementation-independent theory of that problem. A
-companion research plan, **Rewrite Materialization and Recovery for Dynamic
-Durable Graphs**, grounds the same ideas in a concrete Cortex Pulse runtime and
-uses implementation-specific invariants to sharpen the recovery story.
+This paper presents the implementation-independent theory of that problem. A companion research
+plan, **Rewrite Materialization and Recovery for Dynamic Durable Graphs**, grounds the same ideas in
+the concrete Pulse runtime and uses implementation-specific invariants to sharpen the recovery
+story.
 
 This paper answers that question by separating three levels of meaning:
 
 1. **workflow meaning**, expressed in a typed workflow language
 2. **compiled executable structure**, expressed as a graph artifact
-3. **durable operational semantics**, expressed as phase-based execution with
-   graph substitution
+3. **durable operational semantics**, expressed as phase-based execution with graph substitution
 
 The key terminological choice is deliberate:
 
 - **graph substitution** is the primary term of this paper
-- **graph rewriting** is used only as the umbrella term from the literature on
-  algebraic graph transformation
+- **graph rewriting** is used only as the umbrella term from the literature on algebraic graph
+  transformation
 
-The reason is precision. The runtime operation is not arbitrary graph surgery.
-It substitutes a fragment into a durable graph through a bounded, typed,
-interface-preserving rule.
+The reason is precision. The runtime operation is not arbitrary graph surgery. It substitutes a
+fragment into a durable graph through a bounded, typed, interface-preserving rule.
 
 ---
 
 ## 2. Glossary
 
-- **workflow**: a semantic program describing obligations, dependencies,
-  branching, waiting, and artifact boundaries
+- **workflow**: a semantic program describing obligations, dependencies, branching, waiting, and
+  artifact boundaries
 - **workflow IR**: a canonical typed intermediate form of workflow meaning
-- **compiled workflow artifact**: the executable result of lowering a workflow
-  IR into a graph package
-- **materialized run state**: the currently executable graph and node/output
-  state obtained by applying a lineage prefix to an original compiled artifact
+- **compiled workflow artifact**: the executable result of lowering a workflow IR into a graph
+  package
+- **materialized run state**: the currently executable graph and node/output state obtained by
+  applying a lineage prefix to an original compiled artifact
 - **node**: a durable execution locus with identity, status, and outputs
 - **fragment**: a graph package intended to be substituted into another graph
-- **substitution**: the operation of splicing a fragment into a graph through
-  an explicit boundary contract
-- **graph rewriting**: the broader literature umbrella; this paper studies a
-  substitution calculus within that space
-- **materialization**: durable installation of admitted substitutions into the
-  graph state
+- **substitution**: the operation of splicing a fragment into a graph through an explicit boundary
+  contract
+- **graph rewriting**: the broader literature umbrella; this paper studies a substitution calculus
+  within that space
+- **materialization**: durable installation of admitted substitutions into the graph state
 - **lineage**: append-only history of admitted substitutions
-- **compatibility witness**: a fingerprint or derivation witness tying a
-  compiled artifact to the semantics that produced it
+- **compatibility witness**: a fingerprint or derivation witness tying a compiled artifact to the
+  semantics that produced it
 
 ---
 
@@ -121,18 +115,16 @@ flowchart TD
     D --> E["Recovery"]
 ```
 
-The stack matters because different correctness questions live at different
-layers:
+The stack matters because different correctness questions live at different layers:
 
-- **workflow meaning** asks whether a program denotes the intended dependency
-  structure
+- **workflow meaning** asks whether a program denotes the intended dependency structure
 - **lowering** asks whether the compiled graph preserves workflow meaning
 - **execution** asks whether the runtime reduces graph states soundly
 - **substitution** asks whether topology evolution preserves admissibility
 - **durability** asks whether crash, resume, and explanation remain coherent
 
-Blurring these layers weakens the theory. A runtime graph is not the meaning of
-the source workflow; it is the executable artifact produced by a lowering.
+Blurring these layers weakens the theory. A runtime graph is not the meaning of the source workflow;
+it is the executable artifact produced by a lowering.
 
 ---
 
@@ -140,8 +132,7 @@ the source workflow; it is the executable artifact produced by a lowering.
 
 ### 4.1 Workflow IR
 
-We assume a typed workflow language with the following representative core
-constructors:
+We assume a typed workflow language with the following representative core constructors:
 
 ```text
 W ::= step a
@@ -161,12 +152,11 @@ Intuitively:
 - `await` introduces suspension on an external signal or fact
 - `artifact` marks a durable product boundary
 
-This IR is semantic, not directly executable. It does not say how node identities
-are serialized, how retries are represented, or how persistence occurs.
+This IR is semantic, not directly executable. It does not say how node identities are serialized,
+how retries are represented, or how persistence occurs.
 
-The purpose of introducing the IR in this paper is narrow: it marks the
-compilation boundary between workflow meaning and graph execution. The core
-formal development begins only after lowering.
+The purpose of introducing the IR in this paper is narrow: it marks the compilation boundary between
+workflow meaning and graph execution. The core formal development begins only after lowering.
 
 ### 4.2 Compiled Workflow Artifact
 
@@ -180,8 +170,8 @@ where:
 
 - $T = (V, E)$ is a finite directed acyclic graph
 - $D : V \to \text{NodeDef}$ assigns executable node definitions
-- $\Gamma$ is the interface environment describing input/output contracts,
-  signal contracts, and artifact contracts
+- $\Gamma$ is the interface environment describing input/output contracts, signal contracts, and
+  artifact contracts
 - $\kappa$ is a compatibility witness
 
 For the purposes of this paper, the compatibility witness has the form:
@@ -193,37 +183,34 @@ $$
 where:
 
 - $\nu$ identifies the lowering family
-- $\lambda$ identifies the contract and interface regime used to interpret the
-  lowered artifact
+- $\lambda$ identifies the contract and interface regime used to interpret the lowered artifact
 - $h$ is a digest of the normalized source artifact under $(\nu, \lambda)$
 
-Two compiled artifacts need not have the same digest in order to interact, but
-they must agree on the lowering family and contract interpretation regime. We
-write:
+Two compiled artifacts need not have the same digest in order to interact, but they must agree on
+the lowering family and contract interpretation regime. We write:
 
 $$
 \mathsf{Compat}_\kappa(\kappa, \kappa_F)
 $$
 
-for the predicate that the ambient compiled artifact and a fragment were
-produced under compatible lowering and contract interpretation regimes. In the
-minimal version used by this paper:
+for the predicate that the ambient compiled artifact and a fragment were produced under compatible
+lowering and contract interpretation regimes. In the minimal version used by this paper:
 
 $$
 \mathsf{Compat}_\kappa((\nu, \lambda, h), (\nu_F, \lambda_F, h_F)) \iff \nu = \nu_F \land \lambda = \lambda_F
 $$
 
-The digests may differ because the ambient workflow and the fragment may denote
-different source programs. Compatibility requires only that they inhabit the
-same lowering family and contract regime.
+The digests may differ because the ambient workflow and the fragment may denote different source
+programs. Compatibility requires only that they inhabit the same lowering family and contract
+regime.
 
-This minimal definition is intentionally stricter than lowering-family equality
-alone. Two fragments may be lowered by the same compiler family while still
-disagreeing about the contract language attached to boundary nodes. Equality on
-$(\nu, \lambda)$ is therefore the smallest useful semantic approximation.
+This minimal definition is intentionally stricter than lowering-family equality alone. Two fragments
+may be lowered by the same compiler family while still disagreeing about the contract language
+attached to boundary nodes. Equality on $(\nu, \lambda)$ is therefore the smallest useful semantic
+approximation.
 
-The point of $\kappa$ is semantic rather than operational: a materialized graph
-should always be interpreted relative to the compilation law that produced it.
+The point of $\kappa$ is semantic rather than operational: a materialized graph should always be
+interpreted relative to the compilation law that produced it.
 
 ### 4.3 Example
 
@@ -263,19 +250,17 @@ workflow QuarterlyPortfolioRebalance {
 }
 ```
 
-Its lowering may produce a graph whose nodes are durable execution loci while
-preserving the workflow meaning that three acquisition steps are initially
-independent, then join at `computeTargetAllocations`, then fan out again into
-three asymmetric branches before joining at `aggregateExecutionPlan`. That
-shape matters because the ready frontier widens and narrows over the same DAG,
-and later substitutions may widen it again.
+Its lowering may produce a graph whose nodes are durable execution loci while preserving the
+workflow meaning that three acquisition steps are initially independent, then join at
+`computeTargetAllocations`, then fan out again into three asymmetric branches before joining at
+`aggregateExecutionPlan`. That shape matters because the ready frontier widens and narrows over the
+same DAG, and later substitutions may widen it again.
 
 ---
 
 ## 5. Executable Graphs and Interface Contracts
 
-The compiled topology alone is not enough. Dynamic substitution requires typed
-fragment contracts.
+The compiled topology alone is not enough. Dynamic substitution requires typed fragment contracts.
 
 ### 5.1 Graph Package
 
@@ -294,8 +279,8 @@ where:
 - $\varnothing \neq \mathrm{Out}_F \subseteq V_F$ are exit nodes
 - $\kappa_F$ is a compatibility witness for the fragment
 
-The interface contract should be read semantically, not merely topologically.
-A fragment boundary may constrain:
+The interface contract should be read semantically, not merely topologically. A fragment boundary
+may constrain:
 
 - value types or schemas
 - artifact shapes
@@ -305,8 +290,7 @@ A fragment boundary may constrain:
 
 ### 5.2 Minimal Contract Discipline
 
-To keep the paper's formal core honest, we assume only a minimal contract
-discipline.
+To keep the paper's formal core honest, we assume only a minimal contract discipline.
 
 Let $(\mathcal{K}, \sqsubseteq)$ be a preorder of contracts, where:
 
@@ -314,8 +298,7 @@ $$
 c_1 \sqsubseteq c_2
 $$
 
-means "a value or effect satisfying $c_1$ is acceptable wherever $c_2$ is
-required."
+means "a value or effect satisfying $c_1$ is acceptable wherever $c_2$ is required."
 
 For each relevant boundary node $v$, the interface environment provides:
 
@@ -328,39 +311,36 @@ $$
 \Gamma^+(u) \sqsubseteq \Gamma^-(v)
 $$
 
-One concrete toy instantiation takes $\mathcal{K}$ to be finite record schemas
-ordered by width subtyping:
+One concrete toy instantiation takes $\mathcal{K}$ to be finite record schemas ordered by width
+subtyping:
 
 $$
 \{f_1:\tau_1, \ldots, f_n:\tau_n, \ldots\} \sqsubseteq \{f_1:\tau_1, \ldots, f_n:\tau_n\}
 $$
 
-meaning that a provider may offer additional fields beyond what the consumer
-requires.
+meaning that a provider may offer additional fields beyond what the consumer requires.
 
-Under that instantiation, semantic admissibility does real work. In the running
-rebalance example, a predecessor might offer
-`{positions, marketData, riskLimits}` while a candidate fragment entry requires
-`{positions, custodianBalances}`. Structural rewiring could still succeed, but
-semantic admissibility fails because `custodianBalances` is absent even though
-the topology alone would permit the splice.
+Under that instantiation, semantic admissibility does real work. In the running rebalance example, a
+predecessor might offer `{positions, marketData, riskLimits}` while a candidate fragment entry
+requires `{positions, custodianBalances}`. Structural rewiring could still succeed, but semantic
+admissibility fails because `custodianBalances` is absent even though the topology alone would
+permit the splice.
 
-This is intentionally minimal. A richer type-and-effect discipline could refine
-it, but this preorder is enough to state semantic admissibility in a falsifiable
-way without pretending to solve the entire typing problem.
+This is intentionally minimal. A richer type-and-effect discipline could refine it, but this
+preorder is enough to state semantic admissibility in a falsifiable way without pretending to solve
+the entire typing problem.
 
-The abstraction is deliberately weak. It does not yet model named ports,
-channel multiplicity, linear or affine resources, or retention obligations for
-state that may no longer be present in the current materialized graph. Those
-belong to richer interface calculi. The claim here is narrower: even a simple
-contract preorder is enough to distinguish structurally valid substitutions from
+The abstraction is deliberately weak. It does not yet model named ports, channel multiplicity,
+linear or affine resources, or retention obligations for state that may no longer be present in the
+current materialized graph. Those belong to richer interface calculi. The claim here is narrower:
+even a simple contract preorder is enough to distinguish structurally valid substitutions from
 semantically admissible ones.
 
 ### 5.3 Why Structural Interfaces Are Insufficient
 
-Entry and exit node sets alone only say where reconnection occurs. They do not
-say whether the substituted fragment can actually inhabit the obligation being
-refined. A durable dynamic workflow semantics therefore needs both:
+Entry and exit node sets alone only say where reconnection occurs. They do not say whether the
+substituted fragment can actually inhabit the obligation being refined. A durable dynamic workflow
+semantics therefore needs both:
 
 - **structural fit**, meaning the splice preserves graph well-formedness
 - **semantic fit**, meaning contracts compose across the substitution boundary
@@ -371,8 +351,7 @@ This distinction is one of the central obligations of the theory.
 
 ## 6. Phase-Based Durable Execution
 
-Execution proceeds relative to an original compiled artifact and a materialized
-run state:
+Execution proceeds relative to an original compiled artifact and a materialized run state:
 
 $$
 \Sigma_w = (\mathcal{C}_0, \mathcal{C}_w, \sigma, o, \ell, w, \chi)
@@ -381,12 +360,10 @@ $$
 where:
 
 - $\mathcal{C}_0$ is the original compiled workflow artifact
-- $\mathcal{C}_w = \mathsf{Materialize}(\mathcal{C}_0, \ell_{\leq w})$ is the
-  current materialized graph artifact for the admitted lineage prefix
-- $\sigma : V_w \to \text{NodeStatus}$ is the total status map over
-  $\mathcal{C}_w$
-- $o : V_w \rightharpoonup \text{Value}$ is the partial output map over
-  $\mathcal{C}_w$
+- $\mathcal{C}_w = \mathsf{Materialize}(\mathcal{C}_0, \ell_{\leq w})$ is the current materialized
+  graph artifact for the admitted lineage prefix
+- $\sigma : V_w \to \text{NodeStatus}$ is the total status map over $\mathcal{C}_w$
+- $o : V_w \rightharpoonup \text{Value}$ is the partial output map over $\mathcal{C}_w$
 - $\ell$ is the append-only substitution lineage
 - $w$ is the materialization watermark
 - $\chi$ is a materialized-state integrity witness
@@ -399,9 +376,8 @@ NodeStatus =
 \mid \text{Skipped} \mid \text{Waiting}(s) \mid \text{Rewritten}
 $$
 
-`Rewritten` is terminal and dependency-satisfying. It represents a durable step
-boundary that has been refined by substitution while remaining part of the
-explanatory structure.
+`Rewritten` is terminal and dependency-satisfying. It represents a durable step boundary that has
+been refined by substitution while remaining part of the explanatory structure.
 
 The execution discipline is phase-based:
 
@@ -420,22 +396,20 @@ flowchart TD
 
 This picture clarifies a subtle but important point:
 
-- **concurrent node execution** is a question about reducing facts over a fixed
-  materialized graph
+- **concurrent node execution** is a question about reducing facts over a fixed materialized graph
 - **concurrent substitution** is a question about changing the graph itself
 
 They are not the same theorem.
 
-The loop above is a runtime control loop, not a cycle in the workflow topology.
-Each materialized artifact $\mathcal{C}_w$ remains a DAG. The back-edge means
-only that the next ready frontier is computed again, possibly over a different
-materialized graph if a substitution was admitted at the previous phase
-boundary.
+The loop above is a runtime control loop, not a cycle in the workflow topology. Each materialized
+artifact $\mathcal{C}_w$ remains a DAG. The back-edge means only that the next ready frontier is
+computed again, possibly over a different materialized graph if a substitution was admitted at the
+previous phase boundary.
 
 ### 6.1 Frontier Semantics
 
-Let $pred_w(v)$ denote the immediate predecessors of node $v$ in the current
-materialized graph $\mathcal{C}_w$.
+Let $pred_w(v)$ denote the immediate predecessors of node $v$ in the current materialized graph
+$\mathcal{C}_w$.
 
 The ready frontier is:
 
@@ -445,9 +419,8 @@ $$
 \land \forall u \in pred_w(v).\ \sigma(u) \in \{\mathrm{Completed}, \mathrm{Skipped}, \mathrm{Rewritten}\} \}
 $$
 
-The frontier is an antichain in the dependency order. Nodes in the frontier may
-be executed concurrently because readiness is defined relative to the same
-materialized topology.
+The frontier is an antichain in the dependency order. Nodes in the frontier may be executed
+concurrently because readiness is defined relative to the same materialized topology.
 
 ### 6.2 Base Phase Discipline
 
@@ -456,8 +429,8 @@ The base calculus adopts a simple rule:
 - many nodes may execute concurrently within one frontier phase
 - substitution is admitted only at a phase boundary
 
-This is not merely an implementation convenience. It is the semantic barrier
-that separates reduction over facts from mutation of topology.
+This is not merely an implementation convenience. It is the semantic barrier that separates
+reduction over facts from mutation of topology.
 
 ---
 
@@ -477,14 +450,12 @@ where:
 - $\rho$ is a boundary policy
 - $\mathcal{F}$ is a fragment
 
-The boundary policy determines whether the anchor is replaced or retained as an
-envelope.
+The boundary policy determines whether the anchor is replaced or retained as an envelope.
 
-The literature uses **graph rewriting** broadly for systems that transform
-graphs by local rules. This paper uses **graph substitution** for the concrete
-runtime calculus because the admissible operation is more specific: it chooses a
-durable anchor node, a fragment with explicit boundary interface, and a splice
-discipline that preserves the already discharged past.
+The literature uses **graph rewriting** broadly for systems that transform graphs by local rules.
+This paper uses **graph substitution** for the concrete runtime calculus because the admissible
+operation is more specific: it chooses a durable anchor node, a fragment with explicit boundary
+interface, and a splice discipline that preserves the already discharged past.
 
 ### 7.2 Replace and Envelope
 
@@ -493,8 +464,7 @@ Let:
 - $\operatorname{Pred}(a) = \{ u \mid (u, a) \in E \}$
 - $\operatorname{Succ}(a) = \{ v \mid (a, v) \in E \}$
 
-For a **replace** substitution, the anchor is removed and the fragment is
-spliced into its place:
+For a **replace** substitution, the anchor is removed and the fragment is spliced into its place:
 
 $$
 V' = (V \setminus \{a\}) \cup V_F
@@ -506,24 +476,22 @@ $$
 
 where $I(a)$ is the set of edges incident to $a$.
 
-The base calculus intentionally uses full bipartite reconnection from every
-predecessor to every fragment entry and from every fragment exit to every
-successor. Richer port-matching or channel-discipline rules are refinements of
-the interface system, not part of this minimal core. Accordingly, the base
-calculus proves compatibility for the induced reconnections it defines; it does
-not claim that practical runtimes may ignore routing, arity, or multiplicity
-constraints. Systems that require single-input consumers, named ports, or
-linear channels must refine $\Gamma$ with that additional structure.
+The base calculus intentionally uses full bipartite reconnection from every predecessor to every
+fragment entry and from every fragment exit to every successor. Richer port-matching or
+channel-discipline rules are refinements of the interface system, not part of this minimal core.
+Accordingly, the base calculus proves compatibility for the induced reconnections it defines; it
+does not claim that practical runtimes may ignore routing, arity, or multiplicity constraints.
+Systems that require single-input consumers, named ports, or linear channels must refine $\Gamma$
+with that additional structure.
 
-For an **envelope** substitution, the anchor remains as the stable step
-boundary and the fragment is inserted after the anchor's own completion:
+For an **envelope** substitution, the anchor remains as the stable step boundary and the fragment is
+inserted after the anchor's own completion:
 
 $$
 \sigma(a) \in \{\mathrm{Completed}, \mathrm{Rewritten}\}
 $$
 
-and, whenever downstream obligations depend on the anchor's output, $o(a)$ is
-defined.
+and, whenever downstream obligations depend on the anchor's output, $o(a)$ is defined.
 
 $$
 V' = V \cup V_F
@@ -533,18 +501,17 @@ $$
 E' = (E \setminus (\{a\} \times \operatorname{Succ}(a))) \cup (\{a\} \times \mathrm{In}_F) \cup E_F \cup (\mathrm{Out}_F \times \operatorname{Succ}(a))
 $$
 
-The envelope form is useful when the anchor's output, audit trail, or semantic
-identity should remain explicit.
+The envelope form is useful when the anchor's output, audit trail, or semantic identity should
+remain explicit.
 
-Replace substitution does not require $o(a)$ to remain defined because the
-anchor leaves the future topology. Envelope substitution may require it because
-the anchor remains part of the explanatory and dataflow structure.
+Replace substitution does not require $o(a)$ to remain defined because the anchor leaves the future
+topology. Envelope substitution may require it because the anchor remains part of the explanatory
+and dataflow structure.
 
 ### 7.3 Example
 
-Suppose the rebalancing workflow's `computeTargetAllocations` step completes
-and discovers unexpected crypto exposure requiring an additional execution
-branch before aggregation.
+Suppose the rebalancing workflow's `computeTargetAllocations` step completes and discovers
+unexpected crypto exposure requiring an additional execution branch before aggregation.
 
 Materialized shape before substitution:
 
@@ -557,11 +524,6 @@ flowchart TD
     FI --> A
     DER --> A
 
-    classDef anchor fill:#f6f1e8,stroke:#8a5a00,color:#4b3200,stroke-width:2px;
-    classDef branch fill:#eef2fb,stroke:#315ea8,color:#19325a,stroke-width:1.5px;
-
-    class C anchor;
-    class EQ,FI,DER,A branch;
 ```
 
 Envelope substitution at `computeTargetAllocations`:
@@ -578,18 +540,11 @@ flowchart TD
     DER --> A
     CR2 --> A
 
-    classDef anchor fill:#f6f1e8,stroke:#8a5a00,color:#4b3200,stroke-width:2px;
-    classDef branch fill:#eef2fb,stroke:#315ea8,color:#19325a,stroke-width:1.5px;
-    classDef inserted fill:#eef7f2,stroke:#1f6b4f,color:#103827,stroke-width:1.5px;
-
-    class C anchor;
-    class EQ,FI,DER,A branch;
-    class CR1,CR2 inserted;
 ```
 
-This is not arbitrary mutation. The substitution widens the fan-out by one new
-branch, changes the predecessor set of `aggregateExecutionPlan`, and still
-remains a local refinement of a durable step boundary.
+This is not arbitrary mutation. The substitution widens the fan-out by one new branch, changes the
+predecessor set of `aggregateExecutionPlan`, and still remains a local refinement of a durable step
+boundary.
 
 ---
 
@@ -611,25 +566,23 @@ A substitution is admissible only if all of the following hold.
    $\Gamma^+(u) \sqsubseteq \Gamma_F^-(x)$
 2. for every exit node $y \in \mathrm{Out}_F$ rewired to a successor $v$,
    $\Gamma_F^+(y) \sqsubseteq \Gamma^-(v)$
-3. retained-anchor substitutions preserve any contract that downstream nodes
-   rely on from the anchor
+3. retained-anchor substitutions preserve any contract that downstream nodes rely on from the anchor
 4. $\mathsf{Compat}_\kappa(\kappa, \kappa_F)$ holds
 
-These clauses define only a minimal semantic admissibility notion. Richer
-contract systems remain compatible with the paper's structure but are not
-required by the core results below. In particular, they do not yet express
-port-level routing, arity bounds, linear consumption, or snapshot-retention
-obligations. Those are extensions of the interface discipline, not hidden
-assumptions of the present calculus.
+These clauses define only a minimal semantic admissibility notion. Richer contract systems remain
+compatible with the paper's structure but are not required by the core results below. In particular,
+they do not yet express port-level routing, arity bounds, linear consumption, or snapshot-retention
+obligations. Those are extensions of the interface discipline, not hidden assumptions of the present
+calculus.
 
 ### 8.3 Causal Admissibility
 
-Substitution must preserve the already discharged past. The past may justify a
-substitution, but substitution does not reinterpret already completed causal
-history. It refines the remaining obligation.
+Substitution must preserve the already discharged past. The past may justify a substitution, but
+substitution does not reinterpret already completed causal history. It refines the remaining
+obligation.
 
-This distinguishes substitution from process migration. Substitution is local
-future refinement, not global re-interpretation of executed history.
+This distinguishes substitution from process migration. Substitution is local future refinement, not
+global re-interpretation of executed history.
 
 ### 8.4 Resource Admissibility
 
@@ -653,8 +606,8 @@ $$
 \mathsf{Cost}(a, \mathcal{F}, T) = (c_V, c_E, c_D, c_F, c_S)
 $$
 
-be the structural cost of substituting fragment $\mathcal{F}$ at anchor $a$ in
-topology $T$. Resource admissibility requires:
+be the structural cost of substituting fragment $\mathcal{F}$ at anchor $a$ in topology $T$.
+Resource admissibility requires:
 
 $$
 \mathsf{Cost}(a, \mathcal{F}, T) \leq B
@@ -666,20 +619,19 @@ $$
 B' = B - \mathsf{Cost}(a, \mathcal{F}, T)
 $$
 
-Budgets are not the whole safety story, but they make the calculus operational
-by bounding expansion.
+Budgets are not the whole safety story, but they make the calculus operational by bounding
+expansion.
 
-No core result below depends on this budget discipline. It is an operational
-guard layered on top of the substitution calculus rather than a constitutive
-part of the paper's minimal proof core.
+No core result below depends on this budget discipline. It is an operational guard layered on top of
+the substitution calculus rather than a constitutive part of the paper's minimal proof core.
 
 ### 8.5 Concrete Rejection Example
 
-The admissibility clauses are meant to reject substitutions that are
-topologically plausible but semantically wrong.
+The admissibility clauses are meant to reject substitutions that are topologically plausible but
+semantically wrong.
 
-Return to the rebalance example and let `computeTargetAllocations` be the
-anchor. Suppose a predecessor $u$ offers
+Return to the rebalance example and let `computeTargetAllocations` be the anchor. Suppose a
+predecessor $u$ offers
 
 $$
 \Gamma^+(u) = \{positions, marketData, riskLimits\}
@@ -703,38 +655,35 @@ $$
 \Gamma^-(v) = \{executionPlan\}.
 $$
 
-The splice may still satisfy structural admissibility: the anchor exists, the
-fragment is finite and acyclic, and the resulting graph remains a DAG. But
-semantic admissibility fails twice:
+The splice may still satisfy structural admissibility: the anchor exists, the fragment is finite and
+acyclic, and the resulting graph remains a DAG. But semantic admissibility fails twice:
 
-1. $\Gamma^+(u) \not\sqsubseteq \Gamma_F^-(x)$ because the predecessor does
-   not provide `custodianBalances`
-2. $\Gamma_F^+(y) \not\sqsubseteq \Gamma^-(v)$ because a `cryptoLiquidationPlan`
-   is not an `executionPlan`
+1. $\Gamma^+(u) \not\sqsubseteq \Gamma_F^-(x)$ because the predecessor does not provide
+   `custodianBalances`
+2. $\Gamma_F^+(y) \not\sqsubseteq \Gamma^-(v)$ because a `cryptoLiquidationPlan` is not an
+   `executionPlan`
 
-The candidate substitution is therefore rejected before materialization, even
-though bare graph surgery would permit the splice.
+The candidate substitution is therefore rejected before materialization, even though bare graph
+surgery would permit the splice.
 
-Envelope substitution adds one more check. If the anchor $a$ is retained as a
-durable boundary but the substitution would stop exposing an anchor contract
-that downstream obligations still rely on, clause 8.2(3) rejects it. The point
-is that retained history remains semantically live, not merely visually present.
+Envelope substitution adds one more check. If the anchor $a$ is retained as a durable boundary but
+the substitution would stop exposing an anchor contract that downstream obligations still rely on,
+clause 8.2(3) rejects it. The point is that retained history remains semantically live, not merely
+visually present.
 
 ---
 
 ## 9. Durability, Lineage, and Materialization
 
-Substitution is durable only if admission and materialization are modeled
-explicitly.
+Substitution is durable only if admission and materialization are modeled explicitly.
 
 ### 9.1 Lineage and Watermark
 
 Let:
 
-- $\ell = [s_1, \ldots, s_n]$ be the totally ordered, append-only lineage of
-  admitted substitutions
-- $w \leq n$ be the watermark such that the materialized graph state reflects
-  exactly the prefix $\ell_{\leq w}$
+- $\ell = [s_1, \ldots, s_n]$ be the totally ordered, append-only lineage of admitted substitutions
+- $w \leq n$ be the watermark such that the materialized graph state reflects exactly the prefix
+  $\ell_{\leq w}$
 
 This yields a precise semantics:
 
@@ -742,25 +691,22 @@ $$
 \mathcal{C}_w = \mathsf{Materialize}(\mathcal{C}_0, \ell_{\leq w})
 $$
 
-The original compiled artifact $\mathcal{C}_0$ defines the space of durable
-obligations. The materialized artifact $\mathcal{C}_w$ defines the current
-execution surface after the admitted lineage prefix has been installed.
+The original compiled artifact $\mathcal{C}_0$ defines the space of durable obligations. The
+materialized artifact $\mathcal{C}_w$ defines the current execution surface after the admitted
+lineage prefix has been installed.
 
 ### 9.2 Integrity Witness
 
-The watermark alone states prefix application. It does not by itself certify
-that the materialized graph package, node state, and provenance all agree.
+The watermark alone states prefix application. It does not by itself certify that the materialized
+graph package, node state, and provenance all agree.
 
-For that reason the durable state should also carry an integrity witness
-$\chi$, such as:
+For that reason the durable state should also carry an integrity witness $\chi$, such as:
 
 - a topology hash
 - a normalized graph-package hash
-- a stronger derivation witness tying materialized state to the expected
-  compiled artifact
+- a stronger derivation witness tying materialized state to the expected compiled artifact
 
-The paper treats this as part of the semantics rather than optional operator
-metadata.
+The paper treats this as part of the semantics rather than optional operator metadata.
 
 Each successful materialization step computes a fresh integrity witness:
 
@@ -776,12 +722,13 @@ $$
 
 The paper assumes only the following minimal axioms:
 
-- **soundness:** $\mathsf{Verify}(\mathsf{Witness}(\mathcal{C}, \sigma, o, w), \mathcal{C}, \sigma, o, w)$
+- **soundness:**
+  $\mathsf{Verify}(\mathsf{Witness}(\mathcal{C}, \sigma, o, w), \mathcal{C}, \sigma, o, w)$
 - **determinism:** if $(\mathcal{C}, \sigma, o, w) = (\mathcal{C}', \sigma', o', w')$ then
   $\mathsf{Witness}(\mathcal{C}, \sigma, o, w) = \mathsf{Witness}(\mathcal{C}', \sigma', o', w')$
 
-Stronger collision-resistance or proof-carrying interpretations are valuable,
-but they are not required by the paper's minimal recovery claim.
+Stronger collision-resistance or proof-carrying interpretations are valuable, but they are not
+required by the paper's minimal recovery claim.
 
 ### 9.3 Recovery Law
 
@@ -793,131 +740,123 @@ $$
 
 subject to:
 
-- compatibility checks for every admitted fragment in $\ell_{\leq w}$ derived
-  from the compiled artifact witness $\kappa$
+- compatibility checks for every admitted fragment in $\ell_{\leq w}$ derived from the compiled
+  artifact witness $\kappa$
 - integrity verification of $\chi$
 
-The aim is not merely to restart execution, but to resume from a state whose
-interpretation is stable.
+The aim is not merely to restart execution, but to resume from a state whose interpretation is
+stable.
 
 A **canonical schedulable state** is the unique normalized state obtained by:
 
-1. deterministically materializing $\mathcal{C}_w = \mathsf{Materialize}(\mathcal{C}_0, \ell_{\leq w})$
+1. deterministically materializing
+   $\mathcal{C}_w = \mathsf{Materialize}(\mathcal{C}_0, \ell_{\leq w})$
 2. verifying $\chi$ against $(\mathcal{C}_w, \sigma, o, w)$
-3. normalizing transient runtime state and recomputing the ready frontier over
-   $\mathcal{C}_w$
+3. normalizing transient runtime state and recomputing the ready frontier over $\mathcal{C}_w$
 
-Recovery is correct only if it produces that same $\mathcal{C}_w$ and the same
-normalized ready frontier from the same persisted inputs.
+Recovery is correct only if it produces that same $\mathcal{C}_w$ and the same normalized ready
+frontier from the same persisted inputs.
 
 ---
 
 ## 10. Concurrency and Independence
 
-The base calculus allows concurrent node execution but treats substitution as a
-phase-boundary act. This should be understood as a semantic discipline. The
-base machine therefore separates two semantic phases:
+The base calculus allows concurrent node execution but treats substitution as a phase-boundary act.
+This should be understood as a semantic discipline. The base machine therefore separates two
+semantic phases:
 
-- a **reduction phase** that accumulates node-local facts over a fixed
-  materialized topology
-- a **substitution phase** that may change that topology before the next ready
-  frontier is computed
+- a **reduction phase** that accumulates node-local facts over a fixed materialized topology
+- a **substitution phase** that may change that topology before the next ready frontier is computed
 
-This separation is not cosmetic. It isolates the order-insensitive fact
-fragment from the topology-changing fragment whose admissibility depends on the
-ambient graph, the candidate fragment, and the remaining budget.
+This separation is not cosmetic. It isolates the order-insensitive fact fragment from the
+topology-changing fragment whose admissibility depends on the ambient graph, the candidate fragment,
+and the remaining budget.
 
 ### 10.1 Reduction Phase
 
-Within a fixed materialized topology, the execution kernel from the previous
-paper applies unchanged. Frontier nodes run concurrently from the same
-materialized graph, emit node-local facts, and those facts are accumulated,
-closed, and classified without changing the topology to which readiness is
-defined.
+Within a fixed materialized topology, the execution kernel from the previous paper applies
+unchanged. Frontier nodes run concurrently from the same materialized graph, emit node-local facts,
+and those facts are accumulated, closed, and classified without changing the topology to which
+readiness is defined.
 
-That is the coordination-friendly fragment of the machine. The important point
-is not that every operational detail is monotone, but that within one fixed
-topology the reduction kernel only accumulates information needed to move from
-pending work toward a more settled state. Later execution in the same phase
-does not reinterpret the meaning of an earlier frontier fact by changing the
-graph beneath it.
+That is the coordination-friendly fragment of the machine. The important point is not that every
+operational detail is monotone, but that within one fixed topology the reduction kernel only
+accumulates information needed to move from pending work toward a more settled state. Later
+execution in the same phase does not reinterpret the meaning of an earlier frontier fact by changing
+the graph beneath it.
 
 ### 10.2 Coordinated Substitution Phase
 
-Substitution is different because admissibility is proposal-set-sensitive.
-Whether a candidate fragment may be installed can depend on:
+Substitution is different because admissibility is proposal-set-sensitive. Whether a candidate
+fragment may be installed can depend on:
 
 - compatibility at the anchor boundary
 - the resulting topology
 - the remaining structural budget
 - other proposals that may consume that same budget or overlap in effect
 
-For that reason substitution is isolated at a phase boundary. The barrier is
-the natural coordination boundary induced by the current semantics: the runtime
-finishes reduction on the current materialized graph, then admits and
-materializes any accepted substitutions before defining the next ready frontier.
+For that reason substitution is isolated at a phase boundary. The barrier is the natural
+coordination boundary induced by the current semantics: the runtime finishes reduction on the
+current materialized graph, then admits and materializes any accepted substitutions before defining
+the next ready frontier.
 
 ### 10.3 Why This Restriction Is Natural
 
-Ordinary node execution accumulates facts about an already materialized graph.
-Substitution changes the graph to which readiness and downstream obligations are
-defined. Mixing these two levels without a barrier complicates:
+Ordinary node execution accumulates facts about an already materialized graph. Substitution changes
+the graph to which readiness and downstream obligations are defined. Mixing these two levels without
+a barrier complicates:
 
 - replay
 - provenance
 - admissibility
 - termination reasoning
 
-This restriction is conservative and not free. In a wide frontier, a single
-admitted substitution may delay further reduction until the next
-materialization boundary, sacrificing some throughput and liveness for a simpler
-replay story, a single lineage order, and a cleaner proof boundary. The claim
-is not that the barrier is always optimal, only that it is an explicit baseline
-whose relaxation requires additional laws rather than informal scheduling
-intuition.
+This restriction is conservative and not free. In a wide frontier, a single admitted substitution
+may delay further reduction until the next materialization boundary, sacrificing some throughput and
+liveness for a simpler replay story, a single lineage order, and a cleaner proof boundary. The claim
+is not that the barrier is always optimal, only that it is an explicit baseline whose relaxation
+requires additional laws rather than informal scheduling intuition.
 
 ### 10.4 Independent Substitutions
 
-A richer calculus may admit more than one substitution in a logical phase, but
-that requires an explicit independence relation. At minimum, one would want
-conditions such as:
+A richer calculus may admit more than one substitution in a logical phase, but that requires an
+explicit independence relation. At minimum, one would want conditions such as:
 
 - disjoint anchor regions
 - no interface overlap
 - a formal commutation relation over interface effects
 - a stable explanation of lineage order
 
-Those conditions define a stronger machine. They should not be smuggled into
-the base semantics by informal analogy.
+Those conditions define a stronger machine. They should not be smuggled into the base semantics by
+informal analogy.
 
 ---
 
 ## 11. Edge-Oriented Forms as Derived Notation
 
-Edge-oriented refinement is still useful to describe insertion between two
-durable steps. For example:
+Edge-oriented refinement is still useful to describe insertion between two durable steps. For
+example:
 
 ```text
 insertBetween(gather, review, validateEvidence)
 ```
 
-is often easier to read than a node-centered substitution formula. But the
-semantic core should remain node-centered.
+is often easier to read than a node-centered substitution formula. But the semantic core should
+remain node-centered.
 
-The reason is not only implicit joining. It is that a durable node carries the
-execution meaning:
+The reason is not only implicit joining. It is that a durable node carries the execution meaning:
 
 - it owns status transitions
 - it may carry outputs
 - it may wait or fail
 - it anchors provenance
 
-An edge denotes a dependency relation. A node denotes a durable step boundary.
-Since dynamic durable workflows evolve by refining obligations embodied by
-durable steps, vertex-anchored substitution is the better core object.
+An edge denotes a dependency relation. A node denotes a durable step boundary. Since dynamic durable
+workflows evolve by refining obligations embodied by durable steps, vertex-anchored substitution is
+the better core object.
 
-Accordingly, edge-oriented forms are best treated as derived notation or a
-surface language convenience that lowers into the node-centered calculus.
+Accordingly, edge-oriented forms are best treated as derived notation or a surface language
+convenience that lowers into the node-centered calculus.
 
 ---
 
@@ -929,37 +868,35 @@ The paper's core formal obligations are the following.
 
 #### Substitution Safety
 
-Admissible substitution preserves graph well-formedness, causal structure, and
-interface compatibility.
+Admissible substitution preserves graph well-formedness, causal structure, and interface
+compatibility.
 
 #### Phase Determinism
 
-Within a fixed materialized topology, reducing a frontier phase is
-order-insensitive with respect to the accumulation order of independent node
-facts, provided that frontier execution emits node-local facts keyed by the
-executing node or else emits into a deterministic reducer. The intended proof
+Within a fixed materialized topology, reducing a frontier phase is order-insensitive with respect to
+the accumulation order of independent node facts, provided that frontier execution emits node-local
+facts keyed by the executing node or else emits into a deterministic reducer. The intended proof
 strategy is:
 
-1. each node $v$ in the current frontier contributes facts affecting only the
-   loci owned by $v$, such as $\sigma(v)$ and $o(v)$
+1. each node $v$ in the current frontier contributes facts affecting only the loci owned by $v$,
+   such as $\sigma(v)$ and $o(v)$
 2. for distinct frontier nodes $u \neq v$, those node-local updates commute
-3. closure and classification are deterministic functions of the resulting
-   normalized materialized state
+3. closure and classification are deterministic functions of the resulting normalized materialized
+   state
 
-This excludes the obvious counterexample in which concurrent frontier nodes
-perform uncontrolled writes to the same shared artifact key. Such effects must
-either be represented as node-local outputs or mediated by a deterministic
-reduction step before the theorem applies.
+This excludes the obvious counterexample in which concurrent frontier nodes perform uncontrolled
+writes to the same shared artifact key. Such effects must either be represented as node-local
+outputs or mediated by a deterministic reduction step before the theorem applies.
 
 #### Recovery Correctness
 
-Resume from materialized lineage prefix, compatibility witness, and integrity
-witness reconstructs the canonical schedulable state defined in §9.3.
+Resume from materialized lineage prefix, compatibility witness, and integrity witness reconstructs
+the canonical schedulable state defined in §9.3.
 
 ### 12.2 Extension Program
 
-The following are intentionally outside the paper's core formal development but
-define its natural continuation.
+The following are intentionally outside the paper's core formal development but define its natural
+continuation.
 
 #### Lowering Soundness
 
@@ -969,62 +906,56 @@ $$
 \llbracket W \rrbracket_{\mathrm{wf}} \equiv \llbracket \mathrm{compile}(W) \rrbracket_{\mathrm{graph}}
 $$
 
-for an appropriate denotational semantics of workflows, graphs, and their
-equivalence. This is a research program for the workflow/lowering boundary, not
-part of the minimal substitution calculus proved here.
+for an appropriate denotational semantics of workflows, graphs, and their equivalence. This is a
+research program for the workflow/lowering boundary, not part of the minimal substitution calculus
+proved here.
 
 #### Routed Interfaces and Resource-Aware Contracts
 
-The minimal preorder on $\mathcal{K}$ intentionally leaves out named ports,
-arity constraints, linear or affine resources, and retention obligations for
-values that later substitutions may still depend on. A stronger interface
-calculus would enrich $\Gamma$ with those structures so that executable routing
-policies and resource-sensitive admissibility can be stated directly.
+The minimal preorder on $\mathcal{K}$ intentionally leaves out named ports, arity constraints,
+linear or affine resources, and retention obligations for values that later substitutions may still
+depend on. A stronger interface calculus would enrich $\Gamma$ with those structures so that
+executable routing policies and resource-sensitive admissibility can be stated directly.
 
 #### Concurrent Substitution Commutation
 
-For a richer extension, independent substitutions may admit a commutation law.
-That requires an explicit independence relation and belongs to a stronger
-calculus than the base one defined here.
+For a richer extension, independent substitutions may admit a commutation law. That requires an
+explicit independence relation and belongs to a stronger calculus than the base one defined here.
 
 #### Budget-Bounded Growth
 
-If substitution cost is tracked and budget decreases monotonically, one would
-like a bounded-growth result limiting the number or size of admitted
-substitutions in a run. That is an operational extension, not part of the
-minimal semantic core established here.
+If substitution cost is tracked and budget decreases monotonically, one would like a bounded-growth
+result limiting the number or size of admitted substitutions in a run. That is an operational
+extension, not part of the minimal semantic core established here.
 
 ---
 
 ## 13. Related Work
 
-Algebraic graph transformation studies local graph change through rule-based
-systems such as DPO and SPO rewriting. This paper does not claim novelty over
-graph transformation as such. Its contribution is to specialize that space to a
-durable workflow setting with named step boundaries, lineage, materialization,
-and recovery.
+Algebraic graph transformation studies local graph change through rule-based systems such as DPO and
+SPO rewriting. This paper does not claim novelty over graph transformation as such. Its contribution
+is to specialize that space to a durable workflow setting with named step boundaries, lineage,
+materialization, and recovery.
 
-Process calculi and workflow encodings provide rich accounts of concurrency,
-communication, and mobility. Their center of gravity is usually process
-interaction rather than durable materialized execution over named workflow
-steps. The contribution here is the layering between workflow meaning, compiled
-graph artifact, substitution, and recovery.
+Process calculi and workflow encodings provide rich accounts of concurrency, communication, and
+mobility. Their center of gravity is usually process interaction rather than durable materialized
+execution over named workflow steps. The contribution here is the layering between workflow meaning,
+compiled graph artifact, substitution, and recovery.
 
-Durable execution systems such as Temporal and Restate provide strong replay and
-suspension semantics. The present contribution is orthogonal: it asks how
-durable execution should behave when the future topology itself changes through
-admitted local substitution.
+Durable execution systems such as Temporal and Restate provide strong replay and suspension
+semantics. The present contribution is orthogonal: it asks how durable execution should behave when
+the future topology itself changes through admitted local substitution.
 
-Accordingly, the claim is not that vertex-anchored substitution is the only
-possible graph evolution formalism, but that it is the right semantic center
-for durable step refinement in this layered setting.
+Accordingly, the claim is not that vertex-anchored substitution is the only possible graph evolution
+formalism, but that it is the right semantic center for durable step refinement in this layered
+setting.
 
 ---
 
 ## 14. Boundary of the Theory
 
-This paper gives a theory of **dynamic durable execution by local substitution**.
-It does not claim to solve all process evolution problems.
+This paper gives a theory of **dynamic durable execution by local substitution**. It does not claim
+to solve all process evolution problems.
 
 In particular, the theory should be distinguished from:
 
@@ -1033,15 +964,15 @@ In particular, the theory should be distinguished from:
 - arbitrary graph surgery without boundary contracts
 - semantic equivalence of unrelated lowered artifacts
 
-Those are valid research directions, but they are not the same object as local
-durable graph substitution.
+Those are valid research directions, but they are not the same object as local durable graph
+substitution.
 
 ---
 
 ## 15. Conclusion
 
-The conceptual payoff of graph substitution is that it gives dynamic durable
-workflows a stable semantic center.
+The conceptual payoff of graph substitution is that it gives dynamic durable workflows a stable
+semantic center.
 
 - workflow meaning lives in a typed language and IR
 - executable structure lives in a compiled graph artifact
@@ -1049,20 +980,21 @@ workflows a stable semantic center.
 - topology evolution lives in a substitution calculus
 - recovery and explanation live in lineage, materialization, and integrity
 
-This layering makes the design space easier to reason about. It explains why
-vertex-anchored substitution is the right core abstraction, why concurrency of
-execution and concurrency of substitution are different problems, and why
-durability requires more than replay alone.
+This layering makes the design space easier to reason about. It explains why vertex-anchored
+substitution is the right core abstraction, why concurrency of execution and concurrency of
+substitution are different problems, and why durability requires more than replay alone.
 
-For motivating contexts such as Cortex and its downstream host applications,
-this theory offers a principled route to dynamic workflow execution without
-collapsing workflow semantics, runtime execution, and graph evolution into a
-single informal notion.
+For motivating contexts such as Cortex and its downstream host applications, this theory offers a
+principled route to dynamic workflow execution without collapsing workflow semantics, runtime
+execution, and graph evolution into a single informal notion.
 
 ## References
 
-1. Ehrig, H., Ehrig, K., Prange, U., Taentzer, G. (2006). *Fundamentals of Algebraic Graph Transformation*. Springer. <https://link.springer.com/book/10.1007/3-540-31188-2>
-2. Milner, R. (1999). *Communicating and Mobile Systems: The Pi-Calculus*. Cambridge University Press.
-3. van der Aalst, W. M. P. (1998). *The Application of Petri Nets to Workflow Management*. Journal of Circuits, Systems and Computers 8(1):21–66.
-4. Temporal Technologies. *Temporal*. <https://temporal.io>
-5. Restate. *Workflows*. <https://docs.restate.dev/tour/workflows>
+1. Ehrig, H., Ehrig, K., Prange, U., Taentzer, G. (2006). _Fundamentals of Algebraic Graph
+   Transformation_. Springer. <https://link.springer.com/book/10.1007/3-540-31188-2>
+2. Milner, R. (1999). _Communicating and Mobile Systems: The Pi-Calculus_. Cambridge University
+   Press.
+3. van der Aalst, W. M. P. (1998). _The Application of Petri Nets to Workflow Management_. Journal
+   of Circuits, Systems and Computers 8(1):21–66.
+4. Temporal Technologies. _Temporal_. <https://temporal.io>
+5. Restate. _Workflows_. <https://docs.restate.dev/tour/workflows>

--- a/docs/Publications/Paper-4-wire-language/Figures/index.md
+++ b/docs/Publications/Paper-4-wire-language/Figures/index.md
@@ -4,13 +4,17 @@ description: Figure inventory and export notes for the Wire Language paper.
 date: 2026-04-24
 updated: 2026-04-28
 status: draft
+related:
+  - docs/Publications/Paper-4-wire-language/manuscript.md
+  - docs/Publications/Paper-4-wire-language/index.md
 ---
 
 # Paper 4 Figures
 
 ## Inventory
 
-- [wire-layering-overview.mmd](wire-layering-overview.mmd) — main layering figure showing registered authority, Wire, Circuit, Pulse, and downstream bindings.
+- [wire-layering-overview.mmd](wire-layering-overview.mmd) — main layering figure showing registered
+  authority, Wire, Circuit, Pulse, and downstream bindings.
 
 ## Export status
 

--- a/docs/Publications/Paper-4-wire-language/index.md
+++ b/docs/Publications/Paper-4-wire-language/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Paper 4 — Wire Language"
-description: Landing page for the Wire Language paper. Abstract, status, figures, and related material.
+description:
+  Landing page for the Wire Language paper. Abstract, status, figures, and related material.
 sidebar:
   label: Paper 4
   order: 4
@@ -16,7 +17,8 @@ related:
 
 # Paper 4 — Wire Language
 
-Wire is the author-facing language layer of Cortex: a small graph language for composing registered authority into executable topology and bounded structural proposals.
+Wire is the author-facing language layer of Cortex: a small graph language for composing registered
+authority into executable topology and bounded structural proposals.
 
 ## Status
 
@@ -24,18 +26,29 @@ Draft manuscript. See [manuscript.md](manuscript.md) for the full text.
 
 ## Abstract
 
-This paper presents Wire, a source language for authoring typed workflow and reasoning graphs above the Cortex substrate. Its central claim is that authoring should keep **authority closed** and **composition open**: executors, contracts, tools, and policy are registered externally, while the language itself exposes a small algebra for composing them into executable graphs and candidate rewrite fragments. The paper argues for homogeneous topological edges, endpoint-owned compatibility, partial-node reuse, and a shared authoring surface for both initial topology and bounded structural proposals.
+This paper presents Wire, a source language for authoring typed workflow and reasoning graphs above
+the Cortex substrate. Its central claim is that authoring should keep **authority closed** and
+**composition open**: executors, contracts, tools, and policy are registered externally, while the
+language itself exposes a small algebra for composing them into executable graphs and candidate
+rewrite fragments. The paper argues for homogeneous topological edges, endpoint-owned compatibility,
+partial-node reuse, and a shared authoring surface for both initial topology and bounded structural
+proposals.
 
 ## Figures
 
 - [Figures/index.md](Figures/index.md) — figure inventory and export status.
-- [wire-layering-overview.mmd](Figures/wire-layering-overview.mmd) — source for the main Wire layering figure.
+- [wire-layering-overview.mmd](Figures/wire-layering-overview.mmd) — source for the main Wire
+  layering figure.
 - Publication-exported vector figures are not checked in yet.
 
 ## Related
 
 - [manuscript.md](manuscript.md) — full manuscript.
-- [../Paper-2-algebraic-foundations/](../Paper-2-algebraic-foundations/) — algebraic substrate beneath Wire.
-- [../Paper-3-graph-substitution-semantics/](../Paper-3-graph-substitution-semantics/) — substitution and materialization semantics that Wire hands off to.
-- [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) — architecture chapter.
-- [../../Reference/Wire/grammar.md](../../Reference/Wire/grammar.md) — current normative grammar surface.
+- [../Paper-2-algebraic-foundations/](../Paper-2-algebraic-foundations/) — algebraic substrate
+  beneath Wire.
+- [../Paper-3-graph-substitution-semantics/](../Paper-3-graph-substitution-semantics/) —
+  substitution and materialization semantics that Wire hands off to.
+- [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) — architecture
+  chapter.
+- [../../Reference/Wire/grammar.md](../../Reference/Wire/grammar.md) — current normative grammar
+  surface.

--- a/docs/Publications/Paper-4-wire-language/manuscript.md
+++ b/docs/Publications/Paper-4-wire-language/manuscript.md
@@ -1,6 +1,8 @@
 ---
 title: "Wire: Closed Alphabets, Open Composition for Typed Workflow Graphs"
-description: Draft manuscript on Wire as an authoring language for typed workflow graphs, bounded structural proposals, and registered authority.
+description:
+  Draft manuscript on Wire as an authoring language for typed workflow graphs, bounded structural
+  proposals, and registered authority.
 kind: publication
 status: draft
 authors:
@@ -18,15 +20,42 @@ related:
 
 ## Abstract
 
-We present **Wire**, a source language for authoring typed workflow and reasoning graphs above a durable graph-execution substrate. The language is designed around one architectural rule: **authority stays closed; composition stays open**. Executors, contracts, tools, prompts, and policy are registered externally. Wire does not invent new runtime authority; it composes the authority that the host environment has already made available. This separation yields a compact graph language with four distinctive properties. First, topology remains honest: the core composition layer is a small graph algebra rather than a hidden API in a host language. Second, edges remain homogeneous and purely topological; compatibility lives on node endpoints through offered and accepted contracts. Third, reuse is expressed compositionally through partial nodes and configuration layering rather than through a second template language. Fourth, the same source language can describe both initial executable graphs and candidate structural proposals, while runtime admission, budgeting, and materialization remain outside the language.
+We present **Wire**, a source language for authoring typed workflow and reasoning graphs above a
+durable graph-execution substrate. The language is designed around one architectural rule:
+**authority stays closed; composition stays open**. Executors, contracts, tools, prompts, and policy
+are registered externally. Wire does not invent new runtime authority; it composes the authority
+that the host environment has already made available. This separation yields a compact graph
+language with four distinctive properties. First, topology remains honest: the core composition
+layer is a small graph algebra rather than a hidden API in a host language. Second, edges remain
+homogeneous and purely topological; compatibility lives on node endpoints through offered and
+accepted contracts. Third, reuse is expressed compositionally through partial nodes and
+configuration layering rather than through a second template language. Fourth, the same source
+language can describe both initial executable graphs and candidate structural proposals, while
+runtime admission, budgeting, and materialization remain outside the language.
 
-The paper develops the design rationale for this split, gives a minimal semantic account of endpoint-typed composition, and reports the current implementation surface in Cortex: parsing, compilation to executable circuits, compatibility witnesses, vocabulary catalog generation, topological memory annotations, latent condition compilation, and append-style proposal fitting. We do not claim a full metatheory for Wire in this paper. The contribution is the language boundary itself: a safe authoring surface for graph programs that need typed structure, bounded extensibility, and downstream-owned semantics.
+The paper develops the design rationale for this split, gives a minimal semantic account of
+endpoint-typed composition, and reports the current implementation surface in Cortex: parsing,
+compilation to executable circuits, compatibility witnesses, vocabulary catalog generation,
+topological memory annotations, latent condition compilation, and append-style proposal fitting. We
+do not claim a full metatheory for Wire in this paper. The contribution is the language boundary
+itself: a safe authoring surface for graph programs that need typed structure, bounded
+extensibility, and downstream-owned semantics.
 
 ## 1. Introduction
 
-Workflow systems and agent runtimes increasingly need an author-facing surface for graph structure. Two common approaches dominate. The first embeds graph authoring in a host language API. The second allows a planner or model to synthesize ad hoc structure through untyped text or imperative tool calls. Both approaches lose something important. Host-language embeddings blur graph meaning with general programming machinery. Open-ended text generation makes structure, authority, and runtime policy hard to separate.
+Workflow systems and agent runtimes increasingly need an author-facing surface for graph structure.
+Two common approaches dominate. The first embeds graph authoring in a host language API. The second
+allows a planner or model to synthesize ad hoc structure through untyped text or imperative tool
+calls. Both approaches lose something important. Host-language embeddings blur graph meaning with
+general programming machinery. Open-ended text generation makes structure, authority, and runtime
+policy hard to separate.
 
-Wire starts from a narrower goal: give authors and agents a small language for expressing graph structure over a vocabulary that has already been registered elsewhere. The language should be strong enough to define executable topology, endpoint contracts, reuse by partial instantiation, and candidate graph fragments for bounded structural change. It should not be strong enough to mint new runtime authority, redefine scheduler policy, or smuggle arbitrary host-language computation into the graph layer.
+Wire starts from a narrower goal: give authors and agents a small language for expressing graph
+structure over a vocabulary that has already been registered elsewhere. The language should be
+strong enough to define executable topology, endpoint contracts, reuse by partial instantiation, and
+candidate graph fragments for bounded structural change. It should not be strong enough to mint new
+runtime authority, redefine scheduler policy, or smuggle arbitrary host-language computation into
+the graph layer.
 
 The resulting design can be summarized in one sentence:
 
@@ -35,9 +64,13 @@ The resulting design can be summarized in one sentence:
 This paper makes four claims.
 
 1. Authoring should separate **authority registration** from **graph composition**.
-2. Endpoint-typed composition over a small graph algebra is sufficient for a wide class of practical workflow and reasoning graphs.
-3. Initial topology and candidate structural proposals should share one authoring surface, while admission and materialization remain runtime concerns.
-4. The right extensibility rule for this language is **closed alphabets, open composition**: grow the registered vocabulary or add bounded composition forms, but do not casually enlarge the core operator set.
+2. Endpoint-typed composition over a small graph algebra is sufficient for a wide class of practical
+   workflow and reasoning graphs.
+3. Initial topology and candidate structural proposals should share one authoring surface, while
+   admission and materialization remain runtime concerns.
+4. The right extensibility rule for this language is **closed alphabets, open composition**: grow
+   the registered vocabulary or add bounded composition forms, but do not casually enlarge the core
+   operator set.
 
 ## 2. Position in the Cortex Stack
 
@@ -51,7 +84,8 @@ flowchart LR
     D[Downstream bindings<br/>domain policy and artifacts] --> R
 ```
 
-*Figure 1.* Wire is an authoring layer above registered authority and below the compiled executable artifact.
+_Figure 1._ Wire is an authoring layer above registered authority and below the compiled executable
+artifact.
 
 This placement matters because it keeps three responsibilities distinct:
 
@@ -59,49 +93,67 @@ This placement matters because it keeps three responsibilities distinct:
 - Pulse owns execution, admission, budgeting, persistence, and resume behavior.
 - Wire owns author-facing composition.
 
-That separation also prevents a recurring category error. A `.wire` file is not a scheduler script and not a general-purpose program. It is a graph program authored over a closed vocabulary.
+That separation also prevents a recurring category error. A `.wire` file is not a scheduler script
+and not a general-purpose program. It is a graph program authored over a closed vocabulary.
 
 ## 3. Closed Alphabets, Open Composition
 
-The central design rule of Wire is that the language is closed over **authority** and open over **composition**.
+The central design rule of Wire is that the language is closed over **authority** and open over
+**composition**.
 
-Closed authority means that executors, contracts, tools, prompts, memory presets, and configuration constructors are registered by the host environment or a library. A Wire program may reference them by name; it does not define their runtime behavior.
+Closed authority means that executors, contracts, tools, prompts, memory presets, and configuration
+constructors are registered by the host environment or a library. A Wire program may reference them
+by name; it does not define their runtime behavior.
 
-Open composition means that those authorities may be arranged into arbitrarily large graphs, partial-node families, and bounded proposal fragments using a small composition layer.
+Open composition means that those authorities may be arranged into arbitrarily large graphs,
+partial-node families, and bounded proposal fragments using a small composition layer.
 
 This split has three benefits.
 
 - It keeps the language small and inspectable.
 - It gives downstream systems control over what a Wire author is allowed to use.
-- It makes LLM-facing authoring safer: a model may propose topology over a known vocabulary instead of inventing opaque capabilities.
+- It makes LLM-facing authoring safer: a model may propose topology over a known vocabulary instead
+  of inventing opaque capabilities.
 
 The language therefore grows best by extending one of two surfaces:
 
 - the registered vocabulary
 - bounded composition forms over the existing graph algebra
 
-What it should not do casually is grow a large new operator alphabet. That is why the current design keeps the core operator set deliberately small.
+What it should not do casually is grow a large new operator alphabet. That is why the current design
+keeps the core operator set deliberately small.
 
 ## 4. Endpoint-Typed Composition
 
-Wire keeps edges homogeneous and purely topological. Compatibility does not live on the edge itself. It lives on the endpoints.
+Wire keeps edges homogeneous and purely topological. Compatibility does not live on the edge itself.
+It lives on the endpoints.
 
 Let each node expose:
 
 - offered output contracts $\Gamma^+(v)$
 - accepted input contracts $\Gamma^-(v)$
 
-Then composition across an edge $(u, v)$ is admissible when the offered contract is acceptable at the sink boundary:
+Then composition across an edge $(u, v)$ is admissible when the offered contract is acceptable at
+the sink boundary:
 
 $$
 \Gamma^+(u) \sqsubseteq \Gamma^-(v)
 $$
 
-In the current regime, $\sqsubseteq$ is nominal contract-name equality extended with optional per-port labels: the match unit is the port key $(\text{direction}, \text{contract}, \text{label})$, and an absent label is a distinct key, not a wildcard. There is no structural refinement relation over contract fields, and no implicit subtyping graph; the check is resolved at compile time against the registered contract catalog. Richer regimes — parameterized contracts, refinement judgements, or field-level structural compatibility — are future work (see §8); the current language deliberately keeps the compile-time check simple and nominal.
+In the current regime, $\sqsubseteq$ is nominal contract-name equality extended with optional
+per-port labels: the match unit is the port key $(\text{direction}, \text{contract}, \text{label})$,
+and an absent label is a distinct key, not a wildcard. There is no structural refinement relation
+over contract fields, and no implicit subtyping graph; the check is resolved at compile time against
+the registered contract catalog. Richer regimes — parameterized contracts, refinement judgements, or
+field-level structural compatibility — are future work (see §8); the current language deliberately
+keeps the compile-time check simple and nominal.
 
-This choice is deliberate. If edges themselves carried semantic selectors, routing operators, or transformation code, then every graph edit would become a small program synthesis problem. Endpoint-owned compatibility keeps the graph layer structurally honest.
+This choice is deliberate. If edges themselves carried semantic selectors, routing operators, or
+transformation code, then every graph edit would become a small program synthesis problem.
+Endpoint-owned compatibility keeps the graph layer structurally honest.
 
-This is also why default connection syntax can remain simple while explicit endpoint syntax exists as a disambiguation tool rather than as the primary model.
+This is also why default connection syntax can remain simple while explicit endpoint syntax exists
+as a disambiguation tool rather than as the primary model.
 
 For example, a simple typed path can remain visually close to the graph it denotes:
 
@@ -123,9 +175,12 @@ node report :
 let deep_report = planner => analyst => report;
 ```
 
-The graph is explicit. The contracts sit on the boundaries. The executors are named but not defined in the language.
+The graph is explicit. The contracts sit on the boundaries. The executors are named but not defined
+in the language.
 
-When two ports on the same node would otherwise share $(\text{direction}, \text{contract})$, port labels are required to disambiguate; the label becomes part of the port key and participates in matching.
+When two ports on the same node would otherwise share $(\text{direction}, \text{contract})$, port
+labels are required to disambiguate; the label becomes part of the port key and participates in
+matching.
 
 ```wire
 node splitter :
@@ -142,11 +197,15 @@ node consumer :
 let decide = splitter => consumer;
 ```
 
-Here `primary:` labels on both sides match and produce the single admissible edge; the `fallback:` output remains on the composed boundary because no labeled sink accepts it. Labeled routing is available but is not the default: unlabeled composition suffices for the common case.
+Here `primary:` labels on both sides match and produce the single admissible edge; the `fallback:`
+output remains on the composed boundary because no labeled sink accepts it. Labeled routing is
+available but is not the default: unlabeled composition suffices for the common case.
 
 ## 5. Reuse Without a Second Language
 
-Wire reuses graph structure through the same value layer it uses for ordinary nodes. The key mechanism is the **partial node**: a configured executor value whose remaining structural choices are pinned later.
+Wire reuses graph structure through the same value layer it uses for ordinary nodes. The key
+mechanism is the **partial node**: a configured executor value whose remaining structural choices
+are pinned later.
 
 ```wire
 let analyst_base = @llm.analyst {
@@ -161,25 +220,38 @@ node critic :
 };
 ```
 
-This matters because it avoids a common DSL failure mode: one language for graphs, another for templates, and a third for runtime configuration. In Wire, reuse stays inside the same algebra. The same mechanism also gives rewrite proposals a disciplined instantiation path: proposals can introduce new nodes by applying bounded configuration deltas to already-registered authority.
+This matters because it avoids a common DSL failure mode: one language for graphs, another for
+templates, and a third for runtime configuration. In Wire, reuse stays inside the same algebra. The
+same mechanism also gives rewrite proposals a disciplined instantiation path: proposals can
+introduce new nodes by applying bounded configuration deltas to already-registered authority.
 
-The current design intentionally stops short of full composition-level lambdas. That is a real future direction, but only if variable-arity or abstraction-emitting rewrites become load-bearing. For the current paper, the important point is simpler: Wire already gets meaningful reuse without abandoning graph transparency.
+The current design intentionally stops short of full composition-level lambdas. That is a real
+future direction, but only if variable-arity or abstraction-emitting rewrites become load-bearing.
+For the current paper, the important point is simpler: Wire already gets meaningful reuse without
+abandoning graph transparency.
 
 ## 6. One Surface for Initial Graphs and Candidate Proposals
 
-Wire does not admit topology changes by itself. That remains a runtime responsibility. But it does use the same authoring surface for two related tasks:
+Wire does not admit topology changes by itself. That remains a runtime responsibility. But it does
+use the same authoring surface for two related tasks:
 
 - authoring the initial executable graph
 - describing a candidate fragment to be proposed later
 
-This is a stronger result than it first appears. It means the authoring story for bounded structural change does not require a second graph language. The same vocabulary, endpoint compatibility discipline, and composition forms can be used to express a proposal fragment, while the runtime still owns:
+This is a stronger result than it first appears. It means the authoring story for bounded structural
+change does not require a second graph language. The same vocabulary, endpoint compatibility
+discipline, and composition forms can be used to express a proposal fragment, while the runtime
+still owns:
 
 - whether the fragment fits the anchor
 - whether its exits fit the surrounding graph
 - whether it fits the remaining structural budget
 - whether and how it is materialized durably
 
-This is the language-level counterpart to the substitution semantics developed in the previous paper. Paper 3 explains why admitted dynamic change should be modeled as substitution over compiled artifacts. This paper explains why the authoring layer can remain small even when programs are allowed to propose such change.
+This is the language-level counterpart to the substitution semantics developed in the previous
+paper. Paper 3 explains why admitted dynamic change should be modeled as substitution over compiled
+artifacts. This paper explains why the authoring layer can remain small even when programs are
+allowed to propose such change.
 
 A minimal append-style proposal can therefore look like:
 
@@ -190,7 +262,9 @@ let d = @llm.fizzToBar { prompt = "Bridge fizz to bar."; };
 c => d
 ```
 
-The authoring surface is ordinary Wire. What makes this fragment a proposal rather than an initial graph is not the syntax alone, but the surrounding runtime context: anchor hole, contract fit, remaining budget, and admission policy.
+The authoring surface is ordinary Wire. What makes this fragment a proposal rather than an initial
+graph is not the syntax alone, but the surrounding runtime context: anchor hole, contract fit,
+remaining budget, and admission policy.
 
 ## 7. Implementation Surface
 
@@ -205,43 +279,76 @@ Wire is no longer a purely architectural sketch. The current implementation alre
 - closed-world conditional forms lowered into latent branch machinery
 - append-style proposal compilation and hole-fit validation
 
-The important point is not that every future semantic claim has been proved. It is that the language boundary is real enough to test. That matters for publication scope. Wire is not just a desired syntax. It is a working authoring surface with identifiable semantics and pressure points.
+The important point is not that every future semantic claim has been proved. It is that the language
+boundary is real enough to test. That matters for publication scope. Wire is not just a desired
+syntax. It is a working authoring surface with identifiable semantics and pressure points.
 
 ## 8. Boundaries and Open Questions
 
 Three boundaries should remain explicit.
 
-First, Wire is not a runtime policy language. Admission, budgeting, replay, persistence, and materialization remain outside it.
+First, Wire is not a runtime policy language. Admission, budgeting, replay, persistence, and
+materialization remain outside it.
 
-Second, closed-world branch selection should not be conflated with open structural proposals. A declared conditional with latent alternatives is a different semantic object from a planner-generated graph fragment, even if early implementations lower both through similar machinery. The structural distinction is timing: latent branches are compiled and statically validated with the initial circuit, and the runtime only selects an alternative whose full typing and budget footprint were known at compile time; open proposals are compiled, endpoint-checked, budget-checked, and materialized at runtime, against graph state the compile-time environment did not see.
+Second, closed-world branch selection should not be conflated with open structural proposals. A
+declared conditional with latent alternatives is a different semantic object from a
+planner-generated graph fragment, even if early implementations lower both through similar
+machinery. The structural distinction is timing: latent branches are compiled and statically
+validated with the initial circuit, and the runtime only selects an alternative whose full typing
+and budget footprint were known at compile time; open proposals are compiled, endpoint-checked,
+budget-checked, and materialized at runtime, against graph state the compile-time environment did
+not see.
 
-Third, the current endpoint model is still compatibility-first rather than full multi-channel projection. Contracts label admissible flow between nodes. They do not yet imply arbitrary field-level routing across edges. That limitation is a feature for now: it keeps the language honest with respect to the runtime.
+Third, the current endpoint model is still compatibility-first rather than full multi-channel
+projection. Contracts label admissible flow between nodes. They do not yet imply arbitrary
+field-level routing across edges. That limitation is a feature for now: it keeps the language honest
+with respect to the runtime.
 
-Open questions remain. Known-arity composition repetition may justify templates. Variable-arity composition or abstraction-emitting rewrites may eventually justify lambdas. Richer compatibility regimes may need to appear in compiled artifact witnesses. None of those are required to justify the current language boundary.
+Open questions remain. Known-arity composition repetition may justify templates. Variable-arity
+composition or abstraction-emitting rewrites may eventually justify lambdas. Richer compatibility
+regimes may need to appear in compiled artifact witnesses. None of those are required to justify the
+current language boundary.
 
 ## 9. Related Work
 
 Wire belongs at the intersection of several traditions.
 
-From **algebraic graphs**, it takes the idea that overlay and connect can form a small honest graph algebra rather than a hidden implementation detail. From **selective and build-system semantics**, it inherits the idea that static structure and dynamic choice should be separated carefully. From **workflow DSLs and durable execution systems**, it inherits the need for authoring surfaces that survive compilation and runtime interaction without collapsing into a host-language embedding.
+From **algebraic graphs**, it takes the idea that overlay and connect can form a small honest graph
+algebra rather than a hidden implementation detail. From **selective and build-system semantics**,
+it inherits the idea that static structure and dynamic choice should be separated carefully. From
+**workflow DSLs and durable execution systems**, it inherits the need for authoring surfaces that
+survive compilation and runtime interaction without collapsing into a host-language embedding.
 
-What distinguishes Wire in this context is the particular boundary it draws. The language is not trying to be a full workflow programming language, a host-language EDSL, or a scheduler policy surface. It is an authoring layer for typed topology over registered authority, with bounded structural proposals as a first-class downstream use case.
+What distinguishes Wire in this context is the particular boundary it draws. The language is not
+trying to be a full workflow programming language, a host-language EDSL, or a scheduler policy
+surface. It is an authoring layer for typed topology over registered authority, with bounded
+structural proposals as a first-class downstream use case.
 
 ## 10. Conclusion
 
-Wire is valuable not because it is a large language, but because it is a narrow one with the right boundary. By keeping authority closed and composition open, it gives Cortex an authoring surface that is compact, typed, graph-honest, and compatible with bounded structural evolution. That makes it suitable both for human authors and for model-assisted graph construction without turning the language into an unbounded authority generator.
+Wire is valuable not because it is a large language, but because it is a narrow one with the right
+boundary. By keeping authority closed and composition open, it gives Cortex an authoring surface
+that is compact, typed, graph-honest, and compatible with bounded structural evolution. That makes
+it suitable both for human authors and for model-assisted graph construction without turning the
+language into an unbounded authority generator.
 
-The next steps are clear: sharpen the contract regime carried by compiled artifacts, keep closed-world selection distinct from open proposals, and evaluate when composition-level abstraction becomes necessary. None of those weaken the main claim of this paper. They follow from it.
+The next steps are clear: sharpen the contract regime carried by compiled artifacts, keep
+closed-world selection distinct from open proposals, and evaluate when composition-level abstraction
+becomes necessary. None of those weaken the main claim of this paper. They follow from it.
 
 ## References
 
-1. Andrey Mokhov. *Algebraic Graphs with Class*. 2017.
-2. Andrey Mokhov, Neil Mitchell, Simon Peyton Jones. *Build Systems a la Carte: Theory and Practice*. 2020.
-3. Andrey Mokhov, Georgy Lukyanov, Simon Marlow, Conor McBride. *Selective Applicative Functors*. 2019.
-4. Alexandra Matache, Nicolas Wu, and Sam Staton. *Scoped Effects as Parameterized Algebraic Theories*. 2024.
-5. Temporal Technologies. *Temporal*. <https://temporal.io>
-6. Microsoft. *Azure Durable Functions*. <https://learn.microsoft.com/en-us/azure/azure-functions/durable/>
-7. Restate. *Workflows*. <https://docs.restate.dev/tour/workflows>
+1. Andrey Mokhov. _Algebraic Graphs with Class_. 2017.
+2. Andrey Mokhov, Neil Mitchell, Simon Peyton Jones. _Build Systems a la Carte: Theory and
+   Practice_. 2020.
+3. Andrey Mokhov, Georgy Lukyanov, Simon Marlow, Conor McBride. _Selective Applicative
+   Functors_. 2019.
+4. Alexandra Matache, Nicolas Wu, and Sam Staton. _Scoped Effects as Parameterized Algebraic
+   Theories_. 2024.
+5. Temporal Technologies. _Temporal_. <https://temporal.io>
+6. Microsoft. _Azure Durable Functions_.
+   <https://learn.microsoft.com/en-us/azure/azure-functions/durable/>
+7. Restate. _Workflows_. <https://docs.restate.dev/tour/workflows>
 
 ## Figures
 

--- a/docs/Publications/index.md
+++ b/docs/Publications/index.md
@@ -1,6 +1,8 @@
 ---
 title: Cortex Publications
-description: Formal write-ups and papers on Cortex's algebraic and semantic foundations. Each paper lives in its own folder with manuscript and figures alongside.
+description:
+  Formal write-ups and papers on Cortex's algebraic and semantic foundations. Each paper lives in
+  its own folder with manuscript and figures alongside.
 sidebar:
   label: Publications
   order: 6
@@ -8,22 +10,28 @@ sidebar:
 
 # Cortex Publications
 
-Publication-grade write-ups of Cortex's theoretical foundations and engineering
-results. This folder now holds the active paper candidates.
-Companion theory and proof plans live under [../Roadmap/Plans/](../Roadmap/Plans/).
+Publication-grade write-ups of Cortex's theoretical foundations and engineering results. This folder
+now holds the active paper candidates. Companion theory and proof plans live under
+[../Roadmap/Plans/](../Roadmap/Plans/).
 
 ## Papers
 
-- **[Paper-1-staged-reduction/](Paper-1-staged-reduction/)** — fixed-topology staged reduction and structural recovery safety.
-- **[Paper-2-algebraic-foundations/](Paper-2-algebraic-foundations/)** — algebraic kernel and extension boundary of the fixed-topology calculus.
-- **[Paper-3-graph-substitution-semantics/](Paper-3-graph-substitution-semantics/)** — compiled artifacts, graph substitution, and dynamic-topology semantics.
-- **[Paper-4-wire-language/](Paper-4-wire-language/)** — authoring language for typed topology, registered authority, and bounded structural proposals.
+- **[Paper-1-staged-reduction/](Paper-1-staged-reduction/)** — fixed-topology staged reduction and
+  structural recovery safety.
+- **[Paper-2-algebraic-foundations/](Paper-2-algebraic-foundations/)** — algebraic kernel and
+  extension boundary of the fixed-topology calculus.
+- **[Paper-3-graph-substitution-semantics/](Paper-3-graph-substitution-semantics/)** — compiled
+  artifacts, graph substitution, and dynamic-topology semantics.
+- **[Paper-4-wire-language/](Paper-4-wire-language/)** — authoring language for typed topology,
+  registered authority, and bounded structural proposals.
 
 ## Supporting material
 
 - **[roadmap.md](roadmap.md)** — publication portfolio and dependency sketch.
-- **[../Roadmap/Plans/lean-mechanization.md](../Roadmap/Plans/lean-mechanization.md)** — supporting research plan for machine-checked fixed-topology results.
-- **[../Roadmap/Plans/rewrite-materialization-and-recovery.md](../Roadmap/Plans/rewrite-materialization-and-recovery.md)** — supporting research plan for runtime-grounded rewrite recovery.
+- **[../Roadmap/Plans/lean-mechanization.md](../Roadmap/Plans/lean-mechanization.md)** — supporting
+  research plan for machine-checked fixed-topology results.
+- **[../Roadmap/Plans/rewrite-materialization-and-recovery.md](../Roadmap/Plans/rewrite-materialization-and-recovery.md)**
+  — supporting research plan for runtime-grounded rewrite recovery.
 - **[Notes/](Notes/)** — working notes and idea memos that feed the papers.
 
 ## Per-paper structure
@@ -36,10 +44,12 @@ Each `paper-N-*/` folder contains:
 
 ## Template
 
-Use [../Templates/publication-manuscript.md](../Templates/publication-manuscript.md) for new manuscripts.
+Use [../Templates/publication-manuscript.md](../Templates/publication-manuscript.md) for new
+manuscripts.
 
 ## Related
 
 - [../Research-notes/](../Research-notes/) — dated research synthesis that underlies the papers.
 - [../Roadmap/Plans/](../Roadmap/Plans/) — companion research and implementation plans.
-- [../Architecture/03-formalism-stack.md](../Architecture/03-formalism-stack.md) — architecture chapter that cites the papers.
+- [../Architecture/03-formalism-stack.md](../Architecture/03-formalism-stack.md) — architecture
+  chapter that cites the papers.

--- a/docs/Publications/roadmap.md
+++ b/docs/Publications/roadmap.md
@@ -1,6 +1,7 @@
 ---
 title: Publications Roadmap
-description: Publication portfolio and dependency sketch for Cortex papers and companion research plans.
+description:
+  Publication portfolio and dependency sketch for Cortex papers and companion research plans.
 sidebar:
   label: Roadmap
   order: 1
@@ -13,39 +14,48 @@ Plan and state of the current Cortex publication portfolio.
 
 ## Paper status
 
-| # | Title | Status | Role |
-|---|---|---|---|
-| 1 | [Staged reduction](Paper-1-staged-reduction/) | Draft | Runtime-grounded fixed-topology paper |
-| 2 | [Algebraic foundations](Paper-2-algebraic-foundations/) | Draft | Core fixed-topology theory |
-| 3 | [Graph substitution semantics](Paper-3-graph-substitution-semantics/) | Draft | Dynamic substitution theory |
-| 4 | [Wire language](Paper-4-wire-language/) | Draft | Authoring language and authority-composition paper |
+| #   | Title                                                                 | Status | Role                                               |
+| --- | --------------------------------------------------------------------- | ------ | -------------------------------------------------- |
+| 1   | [Staged reduction](Paper-1-staged-reduction/)                         | Draft  | Runtime-grounded fixed-topology paper              |
+| 2   | [Algebraic foundations](Paper-2-algebraic-foundations/)               | Draft  | Core fixed-topology theory                         |
+| 3   | [Graph substitution semantics](Paper-3-graph-substitution-semantics/) | Draft  | Dynamic substitution theory                        |
+| 4   | [Wire language](Paper-4-wire-language/)                               | Draft  | Authoring language and authority-composition paper |
 
 ## Supporting research plans
 
-| Plan | Status | Role |
-|---|---|---|
-| [Lean mechanization](../Roadmap/Plans/lean-mechanization.md) | Proposed | Machine-checked support for the fixed-topology core |
-| [Rewrite materialization and recovery](../Roadmap/Plans/rewrite-materialization-and-recovery.md) | Proposed | Runtime-grounded rewrite and recovery theory |
+| Plan                                                                                             | Status   | Role                                                |
+| ------------------------------------------------------------------------------------------------ | -------- | --------------------------------------------------- |
+| [Lean mechanization](../Roadmap/Plans/lean-mechanization.md)                                     | Proposed | Machine-checked support for the fixed-topology core |
+| [Rewrite materialization and recovery](../Roadmap/Plans/rewrite-materialization-and-recovery.md) | Proposed | Runtime-grounded rewrite and recovery theory        |
 
 ## Dependency sketch
 
 Paper 2 is the keystone paper.
 
-- Paper 1 sharpens the fixed-topology runtime story and narrows the structural-safety claim to what the runtime actually needs.
-- The Lean mechanization plan supports Papers 1 and 2 with machine-checked closure and recovery obligations.
-- Paper 3 extends the theory from fixed topology to compiled artifacts, substitution, and lineage-plus-materialization semantics.
-- Paper 4 explains the authoring layer above that substrate: closed authority registration, endpoint-typed composition, partial reuse, and bounded proposal authoring.
-- The rewrite materialization and recovery plan connects Paper 3's substitution theory back to runtime recovery and admission policy.
+- Paper 1 sharpens the fixed-topology runtime story and narrows the structural-safety claim to what
+  the runtime actually needs.
+- The Lean mechanization plan supports Papers 1 and 2 with machine-checked closure and recovery
+  obligations.
+- Paper 3 extends the theory from fixed topology to compiled artifacts, substitution, and
+  lineage-plus-materialization semantics.
+- Paper 4 explains the authoring layer above that substrate: closed authority registration,
+  endpoint-typed composition, partial reuse, and bounded proposal authoring.
+- The rewrite materialization and recovery plan connects Paper 3's substitution theory back to
+  runtime recovery and admission policy.
 
 ## Working notes
 
-Idea memos and working-stage material that feed the manuscripts live in [Notes/](Notes/). Current notes:
+Idea memos and working-stage material that feed the manuscripts live in [Notes/](Notes/). Current
+notes:
 
-- **[Notes/frontier-ideas.md](Notes/frontier-ideas.md)** — raw idea bank; items move into specific papers and plans as they mature.
-- **[Notes/deterministic-multi-rewrite-admission.md](Notes/deterministic-multi-rewrite-admission.md)** — current runtime semantics and validation questions for same-wave multi-proposal admission.
+- **[Notes/frontier-ideas.md](Notes/frontier-ideas.md)** — raw idea bank; items move into specific
+  papers and plans as they mature.
+- **[Notes/deterministic-multi-rewrite-admission.md](Notes/deterministic-multi-rewrite-admission.md)**
+  — current runtime semantics and validation questions for same-wave multi-proposal admission.
 
 ## Related
 
 - [index.md](index.md) — publications landing.
 - [../Roadmap/Plans/](../Roadmap/Plans/) — companion research plans.
-- [../Architecture/03-formalism-stack.md](../Architecture/03-formalism-stack.md) — architecture chapter consolidating the papers' claims.
+- [../Architecture/03-formalism-stack.md](../Architecture/03-formalism-stack.md) — architecture
+  chapter consolidating the papers' claims.

--- a/docs/Reference/Pulse/events.md
+++ b/docs/Reference/Pulse/events.md
@@ -1,6 +1,8 @@
 ---
 title: "Pulse Run-Event Catalog"
-description: "Normative event catalog for Pulse: lifecycle, stage, scheduler, and diagnostic events. Severity, field set, retention contract."
+description:
+  "Normative event catalog for Pulse: lifecycle, stage, scheduler, and diagnostic events. Severity,
+  field set, retention contract."
 sidebar:
   label: "Pulse run events"
   order: 15
@@ -9,11 +11,16 @@ status: accepted
 
 # Pulse Run-Event Catalog
 
-Pulse emits a structured event on every material run transition and on diagnostic conditions. Events are persisted per run and surfaced through the run-detail endpoint; event persistence is best-effort and never blocks the run itself.
+Pulse emits a structured event on every material run transition and on diagnostic conditions. Events
+are persisted per run and surfaced through the run-detail endpoint; event persistence is best-effort
+and never blocks the run itself.
 
-This page is the event catalog and field contract. Architectural framing is in [chapter 06](../../Architecture/06-pulse-runtime.md); persistence is in [`schema.md §7`](./schema.md#7-run-events).
+This page is the event catalog and field contract. Architectural framing is in
+[chapter 06](../../Architecture/06-pulse-runtime.md); persistence is in
+[`schema.md §7`](./schema.md#7-run-events).
 
-Event-type identifiers are dot-separated and namespaced by subject (`run.`, `stage.`, `schedule.`, `lease.`). New entries should follow the same convention.
+Event-type identifiers are dot-separated and namespaced by subject (`run.`, `stage.`, `schedule.`,
+`lease.`). New entries should follow the same convention.
 
 ## 1. Severity
 
@@ -30,65 +37,67 @@ data RunEventSeverity
 
 ## 2. Event record
 
-Every event carries the fields below. `event_type` identifies the event; `details` is an event-specific JSON object.
+Every event carries the fields below. `event_type` identifies the event; `details` is an
+event-specific JSON object.
 
-| Field         | Description                                                  |
-|---------------|--------------------------------------------------------------|
-| `run_id`      | Run identity.                                                |
-| `event_type`  | One of the catalog entries in §3.                            |
-| `severity`    | `info` / `warn` / `error`.                                   |
-| `message`     | Human-readable description.                                  |
-| `details`     | Optional event-specific JSON.                                |
-| `created_at`  | Event timestamp.                                             |
+| Field        | Description                       |
+| ------------ | --------------------------------- |
+| `run_id`     | Run identity.                     |
+| `event_type` | One of the catalog entries in §3. |
+| `severity`   | `info` / `warn` / `error`.        |
+| `message`    | Human-readable description.       |
+| `details`    | Optional event-specific JSON.     |
+| `created_at` | Event timestamp.                  |
 
 Common `details` fields observed across events (present when applicable):
 
-| Field              | Description                                              |
-|--------------------|----------------------------------------------------------|
-| `stage`            | Stage identity (stage events).                           |
-| `error_type`       | Error category ([`service-api.md §6`](./service-api.md#6-error-taxonomy)). |
-| `next_run_at`      | Scheduler target time (schedule events).                 |
-| `outcome`          | Run-outcome tag (schedule events).                       |
+| Field         | Description                                                                |
+| ------------- | -------------------------------------------------------------------------- |
+| `stage`       | Stage identity (stage events).                                             |
+| `error_type`  | Error category ([`service-api.md §6`](./service-api.md#6-error-taxonomy)). |
+| `next_run_at` | Scheduler target time (schedule events).                                   |
+| `outcome`     | Run-outcome tag (schedule events).                                         |
 
 ## 3. Catalog
 
 ### Run lifecycle
 
-| `event_type`                         | Severity | Emitted when                                                                |
-|--------------------------------------|----------|-----------------------------------------------------------------------------|
-| `run.completed`                      | info     | All stages completed successfully.                                          |
-| `run.failed`                         | error    | Scheduler observed an executor exception.                                   |
-| `run.failed.settled`                 | error    | Graph settled with failures at the end of execution.                        |
-| `run.suspended`                      | info     | Run suspended waiting on an external signal.                                |
-| `run.cancelled`                      | info     | Task cancelled by operator request.                                         |
-| `run.shutdown`                       | info     | Shutdown requested; executor stopping at a stage boundary.                  |
-| `run.stuck`                          | error    | Frontier empty but not all nodes settled (blocked-graph diagnostic).        |
-| `run.graph_state_persist_failed`     | error    | Graph-state persistence write failed mid-run.                               |
+| `event_type`                     | Severity | Emitted when                                                         |
+| -------------------------------- | -------- | -------------------------------------------------------------------- |
+| `run.completed`                  | info     | All stages completed successfully.                                   |
+| `run.failed`                     | error    | Scheduler observed an executor exception.                            |
+| `run.failed.settled`             | error    | Graph settled with failures at the end of execution.                 |
+| `run.suspended`                  | info     | Run suspended waiting on an external signal.                         |
+| `run.cancelled`                  | info     | Task cancelled by operator request.                                  |
+| `run.shutdown`                   | info     | Shutdown requested; executor stopping at a stage boundary.           |
+| `run.stuck`                      | error    | Frontier empty but not all nodes settled (blocked-graph diagnostic). |
+| `run.graph_state_persist_failed` | error    | Graph-state persistence write failed mid-run.                        |
 
 ### Stage
 
-| `event_type`                             | Severity | Emitted when                                                                     |
-|------------------------------------------|----------|----------------------------------------------------------------------------------|
-| `stage.completed`                        | info     | Stage returned `StageComplete`.                                                  |
-| `stage.failed`                           | error    | Stage returned a terminal failure.                                               |
-| `stage.skipped`                          | warn     | Stage skipped after retry exhaustion under `ExhaustionSkipsStage` policy.        |
-| `stage.rewritten`                        | info     | Stage emitted `StageRewrite` and the runtime admitted the proposal.              |
-| `stage.rewrite_degraded`                 | warn     | Stage accepted degraded output after rewrite-budget exhaustion.                  |
-| `stage.worker_exception_reified`         | error    | Async worker exception escaped `spawnNodeWorker`; reified into a node result.    |
-| `stage.worker_exception_unattributed`    | error    | Async worker exception escaped with no matching worker handle.                   |
-| `stage.cancel_before_retry_persist_failed` | warn   | Cancel-before-retry state failed to persist.                                     |
+| `event_type`                               | Severity | Emitted when                                                                  |
+| ------------------------------------------ | -------- | ----------------------------------------------------------------------------- |
+| `stage.completed`                          | info     | Stage returned `StageComplete`.                                               |
+| `stage.failed`                             | error    | Stage returned a terminal failure.                                            |
+| `stage.skipped`                            | warn     | Stage skipped after retry exhaustion under `ExhaustionSkipsStage` policy.     |
+| `stage.rewritten`                          | info     | Stage emitted `StageRewrite` and the runtime admitted the proposal.           |
+| `stage.rewrite_degraded`                   | warn     | Stage accepted degraded output after rewrite-budget exhaustion.               |
+| `stage.worker_exception_reified`           | error    | Async worker exception escaped `spawnNodeWorker`; reified into a node result. |
+| `stage.worker_exception_unattributed`      | error    | Async worker exception escaped with no matching worker handle.                |
+| `stage.cancel_before_retry_persist_failed` | warn     | Cancel-before-retry state failed to persist.                                  |
 
 ### Scheduler
 
-| `event_type`        | Severity | Emitted when                                                              |
-|---------------------|----------|---------------------------------------------------------------------------|
-| `schedule.advanced` | info     | Scheduler advanced `next_run_at` after run finalization.                  |
-| `schedule.restored` | warn     | One-off task visibility restored (e.g. after failure) for manual retry.   |
-| `lease.lost`        | error    | Run's lease expired; scheduler observed the loss before reclaim.          |
+| `event_type`        | Severity | Emitted when                                                            |
+| ------------------- | -------- | ----------------------------------------------------------------------- |
+| `schedule.advanced` | info     | Scheduler advanced `next_run_at` after run finalization.                |
+| `schedule.restored` | warn     | One-off task visibility restored (e.g. after failure) for manual retry. |
+| `lease.lost`        | error    | Run's lease expired; scheduler observed the loss before reclaim.        |
 
 ## 4. Persistence contract
 
-- Persistence is best-effort: a write failure is logged and the run continues. Event history is supplementary observability and is never load-bearing for correctness.
+- Persistence is best-effort: a write failure is logged and the run continues. Event history is
+  supplementary observability and is never load-bearing for correctness.
 - Events are append-only once written; there is no update path.
 - Retention is governed at the schema level; callers should not depend on unbounded history.
 - Events are read through the run-detail API, not by querying the event table directly.
@@ -98,9 +107,11 @@ Common `details` fields observed across events (present when applicable):
 - [./schema.md](./schema.md) — run-event table.
 - [./service-api.md](./service-api.md) — run-detail endpoint and error taxonomy.
 - [./signals.md](./signals.md) — signal-related events (`run.suspended`).
-- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — runtime framing.
-- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md) — rewrite event semantics.
+- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — runtime
+  framing.
+- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md)
+  — rewrite event semantics.
 
 ---
 
-*End of Pulse Run-Event Catalog.*
+_End of Pulse Run-Event Catalog._

--- a/docs/Reference/Pulse/host-actions.md
+++ b/docs/Reference/Pulse/host-actions.md
@@ -1,6 +1,8 @@
 ---
 title: "Pulse Host-Action Contract"
-description: "Normative contract for Pulse → host callouts: direction, authentication, idempotency, retry and timeout semantics, response shape."
+description:
+  "Normative contract for Pulse → host callouts: direction, authentication, idempotency, retry and
+  timeout semantics, response shape."
 sidebar:
   label: "Pulse host actions"
   order: 13
@@ -9,18 +11,23 @@ status: accepted
 
 # Pulse Host-Action Contract
 
-Pulse does not execute domain work. When a stage needs host-owned state — to read, validate, or mutate — it calls the host through a host-action endpoint the host provides. This page states the generic contract. A specific host's endpoint catalog is its own downstream binding.
+Pulse does not execute domain work. When a stage needs host-owned state — to read, validate, or
+mutate — it calls the host through a host-action endpoint the host provides. This page states the
+generic contract. A specific host's endpoint catalog is its own downstream binding.
 
-Architectural framing is in [chapter 06](../../Architecture/06-pulse-runtime.md). Service-API fundamentals (auth, idempotency) repeat in both directions and are specified here for the Pulse → host direction.
+Architectural framing is in [chapter 06](../../Architecture/06-pulse-runtime.md). Service-API
+fundamentals (auth, idempotency) repeat in both directions and are specified here for the Pulse →
+host direction.
 
 ## 1. Direction and scope
 
-| Direction       | Transport | Purpose                                        |
-|-----------------|-----------|------------------------------------------------|
-| Host → Pulse    | Pulse service API ([`service-api.md`](./service-api.md)) | Task lifecycle: create, trigger, cancel, retry, signal, inspect.       |
-| **Pulse → host**| Host-action API (this contract)                         | **Per-stage domain work**: fetches, validations, persistence writes, irreversible side effects. |
+| Direction        | Transport                                                | Purpose                                                                                         |
+| ---------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Host → Pulse     | Pulse service API ([`service-api.md`](./service-api.md)) | Task lifecycle: create, trigger, cancel, retry, signal, inspect.                                |
+| **Pulse → host** | Host-action API (this contract)                          | **Per-stage domain work**: fetches, validations, persistence writes, irreversible side effects. |
 
-Host actions are internal endpoints. They are never exposed to end users. The host may serve them from a dedicated internal port or gate them on the service credential.
+Host actions are internal endpoints. They are never exposed to end users. The host may serve them
+from a dedicated internal port or gate them on the service credential.
 
 ## 2. Authentication
 
@@ -30,7 +37,9 @@ Every request carries the shared service credential:
 X-Pulse-Credential: <service-secret>
 ```
 
-The host validates the credential with constant-time comparison and fails closed when unconfigured. The same secret is used in both directions so a single deployment-time rotation covers the full boundary.
+The host validates the credential with constant-time comparison and fails closed when unconfigured.
+The same secret is used in both directions so a single deployment-time rotation covers the full
+boundary.
 
 ## 3. Idempotency
 
@@ -40,24 +49,34 @@ Every mutating host-action call carries the Pulse-assigned idempotency key:
 X-Idempotency-Key: <run_id>/<stage_name>/<action_name>
 ```
 
-The host is expected to implement exactly-once semantics keyed on this header: a duplicate key returns the original response without re-executing the domain work. Pulse guarantees the key is stable across crash-resume and network-retry boundaries.
+The host is expected to implement exactly-once semantics keyed on this header: a duplicate key
+returns the original response without re-executing the domain work. Pulse guarantees the key is
+stable across crash-resume and network-retry boundaries.
 
 Read-only host actions may omit the header.
 
 ## 4. Retry and timeout semantics
 
-Host-action failures surface as `host_action_failure` in Pulse's error taxonomy ([`service-api.md §6`](./service-api.md#6-error-taxonomy)). Retryability is decided by the stage's retry policy, not by the host response.
+Host-action failures surface as `host_action_failure` in Pulse's error taxonomy
+([`service-api.md §6`](./service-api.md#6-error-taxonomy)). Retryability is decided by the stage's
+retry policy, not by the host response.
 
 - A host that wants Pulse to retry responds with a retryable error shape (see §5).
 - A host that wants the run to fail non-retryably responds with a terminal error shape.
-- The per-stage timeout (`sdTimeoutSeconds` or the task default) applies to the whole Pulse → host call. A host action that does not complete within it produces `stage_timeout`.
-- Cancellation is not propagated over host-action calls. If Pulse is cancelled mid-call, it waits for the response, records it, and finalizes at the next safe boundary.
+- The per-stage timeout (`sdTimeoutSeconds` or the task default) applies to the whole Pulse → host
+  call. A host action that does not complete within it produces `stage_timeout`.
+- Cancellation is not propagated over host-action calls. If Pulse is cancelled mid-call, it waits
+  for the response, records it, and finalizes at the next safe boundary.
 
 ## 5. Response shape
 
-Success responses return the JSON body the stage action expects. There is no success envelope — the response schema is bilateral between the stage's declared output type and the host endpoint.
+Success responses return the JSON body the stage action expects. There is no success envelope — the
+response schema is bilateral between the stage's declared output type and the host endpoint.
 
-Failure handling is host-negotiated today: Cortex has no generic host-action response decoder, so the stage action itself interprets the host's error response and surfaces the resulting `host_action_failure` to the taxonomy ([`service-api.md §6`](./service-api.md#6-error-taxonomy)). The recommended error shape is:
+Failure handling is host-negotiated today: Cortex has no generic host-action response decoder, so
+the stage action itself interprets the host's error response and surfaces the resulting
+`host_action_failure` to the taxonomy ([`service-api.md §6`](./service-api.md#6-error-taxonomy)).
+The recommended error shape is:
 
 ```json
 {
@@ -68,26 +87,31 @@ Failure handling is host-negotiated today: Cortex has no generic host-action res
 }
 ```
 
-A stage action that adopts this envelope preserves the retryability and category information through to the stage log and run events without additional mapping. Hosts may define categories beyond Pulse's generic taxonomy; consumer-specific categories are documented in that consumer's binding page.
+A stage action that adopts this envelope preserves the retryability and category information through
+to the stage log and run events without additional mapping. Hosts may define categories beyond
+Pulse's generic taxonomy; consumer-specific categories are documented in that consumer's binding
+page.
 
 ## 6. What does not route through host actions
 
 Model calls and tool invocations stay inside Cortex and do not go through the host:
 
-| Action       | Owner   | Protocol                                 |
-|--------------|---------|------------------------------------------|
-| `callModel`  | Cortex  | Provider-neutral LLM interface.          |
-| `callTool`   | Cortex  | Gatherer tool dispatch.                  |
+| Action      | Owner  | Protocol                        |
+| ----------- | ------ | ------------------------------- |
+| `callModel` | Cortex | Provider-neutral LLM interface. |
+| `callTool`  | Cortex | Gatherer tool dispatch.         |
 
-A host must not proxy these. Model and tool usage is tracked in Pulse's own records and surfaced through Pulse's API.
+A host must not proxy these. Model and tool usage is tracked in Pulse's own records and surfaced
+through Pulse's API.
 
 ## Related
 
 - [./service-api.md](./service-api.md) — the inverse direction (host → Pulse).
 - [./types.md](./types.md) — `StageAction`, `StageContext`, stage-result alphabet.
-- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — runtime framing.
+- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — runtime
+  framing.
 - [../../Consumers/](../../Consumers/) — downstream binding examples.
 
 ---
 
-*End of Pulse Host-Action Contract.*
+_End of Pulse Host-Action Contract._

--- a/docs/Reference/Pulse/index.md
+++ b/docs/Reference/Pulse/index.md
@@ -9,19 +9,24 @@ status: accepted
 
 # Pulse Reference
 
-Consultable normative material for the Pulse runtime. Architectural framing lives in [chapter 06](../../Architecture/06-pulse-runtime.md); this directory states the rules.
+Consultable normative material for the Pulse runtime. Architectural framing lives in
+[chapter 06](../../Architecture/06-pulse-runtime.md); this directory states the rules.
 
 ## Contents
 
-- **[schema.md](schema.md)** — DB enums, task definitions, runs, checkpoints, stage log, stage attempt log, run events, signals.
-- **[types.md](types.md)** — task envelope, checkpoint envelope, stage plan, retry policy, memory strategy, stage result.
-- **[service-api.md](service-api.md)** — inbound HTTP endpoints, authentication, idempotency, cancellation protocol, error taxonomy.
+- **[schema.md](schema.md)** — DB enums, task definitions, runs, checkpoints, stage log, stage
+  attempt log, run events, signals.
+- **[types.md](types.md)** — task envelope, checkpoint envelope, stage plan, retry policy, memory
+  strategy, stage result.
+- **[service-api.md](service-api.md)** — inbound HTTP endpoints, authentication, idempotency,
+  cancellation protocol, error taxonomy.
 - **[host-actions.md](host-actions.md)** — outbound contract for Pulse → host callouts.
 - **[signals.md](signals.md)** — signal protocol, state machine, producer and consumer semantics.
 - **[events.md](events.md)** — run-event catalog: lifecycle, stage, and rewrite events.
 
 ## Related
 
-- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — Pulse runtime architecture.
+- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — Pulse runtime
+  architecture.
 - [../terminology.md](../terminology.md) — normative vocabulary.
 - [../../Consumers/](../../Consumers/) — downstream binding examples.

--- a/docs/Reference/Pulse/schema.md
+++ b/docs/Reference/Pulse/schema.md
@@ -1,6 +1,8 @@
 ---
 title: "Pulse Schema Reference"
-description: "Normative DB schema for the Pulse durable runtime: enums, task definitions, runs, checkpoints, stage log, stage attempt log."
+description:
+  "Normative DB schema for the Pulse durable runtime: enums, task definitions, runs, checkpoints,
+  stage log, stage attempt log."
 sidebar:
   label: "Pulse schema"
   order: 10
@@ -9,7 +11,9 @@ status: accepted
 
 # Pulse Schema Reference
 
-Pulse owns its own schema (`pulse`) and DB role. Host tables are never read or written by Pulse; operator surfaces read Pulse state through the [Pulse service API](./service-api.md), not by querying these tables directly.
+Pulse owns its own schema (`pulse`) and DB role. Host tables are never read or written by Pulse;
+operator surfaces read Pulse state through the [Pulse service API](./service-api.md), not by
+querying these tables directly.
 
 All columns below are in the `pulse` schema.
 
@@ -22,7 +26,8 @@ pulse.trigger_source  -- schedule | manual | retry
 pulse.stage_status    -- started | completed | failed | skipped
 ```
 
-`waiting` is the run-level state used while at least one node is suspended on a signal and no other node is runnable.
+`waiting` is the run-level state used while at least one node is suspended on a signal and no other
+node is runnable.
 
 Status and source columns use PostgreSQL enums for type safety.
 
@@ -45,9 +50,13 @@ pulse.task_definitions
   updated_at         timestamptz not null
 ```
 
-`scheduler_claimed` is the atomic claim flag. The scheduler sets it `true` under CAS when it creates a run, and resets it to `false` during schedule finalization (on completion, failure, cancellation, or lease-expiry recovery). The enabled-tasks index filters on `WHERE enabled = true AND scheduler_claimed = false`.
+`scheduler_claimed` is the atomic claim flag. The scheduler sets it `true` under CAS when it creates
+a run, and resets it to `false` during schedule finalization (on completion, failure, cancellation,
+or lease-expiry recovery). The enabled-tasks index filters on
+`WHERE enabled = true AND scheduler_claimed = false`.
 
-`config` carries a `CortexTaskEnvelope` ([types reference](./types.md#1-task-envelope)) that the launch path decodes eagerly at creation and at execution time.
+`config` carries a `CortexTaskEnvelope` ([types reference](./types.md#1-task-envelope)) that the
+launch path decodes eagerly at creation and at execution time.
 
 ## 3. Runs
 
@@ -72,7 +81,10 @@ pulse.runs
   created_at           timestamptz not null
 ```
 
-`parent_run_id` links a retry to its origin. Retry creates a fresh run and does not inherit the parent's checkpoint lineage — see [run identity](../../Architecture/06-pulse-runtime.md#run-identity-and-operator-verbs) for the full verb table.
+`parent_run_id` links a retry to its origin. Retry creates a fresh run and does not inherit the
+parent's checkpoint lineage — see
+[run identity](../../Architecture/06-pulse-runtime.md#run-identity-and-operator-verbs) for the full
+verb table.
 
 ## 4. Checkpoints
 
@@ -86,7 +98,9 @@ pulse.checkpoints
   updated_at        timestamptz not null
 ```
 
-Mutable latest-checkpoint per run. The `state` payload is a versioned [`CheckpointEnvelope`](./types.md#2-checkpoint-envelope); mismatched envelopes fail the run non-retryably on resume rather than silently resuming against changed code.
+Mutable latest-checkpoint per run. The `state` payload is a versioned
+[`CheckpointEnvelope`](./types.md#2-checkpoint-envelope); mismatched envelopes fail the run
+non-retryably on resume rather than silently resuming against changed code.
 
 ## 5. Stage log
 
@@ -117,7 +131,8 @@ pulse.stage_attempt_log
   completed_at     timestamptz
 ```
 
-One row per stage attempt. Stages with retry policies produce a row per retry, preserving the failure/retry timeline for operator inspection.
+One row per stage attempt. Stages with retry policies produce a row per retry, preserving the
+failure/retry timeline for operator inspection.
 
 ## 7. Run events
 
@@ -132,7 +147,8 @@ pulse.run_events
   created_at   timestamptz not null default now()
 ```
 
-Append-only per-run event log. The normative event catalog, severity, and field contract live in [`events.md`](./events.md); persistence is best-effort — event writes never block or fail a run.
+Append-only per-run event log. The normative event catalog, severity, and field contract live in
+[`events.md`](./events.md); persistence is best-effort — event writes never block or fail a run.
 
 ## 8. Signals
 
@@ -153,15 +169,20 @@ pulse.signals
   unique index (run_id, signal_name) where status = 'pending'
 ```
 
-Durable external-event storage. The signal protocol, delivery semantics, and `StageSuspend` interaction are in [`signals.md`](./signals.md).
+Durable external-event storage. The signal protocol, delivery semantics, and `StageSuspend`
+interaction are in [`signals.md`](./signals.md).
 
 ## Appendix A — Ownership
 
-The `pulse` DB role has full ownership of every table in this schema and no access to host tables. Cross-boundary reads are mediated by Pulse's HTTP API. Running Pulse and a host application in the same PostgreSQL cluster is an operational shortcut; the architectural boundary is service-API-first so migrating to a separate database is cheap.
+The `pulse` DB role has full ownership of every table in this schema and no access to host tables.
+Cross-boundary reads are mediated by Pulse's HTTP API. Running Pulse and a host application in the
+same PostgreSQL cluster is an operational shortcut; the architectural boundary is service-API-first
+so migrating to a separate database is cheap.
 
 ## Related
 
-- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — architectural framing.
+- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — architectural
+  framing.
 - [./types.md](./types.md) — Haskell types carried in the jsonb columns.
 - [./service-api.md](./service-api.md) — endpoints that read and mutate these tables.
 - [./host-actions.md](./host-actions.md) — the Pulse → host callout contract.
@@ -170,4 +191,4 @@ The `pulse` DB role has full ownership of every table in this schema and no acce
 
 ---
 
-*End of Pulse Schema Reference.*
+_End of Pulse Schema Reference._

--- a/docs/Reference/Pulse/service-api.md
+++ b/docs/Reference/Pulse/service-api.md
@@ -1,6 +1,8 @@
 ---
 title: "Pulse Service API Reference"
-description: "Normative HTTP contract for the Pulse runtime: task management, run inspection, cancellation, health, authentication, idempotency."
+description:
+  "Normative HTTP contract for the Pulse runtime: task management, run inspection, cancellation,
+  health, authentication, idempotency."
 sidebar:
   label: "Pulse service API"
   order: 12
@@ -9,25 +11,29 @@ status: accepted
 
 # Pulse Service API Reference
 
-Pulse exposes its own HTTP API for task management. Downstream consumers (operator surfaces, admin panels, product APIs) communicate with Pulse through this contract, never by reading or writing Pulse tables directly.
+Pulse exposes its own HTTP API for task management. Downstream consumers (operator surfaces, admin
+panels, product APIs) communicate with Pulse through this contract, never by reading or writing
+Pulse tables directly.
 
-Architectural framing is in [chapter 06](../../Architecture/06-pulse-runtime.md). This reference states the endpoints, auth, and idempotency rules.
+Architectural framing is in [chapter 06](../../Architecture/06-pulse-runtime.md). This reference
+states the endpoints, auth, and idempotency rules.
 
 ## 1. Endpoints
 
-| Endpoint                                      | Description                                                                      |
-|-----------------------------------------------|----------------------------------------------------------------------------------|
-| `POST /Pulse/v1/tasks`                        | Create a task definition. Validates the `CortexTaskEnvelope` eagerly.            |
-| `GET  /Pulse/v1/tasks`                        | List task definitions with schedule state.                                       |
-| `GET  /Pulse/v1/tasks/:id`                    | Task detail.                                                                     |
-| `POST /Pulse/v1/tasks/:id/trigger`            | Manual trigger. Creates a run with `trigger_source = manual`.                    |
-| `GET  /Pulse/v1/runs/:id`                     | Run detail: status, checkpoint, stage log with per-attempt history.              |
-| `POST /Pulse/v1/runs/:id/cancel`              | Request cancellation. Sets `cancel_requested_at`; the executor finalizes.        |
-| `POST /Pulse/v1/runs/:id/retry`               | Create a fresh run linked by `parent_run_id`. Accepts all terminal states.       |
-| `POST /Pulse/v1/runs/:id/signal`              | Deliver a named external signal to a waiting node. Wakes the run if pending.     |
-| `GET  /Pulse/v1/health`                       | Heartbeat, active run count, max concurrent limit, scheduler state.              |
+| Endpoint                           | Description                                                                  |
+| ---------------------------------- | ---------------------------------------------------------------------------- |
+| `POST /Pulse/v1/tasks`             | Create a task definition. Validates the `CortexTaskEnvelope` eagerly.        |
+| `GET  /Pulse/v1/tasks`             | List task definitions with schedule state.                                   |
+| `GET  /Pulse/v1/tasks/:id`         | Task detail.                                                                 |
+| `POST /Pulse/v1/tasks/:id/trigger` | Manual trigger. Creates a run with `trigger_source = manual`.                |
+| `GET  /Pulse/v1/runs/:id`          | Run detail: status, checkpoint, stage log with per-attempt history.          |
+| `POST /Pulse/v1/runs/:id/cancel`   | Request cancellation. Sets `cancel_requested_at`; the executor finalizes.    |
+| `POST /Pulse/v1/runs/:id/retry`    | Create a fresh run linked by `parent_run_id`. Accepts all terminal states.   |
+| `POST /Pulse/v1/runs/:id/signal`   | Deliver a named external signal to a waiting node. Wakes the run if pending. |
+| `GET  /Pulse/v1/health`            | Heartbeat, active run count, max concurrent limit, scheduler state.          |
 
-The health endpoint reports per-type active counts under `phsActiveRunsByType` when per-task-type caps are configured.
+The health endpoint reports per-type active counts under `phsActiveRunsByType` when per-task-type
+caps are configured.
 
 ## 2. Authentication
 
@@ -37,7 +43,8 @@ All requests carry a service credential:
 X-Pulse-Credential: <service-secret>
 ```
 
-The credential is a shared secret provisioned at deployment time, distinct from user authentication. The server validates it with constant-time comparison and fails closed when unconfigured.
+The credential is a shared secret provisioned at deployment time, distinct from user authentication.
+The server validates it with constant-time comparison and fails closed when unconfigured.
 
 ## 3. Idempotency
 
@@ -47,43 +54,55 @@ Every mutating request must include:
 X-Idempotency-Key: <run_id>/<stage_name>/<action_name>
 ```
 
-The server reserves the key before execution and caches the response after. Duplicate requests with the same key return the cached response without re-executing. Idempotency keys are retained for 7 days.
+The server reserves the key before execution and caches the response after. Duplicate requests with
+the same key return the cached response without re-executing. Idempotency keys are retained for 7
+days.
 
-This gives Pulse exactly-once semantics across crash-resume and network-retry boundaries: a retry after a timeout cannot cause a second execution.
+This gives Pulse exactly-once semantics across crash-resume and network-retry boundaries: a retry
+after a timeout cannot cause a second execution.
 
 ## 4. Cancellation protocol
 
 1. Caller issues `POST /Pulse/v1/runs/:id/cancel`.
 2. Pulse sets `cancel_requested_at` on `pulse.runs`.
-3. The executor checks the flag at stage boundaries, between tool-loop steps, and before any irreversible stage action.
-4. When cancelled, Pulse writes a checkpoint at the last completed stage, transitions the run to `cancelled` with a reason, and advances the schedule.
+3. The executor checks the flag at stage boundaries, between tool-loop steps, and before any
+   irreversible stage action.
+4. When cancelled, Pulse writes a checkpoint at the last completed stage, transitions the run to
+   `cancelled` with a reason, and advances the schedule.
 
 Only Pulse moves runs to terminal states. No caller may write these transitions directly.
 
 ## 5. Observability
 
-Pulse emits structured events on lifecycle transitions, stage transitions, and scheduler decisions. The full event catalog, severity classification, and field contract live in [`events.md`](./events.md). Events are read through `GET /Pulse/v1/runs/:id`, not by querying the event table directly.
+Pulse emits structured events on lifecycle transitions, stage transitions, and scheduler decisions.
+The full event catalog, severity classification, and field contract live in
+[`events.md`](./events.md). Events are read through `GET /Pulse/v1/runs/:id`, not by querying the
+event table directly.
 
-Model-call and tool-invocation cost is tracked in Pulse's own usage records. Consumers that need aggregate cost visibility query it through the API or subscribe to the event stream; they do not read Pulse tables.
+Model-call and tool-invocation cost is tracked in Pulse's own usage records. Consumers that need
+aggregate cost visibility query it through the API or subscribe to the event stream; they do not
+read Pulse tables.
 
 ## 6. Error taxonomy
 
-Error categories used across run and stage failures. Consumer-specific error categories live in the consumer's own page.
+Error categories used across run and stage failures. Consumer-specific error categories live in the
+consumer's own page.
 
-| Category                | Retryable    | Description                                  |
-|-------------------------|--------------|----------------------------------------------|
-| `model_timeout`         | yes          | LLM call exceeded deadline.                  |
-| `model_refusal`         | no           | LLM refused the request.                     |
-| `model_rate_limit`      | yes (backoff)| Provider rate limit hit.                     |
-| `tool_failure`          | depends      | Tool call failed.                            |
-| `stale_data`            | yes (refresh)| Upstream data too old.                       |
-| `config_decode_error`   | no           | Operator must fix config.                    |
-| `checkpoint_corruption` | no           | Manual intervention required.                |
-| `checkpoint_incompatible`| no          | Envelope version does not match current code.|
-| `stage_timeout`         | per retry policy | Per-stage timeout fired.                 |
-| `host_action_failure`   | depends      | Downstream host-action call failed.          |
+| Category                  | Retryable        | Description                                   |
+| ------------------------- | ---------------- | --------------------------------------------- |
+| `model_timeout`           | yes              | LLM call exceeded deadline.                   |
+| `model_refusal`           | no               | LLM refused the request.                      |
+| `model_rate_limit`        | yes (backoff)    | Provider rate limit hit.                      |
+| `tool_failure`            | depends          | Tool call failed.                             |
+| `stale_data`              | yes (refresh)    | Upstream data too old.                        |
+| `config_decode_error`     | no               | Operator must fix config.                     |
+| `checkpoint_corruption`   | no               | Manual intervention required.                 |
+| `checkpoint_incompatible` | no               | Envelope version does not match current code. |
+| `stage_timeout`           | per retry policy | Per-stage timeout fired.                      |
+| `host_action_failure`     | depends          | Downstream host-action call failed.           |
 
-The error category and retryable flag are persisted in the stage log and emitted in observability events.
+The error category and retryable flag are persisted in the stage log and emitted in observability
+events.
 
 ## Related
 
@@ -91,9 +110,10 @@ The error category and retryable flag are persisted in the stage log and emitted
 - [./types.md](./types.md) — request and response shapes.
 - [./host-actions.md](./host-actions.md) — the inverse direction: Pulse → host callouts.
 - [./events.md](./events.md) — run-event catalog.
-- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — runtime framing.
+- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — runtime
+  framing.
 - [../../Consumers/](../../Consumers/) — downstream binding examples.
 
 ---
 
-*End of Pulse Service API Reference.*
+_End of Pulse Service API Reference._

--- a/docs/Reference/Pulse/signals.md
+++ b/docs/Reference/Pulse/signals.md
@@ -1,6 +1,8 @@
 ---
 title: "Pulse Signals Reference"
-description: "Normative contract for durable signals: naming, state machine, producer and consumer protocols, delivery semantics, storage."
+description:
+  "Normative contract for durable signals: naming, state machine, producer and consumer protocols,
+  delivery semantics, storage."
 sidebar:
   label: "Pulse signals"
   order: 14
@@ -9,9 +11,14 @@ status: accepted
 
 # Pulse Signals Reference
 
-Signals are Pulse's durable external-event primitive. A stage that cannot proceed until an out-of-band event arrives emits `StageSuspend SignalName`; the runtime parks the stage's node and persists the wait. When the corresponding signal is delivered through the service API, the wait atomically transitions to delivered and the run wakes at that node.
+Signals are Pulse's durable external-event primitive. A stage that cannot proceed until an
+out-of-band event arrives emits `StageSuspend SignalName`; the runtime parks the stage's node and
+persists the wait. When the corresponding signal is delivered through the service API, the wait
+atomically transitions to delivered and the run wakes at that node.
 
-This page states the contract. Architectural framing is in [chapter 06](../../Architecture/06-pulse-runtime.md); the service endpoint is [`service-api.md`](./service-api.md#1-endpoints).
+This page states the contract. Architectural framing is in
+[chapter 06](../../Architecture/06-pulse-runtime.md); the service endpoint is
+[`service-api.md`](./service-api.md#1-endpoints).
 
 ## 1. Identity and scope
 
@@ -19,9 +26,14 @@ This page states the contract. Architectural framing is in [chapter 06](../../Ar
 newtype SignalName = SignalName { unSignalName :: Text }
 ```
 
-A signal name is an opaque text tag. Signals are scoped to a run: the same name in two different runs is two different signals. Within a run, at most one wait per signal name may be `pending` at a time — a partial unique index on `(run_id, signal_name) WHERE status = 'pending'` enforces this. A name may be reused for a second wait once the prior wait has been delivered or expired.
+A signal name is an opaque text tag. Signals are scoped to a run: the same name in two different
+runs is two different signals. Within a run, at most one wait per signal name may be `pending` at a
+time — a partial unique index on `(run_id, signal_name) WHERE status = 'pending'` enforces this. A
+name may be reused for a second wait once the prior wait has been delivered or expired.
 
-The `node_id` on a signal row is informational — it records which node registered the wait — and does not participate in uniqueness. It is nullable for cases where a wait is not attributable to a single node.
+The `node_id` on a signal row is informational — it records which node registered the wait — and
+does not participate in uniqueness. It is nullable for cases where a wait is not attributable to a
+single node.
 
 ## 2. State machine
 
@@ -34,9 +46,12 @@ stateDiagram-v2
     expired --> [*]
 ```
 
-- **pending** — a stage has emitted `StageSuspend SignalName`, the wait row is persisted, and the run is in `waiting`.
-- **delivered** — a caller has delivered the signal; the wait row carries the delivery payload and timestamp.
-- **expired** — an optional `expiresAt` has elapsed without delivery; the wait cannot be satisfied and the run must be cancelled or retried.
+- **pending** — a stage has emitted `StageSuspend SignalName`, the wait row is persisted, and the
+  run is in `waiting`.
+- **delivered** — a caller has delivered the signal; the wait row carries the delivery payload and
+  timestamp.
+- **expired** — an optional `expiresAt` has elapsed without delivery; the wait cannot be satisfied
+  and the run must be cancelled or retried.
 
 Only Pulse mutates these states. External callers observe them through the service API.
 
@@ -47,9 +62,12 @@ A stage action signals a wait by returning `StageSuspend SignalName`. The execut
 1. Persists a pending signal row.
 2. Transitions the stage's node to `NodeWaiting`.
 3. Writes a checkpoint reflecting the suspension.
-4. Yields the run back to the scheduler. When no node is runnable, the run transitions to the `waiting` run-status and the executor emits a `run.suspended` event ([`events.md`](./events.md#3-catalog)).
+4. Yields the run back to the scheduler. When no node is runnable, the run transitions to the
+   `waiting` run-status and the executor emits a `run.suspended` event
+   ([`events.md`](./events.md#3-catalog)).
 
-The stage action does not return a value on suspension. When the signal is delivered and the stage re-enters, the delivery payload is available to the stage through its memory handle.
+The stage action does not return a value on suspension. When the signal is delivered and the stage
+re-enters, the delivery payload is available to the stage through its memory handle.
 
 ## 4. Consumer protocol — signal delivery
 
@@ -65,9 +83,13 @@ Content-Type: application/json
 }
 ```
 
-Delivery is atomic: the runtime transitions the wait row from `pending` to `delivered`, records the payload and delivery timestamp, and wakes the waiting node in a single transaction. Duplicate deliveries to a signal that is already `delivered` are no-ops and return the original delivery.
+Delivery is atomic: the runtime transitions the wait row from `pending` to `delivered`, records the
+payload and delivery timestamp, and wakes the waiting node in a single transaction. Duplicate
+deliveries to a signal that is already `delivered` are no-ops and return the original delivery.
 
-Attempting to deliver a signal that was never waited on (no matching `pending` row) fails with a structured error. Attempting to deliver an `expired` signal fails with a structured error; the run must be retried to produce a fresh wait.
+Attempting to deliver a signal that was never waited on (no matching `pending` row) fails with a
+structured error. Attempting to deliver an `expired` signal fails with a structured error; the run
+must be retried to produce a fresh wait.
 
 ## 5. Records
 
@@ -93,23 +115,28 @@ data SignalStatus
   | SignalExpired
 ```
 
-`SignalWait` is the persisted wait row; `SignalDelivery` is the delivery record that is appended on a successful delivery. Both are surfaced through the run-detail API.
+`SignalWait` is the persisted wait row; `SignalDelivery` is the delivery record that is appended on
+a successful delivery. Both are surfaced through the run-detail API.
 
 ## 6. Storage and ordering
 
-Signal storage is the durable backing for the protocol; the normative contract is above. Schema-level detail is in [`schema.md §8`](./schema.md#8-signals).
+Signal storage is the durable backing for the protocol; the normative contract is above.
+Schema-level detail is in [`schema.md §8`](./schema.md#8-signals).
 
-- Pending-uniqueness is scoped to `(run_id, signal_name)` via a partial unique index; `node_id` is informational.
+- Pending-uniqueness is scoped to `(run_id, signal_name)` via a partial unique index; `node_id` is
+  informational.
 - Delivery is at-most-once per wait row; there is no implicit queue.
-- Ordering of multiple waits on disjoint signal names is not meaningful — the first one to be delivered wakes its node independently.
+- Ordering of multiple waits on disjoint signal names is not meaningful — the first one to be
+  delivered wakes its node independently.
 
 ## Related
 
 - [./schema.md](./schema.md) — signal table.
 - [./service-api.md](./service-api.md) — the delivery endpoint.
 - [./types.md](./types.md) — `StageResult` and `StageSuspend`.
-- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — runtime framing.
+- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — runtime
+  framing.
 
 ---
 
-*End of Pulse Signals Reference.*
+_End of Pulse Signals Reference._

--- a/docs/Reference/Pulse/types.md
+++ b/docs/Reference/Pulse/types.md
@@ -1,6 +1,8 @@
 ---
 title: "Pulse Types Reference"
-description: "Normative Haskell types carried by Pulse: task envelope, checkpoint envelope, stage plan, retry policy, memory strategy."
+description:
+  "Normative Haskell types carried by Pulse: task envelope, checkpoint envelope, stage plan, retry
+  policy, memory strategy."
 sidebar:
   label: "Pulse types"
   order: 11
@@ -9,9 +11,12 @@ status: accepted
 
 # Pulse Types Reference
 
-These are the types Pulse carries across its durable boundary (DB rows, service-API bodies, checkpoint payloads). They are normative: changing them requires a runtime version bump and an explicit resume-compatibility decision.
+These are the types Pulse carries across its durable boundary (DB rows, service-API bodies,
+checkpoint payloads). They are normative: changing them requires a runtime version bump and an
+explicit resume-compatibility decision.
 
-Architectural framing is in [chapter 06](../../Architecture/06-pulse-runtime.md). The types here state the shapes without repeating the framing.
+Architectural framing is in [chapter 06](../../Architecture/06-pulse-runtime.md). The types here
+state the shapes without repeating the framing.
 
 ## 1. Task envelope
 
@@ -25,11 +30,16 @@ data CortexTaskEnvelope = CortexTaskEnvelope
   }
 ```
 
-`TaskKind` is an opaque, host-registered text tag. Cortex does not enumerate valid kinds; the embedding application registers handlers for the kinds it supports, and Cortex treats anything else as unregistered.
+`TaskKind` is an opaque, host-registered text tag. Cortex does not enumerate valid kinds; the
+embedding application registers handlers for the kinds it supports, and Cortex treats anything else
+as unregistered.
 
-The field name `cortexTaskType` is retained for JSON wire compatibility with stored configs written before `TaskKind` became a newtype — the envelope's `FromJSON`/`ToJSON` instance preserves the original field name. The value is a `TaskKind`, not an enum constructor.
+The field name `cortexTaskType` is retained for JSON wire compatibility with stored configs written
+before `TaskKind` became a newtype — the envelope's `FromJSON`/`ToJSON` instance preserves the
+original field name. The value is a `TaskKind`, not an enum constructor.
 
-The envelope is the launch payload for a task. It is stored in the task definition row and decoded at both creation time (eager validation by the Pulse API) and execution time.
+The envelope is the launch payload for a task. It is stored in the task definition row and decoded
+at both creation time (eager validation by the Pulse API) and execution time.
 
 ### 1.1 Versioned config decoders
 
@@ -37,11 +47,14 @@ The envelope is the launch payload for a task. It is stored in the task definiti
 type ConfigDecoder a = Int -> Aeson.Value -> Either Text a
 ```
 
-Each registered task kind has a versioned decoder keyed on `cortexTaskVersion`. A decoder returns `Left` for unknown versions rather than silently defaulting, and for breaking changes the host provides an explicit upgrade function (`v1 -> v2`) so existing stored configs do not silently fail.
+Each registered task kind has a versioned decoder keyed on `cortexTaskVersion`. A decoder returns
+`Left` for unknown versions rather than silently defaulting, and for breaking changes the host
+provides an explicit upgrade function (`v1 -> v2`) so existing stored configs do not silently fail.
 
 ### 1.2 Extending the task kind set
 
-New task kinds are added host-side by registering a handler and decoder under a new `TaskKind` string. No structural changes to the launch path or to Cortex are required.
+New task kinds are added host-side by registering a handler and decoder under a new `TaskKind`
+string. No structural changes to the launch path or to Cortex are required.
 
 ## 2. Checkpoint envelope
 
@@ -56,27 +69,34 @@ data CheckpointEnvelope = CheckpointEnvelope
   }
 ```
 
-On resume, the executor parses the stored checkpoint payload into a `CheckpointEnvelope` and validates all four versions against the current code. A mismatch produces a `checkpoint_incompatible` failure — the run fails non-retryably rather than silently resuming against a changed stage plan. Legacy checkpoints that predate the envelope format are rejected with a descriptive error.
+On resume, the executor parses the stored checkpoint payload into a `CheckpointEnvelope` and
+validates all four versions against the current code. A mismatch produces a
+`checkpoint_incompatible` failure — the run fails non-retryably rather than silently resuming
+against a changed stage plan. Legacy checkpoints that predate the envelope format are rejected with
+a descriptive error.
 
-Checkpoint state must be serializable and resumable from stored state only. Application-level size limit: 256 KB.
+Checkpoint state must be serializable and resumable from stored state only. Application-level size
+limit: 256 KB.
 
 ## 3. Stage identity
 
-Stage identity splits into four typed ids so that rewrite-capable runs can separate the semantic kind of a stage from its durable execution identity.
+Stage identity splits into four typed ids so that rewrite-capable runs can separate the semantic
+kind of a stage from its durable execution identity.
 
 ```haskell
 class StableStageId stageId where
   stageIdToText :: stageId -> Text
 ```
 
-| Id                 | What it names                                                    |
-|--------------------|------------------------------------------------------------------|
-| `NodeId`           | Durable execution identity stored in graph state, stage logs, checkpoints, and replay checks. |
-| `stageId`          | Semantic stage kind / operator-facing label.                     |
-| `StageTemplateId`  | Reusable serialized stage template.                              |
-| `StageActionId`    | Durable executable identity used to verify that resumed rewritten nodes bind to the intended runtime action. |
+| Id                | What it names                                                                                                |
+| ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| `NodeId`          | Durable execution identity stored in graph state, stage logs, checkpoints, and replay checks.                |
+| `stageId`         | Semantic stage kind / operator-facing label.                                                                 |
+| `StageTemplateId` | Reusable serialized stage template.                                                                          |
+| `StageActionId`   | Durable executable identity used to verify that resumed rewritten nodes bind to the intended runtime action. |
 
-Linear or statically indexed stage plans may reuse `stageId` text as the checkpoint and stage-log identity. Rewrite-capable plans must use `NodeId` as the durable identity.
+Linear or statically indexed stage plans may reuse `stageId` text as the checkpoint and stage-log
+identity. Rewrite-capable plans must use `NodeId` as the durable identity.
 
 ## 4. Stage plan
 
@@ -102,9 +122,13 @@ data StageDefinition stageId = StageDefinition
   }
 ```
 
-`spCheckpointRuntimeVersion` is embedded in checkpoint envelopes and validated on resume. Bumping it after a breaking stage-plan change causes in-flight runs to fail cleanly.
+`spCheckpointRuntimeVersion` is embedded in checkpoint envelopes and validated on resume. Bumping it
+after a breaking stage-plan change causes in-flight runs to fail cleanly.
 
-For rewrite-capable runs, `spInitialRewriteBudget` seeds the per-run structural rewrite budget; Pulse persists the remaining budget in graph state and decrements it atomically with rewrite materialization and watermark advance. Budget semantics are in [chapter 07](../../Architecture/07-rewrites-and-materialization.md).
+For rewrite-capable runs, `spInitialRewriteBudget` seeds the per-run structural rewrite budget;
+Pulse persists the remaining budget in graph state and decrements it atomically with rewrite
+materialization and watermark advance. Budget semantics are in
+[chapter 07](../../Architecture/07-rewrites-and-materialization.md).
 
 ## 5. Retry policy
 
@@ -118,13 +142,18 @@ data StageRetryPolicy = StageRetryPolicy
   }
 ```
 
-`srpPredicateName` is the durable serialized identity of the retryability logic. Reusing a predicate name for different retry semantics across compatible runtime versions is invalid.
+`srpPredicateName` is the durable serialized identity of the retryability logic. Reusing a predicate
+name for different retry semantics across compatible runtime versions is invalid.
 
-**Timeout resolution:** per-stage `sdTimeoutSeconds` takes precedence; if unset, the task-level `timeout_seconds` on the task definition applies.
+**Timeout resolution:** per-stage `sdTimeoutSeconds` takes precedence; if unset, the task-level
+`timeout_seconds` on the task definition applies.
 
-**Retry semantics:** on a retryable failure, the executor re-runs the same stage action with the same input state (the last checkpoint). Each attempt is recorded in the stage attempt log. When the retry budget is exhausted, `srpExhaustion` decides whether the run fails or the stage is skipped.
+**Retry semantics:** on a retryable failure, the executor re-runs the same stage action with the
+same input state (the last checkpoint). Each attempt is recorded in the stage attempt log. When the
+retry budget is exhausted, `srpExhaustion` decides whether the run fails or the stage is skipped.
 
-**Backoff:** fixed or exponential, capped at 300 seconds. Cancellation and shutdown checks run between retry attempts.
+**Backoff:** fixed or exponential, capped at 300 seconds. Cancellation and shutdown checks run
+between retry attempts.
 
 ## 6. Memory strategy
 
@@ -137,10 +166,16 @@ data MemoryStrategy
 
 Memory is a per-node property declared on the wire, not a global run setting.
 
-- `MemoryClassic` — the executor hands the stage exactly what its declared upstream produced (`scInputs`). Local causality by construction.
-- `MemoryTopological cfg` — the stage runs a topological-memory query at entry, using the preset, routing-key filter, and top-N limit from `cfg`. See the topological-memory section of [chapter 06](../../Architecture/06-pulse-runtime.md#topological-memory) for the substrate semantics.
+- `MemoryClassic` — the executor hands the stage exactly what its declared upstream produced
+  (`scInputs`). Local causality by construction.
+- `MemoryTopological cfg` — the stage runs a topological-memory query at entry, using the preset,
+  routing-key filter, and top-N limit from `cfg`. See the topological-memory section of
+  [chapter 06](../../Architecture/06-pulse-runtime.md#topological-memory) for the substrate
+  semantics.
 
-The compiler emits the declared strategy under `circuitTaskNodeMetadata.memory`. The executor copies `stageDef.sdMemoryStrategy` into `StageContext.scMemoryStrategy` at every stage attempt so actions can dispatch on the declared surface without re-reading the plan.
+The compiler emits the declared strategy under `circuitTaskNodeMetadata.memory`. The executor copies
+`stageDef.sdMemoryStrategy` into `StageContext.scMemoryStrategy` at every stage attempt so actions
+can dispatch on the declared surface without re-reading the plan.
 
 ## 7. Stage result
 
@@ -151,15 +186,20 @@ data StageResult
   | StageRewrite  Aeson.Value GraphRewrite
 ```
 
-`StageComplete` is the ordinary case. `StageSuspend` parks the stage's node in `NodeWaiting` until a named signal is delivered. `StageRewrite` carries both the node's durable output and a proposed rewrite; the runtime admits the rewrite under the rules in [chapter 07](../../Architecture/07-rewrites-and-materialization.md).
+`StageComplete` is the ordinary case. `StageSuspend` parks the stage's node in `NodeWaiting` until a
+named signal is delivered. `StageRewrite` carries both the node's durable output and a proposed
+rewrite; the runtime admits the rewrite under the rules in
+[chapter 07](../../Architecture/07-rewrites-and-materialization.md).
 
 ## Related
 
 - [./schema.md](./schema.md) — DB rows that carry these types in jsonb columns.
 - [./service-api.md](./service-api.md) — service endpoints that accept and return these shapes.
-- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — runtime framing.
-- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md) — rewrite and budget semantics.
+- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) — runtime
+  framing.
+- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md)
+  — rewrite and budget semantics.
 
 ---
 
-*End of Pulse Types Reference.*
+_End of Pulse Types Reference._

--- a/docs/Reference/Wire/conditionality.md
+++ b/docs/Reference/Wire/conditionality.md
@@ -1,6 +1,8 @@
 ---
 title: "Wire Reference — Conditionality"
-description: "Reference for exclusive-output reduction, `select(...)`, latent branches, and current implementation status in Cortex."
+description:
+  "Reference for exclusive-output reduction, `select(...)`, latent branches, and current
+  implementation status in Cortex."
 sidebar:
   label: Conditionality
   order: 6
@@ -29,17 +31,22 @@ The short version is:
 - productive arms share a common downstream boundary
 - the current Cortex runtime is a narrower binary subset of this model
 
-This page is normative about the intended language model and informative about the current implementation status. [grammar.md](grammar.md) carries the compact grammar and typing rules; this page expands the same conditional model semantically and explains how the current Cortex implementation realizes a narrower subset.
+This page is normative about the intended language model and informative about the current
+implementation status. [grammar.md](grammar.md) carries the compact grammar and typing rules; this
+page expands the same conditional model semantically and explains how the current Cortex
+implementation realizes a narrower subset.
 
 ## 1. Status and Scope
 
 Two things are true at once:
 
-1. **The target model is clear enough to write down now.**
-   Wire conditionality should be expressed as exclusive-output reduction over latent continuations.
+1. **The target model is clear enough to write down now.** Wire conditionality should be expressed
+   as exclusive-output reduction over latent continuations.
 
-2. **The current implementation is narrower than the target model.**
-   Current Cortex runtime support is still binary and is realized through retained-anchor rewrite machinery. That narrower implementation status is described explicitly in [§10 Current Implementation Status](#10-current-implementation-status).
+2. **The current implementation is narrower than the target model.** Current Cortex runtime support
+   is still binary and is realized through retained-anchor rewrite machinery. That narrower
+   implementation status is described explicitly in
+   [§10 Current Implementation Status](#10-current-implementation-status).
 
 This page therefore does five things:
 
@@ -53,9 +60,11 @@ This page does not repeat the full EBNF for `select(...)`; that lives in [gramma
 
 ## 2. Conditionality Is Exclusive-Output Reduction
 
-The right starting point is not “a node with several possible next edges.” The right starting point is:
+The right starting point is not “a node with several possible next edges.” The right starting point
+is:
 
-> a graph exposes an **exclusive output boundary**, and conditionality reduces that boundary by selecting which continuation becomes the output of the reduced graph.
+> a graph exposes an **exclusive output boundary**, and conditionality reduces that boundary by
+> selecting which continuation becomes the output of the reduced graph.
 
 If a graph `x` yields several mutually exclusive exits, conditionality is the operation that says:
 
@@ -63,7 +72,8 @@ If a graph `x` yields several mutually exclusive exits, conditionality is the op
 - actualize exactly one of them
 - treat the result as the output of a reduced graph `x'`
 
-This is why conditionality is not ordinary `match`, and not ordinary routing into already-live branches.
+This is why conditionality is not ordinary `match`, and not ordinary routing into already-live
+branches.
 
 It is better understood as:
 
@@ -78,11 +88,13 @@ This is also why parentheses are natural in branch bodies:
 (gather_missing_constraints => repair_plan)
 ```
 
-is one **continuation graph**. It has its own entry boundary and its own exit boundary, and `select(...)` may actualize it as one possible continuation.
+is one **continuation graph**. It has its own entry boundary and its own exit boundary, and
+`select(...)` may actualize it as one possible continuation.
 
 ## 3. Why Ordinary Fan-Out Is Wrong
 
-If a conditional were lowered as ordinary graph fan-out, then both branches would appear runnable under the normal readiness rules. That is wrong for Wire.
+If a conditional were lowered as ordinary graph fan-out, then both branches would appear runnable
+under the normal readiness rules. That is wrong for Wire.
 
 In ordinary fan-out:
 
@@ -90,7 +102,8 @@ In ordinary fan-out:
 a => (b, c)
 ```
 
-both `b` and `c` are part of the live graph and both are eligible to become actual work when their inputs are available.
+both `b` and `c` are part of the live graph and both are eligible to become actual work when their
+inputs are available.
 
 That is **not** what a conditional means. A conditional means:
 
@@ -98,7 +111,9 @@ That is **not** what a conditional means. A conditional means:
 - runtime will commit to exactly one of them
 - the unchosen futures never become live topology
 
-The opposite mistake is to hide the choice inside stage-local imperative code. That also fails, because the compiled workflow artifact then stops telling the truth about what obligations may arise.
+The opposite mistake is to hide the choice inside stage-local imperative code. That also fails,
+because the compiled workflow artifact then stops telling the truth about what obligations may
+arise.
 
 The conditional model Wire needs is therefore:
 
@@ -129,7 +144,8 @@ That means the language already knows how to say:
 
 But that is still **not** a full conditional.
 
-Sum groups define an **exclusive output boundary**. They do **not yet** define how continuation graphs should be attached to that boundary. That second step is what conditionality needs.
+Sum groups define an **exclusive output boundary**. They do **not yet** define how continuation
+graphs should be attached to that boundary. That second step is what conditionality needs.
 
 So the full model has two layers:
 
@@ -155,13 +171,16 @@ The intended reading is:
 - exactly one continuation graph is actualized
 - the reduced graph then continues through the selected continuation
 
-This is why the operator belongs **after** the selecting graph, not around it. The left-hand graph is the thing whose output boundary is being reduced.
+This is why the operator belongs **after** the selecting graph, not around it. The left-hand graph
+is the thing whose output boundary is being reduced.
 
-> **Syntax status.** `select(...)` is now the accepted conditional form in [grammar.md](grammar.md). This page remains the fuller semantic reference for how that form should be understood.
+> **Syntax status.** `select(...)` is now the accepted conditional form in [grammar.md](grammar.md).
+> This page remains the fuller semantic reference for how that form should be understood.
 
 ### 5.1 `select(...)` is a single expression unit
 
-`select(...)` should read as one expression unit in the same way ordinary grouped graph expressions do.
+`select(...)` should read as one expression unit in the same way ordinary grouped graph expressions
+do.
 
 So:
 
@@ -184,7 +203,8 @@ This does **not** mean the same thing as:
 x => (a, b) => continuation
 ```
 
-The boundary shape may be similar when all arms are productive, but the actuality story is different:
+The boundary shape may be similar when all arms are productive, but the actuality story is
+different:
 
 - `x => (a, b)` makes both branches live
 - `x select(...)` keeps both branches latent and actualizes one
@@ -237,9 +257,12 @@ a => () = a
 () => a = a
 ```
 
-So `()` is not a strange conditional-only token, and it is not a materialized `Id` node. It is the ordinary empty wire, which disappears when placed in a continuation hole.
+So `()` is not a strange conditional-only token, and it is not a materialized `Id` node. It is the
+ordinary empty wire, which disappears when placed in a continuation hole.
 
-Inside `select(...)`, that means an arm body of `()` contributes **no extra branch-local topology**. If the selected variant already exposes the required downstream boundary, the reduced graph simply continues.
+Inside `select(...)`, that means an arm body of `()` contributes **no extra branch-local topology**.
+If the selected variant already exposes the required downstream boundary, the reduced graph simply
+continues.
 
 In:
 
@@ -262,13 +285,16 @@ and the second branch means:
 - run the repair continuation graph
 - continue with the repaired `ResearchPlan`
 
-This also means `()` is **not** a terminal branch. A terminal branch would absorb the current path and expose no matching downstream boundary. `()` does the opposite: it vanishes under composition, so the current boundary continues unchanged.
+This also means `()` is **not** a terminal branch. A terminal branch would absorb the current path
+and expose no matching downstream boundary. `()` does the opposite: it vanishes under composition,
+so the current boundary continues unchanged.
 
 ## 7. Latent Branches
 
 ### 7.1 Core concept
 
-**Latent branches** are Wire's mechanism for implementing closed-world conditional branching without turning possibilities into live topology.
+**Latent branches** are Wire's mechanism for implementing closed-world conditional branching without
+turning possibilities into live topology.
 
 A conditional does **not** compile to ordinary fan-out. Instead, it compiles to:
 
@@ -286,7 +312,8 @@ Latent branches solve the central correctness problem:
 - runtime commits to exactly one
 - unchosen futures must never become live
 
-This keeps compiled possibility wider than current actuality without making the compiled artifact lie about what may happen.
+This keeps compiled possibility wider than current actuality without making the compiled artifact
+lie about what may happen.
 
 ### 7.3 How latent branches work
 
@@ -307,14 +334,17 @@ the target model is:
 - those continuations are **sealed**
 - exactly one is selected and materialized
 
-For the identity arm `()`, this may mean that no extra branch-local topology is materialized at all. The reduced graph simply continues through the already-correct boundary.
+For the identity arm `()`, this may mean that no extra branch-local topology is materialized at all.
+The reduced graph simply continues through the already-correct boundary.
 
 ### 7.4 Key invariants
 
-- **Sealed internals** — Latent branch contents are not addressable from outside before materialization.
+- **Sealed internals** — Latent branch contents are not addressable from outside before
+  materialization.
 - **Only one becomes live** — Only the selected continuation ever becomes actual live topology.
 - **Owner remains** — The anchor stays visible for provenance and lineage.
-- **Latent until selected** — Unselected branches are not eligible under ordinary readiness rules; conditionality never lowers to ordinary fan-out.
+- **Latent until selected** — Unselected branches are not eligible under ordinary readiness rules;
+  conditionality never lowers to ordinary fan-out.
 
 ## 8. Typing and Composition
 
@@ -347,7 +377,8 @@ review_report select(
 ) => publish_report
 ```
 
-because one branch is productive and the other is absorptive or terminal. That introduces optional downstream execution and is a larger typing step.
+because one branch is productive and the other is absorptive or terminal. That introduces optional
+downstream execution and is a larger typing step.
 
 ### 8.2 Informal typing rule
 
@@ -372,7 +403,8 @@ Bn : Vn -> T
 G select(V1: B1, ..., Vn: Bn) : I -> T
 ```
 
-This is enough for the semantic reference. [grammar.md](grammar.md) carries the compact formal grammar and operator precedence.
+This is enough for the semantic reference. [grammar.md](grammar.md) carries the compact formal
+grammar and operator precedence.
 
 ### 8.3 Shared continuation should stay outside
 
@@ -394,9 +426,12 @@ validate_plan select(
 )
 ```
 
-(The tuple form `(a, b, c, d)` overlays its elements as parallel lanes — see [grammar.md §7.5](grammar.md#75-tuples-of-wires) — and avoids the `<>` / `=>` precedence pitfall: `=> a <> b` parses as `(prior => a) <> b`, not as "connect to the overlay of `a` and `b`".)
+(The tuple form `(a, b, c, d)` overlays its elements as parallel lanes — see
+[grammar.md §7.5](grammar.md#75-tuples-of-wires) — and avoids the `<>` / `=>` precedence pitfall:
+`=> a <> b` parses as `(prior => a) <> b`, not as "connect to the overlay of `a` and `b`".)
 
-because the shared continuation should not be duplicated inside the branch alternatives unless it genuinely differs by branch.
+because the shared continuation should not be duplicated inside the branch alternatives unless it
+genuinely differs by branch.
 
 Keeping shared continuation outside `select(...)`:
 
@@ -480,7 +515,8 @@ The same rules still apply:
 - every arm converges to the same downstream boundary
 - exactly one continuation becomes live
 
-Current Cortex runtime does not yet natively realize this general form. See [§10 Current Implementation Status](#10-current-implementation-status).
+Current Cortex runtime does not yet natively realize this general form. See
+[§10 Current Implementation Status](#10-current-implementation-status).
 
 ## 10. Current Implementation Status
 
@@ -512,10 +548,13 @@ What does **not** exist natively yet:
 So the current implementation status is:
 
 - the accepted `select(...)` language surface is implemented in the parser
-- the current bridge compiler lowers that surface onto the existing binary owner + latent-fragment runtime
-- native runtime ownership is still binary even when the source-level `select(...)` has more than two arms
+- the current bridge compiler lowers that surface onto the existing binary owner + latent-fragment
+  runtime
+- native runtime ownership is still binary even when the source-level `select(...)` has more than
+  two arms
 
-This page treats that narrower implementation as a subset of the intended model, not as the final shape of the language.
+This page treats that narrower implementation as a subset of the intended model, not as the final
+shape of the language.
 
 ## 11. Gas, Budget, and Provenance
 
@@ -531,7 +570,8 @@ because only one branch can actualize.
 
 ### 11.2 Current runtime does not yet reserve latent capacity
 
-Today, selected latent branches still consume ordinary rewrite budget because they are operationally realized through `AppendAfter`.
+Today, selected latent branches still consume ordinary rewrite budget because they are operationally
+realized through `AppendAfter`.
 
 So current Cortex already gives:
 
@@ -542,7 +582,8 @@ but does **not yet** give:
 
 - guaranteed reserved capacity for any later-selected branch regardless of prior open rewrites
 
-If Cortex later decides that compiled latent alternatives must be guaranteed, that is an architectural choice beyond this chapter and likely ADR-worthy.
+If Cortex later decides that compiled latent alternatives must be guaranteed, that is an
+architectural choice beyond this chapter and likely ADR-worthy.
 
 ### 11.3 Provenance remains attached to the owner
 
@@ -558,7 +599,8 @@ Provenance must remain attached to the owner.
 
 The old surface existed for a reason: downstream workflows needed conditional branching.
 
-The goal now is not to remove that capability. The goal is to carry it into Wire under a cleaner and more truthful semantic model.
+The goal now is not to remove that capability. The goal is to carry it into Wire under a cleaner and
+more truthful semantic model.
 
 So the migration stance should be:
 
@@ -592,7 +634,8 @@ The exact legacy names in real workflows will vary, but the semantic mapping is 
 - old pass-through arm becomes `()`
 - shared continuation stays outside
 
-`if` may later exist as sugar if it genuinely helps readability, but the core model should remain exclusive-output reduction over latent continuations.
+`if` may later exist as sugar if it genuinely helps readability, but the core model should remain
+exclusive-output reduction over latent continuations.
 
 ## 13. Current Commitments
 
@@ -613,17 +656,25 @@ This chapter makes the following commitments unless later superseded:
 This chapter intentionally leaves the following open:
 
 1. whether labels are admitted alongside contract-name keys in the initial accepted surface
-2. whether later versions admit terminating or absorptive arms that do not expose the shared downstream boundary
-3. whether a dedicated terminator such as `!` becomes the first extension after the initial `select(...)` design
-4. whether the runtime later gets a distinct selection event rather than piggybacking on ordinary rewrite machinery
-5. whether latent branch capacity becomes reserved rather than merely conceptually distinct from open rewrite capacity
+2. whether later versions admit terminating or absorptive arms that do not expose the shared
+   downstream boundary
+3. whether a dedicated terminator such as `!` becomes the first extension after the initial
+   `select(...)` design
+4. whether the runtime later gets a distinct selection event rather than piggybacking on ordinary
+   rewrite machinery
+5. whether latent branch capacity becomes reserved rather than merely conceptually distinct from
+   open rewrite capacity
 
-This chapter is intended to make the target semantics and the current implementation subset legible alongside the accepted grammar.
+This chapter is intended to make the target semantics and the current implementation subset legible
+alongside the accepted grammar.
 
 ## Related
 
 - [grammar.md](grammar.md) — accepted Wire grammar.
 - [../rewrites.md](../rewrites.md) — runtime rewrite algebra and current `AppendAfter` realization.
-- [../../ADRs/0007-latent-branch-conditional-lowering.md](../../ADRs/0007-latent-branch-conditional-lowering.md) — accepted latent-branch architecture decision.
-- [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) — Wire substrate architecture.
-- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md) — rewrite/materialization architecture.
+- [../../ADRs/0007-latent-branch-conditional-lowering.md](../../ADRs/0007-latent-branch-conditional-lowering.md)
+  — accepted latent-branch architecture decision.
+- [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) — Wire substrate
+  architecture.
+- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md)
+  — rewrite/materialization architecture.

--- a/docs/Reference/Wire/contracts-ports-and-matching.md
+++ b/docs/Reference/Wire/contracts-ports-and-matching.md
@@ -1,6 +1,8 @@
 ---
 title: "Wire Reference — Contracts, Ports, and Matching"
-description: Scoped reference for Wire's type surface. Contracts, port declarations, sum groups, labels, and the port-key match rule `=>` uses.
+description:
+  Scoped reference for Wire's type surface. Contracts, port declarations, sum groups, labels, and
+  the port-key match rule `=>` uses.
 sidebar:
   label: Contracts and ports
   order: 3
@@ -13,30 +15,40 @@ related:
 
 # Wire Reference — Contracts, Ports, and Matching
 
-> **Stub.** This page is a scoped entry point into the type-surface rules in [grammar.md](grammar.md). Until it is fleshed out, jump directly to the grammar sections below.
+> **Stub.** This page is a scoped entry point into the type-surface rules in
+> [grammar.md](grammar.md). Until it is fleshed out, jump directly to the grammar sections below.
 
-> **Implementation warning.** Current compiler behavior parses `contract X;` but
-> does not use it to populate registry membership. With an explicit
-> `WireContractRegistry`, only Haskell-registered contracts are enforced. Track
-> alignment in [GitHub #50](https://github.com/Digimuoto/cortex/issues/50).
+> **Implementation warning.** Current compiler behavior parses `contract X;` but does not use it to
+> populate registry membership. With an explicit `WireContractRegistry`, only Haskell-registered
+> contracts are enforced. The reference grammar names the intended contract-assertion semantics; the
+> compiler path still has a narrower registry-backed implementation.
 
 ## Where the rules live
 
-- **[§4 Contracts](grammar.md#4-contracts)** — global ambient namespace, contract equality, what contracts are not.
-- **[§6.2 Port declarations](grammar.md#62-port-declarations)** — input and output port syntax, port keys `(direction, contract, label)`, label-required cases, label semantics.
-- **[§6.3 Singular vs list-valued ports](grammar.md#63-singular-vs-list-valued-ports)** — arity rules.
+- **[§4 Contracts](grammar.md#4-contracts)** — global ambient namespace, contract equality, what
+  contracts are not.
+- **[§6.2 Port declarations](grammar.md#62-port-declarations)** — input and output port syntax, port
+  keys `(direction, contract, label)`, label-required cases, label semantics.
+- **[§6.3 Singular vs list-valued ports](grammar.md#63-singular-vs-list-valued-ports)** — arity
+  rules.
 - **[§6.4 No output ports](grammar.md#64-no-output-ports)** — zero-output nodes.
-- **[§6.5 Sum-grouped output ports](grammar.md#65-sum-grouped-output-ports)** — `-> A | B` with mutual-exclusion metadata.
-- **[§7.1 The three operators](grammar.md#71-the-three-operators)** — `=>` port-key matching rule.
-- **[§7.6 What is and isn't a match](grammar.md#76-what-is-and-isnt-a-match)** — cross-product-with-filter consequences.
+- **[§6.5 Sum-grouped output ports](grammar.md#65-sum-grouped-output-ports)** — `-> A | B` with
+  mutual-exclusion metadata.
+- **[§7.1 The graph operators](grammar.md#71-the-graph-operators)** — `=>` port-key matching rule.
+- **[§7.6 What is and isn't a match](grammar.md#76-what-is-and-isnt-a-match)** —
+  cross-product-with-filter consequences.
 
 ## Summary of the rules
 
-- A **contract** is a named typed interface. Contracts are ambient in a global namespace, populated by executor vocabulary declarations and by `contract X;` assertions.
-- A **port** is a slot on a node with a **port key** `(direction, contract, label)` where label may be absent.
-- **`=>` matches on port key.** Labeled output connects only to identically-labeled input of the same contract; unlabeled connects only to unlabeled. No wildcard.
+- A **contract** is a named typed interface. Contracts are ambient in a global namespace, populated
+  by executor vocabulary declarations and by `contract X;` assertions.
+- A **port** is a slot on a node with a **port key** `(direction, contract, label)` where label may
+  be absent.
+- **`=>` matches on port key.** Labeled output connects only to identically-labeled input of the
+  same contract; unlabeled connects only to unlabeled. No wildcard.
 - A **singular input** accepts at most one edge; a **list input** `<- [C]` accepts zero or more.
-- A **sum-grouped output** `-> A | B` fires exactly one variant per evaluation; its mutual-exclusion metadata survives to runtime.
+- A **sum-grouped output** `-> A | B` fires exactly one variant per evaluation; its mutual-exclusion
+  metadata survives to runtime.
 - **Labels are semantic commitments**, not decorations. Adding a label changes routing.
 
 See the grammar for the full definitions.

--- a/docs/Reference/Wire/executors-and-alphabet.md
+++ b/docs/Reference/Wire/executors-and-alphabet.md
@@ -1,6 +1,8 @@
 ---
 title: "Wire Reference — Executors and the Alphabet"
-description: Scoped reference for executor registration, the closed alphabet, `@`-application, partial nodes, and ambient identifiers in config values.
+description:
+  Scoped reference for executor registration, the closed alphabet, `@`-application, partial nodes,
+  and ambient identifiers in config values.
 sidebar:
   label: Executors
   order: 5
@@ -15,46 +17,46 @@ related:
 
 # Wire Reference — Executors and the Alphabet
 
-This page defines the semantic boundary behind Wire's executor application
-form:
+This page defines the semantic boundary behind Wire's executor application form:
 
 ```wire
 @qualified.name { config }
 ```
 
-The short version: `@` is **pure staging of registered executor
-authority**. The config record is ordinary Wire data. The executor is a
-registered capability that may later perform effects, call external systems, or
-fail. Applying `@` does not run the executor; it constructs a partial node that
-can be checked, merged, pinned to ports, compiled into a graph, persisted, and
-eventually evaluated by Pulse.
+The short version: `@` is **pure staging of registered executor authority**. The config record is
+ordinary Wire data. The executor is a registered capability that may later perform effects, call
+external systems, or fail. Applying `@` does not run the executor; it constructs a partial node that
+can be checked, merged, pinned to ports, compiled into a graph, persisted, and eventually evaluated
+by Pulse.
 
-Executor *kinds* (model-mediated generation vs registered external call) and
-their backend sub-taxonomy are decided in
-[ADR 0014](../../ADRs/0014-executor-taxonomy-model-vs-external-call.md). This
-page covers the grammar-level and registry-boundary surface above that
-taxonomy.
+Executor _kinds_ (model-mediated generation vs registered external call) and their backend
+sub-taxonomy are decided in [ADR 0014](../../ADRs/0014-executor-taxonomy-model-vs-external-call.md).
+This page covers the grammar-level and registry-boundary surface above that taxonomy.
 
 ## Rule Sources
 
-- **[§5.1 Executor registration](grammar.md#51-executor-registration)** — what an executor is, what each executor declares (config schema, vocabulary, structural constraints, purity class), and how the alphabet is global.
-- **[§5.2 Executor application](grammar.md#52-executor-application)** — `@executor { config }` produces a partial node; schema-checking timing.
-- **[§5.3 Config merge on partial nodes](grammar.md#53-config-merge-on-partial-nodes)** — how `partial // record` produces new partials for "base + delta" reuse.
-- **[§5.5 Ambient identifiers in config values](grammar.md#55-ambient-identifiers-in-config-values)** — tool references and tagged-record config constructors.
+- **[§5.1 Executor registration](grammar.md#51-executor-registration)** — what an executor is, what
+  each executor declares (config schema, vocabulary, structural constraints, purity class), and how
+  the alphabet is global.
+- **[§5.2 Executor application](grammar.md#52-executor-application)** — `@executor { config }`
+  produces a partial node; schema-checking timing.
+- **[§5.3 Config merge on partial nodes](grammar.md#53-config-merge-on-partial-nodes)** — how
+  `partial // record` produces new partials for "base + delta" reuse.
+- **[§5.5 Ambient identifiers in config values](grammar.md#55-ambient-identifiers-in-config-values)**
+  — tool references and tagged-record config constructors.
 
 ## Three Layers
 
 `@` sits at a deliberately narrow boundary between three layers:
 
-| Layer | Owned by | What it contains | What it does not do |
-|---|---|---|---|
-| Pure config data | Wire source language | Records, strings, numbers, booleans, lists, tagged config values, tool-name references | No executor call, host mutation, provider request, persistence side effect, or scheduling |
-| Registry authority | Executor/Capability registries plus consumer bindings | Executor identity, config schema, port/profile declarations, contract vocabulary, purity/effect class, host permissions | No run-state transition; it only admits or rejects staged authority |
-| Runtime evaluation | Pulse plus host interpreters | Durable node scheduling, input snapshots, executor invocation, output validation, retry/cancellation/failure recording | No new executor authority beyond what the compiled graph already materialized |
+| Layer              | Owned by                                              | What it contains                                                                                                        | What it does not do                                                                       |
+| ------------------ | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Pure config data   | Wire source language                                  | Records, strings, numbers, booleans, lists, tagged config values, tool-name references                                  | No executor call, host mutation, provider request, persistence side effect, or scheduling |
+| Registry authority | Executor/Capability registries plus consumer bindings | Executor identity, config schema, port/profile declarations, contract vocabulary, purity/effect class, host permissions | No run-state transition; it only admits or rejects staged authority                       |
+| Runtime evaluation | Pulse plus host interpreters                          | Durable node scheduling, input snapshots, executor invocation, output validation, retry/cancellation/failure recording  | No new executor authority beyond what the compiled graph already materialized             |
 
-This separation is the reason Wire can treat executor applications as values.
-The author can bind and transform a configured executor without performing the
-operation:
+This separation is the reason Wire can treat executor applications as values. The author can bind
+and transform a configured executor without performing the operation:
 
 ```wire
 let analyst_base = @llm.analyst {
@@ -67,13 +69,13 @@ node analyst : <- EvidenceBundle -> AnalysisFragment | ExecutorError =
   analyst_base // { tools = [webSearch, readArtifact]; };
 ```
 
-The `topological { ... }` value is a config constructor, not an executor. The
-leading `@` is what marks a reference to the executor alphabet.
+The `topological { ... }` value is a config constructor, not an executor. The leading `@` is what
+marks a reference to the executor alphabet.
 
 ## Executor Applications
 
-Executors are a closed alphabet registered outside Wire. User code cannot
-define new executors; it composes them.
+Executors are a closed alphabet registered outside Wire. User code cannot define new executors; it
+composes them.
 
 The application form is:
 
@@ -81,46 +83,43 @@ The application form is:
 @qualified.name { field = value; }
 ```
 
-It resolves `qualified.name` against the executor registry and pairs it with a
-pure config record. The result is a **partial node**:
+It resolves `qualified.name` against the executor registry and pairs it with a pure config record.
+The result is a **partial node**:
 
 - it has an executor identity;
 - it has config data;
 - it has no authored node identity yet;
-- it may or may not have enough registry-declared port information to stand in
-  graph position;
+- it may or may not have enough registry-declared port information to stand in graph position;
 - it is `let`-bindable;
 - it can be shallowly, right-biased merged with `//`;
-- it becomes an ordinary node only after a `node` declaration or an admissible
-  port-determined graph use pins its boundary.
+- it becomes an ordinary node only after a `node` declaration or an admissible port-determined graph
+  use pins its boundary.
 
-`@qualified.name { config }` therefore means "stage this registered executor
-with this pure config", not "run this executor now".
+`@qualified.name { config }` therefore means "stage this registered executor with this pure config",
+not "run this executor now".
 
 ## Registry Admission
 
-Before a partial node may become a graph node, the registry boundary must
-establish the following facts:
+Before a partial node may become a graph node, the registry boundary must establish the following
+facts:
 
-| Obligation | Meaning |
-|---|---|
-| Executor exists | The qualified name is present in the loaded executor alphabet. |
-| Config validates | The config record conforms to the executor's schema, including any ambient tool or tagged-constructor references. |
-| Port boundary is declared or derivable | The executor either declares fixed ports, accepts the author's `node` signature, or supplies enough structural constraints for direct graph-position use. |
-| Contracts are known | Every input/output contract is in the executor vocabulary, declared by the loaded Wire program, or admitted by an open-vocabulary executor rule. |
-| Purity/effect class is known | The registry classifies the executor as pure, impure, host-effecting, model-mediated, or another accepted effect category. |
-| Output validation is known | The runtime knows which contract schema or payload-kind check applies to each produced output. |
-| Host authority is explicit | Any external tool, model provider, artifact sink, durable mutation, or host API permission comes from the registry/binding layer, not from Wire syntax alone. |
+| Obligation                             | Meaning                                                                                                                                                       |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Executor exists                        | The qualified name is present in the loaded executor alphabet.                                                                                                |
+| Config validates                       | The config record conforms to the executor's schema, including any ambient tool or tagged-constructor references.                                             |
+| Port boundary is declared or derivable | The executor either declares fixed ports, accepts the author's `node` signature, or supplies enough structural constraints for direct graph-position use.     |
+| Contracts are known                    | Every input/output contract is in the executor vocabulary, declared by the loaded Wire program, or admitted by an open-vocabulary executor rule.              |
+| Purity/effect class is known           | The registry classifies the executor as pure, impure, host-effecting, model-mediated, or another accepted effect category.                                    |
+| Output validation is known             | The runtime knows which contract schema or payload-kind check applies to each produced output.                                                                |
+| Host authority is explicit             | Any external tool, model provider, artifact sink, durable mutation, or host API permission comes from the registry/binding layer, not from Wire syntax alone. |
 
-These obligations are admission facts about a staged node. They do not prove
-that the executor will terminate, succeed, or produce useful content. Runtime
-execution remains fallible.
+These obligations are admission facts about a staged node. They do not prove that the executor will
+terminate, succeed, or produce useful content. Runtime execution remains fallible.
 
 ## Config Purity
 
-Config expressions are pure. They can describe prompts, memory policies,
-provider choices, numeric parameters, tool lists, and nested tagged records, but
-they cannot execute an executor.
+Config expressions are pure. They can describe prompts, memory policies, provider choices, numeric
+parameters, tool lists, and nested tagged records, but they cannot execute an executor.
 
 This matters for reuse:
 
@@ -134,15 +133,14 @@ node gatherer_news : <- PlannerOutput -> EvidenceBundle | ExecutorError =
   gatherer_base // { tools = [webSearch, getAssetNews]; };
 ```
 
-The merge creates a new configured partial node. It does not mutate
-`gatherer_base`, call `@llm.gatherer`, or contact any tool. Tool identifiers in
-config are ordinary names whose meaning is checked by the executor schema and
-host binding.
+The merge creates a new configured partial node. It does not mutate `gatherer_base`, call
+`@llm.gatherer`, or contact any tool. Tool identifiers in config are ordinary names whose meaning is
+checked by the executor schema and host binding.
 
 ## Runtime Evaluation
 
-Pulse evaluates materialized nodes after Wire has compiled and validated the
-graph. At that point the node carries:
+Pulse evaluates materialized nodes after Wire has compiled and validated the graph. At that point
+the node carries:
 
 - a stable materialized identity;
 - an executor reference;
@@ -151,17 +149,15 @@ graph. At that point the node carries:
 - contract metadata for inputs and outputs;
 - effect/purity metadata needed by the runtime and host interpreter.
 
-The executor may still be unsafe or impure in the ordinary sense: it can call a
-model, use a tool, write an artifact, fail, time out, or return invalid output.
-The Cortex boundary is that this authority is explicit and staged before
-runtime. Pulse owns durable scheduling and lifecycle state; the registry and
-host binding own what the executor is allowed to do.
+The executor may still be unsafe or impure in the ordinary sense: it can call a model, use a tool,
+write an artifact, fail, time out, or return invalid output. The Cortex boundary is that this
+authority is explicit and staged before runtime. Pulse owns durable scheduling and lifecycle state;
+the registry and host binding own what the executor is allowed to do.
 
 ## Rewrites And Materialization
 
-Runtime rewrites may transform topology, but they cannot invent executor
-authority. Any rewrite that introduces or changes an `@` application must still
-pass the same registry admission boundary:
+Runtime rewrites may transform topology, but they cannot invent executor authority. Any rewrite that
+introduces or changes an `@` application must still pass the same registry admission boundary:
 
 - the executor must already be registered;
 - the config must validate;
@@ -169,23 +165,23 @@ pass the same registry admission boundary:
 - the effect class and host permissions must remain explicit;
 - output validation must remain known.
 
-The Cortex theory enforces this as a rewrite-admissibility obligation
-alongside graph acyclicity: an admitted rewrite must preserve the registry
-boundary for every materialized executor node.
+The Cortex theory enforces this as a rewrite-admissibility obligation alongside graph acyclicity: an
+admitted rewrite must preserve the registry boundary for every materialized executor node.
 
 ## Summary
 
-- `@qualified.name { config }` is pure staging of registered executor
-  authority.
+- `@qualified.name { config }` is pure staging of registered executor authority.
 - Config data is inert until Pulse evaluates a materialized node.
 - `@` produces a partial node, not a running computation.
-- Registry admission is what turns a staged executor into graph-authorable
-  authority.
-- Rewrites can change topology only inside the same registry boundary; they
-  cannot create new authority by syntax alone.
+- Registry admission is what turns a staged executor into graph-authorable authority.
+- Rewrites can change topology only inside the same registry boundary; they cannot create new
+  authority by syntax alone.
 
 ## Related
 
-- [Partials and execution boundary](./partials-and-execution-boundary.md) — when a partial node may appear directly in graph position.
-- [Contracts, ports, and matching](./contracts-ports-and-matching.md) — the port-key rule that executor-declared port signatures participate in.
-- [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) — substrate architecture.
+- [Partials and execution boundary](./partials-and-execution-boundary.md) — when a partial node may
+  appear directly in graph position.
+- [Contracts, ports, and matching](./contracts-ports-and-matching.md) — the port-key rule that
+  executor-declared port signatures participate in.
+- [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) — substrate
+  architecture.

--- a/docs/Reference/Wire/grammar.md
+++ b/docs/Reference/Wire/grammar.md
@@ -1,6 +1,8 @@
 ---
 title: "Wire Grammar Specification"
-description: "Normative specification of the Wire grammar: keywords, operators, port typing, executor alphabet, composition semantics."
+description:
+  "Normative specification of the Wire grammar: keywords, operators, port typing, executor alphabet,
+  composition semantics."
 sidebar:
   label: Grammar
   order: 1
@@ -13,21 +15,43 @@ related:
 
 # The Wire Language — Specification
 
-A DSL for composing typed dataflow graphs. Three declaration forms, explicit imports, one composition algebra, strict port typing, explicit executor alphabet.
+A DSL for composing typed dataflow graphs. Three declaration forms, explicit imports, one
+composition algebra, strict port typing, explicit executor alphabet.
 
-This spec covers **grammar, static types, and composition semantics**. Evaluation semantics — how a wire actually runs, including gas, topological memory, mutual-exclusion pruning, and rewrite bounds — is specified in a sibling document and referenced only where the grammar hands off to it.
+This spec covers **grammar, static types, and composition semantics**. Evaluation semantics — how a
+wire actually runs, including gas, topological memory, mutual-exclusion pruning, and rewrite bounds
+— is specified in a sibling document and referenced only where the grammar hands off to it.
 
 ---
 
 ## 1. Overview
 
-A Wire program is a `.wire` file that evaluates to a **wire**: a typed dataflow graph value. Wires compose into bigger wires. Every expression the grammar admits over the wire-value class produces a wire; every operation on records, strings, and lists produces values in their own closed algebras. The type-checker's structural question is always the same: **do the ports match on contract (and label)**.
+A Wire program is a `.wire` file that evaluates to a **wire**: a typed dataflow graph value. Wires
+compose into bigger wires. Every expression the grammar admits over the wire-value class produces a
+wire; every operation on records, strings, and lists produces values in their own closed algebras.
+The type-checker's structural question is always the same: **do the ports match on contract (and
+label)**.
 
-The language has exactly three top-level declaration forms (`contract`, `node`, `let`), one cross-file form (`import`), two graph operators (`<>` overlay and `=>` connect), one postfix conditional form (`select(...)`, see §7.7), one record-merge operator (`//`), one concatenation operator (`++` for strings and lists), one sum-group constructor (`|` at output port positions), and one executor-application form (`@name { ... }`). The `->` token is reserved for output-port declarations in node signatures (§6.2); it is not a graph operator.
+The language has exactly three top-level declaration forms (`contract`, `node`, `let`), one
+cross-file form (`import`), two graph operators (`<>` overlay and `=>` connect), one postfix
+conditional form (`select(...)`, see §7.7), one record-merge operator (`//`), one concatenation
+operator (`++` for strings and lists), one sum-group constructor (`|` at output port positions), and
+one executor-application form (`@name { ... }`). The `->` token is reserved for output-port
+declarations in node signatures (§6.2); it is not a graph operator.
 
-Nodes are constructed by applying **executors** — named constructors from a closed alphabet registered outside Wire — to config records. Executors are the only **graph-level** extension point the grammar acknowledges. User code cannot define new executors; it composes them. Config values may also reference other registry-ambient identifiers (tool names, tagged-record constructors); those are scoped to config record positions and documented in §5.5. The semantic boundary behind `@executor { config }` is expanded in [executors-and-alphabet.md](executors-and-alphabet.md): `@` stages registered authority with pure config data; it does not run the executor.
+Nodes are constructed by applying **executors** — named constructors from a closed alphabet
+registered outside Wire — to config records. Executors are the only **graph-level** extension point
+the grammar acknowledges. User code cannot define new executors; it composes them. Config values may
+also reference other registry-ambient identifiers (tool names, tagged-record constructors); those
+are scoped to config record positions and documented in §5.5. The semantic boundary behind
+`@executor { config }` is expanded in [executors-and-alphabet.md](executors-and-alphabet.md): `@`
+stages registered authority with pure config data; it does not run the executor.
 
-**Labels are semantic, not cosmetic.** Ports may be labeled (`<- label: Contract`, `-> label: Contract`); a label is part of the port's identity for `=>` matching, not an annotation for humans. A labeled port connects only to an identically-labeled partner of the same contract; an unlabeled port connects only to an unlabeled partner. There is no wildcard. Author labels when you want routing control; do not label for documentation. Full rule in §6.2, matching semantics in §7.1.
+**Labels are semantic, not cosmetic.** Ports may be labeled (`<- label: Contract`,
+`-> label: Contract`); a label is part of the port's identity for `=>` matching, not an annotation
+for humans. A labeled port connects only to an identically-labeled partner of the same contract; an
+unlabeled port connects only to an unlabeled partner. There is no wildcard. Author labels when you
+want routing control; do not label for documentation. Full rule in §6.2, matching semantics in §7.1.
 
 ---
 
@@ -44,13 +68,14 @@ Whitespace (space, tab, newline) is insignificant except as a token separator.
 
 ### 2.2 Identifiers
 
-Unqualified identifier: `[a-zA-Z_][a-zA-Z0-9_]*`.
-Qualified identifier: one or more unqualified identifiers joined by `.` (e.g. `llm.analyst`, `cortex.deep_report`).
+Unqualified identifier: `[a-zA-Z_][a-zA-Z0-9_]*`. Qualified identifier: one or more unqualified
+identifiers joined by `.` (e.g. `llm.analyst`, `cortex.deep_report`).
 
 Identifier kinds are disambiguated by context and by an optional leading `@`:
 
 - **`@qualified_ident`** — executor reference. Only valid in executor-application position.
-- **`qualified_ident`** — bare reference. May resolve to a `let`-bound value, an imported value, a contract name, or a config-constructor name.
+- **`qualified_ident`** — bare reference. May resolve to a `let`-bound value, an imported value, a
+  contract name, or a config-constructor name.
 
 ### 2.3 Keywords
 
@@ -69,13 +94,16 @@ contract   node   let   import   from   select   true   false
 
 **Lists.** `[a, b, c]`. Trailing comma permitted. Empty list: `[]`.
 
-**Records.** `{ k1 = v1; k2 = v2; }`. Fields are terminated by `;`; every field needs its terminating `;`. Empty record: `{}`.
+**Records.** `{ k1 = v1; k2 = v2; }`. Fields are terminated by `;`; every field needs its
+terminating `;`. Empty record: `{}`.
 
-**Numbers.** Decimal integers and floats: `42`, `3.14`, `-7`. Leading `-` is part of the numeric literal, not an operator — Wire has no arithmetic. No hex, octal, or scientific notation.
+**Numbers.** Decimal integers and floats: `42`, `3.14`, `-7`. Leading `-` is part of the numeric
+literal, not an operator — Wire has no arithmetic. No hex, octal, or scientific notation.
 
 **Booleans.** `true`, `false`.
 
-**Unit.** `()` denotes the empty wire (see §7.4). It has no role at port positions; see §6.4 on how "no output" is expressed.
+**Unit.** `()` denotes the empty wire (see §7.4). It has no role at port positions; see §6.4 on how
+"no output" is expressed.
 
 ### 2.5 Operators and punctuation
 
@@ -83,7 +111,8 @@ contract   node   let   import   from   select   true   false
 <>    =>    ->    //    ++    |    <-    :    ;    ,    =    @    .
 ```
 
-`.` is used in qualified identifiers and in path-assignment notation (§8.3). Parentheses `(` `)`, braces `{` `}`, and brackets `[` `]` are structural delimiters.
+`.` is used in qualified identifiers and in path-assignment notation (§8.3). Parentheses `(` `)`,
+braces `{` `}`, and brackets `[` `]` are structural delimiters.
 
 ---
 
@@ -91,8 +120,10 @@ contract   node   let   import   from   select   true   false
 
 Wire has two disjoint algebras of values:
 
-- **Wire values**: nodes, composed graph expressions, and partial nodes (the staging value between executor application and pinning).
-- **Ordinary values**: records, strings, lists, numbers, booleans. These have their own operators and cannot appear on either side of a graph operator.
+- **Wire values**: nodes, composed graph expressions, and partial nodes (the staging value between
+  executor application and pinning).
+- **Ordinary values**: records, strings, lists, numbers, booleans. These have their own operators
+  and cannot appear on either side of a graph operator.
 
 ### 3.1 Ordinary values
 
@@ -100,57 +131,84 @@ Wire has two disjoint algebras of values:
 
 **Strings.** Immutable text. Concatenated with `++`.
 
-**Lists.** Ordered collections. Concatenated with `++`. Homogeneity is enforced only where a consuming executor schema or constructor signature requires it; the grammar does not specify standalone ordinary-value typing beyond that. Until a list flows into a typed slot, the grammar is permissive about element types.
+**Lists.** Ordered collections. Concatenated with `++`. Homogeneity is enforced only where a
+consuming executor schema or constructor signature requires it; the grammar does not specify
+standalone ordinary-value typing beyond that. Until a list flows into a typed slot, the grammar is
+permissive about element types.
 
 **Numbers and booleans.** Scalar values. Used only as config values.
 
 ### 3.2 Wire values
 
-**Partial node.** An executor applied to a config record: `@executor { config }`. Has no ports yet. Can be `let`-bound, merged with `//` to produce another partial node, pinned into a node via a `node` declaration, or (under constrained conditions, §5.4) used directly in graph position.
+**Partial node.** An executor applied to a config record: `@executor { config }`. Has no ports yet.
+Can be `let`-bound, merged with `//` to produce another partial node, pinned into a node via a
+`node` declaration, or (under constrained conditions, §5.4) used directly in graph position.
 
-**Node.** A partial node with a port signature pinned onto it. Has a boundary. Composes via graph operators. The canonical authored unit is `node = ports + executor(config)`: ports are the graph-facing interface; everything behavioral lives in the executor config record.
+**Node.** A partial node with a port signature pinned onto it. Has a boundary. Composes via graph
+operators. The canonical authored unit is `node = ports + executor(config)`: ports are the
+graph-facing interface; everything behavioral lives in the executor config record.
 
-**Composed wire.** The result of applying a graph operator (`<>` or `=>`) to two wire values. Has a boundary derived from its operands.
+**Composed wire.** The result of applying a graph operator (`<>` or `=>`) to two wire values. Has a
+boundary derived from its operands.
 
-All three — partial nodes, nodes, composed wires — are values. All can be `let`-bound. Only nodes and composed wires can appear in graph expressions unconditionally; partial nodes appear in graph expressions only when their remaining degrees of freedom can be resolved by context (§5.4).
+All three — partial nodes, nodes, composed wires — are values. All can be `let`-bound. Only nodes
+and composed wires can appear in graph expressions unconditionally; partial nodes appear in graph
+expressions only when their remaining degrees of freedom can be resolved by context (§5.4).
 
 ---
 
 ## 4. Contracts
 
-> **Implementation warning.** Current compiler behavior parses `contract X;` but
-> does not use it to populate registry membership. With an explicit
-> `WireContractRegistry`, only Haskell-registered contracts are enforced. Track
-> alignment in [GitHub #50](https://github.com/Digimuoto/cortex/issues/50).
+> **Implementation warning.** Current compiler behavior parses `contract X;` but does not use it to
+> populate registry membership. With an explicit `WireContractRegistry`, only Haskell-registered
+> contracts are enforced. The reference grammar names the intended contract-assertion semantics; the
+> compiler path still has a narrower registry-backed implementation.
 
-A **contract** is a named, typed interface. Contracts are the atoms the type-checker reasons about at port boundaries.
+A **contract** is a named, typed interface. Contracts are the atoms the type-checker reasons about
+at port boundaries.
 
 ### 4.1 The global contract namespace
 
 Contracts live in a single **global ambient namespace**, populated from two sources:
 
-1. **Executor vocabulary declarations.** Each registered executor declares the set of contract names it can produce or consume. Those names enter the global namespace automatically.
-2. **`contract X;` assertions in `.wire` files.** An author may assert a contract name that isn't covered by any executor's vocabulary — typically for contract-polymorphic executors (`@pure`, `@identity`) where the contract is a graph-structural concern rather than an executor-declared one.
+1. **Executor vocabulary declarations.** Each registered executor declares the set of contract names
+   it can produce or consume. Those names enter the global namespace automatically.
+2. **`contract X;` assertions in `.wire` files.** An author may assert a contract name that isn't
+   covered by any executor's vocabulary — typically for contract-polymorphic executors (`@pure`,
+   `@identity`) where the contract is a graph-structural concern rather than an executor-declared
+   one.
 
-Contract names are global. `EvidenceBundle` means the same contract wherever it appears. Two files each asserting `contract EvidenceBundle;` refer to the same contract.
+Contract names are global. `EvidenceBundle` means the same contract wherever it appears. Two files
+each asserting `contract EvidenceBundle;` refer to the same contract.
 
-Redeclaration is **idempotent**: asserting a contract name that already exists (whether from an executor vocabulary or from another file's assertion) is legal and has no effect.
+Redeclaration is **idempotent**: asserting a contract name that already exists (whether from an
+executor vocabulary or from another file's assertion) is legal and has no effect.
 
-Referencing an undeclared contract name is a compile error. "Undeclared" means: not in any executor's vocabulary, and not declared in any loaded `.wire` file.
+Referencing an undeclared contract name is a compile error. "Undeclared" means: not in any
+executor's vocabulary, and not declared in any loaded `.wire` file.
 
 ### 4.2 Contract equality
 
-Two contracts are equal iff their names are equal. Contracts are flat — no parameters, no refinement, no subtyping.
+Two contracts are equal iff their names are equal. Contracts are flat — no parameters, no
+refinement, no subtyping.
 
 ### 4.3 What contracts are not
 
-Contracts are not types in the programming-language sense. They do not describe Wire-level values (records, strings, lists). They only appear in port declarations on nodes, and their role is to gate composition: two ports connect iff their contracts match.
+Contracts are not types in the programming-language sense. They do not describe Wire-level values
+(records, strings, lists). They only appear in port declarations on nodes, and their role is to gate
+composition: two ports connect iff their contracts match.
 
-The structural schema of a contract's values (what bytes flow through an `EvidenceBundle` port) lives outside Wire, in the executor registry. The grammar treats contracts as opaque names; runtime structural validation happens at evaluation time, not at compile time.
+The structural schema of a contract's values (what bytes flow through an `EvidenceBundle` port)
+lives outside Wire, in the executor registry. The grammar treats contracts as opaque names; runtime
+structural validation happens at evaluation time, not at compile time.
 
 ### 4.4 Cost of ambient globality
 
-Contracts declared only in wire files (not anchored to any executor) have no backstop against typos: `contract EvidnceBundle;` silently becomes a different contract from `EvidenceBundle`. The moment such a contract routes through any executor-anchored path, the mismatch surfaces at pinning. For contracts that never touch an executor port, there is no static check beyond name equality. This is acceptable for the current grammar and will be revisited if it causes problems in practice.
+Contracts declared only in wire files (not anchored to any executor) have no backstop against typos:
+`contract EvidnceBundle;` silently becomes a different contract from `EvidenceBundle`. The moment
+such a contract routes through any executor-anchored path, the mismatch surfaces at pinning. For
+contracts that never touch an executor port, there is no static check beyond name equality. This is
+acceptable for the current grammar and will be revisited if it causes problems in practice.
 
 ---
 
@@ -161,32 +219,45 @@ Contracts declared only in wire files (not anchored to any executor) have no bac
 An **executor** is a named constructor registered outside Wire. Each executor declares:
 
 - A **config schema** — what fields its config record may contain, with their types.
-- A **vocabulary** — the set of contract names it can produce or consume. A contract-polymorphic executor (`@pure`, `@identity`) declares itself open-vocabulary, accepting any contract chosen at node declaration.
-- **Structural constraints** — rules the port signature must satisfy. These may be tight ("exactly one input of `EvidenceBundle`, exactly one output of `AnalysisFragment | ExecutorError`") or loose ("at least one input; output is any single contract from the vocabulary").
-- A **purity class** — pure or impure. This does not affect static type-checking; it is carried through to the evaluation-model spec.
+- A **vocabulary** — the set of contract names it can produce or consume. A contract-polymorphic
+  executor (`@pure`, `@identity`) declares itself open-vocabulary, accepting any contract chosen at
+  node declaration.
+- **Structural constraints** — rules the port signature must satisfy. These may be tight ("exactly
+  one input of `EvidenceBundle`, exactly one output of `AnalysisFragment | ExecutorError`") or loose
+  ("at least one input; output is any single contract from the vocabulary").
+- A **purity class** — pure or impure. This does not affect static type-checking; it is carried
+  through to the evaluation-model spec.
 
-The alphabet is global. All executors are referenced by qualified name with a leading `@`. There is no mechanism in Wire for defining new executors; they are added by extending the registry externally.
+The alphabet is global. All executors are referenced by qualified name with a leading `@`. There is
+no mechanism in Wire for defining new executors; they are added by extending the registry
+externally.
 
-The leading `@` is the executor-authority marker. It separates registered
-executor references from ordinary config constructors such as
-`topological { preset = "analyst" }`. Applying `@` creates a staged partial
-node with pure config data; runtime effects happen only later, after the graph
-has been compiled, materialized, and scheduled by Pulse. See
-[executors-and-alphabet.md](executors-and-alphabet.md) for the registry
-admission obligations.
+The leading `@` is the executor-authority marker. It separates registered executor references from
+ordinary config constructors such as `topological { preset = "analyst" }`. Applying `@` creates a
+staged partial node with pure config data; runtime effects happen only later, after the graph has
+been compiled, materialized, and scheduled by Pulse. See
+[executors-and-alphabet.md](executors-and-alphabet.md) for the registry admission obligations.
 
-The boundary between what the executor pins and what the author pins is a degree-of-freedom question. A fully-pinned executor (`@llm.review` with a fixed input/output signature) leaves no choices to the author. A fully-polymorphic executor (`@pure`) leaves every choice open. Most real executors sit in between.
+The boundary between what the executor pins and what the author pins is a degree-of-freedom
+question. A fully-pinned executor (`@llm.review` with a fixed input/output signature) leaves no
+choices to the author. A fully-polymorphic executor (`@pure`) leaves every choice open. Most real
+executors sit in between.
 
 #### Illustrative alphabet
 
 The prelude registry typically includes families like:
 
-- **`@llm.*`** — agent executors backed by an LLM: `@llm.planner`, `@llm.gatherer`, `@llm.analyst`, `@llm.review`, `@llm.rewriter`. Provider is picked via config (`provider = "openrouter"`), not the executor name.
-- **`@artifact.*`** — side-effecting persistence: `@artifact.log`, `@artifact.report`. Typically sinks (no output).
-- **`@cortex.*`** — runtime wrappers: `@cortex.report_run`, `@cortex.analysis_run`. Consume a wire's output, produce an artifact reference.
+- **`@llm.*`** — agent executors backed by an LLM: `@llm.planner`, `@llm.gatherer`, `@llm.analyst`,
+  `@llm.review`, `@llm.rewriter`. Provider is picked via config (`provider = "openrouter"`), not the
+  executor name.
+- **`@artifact.*`** — side-effecting persistence: `@artifact.log`, `@artifact.report`. Typically
+  sinks (no output).
+- **`@cortex.*`** — runtime wrappers: `@cortex.report_run`, `@cortex.analysis_run`. Consume a wire's
+  output, produce an artifact reference.
 - **`@pure`, `@identity`, `@const`** — contract-polymorphic utilities.
 
-These names are conventions of the registry, not grammar. Wire itself only requires that executors be qualified identifiers.
+These names are conventions of the registry, not grammar. Wire itself only requires that executors
+be qualified identifiers.
 
 ### 5.2 Executor application
 
@@ -194,14 +265,18 @@ These names are conventions of the registry, not grammar. Wire itself only requi
 @executor { config }
 ```
 
-Produces a **partial node**: the executor paired with its config record, not yet pinned to a port signature. Partial nodes are values and may be bound, passed, and merged.
+Produces a **partial node**: the executor paired with its config record, not yet pinned to a port
+signature. Partial nodes are values and may be bound, passed, and merged.
 
-Executor config is the only behavioral payload on the node surface. Prompt,
-tools, memory, model choice, timeout, step budget, and executor-specific fields
-are all ordinary config fields. Wire does not define a second metadata channel
-for those concerns.
+Executor config is the only behavioral payload on the node surface. Prompt, tools, memory, model
+choice, timeout, step budget, and executor-specific fields are all ordinary config fields. Wire does
+not define a second metadata channel for those concerns.
 
-Schema-checking timing for partial nodes is **implementation-defined**. The reference implementation checks the partial's config at pinning time — i.e., in the `node ... = <partial>` declaration — because partial-node reuse (§5.3) routinely omits fields that are filled in later by `//`. Implementations are free to perform eager type-checks on provided fields at `@` application, but must not reject a partial node for missing fields until pinning.
+Schema-checking timing for partial nodes is **implementation-defined**. The reference implementation
+checks the partial's config at pinning time — i.e., in the `node ... = <partial>` declaration —
+because partial-node reuse (§5.3) routinely omits fields that are filled in later by `//`.
+Implementations are free to perform eager type-checks on provided fields at `@` application, but
+must not reject a partial node for missing fields until pinning.
 
 ### 5.3 Config merge on partial nodes
 
@@ -216,15 +291,28 @@ let analyst_mechanism_partial = analyst_base // {
 };
 ```
 
-`partial_node // record` produces a new partial node with the config record merged right-biased (§8). The executor is unchanged. This is how node reuse via "base + delta" is expressed. `//` applies to partial nodes and to records; it does not apply to pinned nodes or composed wires.
+`partial_node // record` produces a new partial node with the config record merged right-biased
+(§8). The executor is unchanged. This is how node reuse via "base + delta" is expressed. `//`
+applies to partial nodes and to records; it does not apply to pinned nodes or composed wires.
 
 ### 5.4 Partial nodes in graph position
 
-A partial node may appear directly as an operand of a graph operator iff its executor is **port-determined** — its registered structural constraints uniquely determine its port signature from its config record alone, without reference to composition context. Port-polymorphic executors must be pinned via an explicit `node` declaration before appearing in graph position.
+A partial node may appear directly as an operand of a graph operator iff its executor is
+**port-determined** — its registered structural constraints uniquely determine its port signature
+from its config record alone, without reference to composition context. Port-polymorphic executors
+must be pinned via an explicit `node` declaration before appearing in graph position.
 
-This rule keeps partial-node well-formedness **local**. Whether `@executor { config }` is admissible at a given graph-position is a property of the partial and the executor registry — the type-checker does not walk the enclosing expression tree, and no distant edit can silently change whether an upstream partial is well-typed. Implementers can decide admissibility by inspecting only the partial and the registry.
+This rule keeps partial-node well-formedness **local**. Whether `@executor { config }` is admissible
+at a given graph-position is a property of the partial and the executor registry — the type-checker
+does not walk the enclosing expression tree, and no distant edit can silently change whether an
+upstream partial is well-typed. Implementers can decide admissibility by inspecting only the partial
+and the registry.
 
-`@cortex.report_run { ... }` works in graph position because its structural constraints fix its port signature from its config (for instance, by declaring the expected upstream contract as a config field or by having a single registered signature regardless of config). A chained polymorphic partial like `a => @poly {} => c` is rejected at `@poly` because `@poly` is port-polymorphic and has no local pin; the author must declare the node explicitly:
+`@cortex.report_run { ... }` works in graph position because its structural constraints fix its port
+signature from its config (for instance, by declaring the expected upstream contract as a config
+field or by having a single registered signature regardless of config). A chained polymorphic
+partial like `a => @poly {} => c` is rejected at `@poly` because `@poly` is port-polymorphic and has
+no local pin; the author must declare the node explicitly:
 
 ```wire
 node poly_pinned : <- ContractA -> ContractC = @poly {};
@@ -232,29 +320,51 @@ node poly_pinned : <- ContractA -> ContractC = @poly {};
 a => poly_pinned => c
 ```
 
-The same rule applies to `<>` position: partial nodes in `<>` position must be port-determined (locally self-pinning), because `<>` has no contract-matching mechanism that could drive inference even if the spec allowed whole-expression solving.
+The same rule applies to `<>` position: partial nodes in `<>` position must be port-determined
+(locally self-pinning), because `<>` has no contract-matching mechanism that could drive inference
+even if the spec allowed whole-expression solving.
 
-Authors wanting local reasoning and predictable errors should prefer explicit `node` declarations for any executor whose signature is not trivially fixed. The graph-position form is sugar for the common case where a runtime wrapper like `@cortex.report_run` is pinned entirely by its config; it is not a general inference mechanism.
+Authors wanting local reasoning and predictable errors should prefer explicit `node` declarations
+for any executor whose signature is not trivially fixed. The graph-position form is sugar for the
+common case where a runtime wrapper like `@cortex.report_run` is pinned entirely by its config; it
+is not a general inference mechanism.
 
-Rewrite producers use the same surface as authored workflows: explicit `node`
-declarations plus a final graph expression. There is no separate template-use
-syntax.
+Rewrite producers use the same surface as authored workflows: explicit `node` declarations plus a
+final graph expression. There is no separate template-use syntax.
 
 ### 5.5 Ambient identifiers in config values
 
-The flagship example (§12) and production wires routinely use two kinds of bare identifiers inside config records that the grammar admits but that deserve explicit explanation.
+The flagship example (§12) and production wires routinely use two kinds of bare identifiers inside
+config records that the grammar admits but that deserve explicit explanation.
 
-**Tool references.** Identifiers like `getDate`, `searchAssets`, `webSearch`, `getAssetFundamentals` appear as values inside `tools = [...]` lists:
+**Tool references.** Identifiers like `getDate`, `searchAssets`, `webSearch`, `getAssetFundamentals`
+appear as values inside `tools = [...]` lists:
 
 ```wire
 tools = [getDate, searchAssets, getAssetFundamentals, webSearch];
 ```
 
-These are values drawn from the executor registry's **tool registry** — a sibling namespace to the executor alphabet. Like executors and contracts, tools are globally registered and referenced by bare qualified identifier. An executor's config schema determines which tools its `tools` field (or equivalent) accepts; the author writes the identifier and the runtime resolves it against the registry. Tool references are ambient by the same mechanism as contracts and executors.
+These are values drawn from the executor registry's **tool registry** — a sibling namespace to the
+executor alphabet. Like executors and contracts, tools are globally registered and referenced by
+bare qualified identifier. An executor's config schema determines which tools its `tools` field (or
+equivalent) accepts; the author writes the identifier and the runtime resolves it against the
+registry. Tool references are ambient by the same mechanism as contracts and executors.
 
-**Config constructors.** An identifier immediately followed by a record — `topological { preset = "analyst"; }` — is a **tagged-record** value form. Its grammar is `qualified_ident record_expr` without a leading `@` (see §14.4, `constructor_expr`). It is admitted at value-expression positions inside config records. The grammar treats it opaquely; its semantics are determined by the consuming executor's config schema. When `@llm.analyst`'s schema declares that its `memory` field accepts a value of shape `topological { preset: String; ... }`, the constructor is understood. Config constructors are how executors extend their config vocabulary without baking new keywords into Wire.
+**Config constructors.** An identifier immediately followed by a record —
+`topological { preset = "analyst"; }` — is a **tagged-record** value form. Its grammar is
+`qualified_ident record_expr` without a leading `@` (see §14.4, `constructor_expr`). It is admitted
+at value-expression positions inside config records. The grammar treats it opaquely; its semantics
+are determined by the consuming executor's config schema. When `@llm.analyst`'s schema declares that
+its `memory` field accepts a value of shape `topological { preset: String; ... }`, the constructor
+is understood. Config constructors are how executors extend their config vocabulary without baking
+new keywords into Wire.
 
-In both cases the grammar is neutral — it admits qualified identifiers and tagged records freely. The executor registry is the source of truth for which ones are meaningful in which positions. Misspellings of tool names and malformed config constructors surface at pinning time (when the executor's schema is consulted against the provided config) and, for anything the schema cannot reject statically, at runtime. The grammar does not attempt to enforce tool-registry membership or config-constructor validity at the lexical level.
+In both cases the grammar is neutral — it admits qualified identifiers and tagged records freely.
+The executor registry is the source of truth for which ones are meaningful in which positions.
+Misspellings of tool names and malformed config constructors surface at pinning time (when the
+executor's schema is consulted against the provided config) and, for anything the schema cannot
+reject statically, at runtime. The grammar does not attempt to enforce tool-registry membership or
+config-constructor validity at the lexical level.
 
 ---
 
@@ -266,7 +376,8 @@ In both cases the grammar is neutral — it admits qualified identifiers and tag
 node name : <port_signature> = <partial_node_expression>;
 ```
 
-Where `<port_signature>` is a sequence of port declarations and `<partial_node_expression>` is any expression evaluating to a partial node.
+Where `<port_signature>` is a sequence of port declarations and `<partial_node_expression>` is any
+expression evaluating to a partial node.
 
 Full form:
 
@@ -293,33 +404,53 @@ A port declaration is one of:
 -> label: Contract1 | label2: Contract2
 ```
 
-`label:` is an unqualified identifier. Labels participate in port identity and in `=>` matching. Every port has a **port key** `(direction, contract, label)`, where `label` may be absent; an absent label is a distinct key, not a wildcard.
+`label:` is an unqualified identifier. Labels participate in port identity and in `=>` matching.
+Every port has a **port key** `(direction, contract, label)`, where `label` may be absent; an absent
+label is a distinct key, not a wildcard.
 
-Two ports on the same node must have distinct port keys. Labels are therefore **required** whenever two ports on the same node would otherwise share `(direction, contract)`; omitting the label in that case is a compile error. Labels are **not** required for distinctness between different contracts or between inputs and outputs, but authoring a label is never wrong — it just makes the port addressable by that label during `=>` matching (§7.1).
+Two ports on the same node must have distinct port keys. Labels are therefore **required** whenever
+two ports on the same node would otherwise share `(direction, contract)`; omitting the label in that
+case is a compile error. Labels are **not** required for distinctness between different contracts or
+between inputs and outputs, but authoring a label is never wrong — it just makes the port
+addressable by that label during `=>` matching (§7.1).
 
-**Authoring a label is a semantic commitment.** A labeled port `<- success: T` connects only to outputs also labeled `success:` of contract `T`. It does **not** connect to an unlabeled output of the same contract. Authors who want the unconstrained default should not label.
+**Authoring a label is a semantic commitment.** A labeled port `<- success: T` connects only to
+outputs also labeled `success:` of contract `T`. It does **not** connect to an unlabeled output of
+the same contract. Authors who want the unconstrained default should not label.
 
 ### 6.3 Singular vs list-valued ports
 
-An **output port** is always singular — it produces at most one value per evaluation. Fan-out (one producer, many consumers) is an edge-level property: one output port may connect to many downstream inputs.
+An **output port** is always singular — it produces at most one value per evaluation. Fan-out (one
+producer, many consumers) is an edge-level property: one output port may connect to many downstream
+inputs.
 
-A **singular input port** `<- Contract` accepts at most one incoming edge. **Two or more incoming edges to a singular input is a composition-time type error.** Zero incoming edges is permitted on any well-typed wire value — the port simply remains on the composed wire's input boundary. Full connectivity is checked at **evaluation-time preparation**, not at compile time; see §11 rule 6.
+A **singular input port** `<- Contract` accepts at most one incoming edge. **Two or more incoming
+edges to a singular input is a composition-time type error.** Zero incoming edges is permitted on
+any well-typed wire value — the port simply remains on the composed wire's input boundary. Full
+connectivity is checked at **evaluation-time preparation**, not at compile time; see §11 rule 6.
 
-A **list-valued input port** `<- [Contract]` accepts zero or more incoming edges. At evaluation time, all fired values are collected into a list (order is runtime-defined, outside this spec).
+A **list-valued input port** `<- [Contract]` accepts zero or more incoming edges. At evaluation
+time, all fired values are collected into a list (order is runtime-defined, outside this spec).
 
-This asymmetry is deliberate. Fan-out produces *semantically distinct* values; each deserves its own output port. Fan-in *aggregates* values treated uniformly; they deserve one input port that collects them.
+This asymmetry is deliberate. Fan-out produces _semantically distinct_ values; each deserves its own
+output port. Fan-in _aggregates_ values treated uniformly; they deserve one input port that collects
+them.
 
 ### 6.4 No output ports
 
-A node may have zero output ports — it is then a pure sink, consuming inputs and producing no outward flow. There is no explicit "unit output" syntax; the absence of any `->` declaration in the port signature is how "no output" is expressed:
+A node may have zero output ports — it is then a pure sink, consuming inputs and producing no
+outward flow. There is no explicit "unit output" syntax; the absence of any `->` declaration in the
+port signature is how "no output" is expressed:
 
 ```wire
 node error_sink : <- [ExecutorError] = @artifact.log {};
 ```
 
-There is no `-> ()` form. `()` denotes the empty wire (§7.4); it is not a contract and cannot appear at port positions.
+There is no `-> ()` form. `()` denotes the empty wire (§7.4); it is not a contract and cannot appear
+at port positions.
 
-A node with no input ports is a source; a node with no output ports is a sink. A node with neither (zero total ports) is deferred to v2 (§13).
+A node with no input ports is a source; a node with no output ports is a sink. A node with neither
+(zero total ports) is deferred to v2 (§13).
 
 ### 6.5 Sum-grouped output ports
 
@@ -329,20 +460,29 @@ A single output position may declare multiple variants joined by `|`:
 -> AnalysisFragment | ExecutorError
 ```
 
-This is a **sum group** — a grammar-level construct distinct from independent multi-output declarations. The grammar and runtime both carry the grouping as metadata. Specifically:
+This is a **sum group** — a grammar-level construct distinct from independent multi-output
+declarations. The grammar and runtime both carry the grouping as metadata. Specifically:
 
-1. A sum group contains **at least two** variants. A one-variant "sum" is a syntax error; write the variant as an ordinary port.
-2. Each variant has its own `(direction, contract, optional label)` identity. Two variants with the same contract require disambiguating labels.
-3. **Mutual exclusion is a grammar-level property.** At each evaluation, exactly one variant fires; the others do not produce a value. The runtime enforces this using the metadata.
-4. `=>` matches variants **individually**. An edge forms for each variant whose contract matches an input on the other side of the connect. The sum-grouping metadata survives on the outgoing edges so the runtime knows which edges are part of the same mutual-exclusion set.
+1. A sum group contains **at least two** variants. A one-variant "sum" is a syntax error; write the
+   variant as an ordinary port.
+2. Each variant has its own `(direction, contract, optional label)` identity. Two variants with the
+   same contract require disambiguating labels.
+3. **Mutual exclusion is a grammar-level property.** At each evaluation, exactly one variant fires;
+   the others do not produce a value. The runtime enforces this using the metadata.
+4. `=>` matches variants **individually**. An edge forms for each variant whose contract matches an
+   input on the other side of the connect. The sum-grouping metadata survives on the outgoing edges
+   so the runtime knows which edges are part of the same mutual-exclusion set.
 
 **Sum groups are output-position only.** Input ports may not use `|`.
 
-Sum groups are a general feature for any mutually-exclusive output, not a special error-handling construct. The failure-variant pattern (`-> T | ExecutorError`) is the common case, but authors may use sum groups anywhere a node genuinely produces one of several alternatives per evaluation.
+Sum groups are a general feature for any mutually-exclusive output, not a special error-handling
+construct. The failure-variant pattern (`-> T | ExecutorError`) is the common case, but authors may
+use sum groups anywhere a node genuinely produces one of several alternatives per evaluation.
 
 #### Label asymmetry
 
-Labels inside sum groups attach per-variant. A leading label before the first variant labels only the first variant, not the whole group:
+Labels inside sum groups attach per-variant. A leading label before the first variant labels only
+the first variant, not the whole group:
 
 ```wire
 -> label_a: A | B              # labels only the first variant
@@ -354,13 +494,15 @@ The outer port declaration is one unit; labels bind to their immediate variant.
 
 ### 6.6 Node alias semantics
 
-A `node` declaration binds a name to a specific node value. Subsequent references to that name in graph expressions all refer to **the same node**, not fresh copies. In the wire:
+A `node` declaration binds a name to a specific node value. Subsequent references to that name in
+graph expressions all refer to **the same node**, not fresh copies. In the wire:
 
 ```wire
 planner => gatherer => merge => review => rewriter <> merge => rewriter
 ```
 
-the second `merge` and second `rewriter` are the **same nodes** as the first occurrences. `<>` (overlay) is union on nodes and edges; shared nodes retain their identity.
+the second `merge` and second `rewriter` are the **same nodes** as the first occurrences. `<>`
+(overlay) is union on nodes and edges; shared nodes retain their identity.
 
 This matches `let` alias semantics (§9.3). There is no node-cloning construct.
 
@@ -369,37 +511,57 @@ This matches `let` alias semantics (§9.3). There is no node-cloning construct.
 A `node` declaration is well-formed iff all of the following hold:
 
 1. The named executor is registered.
-2. The config record's **provided** fields have the correct types per the executor's schema (the "full config satisfies schema" check may be deferred to pinning per §5.2).
-3. Every contract referenced in the port signature is in the executor's vocabulary (or the executor is contract-polymorphic).
+2. The config record's **provided** fields have the correct types per the executor's schema (the
+   "full config satisfies schema" check may be deferred to pinning per §5.2).
+3. Every contract referenced in the port signature is in the executor's vocabulary (or the executor
+   is contract-polymorphic).
 4. The port arrangement satisfies the executor's structural constraints.
 5. All port labels required for disambiguation (§6.2, §6.5) are present.
 6. The node has **at least one port**. Zero-port nodes are deferred to v2 (§13).
 
-These are compile-time checks. Whether the executor's *output values* actually conform to their declared contracts at evaluation time is a runtime structural check — not part of the static type system.
+These are compile-time checks. Whether the executor's _output values_ actually conform to their
+declared contracts at evaluation time is a runtime structural check — not part of the static type
+system.
 
 ---
 
 ## 7. Wires and composition
 
-A **wire** is any value of wire kind: a node, a composed graph expression, or (in graph position, with resolvable degrees of freedom) a partial node.
+A **wire** is any value of wire kind: a node, a composed graph expression, or (in graph position,
+with resolvable degrees of freedom) a partial node.
 
-A wire has a **port-boundary**: the set of its unconnected input ports (sources) and unconnected output ports (sinks, including unconnected sum-group variants). Composition acts on boundaries only; internal structure is sealed.
+A wire has a **port-boundary**: the set of its unconnected input ports (sources) and unconnected
+output ports (sinks, including unconnected sum-group variants). Composition acts on boundaries only;
+internal structure is sealed.
 
 ### 7.1 The graph operators
 
-**`<>` — overlay (primitive).** `a <> b` is the graph containing every node and edge in `a` plus every node and edge in `b`. Shared nodes retain their identity (no duplication). No new edges are created.
+**`<>` — overlay (primitive).** `a <> b` is the graph containing every node and edge in `a` plus
+every node and edge in `b`. Shared nodes retain their identity (no duplication). No new edges are
+created.
 
 **`=>` — connect (strict port-matched).** `lhs => rhs` is defined as:
 
-1. Let `S` = unconnected output ports and output variants in the port-boundary of `lhs`. Let `R` = unconnected input ports of `rhs`.
-2. For each `p ∈ S` and each `q ∈ R`: add an edge `p → q` iff their port keys match. The port key is `(contract, label)`, with absent-label treated as a distinct key, not a wildcard. For list inputs, the match requires `contract(q) == [contract(p)]` and `label(q) == label(p)` (or both absent).
+1. Let `S` = unconnected output ports and output variants in the port-boundary of `lhs`. Let `R` =
+   unconnected input ports of `rhs`.
+2. For each `p ∈ S` and each `q ∈ R`: add an edge `p → q` iff their port keys match. The port key is
+   `(contract, label)`, with absent-label treated as a distinct key, not a wildcard. For list
+   inputs, the match requires `contract(q) == [contract(p)]` and `label(q) == label(p)` (or both
+   absent).
 3. The result is `lhs <> rhs` with the added edges.
 
-`=>` is **deterministic**: it adds an edge for every matching pair. It does not choose between candidates. If the resulting graph violates an arity constraint (e.g. two edges into a singular input), that is a composition-time type error surfaced by the arity rules in §6.3 — not by `=>` itself.
+`=>` is **deterministic**: it adds an edge for every matching pair. It does not choose between
+candidates. If the resulting graph violates an arity constraint (e.g. two edges into a singular
+input), that is a composition-time type error surfaced by the arity rules in §6.3 — not by `=>`
+itself.
 
-Unmatched ports on either side remain on the composed wire's boundary. Labels are the mechanism authors use to control matching explicitly; see §6.2.
+Unmatched ports on either side remain on the composed wire's boundary. Labels are the mechanism
+authors use to control matching explicitly; see §6.2.
 
-**No path operator.** An earlier draft included `->` as a singleton-chain specialization of `=>`. It is not part of Wire: it added no expressiveness over `=>`, and the `->` glyph collides with the output-port declaration form (§6.2), creating visual ambiguity in mixed contexts. `=>` covers every connect case. See §13.
+**No path operator.** An earlier draft included `->` as a singleton-chain specialization of `=>`. It
+is not part of Wire: it added no expressiveness over `=>`, and the `->` glyph collides with the
+output-port declaration form (§6.2), creating visual ambiguity in mixed contexts. `=>` covers every
+connect case. See §13.
 
 ### 7.2 Precedence and associativity
 
@@ -411,7 +573,11 @@ infixl 3  =>
 infixl 2  <>
 ```
 
-`//` and `++` live at the same precedence level. The grammar chains them freely, but because they operate on disjoint value kinds, any mixed expression fails type-checking — no well-typed program contains both in one expression. `select(...)` is a postfix suffix on its left-hand graph (see §7.7); it binds tighter than `=>` and `<>` and looser than `//` / `++`. Parentheses are always allowed and always override.
+`//` and `++` live at the same precedence level. The grammar chains them freely, but because they
+operate on disjoint value kinds, any mixed expression fails type-checking — no well-typed program
+contains both in one expression. `select(...)` is a postfix suffix on its left-hand graph (see
+§7.7); it binds tighter than `=>` and `<>` and looser than `//` / `++`. Parentheses are always
+allowed and always override.
 
 Worked examples:
 
@@ -423,16 +589,23 @@ Worked examples:
 
 ### 7.3 Boundary computation
 
-Boundary is a derived property of the resulting graph, not a set-arithmetic operation on operand boundaries.
+Boundary is a derived property of the resulting graph, not a set-arithmetic operation on operand
+boundaries.
 
-Given a wire `w` with node set `nodes(w)` and edge set `edges(w)`: a port `p` on some node `n ∈ nodes(w)` is **internal** iff `edges(w)` contains at least one edge incident to `p`; otherwise `p` is on the **boundary** of `w`.
+Given a wire `w` with node set `nodes(w)` and edge set `edges(w)`: a port `p` on some node
+`n ∈ nodes(w)` is **internal** iff `edges(w)` contains at least one edge incident to `p`; otherwise
+`p` is on the **boundary** of `w`.
 
 For composed wires:
 
-- `nodes(a <> b) = nodes(a) ∪ nodes(b)`; `edges(a <> b) = edges(a) ∪ edges(b)`. Shared nodes contribute once (set union). Boundary of `a <> b` is read off the resulting graph by the rule above.
-- `nodes(a => b) = nodes(a <> b)`; `edges(a => b) = edges(a <> b) ∪ E`, where `E` is the set of edges added by §7.1's connect rule. Boundary of `a => b` is read off the resulting graph.
+- `nodes(a <> b) = nodes(a) ∪ nodes(b)`; `edges(a <> b) = edges(a) ∪ edges(b)`. Shared nodes
+  contribute once (set union). Boundary of `a <> b` is read off the resulting graph by the rule
+  above.
+- `nodes(a => b) = nodes(a <> b)`; `edges(a => b) = edges(a <> b) ∪ E`, where `E` is the set of
+  edges added by §7.1's connect rule. Boundary of `a => b` is read off the resulting graph.
 
-Implementers should compute the graph first and derive boundary from incidence, not attempt to maintain boundary as a separately-tracked set through the operators.
+Implementers should compute the graph first and derive boundary from incidence, not attempt to
+maintain boundary as a separately-tracked set through the operators.
 
 ### 7.4 The empty wire `()`
 
@@ -451,7 +624,8 @@ a => () = a
 (a, b, c)
 ```
 
-In graph position, `(a, b, c)` is the overlay `a <> b <> c` — three independent sub-wires composed as parallel lanes. Each element is itself a graph expression:
+In graph position, `(a, b, c)` is the overlay `a <> b <> c` — three independent sub-wires composed
+as parallel lanes. Each element is itself a graph expression:
 
 ```wire
 (   gatherer_mechanism     => analyst_mechanism
@@ -459,22 +633,37 @@ In graph position, `(a, b, c)` is the overlay `a <> b <> c` — three independen
  ,  gatherer_beneficiaries => analyst_beneficiaries )
 ```
 
-Tuple elements are flattened under composition: `((a, b), c)` is equivalent to `(a, b, c)`. A single-element parenthesized expression `(a)` is just `a`. The single-element tuple spelling `(a,)` is not admitted. The empty tuple `()` is the empty wire (§7.4). Trailing commas are permitted on two-or-more-element tuples.
+Tuple elements are flattened under composition: `((a, b), c)` is equivalent to `(a, b, c)`. A
+single-element parenthesized expression `(a)` is just `a`. The single-element tuple spelling `(a,)`
+is not admitted. The empty tuple `()` is the empty wire (§7.4). Trailing commas are permitted on
+two-or-more-element tuples.
 
 ### 7.6 What is and isn't a match
 
-`=>` is a mechanical cross-product-with-filter over boundary port-pairs. Matching is on **port key** — `(contract, label)` with absent-label a distinct key. The operator adds every edge whose endpoints share a key and never chooses among candidates. The consequences worth naming:
+`=>` is a mechanical cross-product-with-filter over boundary port-pairs. Matching is on **port key**
+— `(contract, label)` with absent-label a distinct key. The operator adds every edge whose endpoints
+share a key and never chooses among candidates. The consequences worth naming:
 
-- **Two unlabeled outputs of contract `C` on `lhs` + one unlabeled singular input of `C` on `rhs`**: two edges into a singular input — arity error (§6.3). The author must label one of the outputs and label the intended consumer accordingly, or restructure the consumer to take `[C]`.
-- **One unlabeled output of `C` on `lhs` + two unlabeled singular inputs of `C` on `rhs`**: two edges from one output, both valid singleton inputs (one producer can fan out). Not an error; if unintended, label one consumer and remove the label from the output's intended target to route explicitly.
-- **Labeled output `success: C` + unlabeled input `<- C`**: no edge. Keys `(C, Some "success")` and `(C, None)` don't match. Add a matching label on the consumer side, or remove the label from the producer.
-- **No matching pairs**: no edges added. Both sides' ports remain on the composed boundary. This is a legitimate `<>`-equivalent outcome when the author is overlaying rather than connecting.
+- **Two unlabeled outputs of contract `C` on `lhs` + one unlabeled singular input of `C` on `rhs`**:
+  two edges into a singular input — arity error (§6.3). The author must label one of the outputs and
+  label the intended consumer accordingly, or restructure the consumer to take `[C]`.
+- **One unlabeled output of `C` on `lhs` + two unlabeled singular inputs of `C` on `rhs`**: two
+  edges from one output, both valid singleton inputs (one producer can fan out). Not an error; if
+  unintended, label one consumer and remove the label from the output's intended target to route
+  explicitly.
+- **Labeled output `success: C` + unlabeled input `<- C`**: no edge. Keys `(C, Some "success")` and
+  `(C, None)` don't match. Add a matching label on the consumer side, or remove the label from the
+  producer.
+- **No matching pairs**: no edges added. Both sides' ports remain on the composed boundary. This is
+  a legitimate `<>`-equivalent outcome when the author is overlaying rather than connecting.
 
-Labels are the routing-control mechanism. Unlabeled ports participate only in unlabeled matches; labeled ports participate only in identically-labeled matches. There is no wildcard.
+Labels are the routing-control mechanism. Unlabeled ports participate only in unlabeled matches;
+labeled ports participate only in identically-labeled matches. There is no wildcard.
 
 ### 7.7 `select(...)` — postfix conditional reduction
 
-`select(...)` is the postfix conditional form. It reduces an exclusive output boundary on its left-hand graph by attaching a continuation graph to each variant and committing to one at runtime.
+`select(...)` is the postfix conditional form. It reduces an exclusive output boundary on its
+left-hand graph by attaching a continuation graph to each variant and committing to one at runtime.
 
 ```wire
 selector select(
@@ -486,20 +675,32 @@ selector select(
 **Surface and parse rules.**
 
 - The form is postfix: the left-hand graph is the **selector**, and `select(...)` is its suffix.
-- Each arm is `Key : expr`, where `Key` is an identifier and `expr` is any wire expression (including `()`, parenthesized continuation graphs, and other `select(...)` forms).
+- Each arm is `Key : expr`, where `Key` is an identifier and `expr` is any wire expression
+  (including `()`, parenthesized continuation graphs, and other `select(...)` forms).
 - Arms are comma-separated; a trailing comma is permitted; at least one arm is required.
-- `select(...)` chains as a postfix: `x select(...) select(...)` is left-folded — equivalent to `(x select(...)) select(...)` — and is admissible whenever the inner `select(...)` itself yields an exclusive output boundary on its result.
+- `select(...)` chains as a postfix: `x select(...) select(...)` is left-folded — equivalent to
+  `(x select(...)) select(...)` — and is admissible whenever the inner `select(...)` itself yields
+  an exclusive output boundary on its result.
 
 **Static rules.**
 
-- The selector must expose an exclusive output boundary (a sum group, §6.5). A non-sum-grouped boundary is a type error.
-- Arm keys resolve against **variant identity** on that boundary. The default key is the variant's contract name; an explicit label (when contract names alone do not disambiguate) uses the labeled-variant key. Reordering arms does not change meaning.
+- The selector must expose an exclusive output boundary (a sum group, §6.5). A non-sum-grouped
+  boundary is a type error.
+- Arm keys resolve against **variant identity** on that boundary. The default key is the variant's
+  contract name; an explicit label (when contract names alone do not disambiguate) uses the
+  labeled-variant key. Reordering arms does not change meaning.
 - Every selector variant must be covered by exactly one arm; duplicate keys are a static error.
-- Every arm is a continuation graph in the same expression namespace as `<>` / `=>`. The empty wire `()` (§7.4) is admissible as an arm body and contributes no extra branch-local topology.
-- Every arm must yield the same downstream output boundary; the result of `selector select(...)` exposes that common boundary. Branches that absorb or terminate the path are deferred (§13).
-- The reduced graph composes with `<>` and `=>` like any other wire (subject to the precedence rule above).
+- Every arm is a continuation graph in the same expression namespace as `<>` / `=>`. The empty wire
+  `()` (§7.4) is admissible as an arm body and contributes no extra branch-local topology.
+- Every arm must yield the same downstream output boundary; the result of `selector select(...)`
+  exposes that common boundary. Branches that absorb or terminate the path are deferred (§13).
+- The reduced graph composes with `<>` and `=>` like any other wire (subject to the precedence rule
+  above).
 
-**Evaluation rules.** Only one arm is materialized — the runtime selects exactly one continuation based on which selector variant fires. Latency, branch ownership, and lowering details are out of scope for the grammar; see [conditionality.md](conditionality.md) for the full semantic model and the current implementation subset.
+**Evaluation rules.** Only one arm is materialized — the runtime selects exactly one continuation
+based on which selector variant fires. Latency, branch ownership, and lowering details are out of
+scope for the grammar; see [conditionality.md](conditionality.md) for the full semantic model and
+the current implementation subset.
 
 ---
 
@@ -511,7 +712,9 @@ selector select(
 { title = "Report"; maxTokens = 16384; tools = [webSearch, getDate]; }
 ```
 
-Fields are terminated by `;`. Field names are unqualified identifiers; values are arbitrary expressions. Commas are graph overlay shorthand in file-return position and separators in list/tuple/select syntax; they are not record field delimiters.
+Fields are terminated by `;`. Field names are unqualified identifiers; values are arbitrary
+expressions. Commas are graph overlay shorthand in file-return position and separators in
+list/tuple/select syntax; they are not record field delimiters.
 
 ### 8.2 `//` — right-biased shallow merge
 
@@ -519,15 +722,19 @@ Fields are terminated by `;`. Field names are unqualified identifiers; values ar
 defaults // overrides
 ```
 
-The result has every field in `defaults` plus every field in `overrides`; on key collision, the right operand wins. Merge is **shallow** — nested records are replaced wholesale, not merged recursively.
+The result has every field in `defaults` plus every field in `overrides`; on key collision, the
+right operand wins. Merge is **shallow** — nested records are replaced wholesale, not merged
+recursively.
 
 Laws:
+
 - `r // {} = r`
 - `{} // r = r`
 - `(r // s) // t = r // (s // t)` (associative)
 - Not commutative.
 
-`//` applies to records and to partial nodes (where it merges the config record, leaving the executor untouched). It does not apply to other value kinds.
+`//` applies to records and to partial nodes (where it merges the config record, leaving the
+executor untouched). It does not apply to other value kinds.
 
 ### 8.3 Path assignment
 
@@ -556,7 +763,8 @@ Repeated paths follow `//`'s right-wins rule: the last assignment to a given pat
 
 ## 9. Top-level forms
 
-A `.wire` file is a sequence of top-level forms. A file may optionally end in a **file-return expression** with no trailing `;`. The file's value is the file-return expression, if present.
+A `.wire` file is a sequence of top-level forms. A file may optionally end in a **file-return
+expression** with no trailing `;`. The file's value is the file-return expression, if present.
 
 ### 9.1 `contract`
 
@@ -564,9 +772,12 @@ A `.wire` file is a sequence of top-level forms. A file may optionally end in a 
 contract Name;
 ```
 
-Asserts a contract name in the global namespace (§4.1). Idempotent. No effect beyond admitting the name to scope.
+Asserts a contract name in the global namespace (§4.1). Idempotent. No effect beyond admitting the
+name to scope.
 
-A file needs `contract X;` only when `X` is not already declared by any loaded executor's vocabulary. For contracts that appear in executor vocabularies — the common case — no explicit declaration is needed in user wire files.
+A file needs `contract X;` only when `X` is not already declared by any loaded executor's
+vocabulary. For contracts that appear in executor vocabularies — the common case — no explicit
+declaration is needed in user wire files.
 
 ### 9.2 `node`
 
@@ -582,9 +793,11 @@ Declares a node. See §6.
 let name = <expression>;
 ```
 
-Binds a name to a value. The expression may be any Wire expression: a record, a string, a list, a partial node, a node, or a graph expression.
+Binds a name to a value. The expression may be any Wire expression: a record, a string, a list, a
+partial node, a node, or a graph expression.
 
-**Alias semantics**: `let` never duplicates. If the expression evaluates to a wire, `let name = ...;` and subsequent references to `name` refer to the same wire.
+**Alias semantics**: `let` never duplicates. If the expression evaluates to a wire,
+`let name = ...;` and subsequent references to `name` refer to the same wire.
 
 ### 9.4 `import`
 
@@ -593,12 +806,17 @@ import name from "path/to/file.wire";
 import { a, b, c } from "path/to/file.wire";
 ```
 
-First form: imports the imported file's **file-return expression** as `name`. Fails if the file is declaration-only (§9.6).
-Second form: imports named `let`-bindings from the file.
+First form: imports the imported file's **file-return expression** as `name`. Fails if the file is
+declaration-only (§9.6). Second form: imports named `let`-bindings from the file.
 
-**Only names bound via `let` enter another file's local value scope on import.** Imports are ordinary value transport: whatever value a `let` name points to — a record, a string, a list, a partial node, a node, a composed wire — is moved across the file boundary with identity intact.
+**Only names bound via `let` enter another file's local value scope on import.** Imports are
+ordinary value transport: whatever value a `let` name points to — a record, a string, a list, a
+partial node, a node, a composed wire — is moved across the file boundary with identity intact.
 
-`node` declarations bind names in the declaration namespace, which is local to the declaring file. They are not directly importable, not because node identity is somehow file-local, but because the declaration namespace is not the value namespace. To expose a node across files, bind a `let` alias to it:
+`node` declarations bind names in the declaration namespace, which is local to the declaring file.
+They are not directly importable, not because node identity is somehow file-local, but because the
+declaration namespace is not the value namespace. To expose a node across files, bind a `let` alias
+to it:
 
 ```wire
 node gatherer_mechanism : <- PlannerOutput -> EvidenceBundle | ExecutorError =
@@ -607,11 +825,23 @@ node gatherer_mechanism : <- PlannerOutput -> EvidenceBundle | ExecutorError =
 let gatherer = gatherer_mechanism;
 ```
 
-Now `import { gatherer } from "./gatherers.wire";` brings the node value into the importing file's scope. **Node identity is preserved across imports.** A node value referenced in both the declaring file and the importing file composes as the same node in the resulting program — no duplication, no fresh instantiation. This is ordinary value semantics; `let` is the namespace bridge.
+Now `import { gatherer } from "./gatherers.wire";` brings the node value into the importing file's
+scope. **Node identity is preserved across imports.** A node value referenced in both the declaring
+file and the importing file composes as the same node in the resulting program — no duplication, no
+fresh instantiation. This is ordinary value semantics; `let` is the namespace bridge.
 
-`contract` declarations are ambient (§4.1). They are not importable because they do not inhabit any file's local value scope; they contribute to the global contract namespace the moment their declaring file is loaded. Authors are encouraged — though not required — to redeclare `contract X;` at the top of any file that references `X`, purely as documentation so a file's contract dependencies are readable from its header. Redeclaration is idempotent (§4.1).
+`contract` declarations are ambient (§4.1). They are not importable because they do not inhabit any
+file's local value scope; they contribute to the global contract namespace the moment their
+declaring file is loaded. Authors are encouraged — though not required — to redeclare `contract X;`
+at the top of any file that references `X`, purely as documentation so a file's contract
+dependencies are readable from its header. Redeclaration is idempotent (§4.1).
 
-**Ambient-by-loading, acknowledged.** Loading a file at all — whether by `import name from "..."` for its file-return value or by `import { x } from "..."` for a specific `let` binding — transitively loads the file's `contract` assertions into the program-wide namespace. Authors relying only on a single `let` export still inherit the file's contract declarations; this is a deliberate property of ambient contracts, not a hidden coupling. If tighter control is ever wanted, it is a v2 concern.
+**Ambient-by-loading, acknowledged.** Loading a file at all — whether by `import name from "..."`
+for its file-return value or by `import { x } from "..."` for a specific `let` binding —
+transitively loads the file's `contract` assertions into the program-wide namespace. Authors relying
+only on a single `let` export still inherit the file's contract declarations; this is a deliberate
+property of ambient contracts, not a hidden coupling. If tighter control is ever wanted, it is a v2
+concern.
 
 ### 9.5 File-return expression
 
@@ -626,47 +856,75 @@ node b : ... = ...;
 a => b
 ```
 
-`a => b` is the file-return expression. Importing this file (first form of §9.4) yields the wire `a => b`.
+`a => b` is the file-return expression. Importing this file (first form of §9.4) yields the wire
+`a => b`.
 
 ### 9.6 Wire files and declaration-only files
 
-A file with a file-return expression is a **wire file** — importable as a wire via §9.4's first form.
+A file with a file-return expression is a **wire file** — importable as a wire via §9.4's first
+form.
 
-A file without a file-return expression is a **declaration-only file**. It contributes exactly two things to the loading program:
+A file without a file-return expression is a **declaration-only file**. It contributes exactly two
+things to the loading program:
 
-1. **Ambient contract assertions.** `contract X;` declarations in the file register `X` in the global contract namespace. This is the idempotent ambient mechanism of §4.1.
-2. **Importable `let` bindings.** Names bound with `let name = ...;` are available to other files via `import { name } from "..."`.
+1. **Ambient contract assertions.** `contract X;` declarations in the file register `X` in the
+   global contract namespace. This is the idempotent ambient mechanism of §4.1.
+2. **Importable `let` bindings.** Names bound with `let name = ...;` are available to other files
+   via `import { name } from "..."`.
 
-Declaration-only files do **not** leak `node` names, nor any other non-`let` construct, into loading files' local scopes. A file that declares a `node foo : ... = ...;` makes `foo` part of that file's internal wire structure only; other files cannot reference `foo` unless the declaring file also binds `let foo_alias = foo;` and the importer explicitly imports `foo_alias`.
+Declaration-only files do **not** leak `node` names, nor any other non-`let` construct, into loading
+files' local scopes. A file that declares a `node foo : ... = ...;` makes `foo` part of that file's
+internal wire structure only; other files cannot reference `foo` unless the declaring file also
+binds `let foo_alias = foo;` and the importer explicitly imports `foo_alias`.
 
 The common use cases are:
 
 - **Prelude files** that register shared contracts not anchored to any executor vocabulary.
-- **Library files** that publish reusable `let`-bound values (shared prompt blocks, tool-list constants, partial-node bases) via explicit imports.
+- **Library files** that publish reusable `let`-bound values (shared prompt blocks, tool-list
+  constants, partial-node bases) via explicit imports.
 
 Neither case requires or justifies implicit node/value leakage.
 
 ### 9.7 Closed composition, open vocabulary
 
-A **program** is a root `.wire` file plus the transitive closure of its `import`s. Ambient contract collection runs over the whole program before any node well-formedness check; referencing a contract name that no file in the program declares (and no loaded executor vocabulary provides) is a compile error, not a lazy-lookup miss.
+A **program** is a root `.wire` file plus the transitive closure of its `import`s. Ambient contract
+collection runs over the whole program before any node well-formedness check; referencing a contract
+name that no file in the program declares (and no loaded executor vocabulary provides) is a compile
+error, not a lazy-lookup miss.
 
-Every contract, node, and value referenced in a file must be discoverable through: executor vocabulary, `contract` declarations anywhere in the program, local `let` bindings, local `node` declarations, or explicit `import`s. There are no implicit globals beyond the executor alphabet, the contract namespace, and the registry-ambient identifier namespaces noted in §5.5.
+Every contract, node, and value referenced in a file must be discoverable through: executor
+vocabulary, `contract` declarations anywhere in the program, local `let` bindings, local `node`
+declarations, or explicit `import`s. There are no implicit globals beyond the executor alphabet, the
+contract namespace, and the registry-ambient identifier namespaces noted in §5.5.
 
-The executor alphabet is ambient by design — executors are referenced with `@qualified.name` and resolve against the global registry. The contract namespace is ambient by §4.1. Everything else requires local declaration or explicit import.
+The executor alphabet is ambient by design — executors are referenced with `@qualified.name` and
+resolve against the global registry. The contract namespace is ambient by §4.1. Everything else
+requires local declaration or explicit import.
 
 ---
 
 ## 10. Execution model (reference only)
 
-This spec does not define evaluation semantics. The following concepts are introduced by the grammar and handed off to the evaluation-model spec for precise definition:
+This spec does not define evaluation semantics. The following concepts are introduced by the grammar
+and handed off to the evaluation-model spec for precise definition:
 
 - **Value production per port.** An output port produces at most one value per evaluation.
-- **Mutual exclusion on sum groups.** A sum-grouped port obeys the grammar-level property that exactly one variant fires per evaluation; the others produce no value. The runtime enforces this using metadata carried by the sum-group construct (§6.5).
-- **Conditional downstream evaluation.** A port that produces no value this evaluation does not activate its downstream consumers. Transitively, any subgraph reachable only through a non-firing edge is not evaluated.
-- **List-valued input aggregation.** A `<- [C]` port receives, at evaluation time, the list of all fired values from its incoming edges.
-- **Executor purity.** Pure executors produce deterministic outputs given their inputs; the runtime may cache or reorder their evaluation. Impure executors may fail and may exhibit nondeterminism; the runtime does not cache them. The grammar does not force impure executors to use sum groups for failure — that is an authoring choice — but the convention in the prelude registry is that impure executors declare sum-grouped outputs with an error variant (typically `ExecutorError`).
+- **Mutual exclusion on sum groups.** A sum-grouped port obeys the grammar-level property that
+  exactly one variant fires per evaluation; the others produce no value. The runtime enforces this
+  using metadata carried by the sum-group construct (§6.5).
+- **Conditional downstream evaluation.** A port that produces no value this evaluation does not
+  activate its downstream consumers. Transitively, any subgraph reachable only through a non-firing
+  edge is not evaluated.
+- **List-valued input aggregation.** A `<- [C]` port receives, at evaluation time, the list of all
+  fired values from its incoming edges.
+- **Executor purity.** Pure executors produce deterministic outputs given their inputs; the runtime
+  may cache or reorder their evaluation. Impure executors may fail and may exhibit nondeterminism;
+  the runtime does not cache them. The grammar does not force impure executors to use sum groups for
+  failure — that is an authoring choice — but the convention in the prelude registry is that impure
+  executors declare sum-grouped outputs with an error variant (typically `ExecutorError`).
 
-The evaluation-model spec also covers: topological memory, gas accounting, rewrite bounds, determinism guarantees, and the relationship between the static graph and the live frontier.
+The evaluation-model spec also covers: topological memory, gas accounting, rewrite bounds,
+determinism guarantees, and the relationship between the static graph and the live frontier.
 
 ---
 
@@ -674,22 +932,32 @@ The evaluation-model spec also covers: topological memory, gas accounting, rewri
 
 A `.wire` file type-checks iff all of the following hold:
 
-1. Every referenced contract is declared (in some executor vocabulary or in some loaded `contract` assertion).
+1. Every referenced contract is declared (in some executor vocabulary or in some loaded `contract`
+   assertion).
 2. Every `@executor { config }` application references a registered executor.
 3. Every executor config validates against the executor's registry schema.
 4. Every `node` declaration is well-formed per §6.7.
 5. Every port label-requirement is satisfied (no two ports on the same node share a port key).
-6. Every graph composition produces a well-formed graph under the arity rules: singular inputs receive at most one edge; list inputs receive zero or more.
-7. The file-return expression (if present) evaluates to a wire value — not a record, string, list, or partial node without resolvable ports.
+6. Every graph composition produces a well-formed graph under the arity rules: singular inputs
+   receive at most one edge; list inputs receive zero or more.
+7. The file-return expression (if present) evaluates to a wire value — not a record, string, list,
+   or partial node without resolvable ports.
 8. `//` and `++` are applied only to their permitted value kinds.
 
-Well-typed wires may have **open boundaries** — unconnected singular inputs are allowed and are part of the wire's importable/composable surface. An entry wire prepared for execution is a stricter category; see below.
+Well-typed wires may have **open boundaries** — unconnected singular inputs are allowed and are part
+of the wire's importable/composable surface. An entry wire prepared for execution is a stricter
+category; see below.
 
-**Evaluation-boundary check.** When a wire is prepared for execution — a step distinct from type-checking — every singular input port on its boundary must be connected to exactly one edge. The mechanism that performs this check and what it does on failure belong to the evaluation-model spec, not the grammar. A file-return wire with unconnected singular inputs is well-typed and importable; it is not ready to run until its caller supplies the missing edges.
+**Evaluation-boundary check.** When a wire is prepared for execution — a step distinct from
+type-checking — every singular input port on its boundary must be connected to exactly one edge. The
+mechanism that performs this check and what it does on failure belong to the evaluation-model spec,
+not the grammar. A file-return wire with unconnected singular inputs is well-typed and importable;
+it is not ready to run until its caller supplies the missing edges.
 
 The type-checker does **not** verify:
 
-- That executor outputs conform to their declared contracts at runtime (structural check at evaluation time).
+- That executor outputs conform to their declared contracts at runtime (structural check at
+  evaluation time).
 - That executor evaluation terminates, succeeds, or produces quality outputs.
 - That a wire's composition is semantically meaningful beyond port compatibility.
 - That the wire is runnable — that check belongs to evaluation preparation.
@@ -698,7 +966,8 @@ The type-checker does **not** verify:
 
 ## 12. Complete example
 
-A parallel-claim-branches thesis stress-test wire, exercising the core graph, config, and runtime-wrapper features:
+A parallel-claim-branches thesis stress-test wire, exercising the core graph, config, and
+runtime-wrapper features:
 
 ```wire
 # ---- contracts ----
@@ -794,41 +1063,68 @@ let thesis =
 
 #### What this exercises
 
-- **Ambient contracts.** No local `contract` declarations needed; every contract name comes from an executor vocabulary (`@llm.*`, `@artifact.*`, `@cortex.*`, prelude).
-- **Top-level declarations.** Uses `let` and `node`; no `circuit`, no meta blocks. Local `contract` declarations are omitted because executor vocabularies declare the contracts.
-- **Executor families.** `@llm.*` for agent executors, `@artifact.log` for side-effecting sink, `@cortex.report_run` for the runtime wrapper at the tail.
-- **Partial-node bases with `//` merge.** `gatherer_base` and `analyst_base` capture shared config; per-node deltas merge on top.
-- **Sum-grouped outputs.** `T | ExecutorError` on every impure node. Mutual exclusion is grammar-level.
-- **List-valued input.** `<- fragments: [AnalysisFragment]` on `merge`; `<- [ExecutorError]` on `error_sink`.
-- **Strict port matching driving all edges.** `(thesis => error_sink)` routes every `ExecutorError` boundary variant into the list-valued sink while leaving the terminal success output available for the runtime wrapper.
-- **Partial node in graph position.** The final `=> @cortex.report_run { ... }` is admissible only because the executor registry makes that partial port-determined (§5.4); composition context does not infer its signature.
-- **Node alias semantics.** The second `merge` and second `rewriter` inside `<> merge => rewriter` are the same nodes as earlier occurrences.
+- **Ambient contracts.** No local `contract` declarations needed; every contract name comes from an
+  executor vocabulary (`@llm.*`, `@artifact.*`, `@cortex.*`, prelude).
+- **Top-level declarations.** Uses `let` and `node`; no `circuit`, no meta blocks. Local `contract`
+  declarations are omitted because executor vocabularies declare the contracts.
+- **Executor families.** `@llm.*` for agent executors, `@artifact.log` for side-effecting sink,
+  `@cortex.report_run` for the runtime wrapper at the tail.
+- **Partial-node bases with `//` merge.** `gatherer_base` and `analyst_base` capture shared config;
+  per-node deltas merge on top.
+- **Sum-grouped outputs.** `T | ExecutorError` on every impure node. Mutual exclusion is
+  grammar-level.
+- **List-valued input.** `<- fragments: [AnalysisFragment]` on `merge`; `<- [ExecutorError]` on
+  `error_sink`.
+- **Strict port matching driving all edges.** `(thesis => error_sink)` routes every `ExecutorError`
+  boundary variant into the list-valued sink while leaving the terminal success output available for
+  the runtime wrapper.
+- **Partial node in graph position.** The final `=> @cortex.report_run { ... }` is admissible only
+  because the executor registry makes that partial port-determined (§5.4); composition context does
+  not infer its signature.
+- **Node alias semantics.** The second `merge` and second `rewriter` inside `<> merge => rewriter`
+  are the same nodes as earlier occurrences.
 - **File-return.** The final composition is the file-return expression, no trailing `;`.
 
 ---
 
 ## 13. Out of scope
 
-The following are intentionally deferred. Each has a known generalization path that does not invalidate existing code.
+The following are intentionally deferred. Each has a known generalization path that does not
+invalidate existing code.
 
-- **Filtered connect `=>?`** — aspect-style composition where `=>` matches only compatible ports and passes the rest through. Admissible later as an additional operator without changing existing `=>`.
+- **Filtered connect `=>?`** — aspect-style composition where `=>` matches only compatible ports and
+  passes the rest through. Admissible later as an additional operator without changing existing
+  `=>`.
 - **Refinement contracts** — `contract A :> B;` with subtyping. Deferred; flat contracts today.
-- **Universal runtime contract `Graph C`** — polymorphic runtimes that accept any graph. Deferred; runtimes today are specialized by input contract.
-- **Executor authoring in `.wire`** — extending the alphabet from within Wire. Deferred; executors are globally registered externally.
-- **First-class functions / lambdas** — user-defined parameterized wire templates. Deferred; reuse today is via partial nodes + `//`.
-- **Zero-port wires** — nodes or wires with no ports at all. Deferred; Wire requires every node to have at least one port.
-- **Sum groups at input positions** — input ports are singular or list-valued; `|` is output-only. Admissible later.
-- **`->` as graph operator** — removed from the canonical grammar. It was a singleton-chain specialization of `=>` with zero additional expressiveness and a visual collision with the `->` output-port marker. `=>` covers every connect case. If a compelling ergonomic case emerges later, reintroducing `->` is additive and non-breaking.
-- **Port projection and internal addressing** — `wire.node.port` reaching into wire internals. Rejected by design; violates boundary sealing.
-- **Multiple built-in type constructors** — `Result`, `Option`, `List` as type constructors. Rejected; failure is topology (via sum groups), fan-in is `[C]` at input ports.
-- **Evaluation model spec** — gas accounting, topological memory, rewrite bounds, determinism guarantees. Deferred to a sibling doc.
-- **Typo backstop for pure wire-side contracts** — contracts declared only in wire files and never touching an executor port have no static check beyond name equality. Revisit if it bites.
+- **Universal runtime contract `Graph C`** — polymorphic runtimes that accept any graph. Deferred;
+  runtimes today are specialized by input contract.
+- **Executor authoring in `.wire`** — extending the alphabet from within Wire. Deferred; executors
+  are globally registered externally.
+- **First-class functions / lambdas** — user-defined parameterized wire templates. Deferred; reuse
+  today is via partial nodes + `//`.
+- **Zero-port wires** — nodes or wires with no ports at all. Deferred; Wire requires every node to
+  have at least one port.
+- **Sum groups at input positions** — input ports are singular or list-valued; `|` is output-only.
+  Admissible later.
+- **`->` as graph operator** — removed from the canonical grammar. It was a singleton-chain
+  specialization of `=>` with zero additional expressiveness and a visual collision with the `->`
+  output-port marker. `=>` covers every connect case. If a compelling ergonomic case emerges later,
+  reintroducing `->` is additive and non-breaking.
+- **Port projection and internal addressing** — `wire.node.port` reaching into wire internals.
+  Rejected by design; violates boundary sealing.
+- **Multiple built-in type constructors** — `Result`, `Option`, `List` as type constructors.
+  Rejected; failure is topology (via sum groups), fan-in is `[C]` at input ports.
+- **Evaluation model spec** — gas accounting, topological memory, rewrite bounds, determinism
+  guarantees. Deferred to a sibling doc.
+- **Typo backstop for pure wire-side contracts** — contracts declared only in wire files and never
+  touching an executor port have no static check beyond name equality. Revisit if it bites.
 
 ---
 
 ## 14. Grammar summary (stratified EBNF)
 
-Precedence is encoded in the grammar's stratification. The normative grammar is the prose of sections 2–9; this EBNF is a reference for implementers.
+Precedence is encoded in the grammar's stratification. The normative grammar is the prose of
+sections 2–9; this EBNF is a reference for implementers.
 
 ### 14.1 Top-level
 
@@ -878,7 +1174,9 @@ label             ::= identifier
 
 ### 14.3 Expressions (stratified by precedence)
 
-Wire has two value kinds sharing an expression namespace. Disambiguation between graph-expression and value-expression readings is **semantic, not syntactic**: the same `expr` production parses both, and type information determines which operators apply.
+Wire has two value kinds sharing an expression namespace. Disambiguation between graph-expression
+and value-expression readings is **semantic, not syntactic**: the same `expr` production parses
+both, and type information determines which operators apply.
 
 ```
 expr              ::= expr_overlay
@@ -936,24 +1234,49 @@ ident_list        ::= identifier { "," identifier } [ "," ]
 
 Notes on ambiguity:
 
-- `partial_expr` (with `@`) can appear in graph-expression or value-expression position; disambiguation is semantic.
-- `constructor_expr` (without `@`) is a plain qualified identifier followed by a record — used for config-value constructors like `topological { preset = "..." }`. It is a value-expression form only; it cannot appear in graph-expression position.
-- `paren_or_tuple` is the empty wire `()` with no contents, ordinary parenthesization with one expression, and a tuple with two or more comma-separated expressions. Single-element `(a,)` is not admitted; use `a` for parenthesization or two-or-more elements for a tuple. In graph-expression position, a tuple overlays its elements; in value-expression position, tuples are not first-class and the form is invalid.
+- `partial_expr` (with `@`) can appear in graph-expression or value-expression position;
+  disambiguation is semantic.
+- `constructor_expr` (without `@`) is a plain qualified identifier followed by a record — used for
+  config-value constructors like `topological { preset = "..." }`. It is a value-expression form
+  only; it cannot appear in graph-expression position.
+- `paren_or_tuple` is the empty wire `()` with no contents, ordinary parenthesization with one
+  expression, and a tuple with two or more comma-separated expressions. Single-element `(a,)` is not
+  admitted; use `a` for parenthesization or two-or-more elements for a tuple. In graph-expression
+  position, a tuple overlays its elements; in value-expression position, tuples are not first-class
+  and the form is invalid.
 
 ---
 
 ## Appendix A — design principles
 
-1. **Wires compose into wires.** The class of wire values is closed under graph operators. Records, strings, and lists have their own closed algebras. The two layers do not mix.
-2. **One rule per mechanism.** One composition primitive (`<>`), one connect (`=>`), one record merge (`//`), one concatenation (`++`), one sum-group constructor (`|`), one executor application (`@name { ... }`). No path-chain sugar: `=>` covers every linear case; `->` is reserved for output-port declarations only.
-3. **Closed alphabets, open composition.** Executors and contracts are the closed inputs; composition is open-ended. The LLM rewriter's action space is `(alphabet, composition) → wire`, which is inspectable.
-4. **Ambient namespaces where global by nature.** Executors are globally registered; contracts are globally named. Everything else (nodes, `let`-values) is local and explicit.
-5. **Labels are semantic.** A labeled port connects only to an identically-labeled partner; unlabeled ports connect only to unlabeled partners. Authoring a label is a commitment to label-routed matching, not a cosmetic annotation. §6.2 for the rule, §7.1 for its role in `=>`.
-6. **Local reasoning over global inference.** Partial-node admissibility in graph position depends only on the partial and the executor registry, not on the enclosing expression. Port-polymorphic executors require explicit `node` declarations. The grammar has no whole-expression constraint solver.
-7. **Strict where it matters, permissive where it doesn't.** Port contracts (and labels) are strictly matched. Config records are shallowly merged right-biased. Ports are unordered sets. Empty wire is identity.
-8. **Grammar-level what, runtime-level how.** The grammar specifies composition. The runtime specifies evaluation. Mutual-exclusion pruning, gas, memory, rewrite bounds, and runnability checks all live downstream of the grammar and leave it small.
-9. **Defer generalizations until pressure.** Filtered connect, refinement, universal graph contracts, lambdas, bootstrap wires — all admissible later. None required today. The current grammar ships the minimum that expresses the current production wires cleanly.
+1. **Wires compose into wires.** The class of wire values is closed under graph operators. Records,
+   strings, and lists have their own closed algebras. The two layers do not mix.
+2. **One rule per mechanism.** One composition primitive (`<>`), one connect (`=>`), one record
+   merge (`//`), one concatenation (`++`), one sum-group constructor (`|`), one executor application
+   (`@name { ... }`). No path-chain sugar: `=>` covers every linear case; `->` is reserved for
+   output-port declarations only.
+3. **Closed alphabets, open composition.** Executors and contracts are the closed inputs;
+   composition is open-ended. The LLM rewriter's action space is `(alphabet, composition) → wire`,
+   which is inspectable.
+4. **Ambient namespaces where global by nature.** Executors are globally registered; contracts are
+   globally named. Everything else (nodes, `let`-values) is local and explicit.
+5. **Labels are semantic.** A labeled port connects only to an identically-labeled partner;
+   unlabeled ports connect only to unlabeled partners. Authoring a label is a commitment to
+   label-routed matching, not a cosmetic annotation. §6.2 for the rule, §7.1 for its role in `=>`.
+6. **Local reasoning over global inference.** Partial-node admissibility in graph position depends
+   only on the partial and the executor registry, not on the enclosing expression. Port-polymorphic
+   executors require explicit `node` declarations. The grammar has no whole-expression constraint
+   solver.
+7. **Strict where it matters, permissive where it doesn't.** Port contracts (and labels) are
+   strictly matched. Config records are shallowly merged right-biased. Ports are unordered sets.
+   Empty wire is identity.
+8. **Grammar-level what, runtime-level how.** The grammar specifies composition. The runtime
+   specifies evaluation. Mutual-exclusion pruning, gas, memory, rewrite bounds, and runnability
+   checks all live downstream of the grammar and leave it small.
+9. **Defer generalizations until pressure.** Filtered connect, refinement, universal graph
+   contracts, lambdas, bootstrap wires — all admissible later. None required today. The current
+   grammar ships the minimum that expresses the current production wires cleanly.
 
 ---
 
-*End of specification.*
+_End of specification._

--- a/docs/Reference/Wire/index.md
+++ b/docs/Reference/Wire/index.md
@@ -1,6 +1,8 @@
 ---
 title: Wire Language Reference
-description: Normative reference for the Wire source language. Grammar, module model, ports and matching, partials and evaluation boundary.
+description:
+  Normative reference for the Wire source language. Grammar, module model, ports and matching,
+  partials and evaluation boundary.
 sidebar:
   label: Wire
   order: 1
@@ -8,22 +10,34 @@ sidebar:
 
 # Wire Language Reference
 
-The Wire language reference is organized into a normative grammar specification plus four topic-focused pages that factor out specific rule areas for quick consultation.
+The Wire language reference is organized into a normative grammar specification plus four
+topic-focused pages that factor out specific rule areas for quick consultation.
 
 ## Contents
 
-- **[grammar.md](grammar.md)** — the normative grammar specification. The authoritative document; other pages in this directory point into its sections.
-- **[modules-imports-and-file-returns.md](modules-imports-and-file-returns.md)** — module model, `import` semantics, file-return expressions, declaration-only files. Corresponds to grammar §9.
-- **[contracts-ports-and-matching.md](contracts-ports-and-matching.md)** — contract namespace, port declarations, sum groups, labels, `=>` port-key matching. Corresponds to grammar §4, §6.2–§6.5, §7.1, §7.6.
-- **[partials-and-execution-boundary.md](partials-and-execution-boundary.md)** — partial nodes in graph position, port-determined rule, evaluation-boundary check. Corresponds to grammar §5.4, §11.
-- **[executors-and-alphabet.md](executors-and-alphabet.md)** — executor registration, `@`-application, config merge, ambient identifiers in config values. Corresponds to grammar §5.1, §5.2, §5.3, §5.5.
+- **[grammar.md](grammar.md)** — the normative grammar specification. The authoritative document;
+  other pages in this directory point into its sections.
+- **[modules-imports-and-file-returns.md](modules-imports-and-file-returns.md)** — module model,
+  `import` semantics, file-return expressions, declaration-only files. Corresponds to grammar §9.
+- **[contracts-ports-and-matching.md](contracts-ports-and-matching.md)** — contract namespace, port
+  declarations, sum groups, labels, `=>` port-key matching. Corresponds to grammar §4, §6.2–§6.5,
+  §7.1, §7.6.
+- **[partials-and-execution-boundary.md](partials-and-execution-boundary.md)** — partial nodes in
+  graph position, port-determined rule, evaluation-boundary check. Corresponds to grammar §5.4, §11.
+- **[executors-and-alphabet.md](executors-and-alphabet.md)** — executor registration,
+  `@`-application, config merge, ambient identifiers in config values. Corresponds to grammar §5.1,
+  §5.2, §5.3, §5.5.
 
-The rewrite algebra, admission, and materialization — a runtime concern — are in the separate [Rewrites reference](../rewrites.md).
+The rewrite algebra, admission, and materialization — a runtime concern — are in the separate
+[Rewrites reference](../rewrites.md).
 
-The grammar spec is self-contained. The four topic pages exist to give readers a shorter, scope-limited entry point when they are looking for specific rules without wanting to read the whole spec.
+The grammar spec is self-contained. The four topic pages exist to give readers a shorter,
+scope-limited entry point when they are looking for specific rules without wanting to read the whole
+spec.
 
 ## Related
 
-- [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) — Wire substrate architecture.
+- [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) — Wire substrate
+  architecture.
 - [../terminology.md](../terminology.md) — accepted Wire terminology.
 - [../../Research-notes/Wire/](../../Research-notes/Wire/) — dated design notes and synthesis.

--- a/docs/Reference/Wire/modules-imports-and-file-returns.md
+++ b/docs/Reference/Wire/modules-imports-and-file-returns.md
@@ -1,6 +1,8 @@
 ---
 title: "Wire Reference — Modules, Imports, and File Returns"
-description: Scoped reference for the Wire module model. File structure, import forms, file-return expressions, declaration-only files.
+description:
+  Scoped reference for the Wire module model. File structure, import forms, file-return expressions,
+  declaration-only files.
 sidebar:
   label: Modules and imports
   order: 2
@@ -13,28 +15,38 @@ related:
 
 # Wire Reference — Modules, Imports, and File Returns
 
-> **Stub.** This page is a scoped entry point into the module-model rules in [grammar.md](grammar.md). Until it is fleshed out, jump directly to the grammar sections below.
+> **Stub.** This page is a scoped entry point into the module-model rules in
+> [grammar.md](grammar.md). Until it is fleshed out, jump directly to the grammar sections below.
 
-> **Implementation warning.** Current compiler behavior parses `contract X;` but
-> does not use it to populate registry membership. With an explicit
-> `WireContractRegistry`, only Haskell-registered contracts are enforced. Track
-> alignment in [GitHub #50](https://github.com/Digimuoto/cortex/issues/50).
+> **Implementation warning.** Current compiler behavior parses `contract X;` but does not use it to
+> populate registry membership. With an explicit `WireContractRegistry`, only Haskell-registered
+> contracts are enforced. The reference grammar names the intended contract-assertion semantics; the
+> compiler path still has a narrower registry-backed implementation.
 
 ## Where the rules live
 
-- **[§9 Top-level forms](grammar.md#9-top-level-forms)** — the whole module model: `contract`, `node`, `let`, `import`, file-return expression, wire files vs declaration-only files, closed composition with open vocabulary.
-- **[§9.4 `import`](grammar.md#94-import)** — import forms, what enters local scope, `let`-aliasing pattern for node exports, ambient contract side effects.
-- **[§9.5 File-return expression](grammar.md#95-file-return-expression)** — last-expression semantics, what makes a file a wire file.
-- **[§9.6 Wire files and declaration-only files](grammar.md#96-wire-files-and-declaration-only-files)** — what declaration-only files contribute.
-- **[§9.7 Closed composition, open vocabulary](grammar.md#97-closed-composition-open-vocabulary)** — the compilation-unit definition: program = root file + transitive imports.
+- **[§9 Top-level forms](grammar.md#9-top-level-forms)** — the whole module model: `contract`,
+  `node`, `let`, `import`, file-return expression, wire files vs declaration-only files, closed
+  composition with open vocabulary.
+- **[§9.4 `import`](grammar.md#94-import)** — import forms, what enters local scope, `let`-aliasing
+  pattern for node exports, ambient contract side effects.
+- **[§9.5 File-return expression](grammar.md#95-file-return-expression)** — last-expression
+  semantics, what makes a file a wire file.
+- **[§9.6 Wire files and declaration-only files](grammar.md#96-wire-files-and-declaration-only-files)**
+  — what declaration-only files contribute.
+- **[§9.7 Closed composition, open vocabulary](grammar.md#97-closed-composition-open-vocabulary)** —
+  the compilation-unit definition: program = root file + transitive imports.
 
 ## Summary of the rules
 
-- A `.wire` file is a sequence of top-level forms (`contract`, `node`, `let`, `import`), optionally terminated by a file-return expression without trailing `;`.
+- A `.wire` file is a sequence of top-level forms (`contract`, `node`, `let`, `import`), optionally
+  terminated by a file-return expression without trailing `;`.
 - `import name from "path";` brings the file's return value into scope as `name`.
 - `import { x, y } from "path";` brings explicit `let` bindings into scope.
-- Only `let` bindings are importable. `node` declarations are exposed across files by `let`-aliasing.
-- Contract declarations are ambient — loading a file registers its `contract X;` assertions globally.
+- Only `let` bindings are importable. `node` declarations are exposed across files by
+  `let`-aliasing.
+- Contract declarations are ambient — loading a file registers its `contract X;` assertions
+  globally.
 - The program is the root file plus the transitive closure of its imports.
 
 See the grammar for the full definitions.

--- a/docs/Reference/Wire/partials-and-execution-boundary.md
+++ b/docs/Reference/Wire/partials-and-execution-boundary.md
@@ -1,6 +1,8 @@
 ---
 title: "Wire Reference — Partials and Execution Boundary"
-description: Scoped reference for partial nodes in graph position, the port-determined rule, and the evaluation-boundary check.
+description:
+  Scoped reference for partial nodes in graph position, the port-determined rule, and the
+  evaluation-boundary check.
 sidebar:
   label: Partials and execution
   order: 4
@@ -15,23 +17,39 @@ related:
 
 # Wire Reference — Partials and Execution Boundary
 
-> **Stub.** This page is a scoped entry point into the partial-node and execution-boundary rules in [grammar.md](grammar.md). Until it is fleshed out, jump directly to the grammar sections below.
+> **Stub.** This page is a scoped entry point into the partial-node and execution-boundary rules in
+> [grammar.md](grammar.md). Until it is fleshed out, jump directly to the grammar sections below.
 
 ## Where the rules live
 
-- **[§5.4 Partial nodes in graph position](grammar.md#54-partial-nodes-in-graph-position)** — the **port-determined rule**. Whether a partial may appear in graph position depends only on the partial and the registry; no whole-expression inference.
-- **[§11 Type-checking summary](grammar.md#11-type-checking-summary)** — well-formedness checks; evaluation-boundary check for runnable wires.
+- **[§5.4 Partial nodes in graph position](grammar.md#54-partial-nodes-in-graph-position)** — the
+  **port-determined rule**. Whether a partial may appear in graph position depends only on the
+  partial and the registry; no whole-expression inference.
+- **[§11 Type-checking summary](grammar.md#11-type-checking-summary)** — well-formedness checks;
+  evaluation-boundary check for runnable wires.
 
-For the `//`-on-partials rule (`base // { delta }` producing a new partial), see **[§5.3 Config merge on partial nodes](grammar.md#53-config-merge-on-partial-nodes)**, covered in the [Executors and the alphabet](./executors-and-alphabet.md) stub.
+For the `//`-on-partials rule (`base // { delta }` producing a new partial), see
+**[§5.3 Config merge on partial nodes](grammar.md#53-config-merge-on-partial-nodes)**, covered in
+the [Executors and the alphabet](./executors-and-alphabet.md) stub.
 
-Executor registration, application, and config-merge rules are covered separately in [Executors and the alphabet](./executors-and-alphabet.md). The rewrite algebra, admission, and materialization — the runtime-side picture — are in the [Rewrites reference](../rewrites.md); this page does not restate them.
+Executor registration, application, and config-merge rules are covered separately in
+[Executors and the alphabet](./executors-and-alphabet.md). The rewrite algebra, admission, and
+materialization — the runtime-side picture — are in the [Rewrites reference](../rewrites.md); this
+page does not restate them.
 
 ## Summary of the rules
 
-- A **partial node** `@executor { config }` is a staged value with no ports pinned. Mergeable with `//`, pinnable via a `node` declaration.
-- A partial may appear in graph position **iff its executor is port-determined** — its structural constraints uniquely pin its port signature from config alone. Port-polymorphic executors must be pinned via `node` declaration first.
-- The rule is **local**: admissibility depends only on the partial and the registry, not on the enclosing expression tree.
-- **Well-typed wires may have open boundaries.** An unconnected singular input is permitted on any well-typed wire.
-- The **evaluation-boundary check** is stricter: a wire prepared for execution must have every singular input connected exactly once. This check runs at evaluation-preparation, not at compile time.
+- A **partial node** `@executor { config }` is a staged value with no ports pinned. Mergeable with
+  `//`, pinnable via a `node` declaration.
+- A partial may appear in graph position **iff its executor is port-determined** — its structural
+  constraints uniquely pin its port signature from config alone. Port-polymorphic executors must be
+  pinned via `node` declaration first.
+- The rule is **local**: admissibility depends only on the partial and the registry, not on the
+  enclosing expression tree.
+- **Well-typed wires may have open boundaries.** An unconnected singular input is permitted on any
+  well-typed wire.
+- The **evaluation-boundary check** is stricter: a wire prepared for execution must have every
+  singular input connected exactly once. This check runs at evaluation-preparation, not at compile
+  time.
 
 See the grammar for the full definitions.

--- a/docs/Reference/development.md
+++ b/docs/Reference/development.md
@@ -1,6 +1,7 @@
 ---
 title: Cortex Development Workflow
-description: Build, test, formatting, docs, theory, and local validation commands for Cortex contributors.
+description:
+  Build, test, formatting, docs, theory, and local validation commands for Cortex contributors.
 sidebar:
   label: Development
   order: 4
@@ -8,9 +9,8 @@ sidebar:
 
 # Cortex Development Workflow
 
-Cortex builds through Nix and the repo `justfile`. Use these surfaces rather
-than running `cabal` or `ghc` directly; they match CI and keep generated plans,
-formatters, and toolchains aligned.
+Cortex builds through Nix and the repo `justfile`. Use these surfaces rather than running `cabal` or
+`ghc` directly; they match CI and keep generated plans, formatters, and toolchains aligned.
 
 ## Prerequisites
 
@@ -23,49 +23,46 @@ nix develop
 
 ## Core Commands
 
-| Command | Purpose |
-|---|---|
-| `just build` | Build the Cortex library (`nix build .#cortex`). |
+| Command            | Purpose                                                  |
+| ------------------ | -------------------------------------------------------- |
+| `just build`       | Build the Cortex library (`nix build .#cortex`).         |
 | `just build-pulse` | Build the Pulse executable (`nix build .#cortex-pulse`). |
-| `just test` | Run the Cortex Haskell test suite. |
-| `just fmt` | Apply repo formatters. |
-| `just fmt-check` | Fail on formatter drift. |
-| `just lint` | Run HLint over Haskell sources. |
-| `just check` | Run `nix flake check`. |
-| `just ci-check` | Run the CI-aligned local check suite. |
+| `just test`        | Run the Cortex Haskell test suite.                       |
+| `just fmt`         | Apply repo formatters.                                   |
+| `just fmt-check`   | Fail on formatter drift.                                 |
+| `just lint`        | Run HLint over Haskell sources.                          |
+| `just check`       | Run `nix flake check`.                                   |
+| `just ci-check`    | Run the CI-aligned local check suite.                    |
 
 ## Documentation
 
-| Command | Purpose |
-|---|---|
-| `just docs-build` / `nix build .#docs-site` | Build the static documentation site. |
-| `just docs-check` | Validate docs by building the site. |
-| `just docs-dev` / `nix run .#docs-dev` | Run the docs development server. |
+| Command                                        | Purpose                                 |
+| ---------------------------------------------- | --------------------------------------- |
+| `just docs-build` / `nix build .#docs-site`    | Build the static documentation site.    |
+| `just docs-check`                              | Validate docs by building the site.     |
+| `just docs-dev` / `nix run .#docs-dev`         | Run the docs development server.        |
 | `just docs-preview` / `nix run .#docs-preview` | Build and preview the static docs site. |
 
-The published docs are built from `docs/` by the GitHub Pages workflow. Keep
-README prose brief and move detailed build, reference, and architecture material
-into this documentation tree.
+The published docs are built from `docs/` by the GitHub Pages workflow. Keep README prose brief and
+move detailed build, reference, and architecture material into this documentation tree.
 
 ## Issues And Pull Requests
 
-Cortex uses GitHub Issues for active work tracking. Use issues for bugs,
-implementation scopes, roadmap slices, and follow-up work. Pull requests
-should link the issue they complete with `Closes #<number>` when the scope
-has a tracker.
+Cortex uses GitHub Issues for active work tracking. Use issues for bugs, implementation scopes,
+roadmap slices, and follow-up work. Pull requests should link the issue they complete with
+`Closes #<number>` when the scope has a tracker.
 
-Do not use Linear or a downstream product tracker as active Cortex planning
-state. Historical docs may retain external issue IDs when they explain past
-migration context, but new Cortex work belongs in this repository's GitHub
-issue system.
+Do not use Linear or a downstream product tracker as active Cortex planning state. Historical docs
+may retain external issue IDs when they explain past migration context, but new Cortex work belongs
+in this repository's GitHub issue system.
 
 ## Lean Theory
 
-| Command | Purpose |
-|---|---|
-| `just lean-build` | Build the Lean proof tree with Lake. |
+| Command           | Purpose                                               |
+| ----------------- | ----------------------------------------------------- |
+| `just lean-build` | Build the Lean proof tree with Lake.                  |
 | `just lean-check` | Run the Nix-backed theory check used by hooks and CI. |
-| `just lean-run` | Build and run the theory smoke executable. |
+| `just lean-run`   | Build and run the theory smoke executable.            |
 
 ## Generated Plans And Agent Links
 
@@ -75,8 +72,8 @@ If Cabal inputs change, regenerate the materialized Haskell plan:
 just update-materialized
 ```
 
-Repo-local agent context lives under `agents/`. Provider files such as
-`AGENTS.md` and `CLAUDE.md` are generated, gitignored symlinks:
+Repo-local agent context lives under `agents/`. Provider files such as `AGENTS.md` and `CLAUDE.md`
+are generated, gitignored symlinks:
 
 ```bash
 just agent-link-codex
@@ -87,9 +84,8 @@ just agent-link-claude
 
 Run the checks relevant to the change:
 
-- Haskell or Nix changes: `just fmt-check`, `just lint`, `just test`, and
-  `just check` as appropriate.
+- Haskell or Nix changes: `just fmt-check`, `just lint`, `just test`, and `just check` as
+  appropriate.
 - Docs changes: `just docs-check`.
 - Theory changes: `just lean-check`.
-- Commits must be signed and verifiable; see the repository
-  `CONTRIBUTING.md`.
+- Commits must be signed and verifiable; see the repository `CONTRIBUTING.md`.

--- a/docs/Reference/index.md
+++ b/docs/Reference/index.md
@@ -8,26 +8,38 @@ sidebar:
 
 # Cortex Reference
 
-Consultable material. Designed to be jumped into for a specific rule or
-workflow rather than read front-to-back.
+Consultable material. Designed to be jumped into for a specific rule or workflow rather than read
+front-to-back.
 
 ## Contents
 
-- **[terminology.md](terminology.md)** — accepted Wire and Cortex terms. Canonical definitions; the source of truth for vocabulary.
+- **[terminology.md](terminology.md)** — accepted Wire and Cortex terms. Canonical definitions; the
+  source of truth for vocabulary.
 - **[Wire/](Wire/)** — Wire language reference:
   - **[grammar.md](Wire/grammar.md)** — normative grammar specification.
-  - **[modules-imports-and-file-returns.md](Wire/modules-imports-and-file-returns.md)** — module model, import semantics, file-return rules.
-  - **[contracts-ports-and-matching.md](Wire/contracts-ports-and-matching.md)** — contract namespace, port declarations, `=>` port-key matching.
-  - **[partials-and-execution-boundary.md](Wire/partials-and-execution-boundary.md)** — partial nodes in graph position, port-determined rule, evaluation-boundary check.
-  - **[executors-and-alphabet.md](Wire/executors-and-alphabet.md)** — executor registration, `@`-application, config merge, ambient identifiers in config values.
-- **[rewrites.md](rewrites.md)** — bounded dynamic rewrite algebra, budget, admission, materialization, hydration, provenance.
-- **[development.md](development.md)** — build, test, formatting, docs, theory, and local validation commands.
+  - **[modules-imports-and-file-returns.md](Wire/modules-imports-and-file-returns.md)** — module
+    model, import semantics, file-return rules.
+  - **[contracts-ports-and-matching.md](Wire/contracts-ports-and-matching.md)** — contract
+    namespace, port declarations, `=>` port-key matching.
+  - **[partials-and-execution-boundary.md](Wire/partials-and-execution-boundary.md)** — partial
+    nodes in graph position, port-determined rule, evaluation-boundary check.
+  - **[executors-and-alphabet.md](Wire/executors-and-alphabet.md)** — executor registration,
+    `@`-application, config merge, ambient identifiers in config values.
+- **[rewrites.md](rewrites.md)** — bounded dynamic rewrite algebra, budget, admission,
+  materialization, hydration, provenance.
+- **[development.md](development.md)** — build, test, formatting, docs, theory, and local validation
+  commands.
 - **[Pulse/](Pulse/)** — Pulse runtime reference:
-  - **[schema.md](Pulse/schema.md)** — DB enums, task definitions, runs, checkpoints, stage log, stage attempt log.
-  - **[types.md](Pulse/types.md)** — task envelope, checkpoint envelope, stage plan, retry policy, memory strategy.
-  - **[service-api.md](Pulse/service-api.md)** — HTTP endpoints, authentication, idempotency, cancellation, error taxonomy.
+  - **[schema.md](Pulse/schema.md)** — DB enums, task definitions, runs, checkpoints, stage log,
+    stage attempt log.
+  - **[types.md](Pulse/types.md)** — task envelope, checkpoint envelope, stage plan, retry policy,
+    memory strategy.
+  - **[service-api.md](Pulse/service-api.md)** — HTTP endpoints, authentication, idempotency,
+    cancellation, error taxonomy.
 
-Architecture chapters (`../Architecture/`) explain why the rules are what they are. References state the rules. The architecture book quotes the references for precision; the references quote the architecture book for context.
+Architecture chapters (`../Architecture/`) explain why the rules are what they are. References state
+the rules. The architecture book quotes the references for precision; the references quote the
+architecture book for context.
 
 ## Related
 

--- a/docs/Reference/rewrites.md
+++ b/docs/Reference/rewrites.md
@@ -1,6 +1,8 @@
 ---
 title: "Rewrites Reference"
-description: "Normative reference for bounded dynamic graph rewrites: algebra, budget, admission, materialization, hydration, provenance."
+description:
+  "Normative reference for bounded dynamic graph rewrites: algebra, budget, admission,
+  materialization, hydration, provenance."
 sidebar:
   label: "Rewrites"
   order: 30
@@ -14,11 +16,19 @@ related:
 
 # Rewrites Reference
 
-Pulse admits bounded structural edits to a live Circuit through a closed algebra, metered in gas, validated at admission, materialized into durable state with explicit provenance. This reference states the normative surface. Architectural framing — why the algebra is narrow, why gas is structural, why authorship is split — lives in [chapter 07](../Architecture/07-rewrites-and-materialization.md).
+Pulse admits bounded structural edits to a live Circuit through a closed algebra, metered in gas,
+validated at admission, materialized into durable state with explicit provenance. This reference
+states the normative surface. Architectural framing — why the algebra is narrow, why gas is
+structural, why authorship is split — lives in
+[chapter 07](../Architecture/07-rewrites-and-materialization.md).
 
 ## Scope
 
-This reference covers the rewrite **algebra**, the **budget** that meters it, the **admission** checks that gate it, the **materialization** contract that commits it, the **hydration** rules that bind rewritten nodes back to runtime actions, and the **structural provenance** persisted per rewrite. Value provenance (where a specific value flowing on an edge came from) is out of scope and is specified in chapter 08.
+This reference covers the rewrite **algebra**, the **budget** that meters it, the **admission**
+checks that gate it, the **materialization** contract that commits it, the **hydration** rules that
+bind rewritten nodes back to runtime actions, and the **structural provenance** persisted per
+rewrite. Value provenance (where a specific value flowing on an edge came from) is out of scope and
+is specified in chapter 08.
 
 ## 1. Algebra
 
@@ -34,10 +44,16 @@ data ExpansionMode
   | ExpandRetainNodeAsEnvelope
 ```
 
-- **`ExpandNode anchor mode spec`** — replace the anchor node with the subgraph. With `ExpandReplaceNode`, the anchor disappears; inbound and outbound edges reattach to the subgraph's entry and exit sets. With `ExpandRetainNodeAsEnvelope`, the anchor persists as the envelope around the fragment and its output is available to the inserted entry nodes on resume (see §5.1).
-- **`AppendAfter anchor spec`** — insert the subgraph downstream of the anchor. The anchor keeps its identity and outbound edges; the subgraph's entry set connects behind the anchor, its exit set continues downstream.
+- **`ExpandNode anchor mode spec`** — replace the anchor node with the subgraph. With
+  `ExpandReplaceNode`, the anchor disappears; inbound and outbound edges reattach to the subgraph's
+  entry and exit sets. With `ExpandRetainNodeAsEnvelope`, the anchor persists as the envelope around
+  the fragment and its output is available to the inserted entry nodes on resume (see §5.1).
+- **`AppendAfter anchor spec`** — insert the subgraph downstream of the anchor. The anchor keeps its
+  identity and outbound edges; the subgraph's entry set connects behind the anchor, its exit set
+  continues downstream.
 
-No other constructors are admitted in v1. Proposals using unrecognized forms are rejected as `invalid_rewrite`.
+No other constructors are admitted in v1. Proposals using unrecognized forms are rejected as
+`invalid_rewrite`.
 
 ### 1.2 `SubgraphSpec`
 
@@ -48,13 +64,18 @@ A `SubgraphSpec` is a self-contained fragment carrying:
 - an explicit **entry set** where inbound edges attach,
 - an explicit **exit set** where outbound edges continue.
 
-Validation rejects missing definitions, orphan nodes, definitions outside the fragment, and any cycle in the resulting materialized graph.
+Validation rejects missing definitions, orphan nodes, definitions outside the fragment, and any
+cycle in the resulting materialized graph.
 
-New node ids inside a spec are deterministic and namespaced by their parent anchor (for example `planner:repair_branch_1:step_1`). Deterministic namespacing is required so identity is stable across replay.
+New node ids inside a spec are deterministic and namespaced by their parent anchor (for example
+`planner:repair_branch_1:step_1`). Deterministic namespacing is required so identity is stable
+across replay.
 
 ### 1.3 Deferred forms
 
-The following constructors are recognized future forms but **not part of the admitted alphabet in v1**: `InsertBefore`, `PruneSubgraph`, `AddJoin`, `ReplaceNode`. Introducing any of them requires a new ADR and a runtime-version bump.
+The following constructors are recognized future forms but **not part of the admitted alphabet in
+v1**: `InsertBefore`, `PruneSubgraph`, `AddJoin`, `ReplaceNode`. Introducing any of them requires a
+new ADR and a runtime-version bump.
 
 ## 2. Stage-result extension
 
@@ -67,9 +88,13 @@ data StageResult
   | StageRewrite  Aeson.Value GraphRewrite
 ```
 
-`StageRewrite` carries **both** the stage's durable output and the proposed edit. Retained or appended subgraphs whose entry nodes depend on that output read it from the retained anchor on resume (see §5.1). Producing a rewrite is therefore "output *and* rewrite," never "output *or* rewrite."
+`StageRewrite` carries **both** the stage's durable output and the proposed edit. Retained or
+appended subgraphs whose entry nodes depend on that output read it from the retained anchor on
+resume (see §5.1). Producing a rewrite is therefore "output _and_ rewrite," never "output _or_
+rewrite."
 
-A stage cannot both suspend and rewrite in a single outcome; the type makes this exclusive by construction.
+A stage cannot both suspend and rewrite in a single outcome; the type makes this exclusive by
+construction.
 
 ## 3. Budget
 
@@ -85,7 +110,8 @@ data RewriteBudget = RewriteBudget
   }
 ```
 
-Gas is **structural-change only** in v1. Semantic weighting (latency, cost class, effect class) is not part of the budget and is deferred to a future ADR.
+Gas is **structural-change only** in v1. Semantic weighting (latency, cost class, effect class) is
+not part of the budget and is deferred to a future ADR.
 
 ### 3.2 `RewriteCost`
 
@@ -97,11 +123,14 @@ Each admitted rewrite consumes a `RewriteCost` computed **statically** from its 
 - `frontierDelta` — peak frontier-breadth increase attributable to the fragment.
 - `ops` — 1 per admitted rewrite.
 
-Admission draws only against remaining budget on every dimension. A proposal whose cost exceeds any dimension is rejected with `rewrite_budget_exceeded`; no partial consumption.
+Admission draws only against remaining budget on every dimension. A proposal whose cost exceeds any
+dimension is rejected with `rewrite_budget_exceeded`; no partial consumption.
 
 ### 3.3 Budget visibility
 
-Remaining budget is persisted in graph state and surfaced on operator surfaces (run detail, rewrite history). Each admitted rewrite records budget-before and budget-after snapshots so operators can identify which rewrite exhausted which dimension.
+Remaining budget is persisted in graph state and surfaced on operator surfaces (run detail, rewrite
+history). Each admitted rewrite records budget-before and budget-after snapshots so operators can
+identify which rewrite exhausted which dimension.
 
 ## 4. Admission
 
@@ -109,33 +138,48 @@ Admission is the runtime's gate. A proposal is admitted only when **every** chec
 
 ### 4.1 Checks
 
-1. **Vocabulary bounds.** Every node instance in the spec references a registered executor; every port contract is a registered `ContractId`. No executors or contracts outside the closed alphabet.
-2. **Endpoint compatibility.** Every new edge connects ports whose contracts are compatible under the port-semantic rules of [chapter 05](../Architecture/05-wire-language.md). Singular and list-valued inputs obey the same arity rules at the rewrite boundary as at compile time.
-3. **Topology validity.** The post-application materialized graph remains a DAG. The anchor exists in the current topology and definition map. Entry and exit sets are non-empty where the rewrite form requires them. No orphans, no dangling references.
-4. **Resource bounds.** Estimated `RewriteCost` fits within the remaining budget on every dimension (§3.2).
-5. **Runtime policy.** The anchor, the run, and the task type permit rewrites of this form. Planner nodes may be restricted to a subset of the algebra; the policy is consulted per proposal.
+1. **Vocabulary bounds.** Every node instance in the spec references a registered executor; every
+   port contract is a registered `ContractId`. No executors or contracts outside the closed
+   alphabet.
+2. **Endpoint compatibility.** Every new edge connects ports whose contracts are compatible under
+   the port-semantic rules of [chapter 05](../Architecture/05-wire-language.md). Singular and
+   list-valued inputs obey the same arity rules at the rewrite boundary as at compile time.
+3. **Topology validity.** The post-application materialized graph remains a DAG. The anchor exists
+   in the current topology and definition map. Entry and exit sets are non-empty where the rewrite
+   form requires them. No orphans, no dangling references.
+4. **Resource bounds.** Estimated `RewriteCost` fits within the remaining budget on every dimension
+   (§3.2).
+5. **Runtime policy.** The anchor, the run, and the task type permit rewrites of this form. Planner
+   nodes may be restricted to a subset of the algebra; the policy is consulted per proposal.
 
 ### 4.2 Rejection taxonomy
 
-| Code                       | Failed check                                                       |
-|----------------------------|---------------------------------------------------------------------|
-| `invalid_rewrite`          | Spec structurally malformed, or uses a deferred / unknown form.     |
-| `vocabulary_violation`     | Executor or contract not registered (check 1).                      |
-| `cycle_introduced`         | Post-application graph is not a DAG (check 3).                      |
-| `rewrite_budget_exceeded`  | Static cost exceeds remaining budget on any dimension (check 4).    |
-| `policy_rejected`          | Runtime policy disallows this rewrite form here (check 5).          |
+| Code                      | Failed check                                                     |
+| ------------------------- | ---------------------------------------------------------------- |
+| `invalid_rewrite`         | Spec structurally malformed, or uses a deferred / unknown form.  |
+| `vocabulary_violation`    | Executor or contract not registered (check 1).                   |
+| `cycle_introduced`        | Post-application graph is not a DAG (check 3).                   |
+| `rewrite_budget_exceeded` | Static cost exceeds remaining budget on any dimension (check 4). |
+| `policy_rejected`         | Runtime policy disallows this rewrite form here (check 5).       |
 
-Each rejection carries a structured reason carrying at least the failing check and the proposing node id.
+Each rejection carries a structured reason carrying at least the failing check and the proposing
+node id.
 
 ### 4.3 Frontier-wave determinism
 
-Admission is deterministic per frontier wave. Multiple frontier nodes may emit proposals in the same wave. The runtime serializes admission against shared remaining budget, assigns monotone `rewrite_id`s to admitted rows, and materializes admitted rows in `rewrite_id` order after frontier classification.
+Admission is deterministic per frontier wave. Multiple frontier nodes may emit proposals in the same
+wave. The runtime serializes admission against shared remaining budget, assigns monotone
+`rewrite_id`s to admitted rows, and materializes admitted rows in `rewrite_id` order after frontier
+classification.
 
-This is deterministic ordered admission, not a commutation law for same-wave rewrites. Concurrent frontier execution for ordinary (non-rewriting) nodes is unaffected.
+This is deterministic ordered admission, not a commutation law for same-wave rewrites. Concurrent
+frontier execution for ordinary (non-rewriting) nodes is unaffected.
 
 ### 4.4 Default policy on rejection
 
-Default is **fail-fast**: the proposing node and its run fail with a legible error carrying the rejection code. Task-specific fallback modes — structured-output-only continuation, operator escalation — are deferred and require a new ADR.
+Default is **fail-fast**: the proposing node and its run fail with a legible error carrying the
+rejection code. Task-specific fallback modes — structured-output-only continuation, operator
+escalation — are deferred and require a new ADR.
 
 ## 5. Materialization
 
@@ -170,27 +214,38 @@ Materialization of a single rewrite applies all of the following in **one atomic
 
 No partial states are observable.
 
-Admitted rewrite lineage may exist beyond the watermark. That means "admitted but not yet applied to the materialized graph", not "applied but missing from persistence".
+Admitted rewrite lineage may exist beyond the watermark. That means "admitted but not yet applied to
+the materialized graph", not "applied but missing from persistence".
 
 ### 5.4 Resume through watermark
 
-Resume reconstructs the materialized graph **only through the watermark**. If rewrite-log lineage exists beyond the watermark, resume deterministically finishes materialization — in `rewrite_id` order — before any scheduling decision.
+Resume reconstructs the materialized graph **only through the watermark**. If rewrite-log lineage
+exists beyond the watermark, resume deterministically finishes materialization — in `rewrite_id`
+order — before any scheduling decision.
 
-Pre-watermark rewrite-capable runs are **legacy** and not guaranteed resumable. Any future watermark schema change requires a runtime-version bump (see [ADR 0011](./../ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md)).
+Pre-watermark rewrite-capable runs are **legacy** and not guaranteed resumable. Any future watermark
+schema change requires a runtime-version bump (see
+[ADR 0011](./../ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md)).
 
 ## 6. Hydration
 
 ### 6.1 Keying
 
-Hydration of rewritten stages is keyed by **stage-template identity** (`StageTemplateId`) — a durable executable identity — and verified against **stage-action identity** (`StageActionId`) — the action the template is expected to bind to. Hydration does not scan ad-hoc stage ids.
+Hydration of rewritten stages is keyed by **stage-template identity** (`StageTemplateId`) — a
+durable executable identity — and verified against **stage-action identity** (`StageActionId`) — the
+action the template is expected to bind to. Hydration does not scan ad-hoc stage ids.
 
 ### 6.2 Duplicate template ids
 
-A materialized plan may contain duplicate `StageTemplateId`s only when they map to the same `StageActionId` and carry identical policy metadata. Any other duplication is rejected at hydration with a structured failure.
+A materialized plan may contain duplicate `StageTemplateId`s only when they map to the same
+`StageActionId` and carry identical policy metadata. Any other duplication is rejected at hydration
+with a structured failure.
 
 ### 6.3 Identity split
 
-The normative split between `NodeId`, `stageId`, `StageTemplateId`, and `StageActionId` is stated in the [Pulse types reference](./Pulse/types.md#3-stage-identity). Rewrite-capable plans must use `NodeId` as the durable execution identity.
+The normative split between `NodeId`, `stageId`, `StageTemplateId`, and `StageActionId` is stated in
+the [Pulse types reference](./Pulse/types.md#3-stage-identity). Rewrite-capable plans must use
+`NodeId` as the durable execution identity.
 
 ## 7. Structural provenance
 
@@ -205,21 +260,28 @@ For **every rewrite event**, admitted or rejected, the runtime persists:
 
 ### 7.1 Rejection rows
 
-Rejected rewrites are **not** silently discarded. Rejection rows appear in the audit trail with the same shape as admitted rows, minus the diff. Operators can inspect why a proposal was refused.
+Rejected rewrites are **not** silently discarded. Rejection rows appear in the audit trail with the
+same shape as admitted rows, minus the diff. Operators can inspect why a proposal was refused.
 
 ### 7.2 Exposure
 
-Operator surfaces expose: the current materialized graph, the rewrite history per run, the remaining budget, and any blocked or waiting reasons introduced by a rewrite. Surfaces are specified in the admin-visibility decisions track ([ADR 0008](../ADRs/0008-pulse-operator-visibility-surfaces.md)).
+Operator surfaces expose: the current materialized graph, the rewrite history per run, the remaining
+budget, and any blocked or waiting reasons introduced by a rewrite. Surfaces are specified in the
+admin-visibility decisions track ([ADR 0008](../ADRs/0008-pulse-operator-visibility-surfaces.md)).
 
 ## Related
 
-- [../Architecture/07-rewrites-and-materialization.md](../Architecture/07-rewrites-and-materialization.md) — architectural framing.
+- [../Architecture/07-rewrites-and-materialization.md](../Architecture/07-rewrites-and-materialization.md)
+  — architectural framing.
 - [./Pulse/types.md](./Pulse/types.md) — `StageResult`, identity types, retry policy.
 - [./Pulse/schema.md](./Pulse/schema.md) — DB shape of runs, checkpoints, stage logs.
-- [../ADRs/0005-budgeted-rewrite-admission-and-materialization.md](../ADRs/0005-budgeted-rewrite-admission-and-materialization.md) — gas and admission decision.
-- [../ADRs/0009-rewrite-provenance-and-topology-integrity.md](../ADRs/0009-rewrite-provenance-and-topology-integrity.md) — provenance and integrity decision.
-- [../ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md](../ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md) — watermark version discipline.
+- [../ADRs/0005-budgeted-rewrite-admission-and-materialization.md](../ADRs/0005-budgeted-rewrite-admission-and-materialization.md)
+  — gas and admission decision.
+- [../ADRs/0009-rewrite-provenance-and-topology-integrity.md](../ADRs/0009-rewrite-provenance-and-topology-integrity.md)
+  — provenance and integrity decision.
+- [../ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md](../ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md)
+  — watermark version discipline.
 
 ---
 
-*End of Rewrites Reference.*
+_End of Rewrites Reference._

--- a/docs/Reference/terminology.md
+++ b/docs/Reference/terminology.md
@@ -1,6 +1,8 @@
 ---
 title: Cortex Terminology
-description: Normative definitions of Wire, Circuit, Graph, Pulse, and related Cortex terms. The source of truth for vocabulary used across the Cortex docs.
+description:
+  Normative definitions of Wire, Circuit, Graph, Pulse, and related Cortex terms. The source of
+  truth for vocabulary used across the Cortex docs.
 status: accepted
 version: "v1"
 related:
@@ -11,7 +13,9 @@ related:
 
 # Cortex Terminology
 
-Normative definitions for the vocabulary used throughout the Cortex docs. When a term appears in an architecture chapter, spec, or research note, this page is where it is defined. Summaries in [`glossary.md`](../glossary.md) are informal; this page is canonical.
+Normative definitions for the vocabulary used throughout the Cortex docs. When a term appears in an
+architecture chapter, spec, or research note, this page is where it is defined. Summaries in
+[`glossary.md`](../glossary.md) are informal; this page is canonical.
 
 Short rule for reading the docs:
 
@@ -23,110 +27,118 @@ Each layer owns a specific set of terms. This page groups them by layer.
 
 ## Substrate layers
 
-| Term | Definition | Owner |
-|---|---|---|
-| **Graph** | The lowest pure algebraic topology layer: vertices, edges, `Empty`, `Overlay`, `Connect`, relation construction, and DAG validation. Pure; no evaluation semantics. | `Cortex.Graph` |
-| **Circuit** | The validated executable topology. Predeclared nodes plus compatible-port edges, ready for execution. A Wire source file compiles to a Circuit. | `Cortex.Circuit` |
-| **Wire** | The source language and file format used to author Circuits. Composes registered authority (nodes and contracts) into a topology. Normative grammar: [grammar.md](Wire/grammar.md). | `Cortex.Wire` |
-| **Pulse** | The durable runtime that schedules and executes a compiled Circuit. Standalone service `cortex-pulse`. | `Cortex.Pulse` |
+| Term        | Definition                                                                                                                                                                          | Owner            |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| **Graph**   | The lowest pure algebraic topology layer: vertices, edges, `Empty`, `Overlay`, `Connect`, relation construction, and DAG validation. Pure; no evaluation semantics.                 | `Cortex.Graph`   |
+| **Circuit** | The validated executable topology. Predeclared nodes plus compatible-port edges, ready for execution. A Wire source file compiles to a Circuit.                                     | `Cortex.Circuit` |
+| **Wire**    | The source language and file format used to author Circuits. Composes registered authority (nodes and contracts) into a topology. Normative grammar: [grammar.md](Wire/grammar.md). | `Cortex.Wire`    |
+| **Pulse**   | The durable runtime that schedules and executes a compiled Circuit. Standalone service `cortex-pulse`.                                                                              | `Cortex.Pulse`   |
 
 ## Wire language
 
 ### Core forms
 
-| Term | Definition |
-|---|---|
-| **Contract** | A named typed interface that flows through a port. Ambient in a global namespace. Carries a payload kind. |
-| **Node** | A pinned executor application with a port signature. Declared via `node name : <ports> = @executor { config };`. Has identity; reused references are the same node. |
-| **Port** | A slot on a node, typed by a contract. Input (`<-`) or output (`->`). May be labeled. |
-| **Port key** | The identity tuple `(direction, contract, label)` that `=>` matches on. Absent-label is a distinct key, not a wildcard. |
-| **Label** | Part of a port's identity for routing, not a decoration. Labeled ports match only identically-labeled partners. |
-| **Sum group** | Output port form `-> A | B` with mutual-exclusion metadata: exactly one variant fires per evaluation. |
-| **Partial node** | Staged value `@executor { config }` with no ports pinned yet. `let`-bindable, `//`-mergeable, pinnable via `node` declaration. |
-| **Wire value** | Any value of wire kind: node, composed graph expression, or (in graph position with port-determined executor) a partial node. |
-| **Port-boundary** | A wire's unconnected input and output ports. The surface `=>` operates on. |
+| Term              | Definition                                                                                                                                                          |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **Contract**      | A named typed interface that flows through a port. Ambient in a global namespace. Carries a payload kind.                                                           |
+| **Node**          | A pinned executor application with a port signature. Declared via `node name : <ports> = @executor { config };`. Has identity; reused references are the same node. |
+| **Port**          | A slot on a node, typed by a contract. Input (`<-`) or output (`->`). May be labeled.                                                                               |
+| **Port key**      | The identity tuple `(direction, contract, label)` that `=>` matches on. Absent-label is a distinct key, not a wildcard.                                             |
+| **Label**         | Part of a port's identity for routing, not a decoration. Labeled ports match only identically-labeled partners.                                                     |
+| **Sum group**     | Output port form `-> A                                                                                                                                              | B` with mutual-exclusion metadata: exactly one variant fires per evaluation. |
+| **Partial node**  | Staged value `@executor { config }` with no ports pinned yet. `let`-bindable, `//`-mergeable, pinnable via `node` declaration.                                      |
+| **Wire value**    | Any value of wire kind: node, composed graph expression, or (in graph position with port-determined executor) a partial node.                                       |
+| **Port-boundary** | A wire's unconnected input and output ports. The surface `=>` operates on.                                                                                          |
 
 ### Composition algebra
 
-| Term | Definition |
-|---|---|
-| **`<>` overlay** | Set union of nodes and edges across two wires. The primitive of the algebra. |
-| **`=>` connect** | Port-key-matched edge addition between boundary ports of two wires. Deterministic cross-product with filter. |
-| **Mokhov algebra** | The algebraic basis for Wire's graph expressions: `Empty \| Vertex \| Overlay \| Connect` per Mokhov's *Algebraic Graphs with Class*. |
+| Term               | Definition                                                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **`<>` overlay**   | Set union of nodes and edges across two wires. The primitive of the algebra.                                                          |
+| **`=>` connect**   | Port-key-matched edge addition between boundary ports of two wires. Deterministic cross-product with filter.                          |
+| **Mokhov algebra** | The algebraic basis for Wire's graph expressions: `Empty \| Vertex \| Overlay \| Connect` per Mokhov's _Algebraic Graphs with Class_. |
 
 ### Value operators
 
-| Term | Definition |
-|---|---|
-| **`//` merge** | Right-biased shallow record merge. Applies to records and to partial-node configs. |
-| **`++` concat** | String and list concatenation. |
-| **`|` sum constructor** | Output-port mutual-exclusion form; distinct grammar construct, not pure sugar. |
+| Term                | Definition                                                                                   |
+| ------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| **`//` merge**      | Right-biased shallow record merge. Applies to records and to partial-node configs.           |
+| **`++` concat**     | String and list concatenation.                                                               |
+| \*\*`               | ` sum constructor\*\*                                                                        | Output-port mutual-exclusion form; distinct grammar construct, not pure sugar. |
 | **`@` application** | Executor application to a config record: `@qualified.name { ... }`. Produces a partial node. |
 
 ### File-level forms
 
-| Term | Definition |
-|---|---|
-| **File-return expression** | A `.wire` file's last expression without trailing `;`. Becomes the file's value. A file is a wire iff it has a file-return. |
-| **Declaration-only file** | A file without a file-return expression. Contributes ambient contracts and importable `let` bindings; nothing else. |
-| **Program** | A root `.wire` file plus the transitive closure of its imports. The unit over which ambient contract collection and cross-file reference resolution runs. |
+| Term                       | Definition                                                                                                                                                |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **File-return expression** | A `.wire` file's last expression without trailing `;`. Becomes the file's value. A file is a wire iff it has a file-return.                               |
+| **Declaration-only file**  | A file without a file-return expression. Contributes ambient contracts and importable `let` bindings; nothing else.                                       |
+| **Program**                | A root `.wire` file plus the transitive closure of its imports. The unit over which ambient contract collection and cross-file reference resolution runs. |
 
 ## Executors and registry
 
-| Term | Definition |
-|---|---|
-| **Executor** | A registered external recipe for turning a node's inputs into outputs. Referenced by `@qualified.name`. LLM call, pure transform, shell-out, or subgraph evaluation. |
-| **Executor alphabet** | The globally-ambient set of registered executor names. Closed: user code cannot define new executors, only compose them. |
-| **Vocabulary** (of an executor) | The set of contract names the executor can produce or consume. |
-| **Structural constraints** (of an executor) | The rules a node's port signature must satisfy to apply the executor. |
-| **Purity class** | `pure` or `impure`. Informational; does not affect static type-checking. |
-| **Port-determined executor** | An executor whose structural constraints uniquely pin its port signature from its config alone. Admissible in graph position without explicit `node` pinning. |
-| **Port-polymorphic executor** | An executor whose port signature has unresolved degrees of freedom after config. Must be pinned via `node` declaration before graph-position use. |
-| **Tool registry** | A sibling ambient namespace to the executor alphabet. Holds named tool values (`getDate`, `searchAssets`, …) referenced inside config records. |
-| **Config constructor** | A tagged-record value form inside a config: `qualified.name { ... }` (no leading `@`). Semantics determined by the consuming executor's schema. |
+| Term                                        | Definition                                                                                                                                                           |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Executor**                                | A registered external recipe for turning a node's inputs into outputs. Referenced by `@qualified.name`. LLM call, pure transform, shell-out, or subgraph evaluation. |
+| **Executor alphabet**                       | The globally-ambient set of registered executor names. Closed: user code cannot define new executors, only compose them.                                             |
+| **Vocabulary** (of an executor)             | The set of contract names the executor can produce or consume.                                                                                                       |
+| **Structural constraints** (of an executor) | The rules a node's port signature must satisfy to apply the executor.                                                                                                |
+| **Purity class**                            | `pure` or `impure`. Informational; does not affect static type-checking.                                                                                             |
+| **Port-determined executor**                | An executor whose structural constraints uniquely pin its port signature from its config alone. Admissible in graph position without explicit `node` pinning.        |
+| **Port-polymorphic executor**               | An executor whose port signature has unresolved degrees of freedom after config. Must be pinned via `node` declaration before graph-position use.                    |
+| **Tool registry**                           | A sibling ambient namespace to the executor alphabet. Holds named tool values (`getDate`, `searchAssets`, …) referenced inside config records.                       |
+| **Config constructor**                      | A tagged-record value form inside a config: `qualified.name { ... }` (no leading `@`). Semantics determined by the consuming executor's schema.                      |
 
 ## Runtime vocabulary
 
-| Term | Definition |
-|---|---|
-| **Envelope** | The JSON-carrier shape every Wire value travels in at runtime: `{ contract, mediaType, producer, value, provenance }`. |
-| **Payload kind** | A contract's runtime category: `json`, `markdown`, `text`, `table`, `artifact_ref`. Selects validation and rendering. |
-| **Contract registry** | The Haskell-owned authoritative definitions of contracts: schema, codec, payload kind, examples, lint rules. |
-| **Evaluation-boundary check** | The runnable-wire gate: every singular input connected to exactly one edge. Runs at evaluation-preparation, not type-checking. |
-| **Rewire** | A bounded runtime topology modification over a live Circuit. Subject to vocabulary, endpoint-compatibility, topology, and resource (gas) bounds. Modules: `Cortex.Pulse.Rewrite` plus the Wire compiler. |
-| **Realized circuit** | The concrete Circuit topology that existed after admitted rewires during a run. A runtime artifact, not a grammar construct. |
-| **Gas** | The structural-change budget consumed by rewires: nodes added, edges added, depth, frontier breadth, rewrite operations. |
-| **Topological memory** | A node-addressable accumulated context from upstream evaluations. Declared on the node, consumed at evaluation time. Canonical home: `Cortex.Nous.Memory.Topological`; Pulse supplies the settled event state. |
-| **Frontier** | The set of graph nodes ready to execute at a given point. Pulse schedules over the frontier. |
+| Term                          | Definition                                                                                                                                                                                                     |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Envelope**                  | The JSON-carrier shape every Wire value travels in at runtime: `{ contract, mediaType, producer, value, provenance }`.                                                                                         |
+| **Payload kind**              | A contract's runtime category: `json`, `markdown`, `text`, `table`, `artifact_ref`. Selects validation and rendering.                                                                                          |
+| **Contract registry**         | The Haskell-owned authoritative definitions of contracts: schema, codec, payload kind, examples, lint rules.                                                                                                   |
+| **Evaluation-boundary check** | The runnable-wire gate: every singular input connected to exactly one edge. Runs at evaluation-preparation, not type-checking.                                                                                 |
+| **Rewire**                    | A bounded runtime topology modification over a live Circuit. Subject to vocabulary, endpoint-compatibility, topology, and resource (gas) bounds. Modules: `Cortex.Pulse.Rewrite` plus the Wire compiler.       |
+| **Realized circuit**          | The concrete Circuit topology that existed after admitted rewires during a run. A runtime artifact, not a grammar construct.                                                                                   |
+| **Gas**                       | The structural-change budget consumed by rewires: nodes added, edges added, depth, frontier breadth, rewrite operations.                                                                                       |
+| **Topological memory**        | A node-addressable accumulated context from upstream evaluations. Declared on the node, consumed at evaluation time. Canonical home: `Cortex.Nous.Memory.Topological`; Pulse supplies the settled event state. |
+| **Frontier**                  | The set of graph nodes ready to execute at a given point. Pulse schedules over the frontier.                                                                                                                   |
 
 ## Ownership boundary
 
-- **Wire composes registered authority.** Wire source references registered nodes, contract IDs, prompts, and wiring. It does not invent executors, tools, payload types, or domain authority.
-- **Haskell owns what the authority means.** Executors, contracts, codecs, payload kinds, and registry schemas are Haskell-defined and live outside Wire.
-- **Product concepts stay downstream.** Launch fields, report sections, model-policy choices, user-facing workflow labels — these live in consumer bindings. They can wrap a Circuit; they are not part of the generic Cortex Circuit layer.
+- **Wire composes registered authority.** Wire source references registered nodes, contract IDs,
+  prompts, and wiring. It does not invent executors, tools, payload types, or domain authority.
+- **Haskell owns what the authority means.** Executors, contracts, codecs, payload kinds, and
+  registry schemas are Haskell-defined and live outside Wire.
+- **Product concepts stay downstream.** Launch fields, report sections, model-policy choices,
+  user-facing workflow labels — these live in consumer bindings. They can wrap a Circuit; they are
+  not part of the generic Cortex Circuit layer.
 
-See [Architecture/01-overview.md](../Architecture/01-overview.md) and [Architecture/02-ownership-and-boundaries.md](../Architecture/02-ownership-and-boundaries.md) for the full ownership story.
+See [Architecture/01-overview.md](../Architecture/01-overview.md) and
+[Architecture/02-ownership-and-boundaries.md](../Architecture/02-ownership-and-boundaries.md) for
+the full ownership story.
 
 ## Doc-kind vocabulary
 
-Terms used to classify docs in `docs/`. See [../map.md](../map.md) for how each doc kind is placed and [../taxonomy.md](../taxonomy.md) for the organizing axes.
+Terms used to classify docs in `docs/`. See [../map.md](../map.md) for how each doc kind is placed
+and [../taxonomy.md](../taxonomy.md) for the organizing axes.
 
-| Term | Where |
-|---|---|
-| **Canonical chapter** | `Architecture/NN-*.md` |
-| **Reference** | `Reference/**/*.md` |
-| **ADR** | `ADRs/NNNN-*.md` |
-| **Epic** | `Roadmap/Epics/*.md` |
-| **Plan** | `Roadmap/Plans/*.md` |
-| **Research note** | `Research-notes/{scope}/YYYY-MM-DD-*.md` |
-| **Experiment** | `Experiments/{scope}/YYYY-MM-DD-*.md` |
-| **Handoff** | `Handoffs/YYYY-MM-DD-*.md` |
-| **Manuscript** | `Publications/paper-N-*/manuscript.md` |
+| Term                  | Where                                    |
+| --------------------- | ---------------------------------------- |
+| **Canonical chapter** | `Architecture/NN-*.md`                   |
+| **Reference**         | `Reference/**/*.md`                      |
+| **ADR**               | `ADRs/NNNN-*.md`                         |
+| **Epic**              | `Roadmap/Epics/*.md`                     |
+| **Plan**              | `Roadmap/Plans/*.md`                     |
+| **Research note**     | `Research-notes/{scope}/YYYY-MM-DD-*.md` |
+| **Experiment**        | `Experiments/{scope}/YYYY-MM-DD-*.md`    |
+| **Handoff**           | `Handoffs/YYYY-MM-DD-*.md`               |
+| **Manuscript**        | `Publications/paper-N-*/manuscript.md`   |
 
 ## Related
 
 - [Wire/grammar.md](Wire/grammar.md) — normative Wire grammar.
 - [../Architecture/01-overview.md](../Architecture/01-overview.md) — canonical overview.
-- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md) — Wire substrate architecture.
+- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md) — Wire substrate
+  architecture.
 - [../glossary.md](../glossary.md) — informal quick-reference.
 - [../taxonomy.md](../taxonomy.md) — conceptual classification.

--- a/docs/Research-notes/Applications/index.md
+++ b/docs/Research-notes/Applications/index.md
@@ -11,5 +11,5 @@ sidebar:
 No application-level research notes are currently retained.
 
 Consumer-specific design that should remain current belongs under
-[../../Consumers/](../../Consumers/). Keep this section for cross-consumer
-research notes that are not specific enough to live in one consumer subtree.
+[../../Consumers/](../../Consumers/). Keep this section for cross-consumer research notes that are
+not specific enough to live in one consumer subtree.

--- a/docs/Research-notes/Foundation/2026-04-11-formalism-stack-synthesis.md
+++ b/docs/Research-notes/Foundation/2026-04-11-formalism-stack-synthesis.md
@@ -1,27 +1,25 @@
 ---
 title: "Research Memo: Cortex Formalism Stack Synthesis"
-description: Compact synthesis of the formal layers Cortex uses for topology, execution intent, and structural authority.
+description:
+  Compact synthesis of the formal layers Cortex uses for topology, execution intent, and structural
+  authority.
 ---
 
 # Research Memo: Cortex Formalism Stack Synthesis
 
-**Date:** 2026-04-11
-**Scope:** Cortex graph topology, Pulse execution outcomes, Wire/Circuit
-authoring boundaries, and the algebraic split needed for rewrite-capable
-execution.
-**Method:** Retained synthesis note, rewritten after Cortex became a standalone
-repository to remove stale branch and consumer-path detail.
-**Confidence profile:** high on the layer split; medium on the exact formal
-presentation that should appear in papers and mechanization.
+**Date:** 2026-04-11 **Scope:** Cortex graph topology, Pulse execution outcomes, Wire/Circuit
+authoring boundaries, and the algebraic split needed for rewrite-capable execution. **Method:**
+Retained synthesis note, rewritten after Cortex became a standalone repository to remove stale
+branch and consumer-path detail. **Confidence profile:** high on the layer split; medium on the
+exact formal presentation that should appear in papers and mechanization.
 
 ## Executive Summary
 
 Cortex wants several small formal layers, not one universal metaphor.
 
-The graph layer is algebraic topology: `Empty`, `Vertex`, `Overlay`, and
-`Connect` describe causal shape and lower to relations. Pulse then interprets
-that topology through a small execution outcome surface. Rewrites are a third
-thing again: bounded structural authority over a materialized graph.
+The graph layer is algebraic topology: `Empty`, `Vertex`, `Overlay`, and `Connect` describe causal
+shape and lower to relations. Pulse then interprets that topology through a small execution outcome
+surface. Rewrites are a third thing again: bounded structural authority over a materialized graph.
 
 The useful split is:
 
@@ -29,21 +27,19 @@ The useful split is:
 - **Intent/effect algebra** - what a vertex may do when evaluated.
 - **Authority algebra** - how much structural change a vertex may propose.
 
-This explains the implementation better than treating the runtime as a single
-graph monad. Graphs describe structure; Pulse interprets node outcomes;
-rewrites are admitted through a separate authority boundary.
+This explains the implementation better than treating the runtime as a single graph monad. Graphs
+describe structure; Pulse interprets node outcomes; rewrites are admitted through a separate
+authority boundary.
 
 ## Findings
 
 ### Topology Is Not Execution
 
-`Cortex.Graph` gives Cortex a small topology language and analysis substrate.
-That layer should remain pure: it should know about vertices, edges, reachability,
-DAG validation, and graph traversal, not about checkpoints, host actions, model
-calls, signals, or product policy.
+`Cortex.Graph` gives Cortex a small topology language and analysis substrate. That layer should
+remain pure: it should know about vertices, edges, reachability, DAG validation, and graph
+traversal, not about checkpoints, host actions, model calls, signals, or product policy.
 
-The runtime consumes topology; it should not be smuggled back into the graph
-layer.
+The runtime consumes topology; it should not be smuggled back into the graph layer.
 
 ### Pulse Has A Small Handled-Effect Kernel
 
@@ -53,36 +49,32 @@ Pulse stage execution is centered around a narrow outcome surface:
 - suspend on signal
 - complete with output and propose a structural rewrite
 
-The executor handles those outcomes into durable state transitions,
-checkpointing, frontier scheduling, signal waiting, rewrite admission, and
-terminal classification.
+The executor handles those outcomes into durable state transitions, checkpointing, frontier
+scheduling, signal waiting, rewrite admission, and terminal classification.
 
-Naming this as an execution-intent layer is useful because replay policy,
-timeout behavior, side-effect classification, signal waiting, and operator
-explanation can hang off the same small surface instead of being hidden inside
-task-specific code.
+Naming this as an execution-intent layer is useful because replay policy, timeout behavior,
+side-effect classification, signal waiting, and operator explanation can hang off the same small
+surface instead of being hidden inside task-specific code.
 
 ### Closed Branch Choice Differs From Open Rewrite
 
-Closed-world conditionals and open-world planner rewrites should not be treated
-as the same semantic phenomenon.
+Closed-world conditionals and open-world planner rewrites should not be treated as the same semantic
+phenomenon.
 
-A closed conditional chooses among known continuations. Its branches are part of
-the compiled artifact, and the runtime materializes the selected branch. This
-resembles selective continuation choice: possible future obligations are known,
-but only one path is activated.
+A closed conditional chooses among known continuations. Its branches are part of the compiled
+artifact, and the runtime materializes the selected branch. This resembles selective continuation
+choice: possible future obligations are known, but only one path is activated.
 
-An open rewrite proposes new future topology within a bounded authority budget.
-It needs admission, structural validation, budget accounting, and provenance.
+An open rewrite proposes new future topology within a bounded authority budget. It needs admission,
+structural validation, budget accounting, and provenance.
 
-The runtime may implement both through shared materialization machinery, but the
-formal semantics and operator explanation should keep them distinct.
+The runtime may implement both through shared materialization machinery, but the formal semantics
+and operator explanation should keep them distinct.
 
 ### Rewrite Is Structural Authority
 
-Runtime graph rewriting is budgeted relation surgery over the materialized
-graph. It is not arbitrary mutation and not general computation in the source
-language.
+Runtime graph rewriting is budgeted relation surgery over the materialized graph. It is not
+arbitrary mutation and not general computation in the source language.
 
 The authority question is separate from node intent:
 
@@ -98,32 +90,30 @@ This suggests a small structural-authority lattice, for example:
 NoChange < ChooseKnownContinuation < Append < ExpandEnvelope < ExpandReplace
 ```
 
-The exact order may change, but the architectural point should stay: structural
-authority is explicit and bounded.
+The exact order may change, but the architectural point should stay: structural authority is
+explicit and bounded.
 
 ### Contract Witnesses Are The Main Theory Gap
 
-The paper-level story wants compiled artifacts with interface environments,
-compatibility witnesses, effect classes, and authority classes. The
-implementation has the beginning of this through Circuit/Wire contracts and
-runtime rewrite validation, but the full witness discipline is not yet the
-central API.
+The paper-level story wants compiled artifacts with interface environments, compatibility witnesses,
+effect classes, and authority classes. The implementation has the beginning of this through
+Circuit/Wire contracts and runtime rewrite validation, but the full witness discipline is not yet
+the central API.
 
-That gap is the right place to invest if Cortex wants reusable fragments,
-stronger artifact contracts, and safer rewrite composition.
+That gap is the right place to invest if Cortex wants reusable fragments, stronger artifact
+contracts, and safer rewrite composition.
 
 ### Concurrent Rewrite Admission Is A Proof Problem
 
-Admitting multiple same-wave rewrites is not just a scheduler optimization. It
-requires a commutation or independence law:
+Admitting multiple same-wave rewrites is not just a scheduler optimization. It requires a
+commutation or independence law:
 
 - compatible anchors
 - non-overlapping interface effects
 - deterministic budget composition
 - stable replay ordering
 
-Until that law exists, deterministic ordered admission is the conservative
-runtime contract.
+Until that law exists, deterministic ordered admission is the conservative runtime contract.
 
 ## Consequences
 
@@ -135,9 +125,9 @@ The formal stack should be presented as layered:
 4. Rewrite authority and materialization.
 5. Artifact, memory, and provenance surfaces above execution.
 
-This keeps proofs and docs from upgrading implementation convenience into
-semantics. It also makes downstream examples clearer: a consumer registers
-authority and product meaning into Cortex; it does not redefine the substrate.
+This keeps proofs and docs from upgrading implementation convenience into semantics. It also makes
+downstream examples clearer: a consumer registers authority and product meaning into Cortex; it does
+not redefine the substrate.
 
 ## Related
 

--- a/docs/Research-notes/Foundation/2026-04-24-calm-coordination-boundaries-on-evolving-graphs.md
+++ b/docs/Research-notes/Foundation/2026-04-24-calm-coordination-boundaries-on-evolving-graphs.md
@@ -1,6 +1,8 @@
 ---
 title: "Research Memo: CALM and Coordination Boundaries on Evolving Graphs"
-description: Reading Cortex as a monotone execution substrate with a coordinated non-monotone substitution boundary, plus implications for rewrite admission.
+description:
+  Reading Cortex as a monotone execution substrate with a coordinated non-monotone substitution
+  boundary, plus implications for rewrite admission.
 date: 2026-04-24
 status: active
 related:
@@ -13,11 +15,14 @@ related:
 
 # Research Memo: CALM and Coordination Boundaries on Evolving Graphs
 
-**Date:** 2026-04-24
-**Scope:** Cortex staged reduction, rewrite admission/materialization, current papers 2 and 3, runtime docs, and external coordination-avoidance literature
-**Artifacts examined:** `src/Cortex/Pulse/GraphRuntime.hs`, `src/Cortex/Pulse/Rewrite.hs`, `src/Cortex/Pulse/Executor/*`, papers 2 and 3, architecture chapters 06 and 07, the deterministic multi-rewrite admission note, and selected CALM / I-confluence literature
-**Method:** implementation-first cross-reference synthesis with targeted literature check
-**Confidence profile:** high on the local Runtime/paper alignment; medium-high on the CALM framing; medium on stronger "minimality" claims that would need a dedicated formal model
+**Date:** 2026-04-24 **Scope:** Cortex staged reduction, rewrite admission/materialization, current
+papers 2 and 3, runtime docs, and external coordination-avoidance literature **Artifacts examined:**
+`src/Cortex/Pulse/GraphRuntime.hs`, `src/Cortex/Pulse/Rewrite.hs`, `src/Cortex/Pulse/Executor/*`,
+papers 2 and 3, architecture chapters 06 and 07, the deterministic multi-rewrite admission note, and
+selected CALM / I-confluence literature **Method:** implementation-first cross-reference synthesis
+with targeted literature check **Confidence profile:** high on the local Runtime/paper alignment;
+medium-high on the CALM framing; medium on stronger "minimality" claims that would need a dedicated
+formal model
 
 **External literature checked:**
 
@@ -31,27 +36,43 @@ related:
 
 The strongest new framing is that Cortex already separates two different semantic fragments:
 
-- a **within-topology reduction fragment** that accumulates node-local facts over a fixed materialized graph
-- a **cross-topology substitution fragment** that changes the graph itself through rewrite admission and materialization
+- a **within-topology reduction fragment** that accumulates node-local facts over a fixed
+  materialized graph
+- a **cross-topology substitution fragment** that changes the graph itself through rewrite admission
+  and materialization
 
-That split aligns cleanly with the CALM line of work. The reduction kernel described in Paper 2 is the coordination-friendly fragment: frontier execution is order-insensitive, fact accumulation is disjoint-key commutative, and closure/classification are deterministic over the resulting normalized state. Rewrite admission is different. It is non-monotone not only when fragments delete structure, but also when admission depends on budgets, overlap checks, and compatibility against the current set of proposals.
+That split aligns cleanly with the CALM line of work. The reduction kernel described in Paper 2 is
+the coordination-friendly fragment: frontier execution is order-insensitive, fact accumulation is
+disjoint-key commutative, and closure/classification are deterministic over the resulting normalized
+state. Rewrite admission is different. It is non-monotone not only when fragments delete structure,
+but also when admission depends on budgets, overlap checks, and compatibility against the current
+set of proposals.
 
-The important payoff is architectural. The Cortex epoch/watermark boundary is not merely a taste-level barrier. It is the current system's natural coordination boundary: inside the epoch, reduction can proceed concurrently over a fixed topology; at the boundary, substitution is serialized because admissibility is non-monotone. That is a stronger and more general story than "rewrites are scary, so we inserted a stop-the-world phase."
+The important payoff is architectural. The Cortex epoch/watermark boundary is not merely a
+taste-level barrier. It is the current system's natural coordination boundary: inside the epoch,
+reduction can proceed concurrently over a fixed topology; at the boundary, substitution is
+serialized because admissibility is non-monotone. That is a stronger and more general story than
+"rewrites are scary, so we inserted a stop-the-world phase."
 
-The main caution is about overclaiming. CALM supports "non-monotone fragments need coordination"; it does not by itself prove that Cortex's exact epoch/watermark structure is the unique possible implementation. The safer statement is that the current epoch boundary is the natural minimal coordination boundary induced by Cortex's present semantics.
+The main caution is about overclaiming. CALM supports "non-monotone fragments need coordination"; it
+does not by itself prove that Cortex's exact epoch/watermark structure is the unique possible
+implementation. The safer statement is that the current epoch boundary is the natural minimal
+coordination boundary induced by Cortex's present semantics.
 
 ---
 
 ## Key Findings
 
 ### [P1] The staged reduction kernel is already Cortex's monotone fragment
-**Category:** Novel Idea
-**Status:** Observed
-**Confidence:** High
-**Primary evidence:** [paper 2](../../Publications/Paper-2-algebraic-foundations/manuscript.md), [GraphRuntime.hs](../../../../src/Cortex/Pulse/GraphRuntime.hs), [paper 1](../../Publications/Paper-1-staged-reduction/manuscript.md)
-**Cross-reference:** `applyNodeFact`, `propagateFailure`, `classifyGraphState`, `readyNodes`
 
-The current fixed-topology kernel already has the shape that a CALM-style argument wants. Within one materialized topology:
+**Category:** Novel Idea **Status:** Observed **Confidence:** High **Primary evidence:**
+[paper 2](../../Publications/Paper-2-algebraic-foundations/manuscript.md),
+[GraphRuntime.hs](../../../src/Cortex/Pulse/GraphRuntime.hs),
+[paper 1](../../Publications/Paper-1-staged-reduction/manuscript.md) **Cross-reference:**
+`applyNodeFact`, `propagateFailure`, `classifyGraphState`, `readyNodes`
+
+The current fixed-topology kernel already has the shape that a CALM-style argument wants. Within one
+materialized topology:
 
 - frontier nodes are chosen from an antichain
 - each node contributes node-local facts
@@ -59,40 +80,48 @@ The current fixed-topology kernel already has the shape that a CALM-style argume
 - closure is idempotent
 - classification is deterministic over the normalized, closed state
 
-This does not mean the whole runtime is monotone in every operational detail. `Running`, `Waiting`, resume normalization, and persistence boundaries are still operational concerns. The useful monotonic object is narrower: the fact-reduction kernel over a fixed topology.
+This does not mean the whole runtime is monotone in every operational detail. `Running`, `Waiting`,
+resume normalization, and persistence boundaries are still operational concerns. The useful
+monotonic object is narrower: the fact-reduction kernel over a fixed topology.
 
-**Why it matters:**
-This gives Cortex a principled name for what Paper 2 actually proves. It is not only a runtime discipline; it is the coordination-free fragment that later topology-changing work can rest on.
+**Why it matters:** This gives Cortex a principled name for what Paper 2 actually proves. It is not
+only a runtime discipline; it is the coordination-free fragment that later topology-changing work
+can rest on.
 
-**Next step:**
-State this explicitly in the papers: the reduction kernel is the fixed-topology fact fragment, not the full evolving-graph machine.
+**Next step:** State this explicitly in the papers: the reduction kernel is the fixed-topology fact
+fragment, not the full evolving-graph machine.
 
 ### [P1] Rewrite admission is non-monotone even in addition-only settings
-**Category:** Missed Abstraction
-**Status:** Observed
-**Confidence:** High
-**Primary evidence:** [Rewrite.hs](../../../../src/Cortex/Pulse/Rewrite.hs), [chapter 07](../../Architecture/07-rewrites-and-materialization.md), [paper 3](../../Publications/Paper-3-graph-substitution-semantics/manuscript.md)
+
+**Category:** Missed Abstraction **Status:** Observed **Confidence:** High **Primary evidence:**
+[Rewrite.hs](../../../src/Cortex/Pulse/Rewrite.hs),
+[chapter 07](../../Architecture/07-rewrites-and-materialization.md),
+[paper 3](../../Publications/Paper-3-graph-substitution-semantics/manuscript.md)
 **Cross-reference:** rewrite budgets, anchor/compatibility checks, same-wave admission semantics
 
-Deletion is only the most obvious source of non-monotonicity. Cortex rewrite admission is already non-monotone because:
+Deletion is only the most obvious source of non-monotonicity. Cortex rewrite admission is already
+non-monotone because:
 
 1. additional proposals can invalidate a previously acceptable proposal through budget consumption
 2. additional proposals can create overlap or interface conflicts
 3. a topology change can alter later well-formedness and admissibility conditions
 
-So even a hypothetical "addition-only" Cortex would still need coordination at the admission layer unless the admitted class were further restricted.
+So even a hypothetical "addition-only" Cortex would still need coordination at the admission layer
+unless the admitted class were further restricted.
 
-**Why it matters:**
-This is the key distinction between "we only append" and "we are monotone." Append-like topology change can still be non-monotone once admission depends on the proposal set and the remaining budget.
+**Why it matters:** This is the key distinction between "we only append" and "we are monotone."
+Append-like topology change can still be non-monotone once admission depends on the proposal set and
+the remaining budget.
 
-**Next step:**
-Make the paper language precise: node execution and rewrite admission are different semantic questions because only the latter is proposal-set-sensitive.
+**Next step:** Make the paper language precise: node execution and rewrite admission are different
+semantic questions because only the latter is proposal-set-sensitive.
 
 ### [P1] The epoch/watermark boundary is the current system's natural coordination boundary
-**Category:** Novel Idea
-**Status:** Inferred
-**Confidence:** High
-**Primary evidence:** [chapter 07](../../Architecture/07-rewrites-and-materialization.md), [deterministic multi-rewrite admission note](../../Publications/Notes/deterministic-multi-rewrite-admission.md), [paper 3](../../Publications/Paper-3-graph-substitution-semantics/manuscript.md)
+
+**Category:** Novel Idea **Status:** Inferred **Confidence:** High **Primary evidence:**
+[chapter 07](../../Architecture/07-rewrites-and-materialization.md),
+[deterministic multi-rewrite admission note](../../Publications/Notes/deterministic-multi-rewrite-admission.md),
+[paper 3](../../Publications/Paper-3-graph-substitution-semantics/manuscript.md)
 **Cross-reference:** same-wave proposal semantics, ordered materialization, watermark-based resume
 
 The runtime already implements the exact split this framing predicts:
@@ -102,41 +131,48 @@ The runtime already implements the exact split this framing predicts:
 3. admitted rewrites are serialized through the admission gate and shared remaining budget
 4. materialization advances the watermark before scheduling resumes on the new topology
 
-That makes the watermark boundary more than a crash-recovery detail. It is also the point where the machine stops doing coordination-friendly fact reduction and starts doing coordinated topology change.
+That makes the watermark boundary more than a crash-recovery detail. It is also the point where the
+machine stops doing coordination-friendly fact reduction and starts doing coordinated topology
+change.
 
 The strongest safe claim is therefore:
 
 > Cortex's epoch boundary is the natural coordination boundary induced by its current semantics.
 
-The stronger claim that this is the unique minimal architecture should be deferred until there is a dedicated formal model of alternative implementations.
+The stronger claim that this is the unique minimal architecture should be deferred until there is a
+dedicated formal model of alternative implementations.
 
-**Why it matters:**
-This turns a design choice into a theorem-shaped systems argument without overclaiming beyond what CALM actually proves.
+**Why it matters:** This turns a design choice into a theorem-shaped systems argument without
+overclaiming beyond what CALM actually proves.
 
-**Next step:**
-Thread this sentence into Paper 3's concurrency section and reserve the stronger minimality claim for a later dedicated paper.
+**Next step:** Thread this sentence into Paper 3's concurrency section and reserve the stronger
+minimality claim for a later dedicated paper.
 
 ### [P2] I-confluence is the right refinement for future same-wave parallel admission
-**Category:** Design Tension
-**Status:** Inferred
-**Confidence:** Medium
-**Primary evidence:** [Coordination Avoidance in Database Systems](https://www.vldb.org/pvldb/vol8/p185-bailis.pdf), [deterministic multi-rewrite admission note](../../Publications/Notes/deterministic-multi-rewrite-admission.md), [ExecutorSpec same-wave tests](../../../../test/Cortex/Pulse/ExecutorSpec.hs)
-**Cross-reference:** same-wave proposals, shared budget, ordered materialization
 
-CALM explains why the current admission layer needs coordination. I-confluence suggests the next refinement: identify a subclass of rewrite sets whose admissibility is invariant under reordering and merge. In Cortex terms, that likely means something like:
+**Category:** Design Tension **Status:** Inferred **Confidence:** Medium **Primary evidence:**
+[Coordination Avoidance in Database Systems](https://www.vldb.org/pvldb/vol8/p185-bailis.pdf),
+[deterministic multi-rewrite admission note](../../Publications/Notes/deterministic-multi-rewrite-admission.md),
+[ExecutorSpec same-wave tests](../../../test/Cortex/Pulse/ExecutorSpec.hs) **Cross-reference:**
+same-wave proposals, shared budget, ordered materialization
+
+CALM explains why the current admission layer needs coordination. I-confluence suggests the next
+refinement: identify a subclass of rewrite sets whose admissibility is invariant under reordering
+and merge. In Cortex terms, that likely means something like:
 
 - disjoint anchor dominions
 - no interface overlap
 - budget effects that compose independently
 - lineage/provenance that remains explanation-stable under either admission order
 
-If such a criterion can be checked cheaply, Cortex could parallelize some same-wave admissions without pretending that all rewrite concurrency is safe.
+If such a criterion can be checked cheaply, Cortex could parallelize some same-wave admissions
+without pretending that all rewrite concurrency is safe.
 
-**Why it matters:**
-This is the credible bridge between the current ordered machine and a stronger future machine. It also gives a rigorous answer to "when can we relax the barrier?".
+**Why it matters:** This is the credible bridge between the current ordered machine and a stronger
+future machine. It also gives a rigorous answer to "when can we relax the barrier?".
 
-**Next step:**
-Turn the current validation list into a real research program: order-sensitivity tests, counterexamples, and a candidate independence predicate.
+**Next step:** Turn the current validation list into a real research program: order-sensitivity
+tests, counterexamples, and a candidate independence predicate.
 
 ---
 
@@ -147,22 +183,33 @@ Two legitimate goals pull against each other here.
 - **Minimal coordination:** push as much work as possible into the within-topology reduction phase.
 - **Dynamic structure:** allow planner- or operator-driven topology change at runtime.
 
-CALM does not eliminate the tension; it clarifies where it lives. The runtime can avoid coordination inside the fixed-topology fact fragment, but topology admission remains the place where consistency forces a barrier unless a stronger independence law is proved.
+CALM does not eliminate the tension; it clarifies where it lives. The runtime can avoid coordination
+inside the fixed-topology fact fragment, but topology admission remains the place where consistency
+forces a barrier unless a stronger independence law is proved.
 
 ---
 
 ## Recommended Actions
 
 ### Act Now
+
 - [ ] Add the monotone-phase / coordinated-phase split to Paper 3's concurrency section.
-- [ ] Keep the claim scoped to "natural coordination boundary" rather than "unique minimal architecture."
+- [ ] Keep the claim scoped to "natural coordination boundary" rather than "unique minimal
+      architecture."
 
 ### Design Next
-- [ ] Define a candidate rewrite-independence criterion over anchors, interfaces, and budget effects.
-- [ ] Add order-sensitivity tests that force different same-wave admission orders and compare topology, budget, lineage, and outcome.
+
+- [ ] Define a candidate rewrite-independence criterion over anchors, interfaces, and budget
+      effects.
+- [ ] Add order-sensitivity tests that force different same-wave admission orders and compare
+      topology, budget, lineage, and outcome.
 
 ### Write Up
-- [ ] Treat this as a likely Paper 5 direction: CALM on evolving graph topologies, or monotone execution with coordinated substitution.
+
+- [ ] Treat this as a likely Paper 5 direction: CALM on evolving graph topologies, or monotone
+      execution with coordinated substitution.
 
 ### Parked
-- Strong uniqueness/minimality theorem — defer until there is a formal comparison against plausible alternative evolving-graph execution models.
+
+- Strong uniqueness/minimality theorem — defer until there is a formal comparison against plausible
+  alternative evolving-graph execution models.

--- a/docs/Research-notes/Foundation/index.md
+++ b/docs/Research-notes/Foundation/index.md
@@ -8,18 +8,19 @@ sidebar:
 
 # Research Notes - Foundation
 
-Substrate-layer research synthesis: formalism, algebraic structure, and
-coordination boundaries.
+Substrate-layer research synthesis: formalism, algebraic structure, and coordination boundaries.
 
 ## Notes
 
-| Date | Title |
-|---|---|
-| 2026-04-11 | [Formalism stack synthesis](2026-04-11-formalism-stack-synthesis.md) |
+| Date       | Title                                                                                                                |
+| ---------- | -------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-11 | [Formalism stack synthesis](2026-04-11-formalism-stack-synthesis.md)                                                 |
 | 2026-04-24 | [CALM and coordination boundaries on evolving graphs](2026-04-24-calm-coordination-boundaries-on-evolving-graphs.md) |
 
 ## Related
 
 - [../index.md](../index.md) - research-notes landing.
-- [../../Architecture/03-formalism-stack.md](../../Architecture/03-formalism-stack.md) - architecture chapter synthesizing this material.
-- [../../Publications/Paper-2-algebraic-foundations/](../../Publications/Paper-2-algebraic-foundations/) - formal write-up of the algebraic foundations.
+- [../../Architecture/03-formalism-stack.md](../../Architecture/03-formalism-stack.md) -
+  architecture chapter synthesizing this material.
+- [../../Publications/Paper-2-algebraic-foundations/](../../Publications/Paper-2-algebraic-foundations/) -
+  formal write-up of the algebraic foundations.

--- a/docs/Research-notes/Runtime/2026-04-24-topological-memory-iteration-synthesis.md
+++ b/docs/Research-notes/Runtime/2026-04-24-topological-memory-iteration-synthesis.md
@@ -1,74 +1,119 @@
 ---
 title: "Topological Memory — Iteration Synthesis"
-description: Research-grade retrospective on the DIG-538 / DIG-539 iteration round for Pulse topological memory — what was tried, what was discarded, what shipped, and what we now understand about the system
+description:
+  Research-grade retrospective on the DIG-538 / DIG-539 iteration round for Pulse topological memory
+  — what was tried, what was discarded, what shipped, and what we now understand about the system
 ---
 
 # Topological Memory — Iteration Synthesis
 
-**Date:** 2026-04-24
-**Scope:** `src/Cortex/Pulse/Memory/*`, `src/Cortex/Graph/Influence.hs`, and downstream reviewer-style retrieval.
-**Context:** retained retrospective for the topological-memory iteration that introduced DAG random-walk influence and pull-based memory retrieval.
+**Date:** 2026-04-24 **Scope:** `src/Cortex/Pulse/Memory/*`, `src/Cortex/Graph/Influence.hs`, and
+downstream reviewer-style retrieval. **Context:** retained retrospective for the topological-memory
+iteration that introduced DAG random-walk influence and pull-based memory retrieval.
 
 ---
 
 ## 1. Executive summary
 
-Over two sub-tickets (DIG-538, DIG-539) we replaced a hop-count graph signal with DAG random-walk influence, reshaped reviewer recall from push to pull, and discarded a PFS-based stop-at-k design after review caught three distinct correctness bugs. The final system is structurally simpler than the intermediate state: `WalkAlgorithm` went away, `composeScore` takes a `Double` influence value instead of `Int` hops, and the reviewer gets Markov-prefill + `cortex_memory_query` tool access under `MemoryTopological`.
+Over two sub-tickets (DIG-538, DIG-539) we replaced a hop-count graph signal with DAG random-walk
+influence, reshaped reviewer recall from push to pull, and discarded a PFS-based stop-at-k design
+after review caught three distinct correctness bugs. The final system is structurally simpler than
+the intermediate state: `WalkAlgorithm` went away, `composeScore` takes a `Double` influence value
+instead of `Int` hops, and the reviewer gets Markov-prefill + `cortex_memory_query` tool access
+under `MemoryTopological`.
 
 Two durable lessons came out of the round:
 
-- *Enumeration and scoring are orthogonal axes.* `WalkAlgorithm` (how candidates are collected) must not carry scoring model (how candidates are ranked). The DIG-538 v1 attempt conflated them and produced a misleading API with a real correctness bug.
-- *Stop-at-k requires monotone priority.* Frontier best-first gives top-k only if the priority function is non-increasing along graph edges. Our `composeScore` isn't monotone — temporal and semantic axes can spike at any depth — so PFS + `take k` under `composeScore` is unsound by construction, independent of implementation bugs.
+- _Enumeration and scoring are orthogonal axes._ `WalkAlgorithm` (how candidates are collected) must
+  not carry scoring model (how candidates are ranked). The DIG-538 v1 attempt conflated them and
+  produced a misleading API with a real correctness bug.
+- _Stop-at-k requires monotone priority._ Frontier best-first gives top-k only if the priority
+  function is non-increasing along graph edges. Our `composeScore` isn't monotone — temporal and
+  semantic axes can spike at any depth — so PFS + `take k` under `composeScore` is unsound by
+  construction, independent of implementation bugs.
 
-The current system is internally coherent and tested, but the *quality* of the new graph axis versus the old one is not yet empirically validated — ordering changes are demonstrable; improved reviews are an assumption.
+The current system is internally coherent and tested, but the _quality_ of the new graph axis versus
+the old one is not yet empirically validated — ordering changes are demonstrable; improved reviews
+are an assumption.
 
 ## 2. What the system is today
 
-Memory is a **deterministic query over the Pulse event substrate**, not a separate store. A stage's view is the result of a walk over `PersistedGraphState` at stage entry — captured once as a `MemorySnapshot` and bound to the stage's `MemoryHandle`.
+Memory is a **deterministic query over the Pulse event substrate**, not a separate store. A stage's
+view is the result of a walk over `PersistedGraphState` at stage entry — captured once as a
+`MemorySnapshot` and bound to the stage's `MemoryHandle`.
 
 Pipeline (`src/Cortex/Pulse/Memory/Query.hs:62`):
 
-1. `walkCandidates` enumerates the reachable cone with BFS; hop-count is carried for display + the `swMaxGraphDistance` pre-filter.
-2. `computeInfluenceMap` runs `dagRandomWalkInfluence` per direction relation (ancestors uses transposed topology; bidirectional runs both and merges per-node maps with `max`).
+1. `walkCandidates` enumerates the reachable cone with BFS; hop-count is carried for display + the
+   `swMaxGraphDistance` pre-filter.
+2. `computeInfluenceMap` runs `dagRandomWalkInfluence` per direction relation (ancestors uses
+   transposed topology; bidirectional runs both and merges per-node maps with `max`).
 3. Hop-count cutoff applied.
-4. Each surviving candidate scored via `composeScore(weights, influence[n], capturedAt, completedAt, scorer, queryText, bodyText)`.
+4. Each surviving candidate scored via
+   `composeScore(weights, influence[n], capturedAt, completedAt, scorer, queryText, bodyText)`.
 5. Sort by `(score DESC, hops ASC, NodeId ASC)`.
 6. `wsLimit` applied after sort.
 
-Per-stage behaviour selected via `MemoryStrategy = MemoryClassic | MemoryTopological TopologicalStrategyConfig` declared on the wire. Agent-driven ad-hoc recall routes through the `cortex_memory_query` tool (`Memory/Tool.hs`), which resolves a preset + optional field overrides and runs the same pure pipeline in-process against the bound handle.
+Per-stage behaviour selected via
+`MemoryStrategy = MemoryClassic | MemoryTopological TopologicalStrategyConfig` declared on the wire.
+Agent-driven ad-hoc recall routes through the `cortex_memory_query` tool (`Memory/Tool.hs`), which
+resolves a preset + optional field overrides and runs the same pure pipeline in-process against the
+bound handle.
 
 ## 3. Design frame evolution (chronological)
 
-### Frame 1 — DIG-529 / DIG-530: substrate + per-stage strategy *(inherited)*
+### Frame 1 — DIG-529 / DIG-530: substrate + per-stage strategy _(inherited)_
 
 - Memory = snapshot + pure walk + score.
 - `MemoryHandle` binds once at stage entry → no frontier-sibling bleed.
 - Wire authors declare `memory = topological { preset = …; routingKey = …; limit = …; };` per node.
 - Evidence: `Memory.hs:5-16`, `Types.hs:523-566`, `docs/Architecture/cortex-pulse.md:683-906`.
 
-### Frame 2 — DIG-538 v1: PFS as stop-at-k enumerator *(tried, discarded)*
+### Frame 2 — DIG-538 v1: PFS as stop-at-k enumerator _(tried, discarded)_
 
-**Hypothesis:** walk candidates in priority order (composite score as priority) and truncate at `k` to avoid scoring the full reachable set on large substrates.
+**Hypothesis:** walk candidates in priority order (composite score as priority) and truncate at `k`
+to avoid scoring the full reachable set on large substrates.
 
-**Implementation path:** `Cortex.Graph.Search` gained a `Frontier` class + `MinFrontier` / `MaxFrontier`, `walkCandidatesPfs` used `maxFrontier` over `composeScore`.
+**Implementation path:** `Cortex.Graph.Search` gained a `Frontier` class + `MinFrontier` /
+`MaxFrontier`, `walkCandidatesPfs` used `maxFrontier` over `composeScore`.
 
 **Three independent bugs surfaced in review:**
 
-1. **Double-`Down` priority wrapping.** `MaxFrontier` wraps its stored priority in `Down` internally; passing `Down p` produced `Down (Down Double)`, which preserves natural `Double` order, so `Set.minView` extracted the *smallest* score first. The `-∞` sentinel for the origin and out-of-scope nodes ended up first.
+1. **Double-`Down` priority wrapping.** `MaxFrontier` wraps its stored priority in `Down`
+   internally; passing `Down p` produced `Down (Down Double)`, which preserves natural `Double`
+   order, so `Set.minView` extracted the _smallest_ score first. The `-∞` sentinel for the origin
+   and out-of-scope nodes ended up first.
 
-2. **Best-first ≠ global top-k for non-monotone priority.** Example: `origin → a → b, origin → c` with `score(b) > score(c) > score(a)`. Best-first expands `origin`, pushes `{a, c}`, extracts `c` first, and with `limit = 1` returns `c` — but globally `b` wins. `composeScore` blends `1/(1 + hops)` (monotone) with temporal + semantic (per-node, non-monotone), so the monotonicity precondition fails by construction.
+2. **Best-first ≠ global top-k for non-monotone priority.** Example: `origin → a → b, origin → c`
+   with `score(b) > score(c) > score(a)`. Best-first expands `origin`, pushes `{a, c}`, extracts `c`
+   first, and with `limit = 1` returns `c` — but globally `b` wins. `composeScore` blends
+   `1/(1 + hops)` (monotone) with temporal + semantic (per-node, non-monotone), so the monotonicity
+   precondition fails by construction.
 
-3. **Bidirectional via overlay collapse.** `walkCandidatesPfs` used `topology <> transposeRelation topology` as a single relation, letting a walk alternate directions — from `A`, the shape `A → B ← C` reached `C` via `A → B → C`. BFS preserved direction cones by walking per-relation and merging with `min`; PFS didn't.
+3. **Bidirectional via overlay collapse.** `walkCandidatesPfs` used
+   `topology <> transposeRelation topology` as a single relation, letting a walk alternate
+   directions — from `A`, the shape `A → B ← C` reached `C` via `A → B → C`. BFS preserved direction
+   cones by walking per-relation and merging with `min`; PFS didn't.
 
-All three have pinned regression tests in `test/Cortex/Pulse/MemorySpec.hs` and `test/Cortex/GraphSpec.hs`.
+All three have pinned regression tests in `test/Cortex/Pulse/MemorySpec.hs` and
+`test/Cortex/GraphSpec.hs`.
 
-**Why discarded rather than repaired:** the correctness fix at commit `ebd166dc` (enumerate fully, priority-sort, post-hoc apply limit) produced observable output identical to BFS. The `WalkAlgorithm = WalkBfs | WalkPfs` knob became dead plumbing. Keeping it would have conflated enumeration strategy with scoring model — a category error that compounds.
+**Why discarded rather than repaired:** the correctness fix at commit `ebd166dc` (enumerate fully,
+priority-sort, post-hoc apply limit) produced observable output identical to BFS. The
+`WalkAlgorithm = WalkBfs | WalkPfs` knob became dead plumbing. Keeping it would have conflated
+enumeration strategy with scoring model — a category error that compounds.
 
 ### Frame 3 — Alternatives considered, not shipped
 
-- **A\* with admissible heuristic.** The only sound upper bound on unknown per-node temporal + semantic contributions is `w_temporal · 1 + w_semantic · 1` — near 2 at default weights, larger than any plausible real score. Under that bound A\* prunes nothing; it degenerates to BFS with bookkeeping overhead.
-- **Iterative Personalized PageRank with damping + ε fixed point.** On a DAG, iteration is unnecessary — one topological pass computes the exact stationary distribution.
-- **`GraphPrior = HopDecay | RandomWalkInfluence` as user-selectable axis.** Deferred. Shipping RandomWalkInfluence unconditionally; if A/B capability is needed later, add the selector with a real reason.
+- **A\* with admissible heuristic.** The only sound upper bound on unknown per-node temporal +
+  semantic contributions is `w_temporal · 1 + w_semantic · 1` — near 2 at default weights, larger
+  than any plausible real score. Under that bound A\* prunes nothing; it degenerates to BFS with
+  bookkeeping overhead.
+- **Iterative Personalized PageRank with damping + ε fixed point.** On a DAG, iteration is
+  unnecessary — one topological pass computes the exact stationary distribution.
+- **`GraphPrior = HopDecay | RandomWalkInfluence` as user-selectable axis.** Deferred. Shipping
+  RandomWalkInfluence unconditionally; if A/B capability is needed later, add the selector with a
+  real reason.
 
 ### Frame 4 — DIG-538 v2 shipped: DAG random-walk influence
 
@@ -88,79 +133,134 @@ dagRandomWalkInfluence alpha origin rel =
           if Set.member origin (relVertices rel) then results else Map.empty
 ```
 
-One `foldTopSort` pass; α = 0.85 hardcoded; returns empty on cyclic input. `composeScore`'s signature swapped from `Int` hops to `Double` influence (`Score.hs`), and `pureQueryMemory` threads the per-node influence map through. `Bidirectional` runs influence per-direction and merges with `max`, mirroring BFS's per-direction + `min` shape for hop distance.
+One `foldTopSort` pass; α = 0.85 hardcoded; returns empty on cyclic input. `composeScore`'s
+signature swapped from `Int` hops to `Double` influence (`Score.hs`), and `pureQueryMemory` threads
+the per-node influence map through. `Bidirectional` runs influence per-direction and merges with
+`max`, mirroring BFS's per-direction + `min` shape for hop distance.
 
-**Why this is sound where PFS wasn't:** no traversal-time decision to get wrong. Every reachable node is scored; ranking is a full sort. The remaining correctness question is whether the *signal* is meaningful — a separate question, tested in isolation.
+**Why this is sound where PFS wasn't:** no traversal-time decision to get wrong. Every reachable
+node is scored; ranking is a full sort. The remaining correctness question is whether the _signal_
+is meaningful — a separate question, tested in isolation.
 
-### Frame 5 — DIG-539 v1: Markov prefill + tool retrieval *(partially shipped, partially reversed)*
+### Frame 5 — DIG-539 v1: Markov prefill + tool retrieval _(partially shipped, partially reversed)_
 
-**Original framing:** "reviewer recall shouldn't stuff the whole ancestor cone into the prompt; use `scInputs` for the Markov boundary + `cortex_memory_query` tool for deeper access under `MemoryTopological`."
+**Original framing:** "reviewer recall shouldn't stuff the whole ancestor cone into the prompt; use
+`scInputs` for the Markov boundary + `cortex_memory_query` tool for deeper access under
+`MemoryTopological`."
 
 **Shipped:**
 
-- `runReviewerTopological` (DeepReport reviewer) uses `runToolLoop` with `cortex_memory_query` in `cortexChoiceTools`; `runReviewerClassic` is single-shot, no tools. Gating is at the tool catalog, not via system-prompt language.
+- `runReviewerTopological` (DeepReport reviewer) uses `runToolLoop` with `cortex_memory_query` in
+  `cortexChoiceTools`; `runReviewerClassic` is single-shot, no tools. Gating is at the tool catalog,
+  not via system-prompt language.
 - `reviewerMemoryToolNudge` tells the model about the Markov-boundary semantics and names the tool.
 - A legacy product-specific memory-strategy environment override was retired.
 
 **Reversed in review:**
 
-- *Review + rewriter stages aren't reviewer-shaped.* In parallel-claim-branches-v1 the Markov boundary of `runReviewStage` / `runRewriterStage` is the **merge** node — `scInputs` is the merged document, not analyst branches. Collapsing "analyst retrieval" to `analystOutputsFromInputs ctx.scInputs` lost sibling-branch access. Fix at `4a9b8495` restored `retrieveAncestorAnalystBranches` (returns `[]` under classic; walks under topological).
-- *The tool-nudge said "use `queryText` to narrow recall," but the scorer was hardcoded to `nullSemanticScorer`.* Fixed at `2e0f73b4` by defaulting to `defaultSemanticScorer` (token-jaccard).
-- *`peelWireValueEnvelope` looked for `wireValues` field; actual `WireValueSet` serialises as `values`.* Dormant bug that became load-bearing once reviewer recall routed through the generic extractor. Fixed at `2e0f73b4`.
+- _Review + rewriter stages aren't reviewer-shaped._ In parallel-claim-branches-v1 the Markov
+  boundary of `runReviewStage` / `runRewriterStage` is the **merge** node — `scInputs` is the merged
+  document, not analyst branches. Collapsing "analyst retrieval" to
+  `analystOutputsFromInputs ctx.scInputs` lost sibling-branch access. Fix at `4a9b8495` restored
+  `retrieveAncestorAnalystBranches` (returns `[]` under classic; walks under topological).
+- _The tool-nudge said "use `queryText` to narrow recall," but the scorer was hardcoded to
+  `nullSemanticScorer`._ Fixed at `2e0f73b4` by defaulting to `defaultSemanticScorer`
+  (token-jaccard).
+- _`peelWireValueEnvelope` looked for `wireValues` field; actual `WireValueSet` serialises as
+  `values`._ Dormant bug that became load-bearing once reviewer recall routed through the generic
+  extractor. Fixed at `2e0f73b4`.
 
 ## 4. Findings
 
-### F1 — Enumeration/scoring split is the right abstraction boundary *(Observed; high confidence)*
+### F1 — Enumeration/scoring split is the right abstraction boundary _(Observed; high confidence)_
 
-`WalkSpec` no longer carries `wsAlgorithm`; `Walk.hs` exports only `walkCandidates` / `directionRelations` / `bfsDistance`; the per-node graph-axis signal lives in `Cortex.Graph.Influence` and is composed in at `Query.hs:82`.
+`WalkSpec` no longer carries `wsAlgorithm`; `Walk.hs` exports only `walkCandidates` /
+`directionRelations` / `bfsDistance`; the per-node graph-axis signal lives in
+`Cortex.Graph.Influence` and is composed in at `Query.hs:82`.
 
-Future graph priors (Katz-style, SimRank, precomputed embeddings) slot in by replacing `dagRandomWalkInfluence`'s output, not by touching the walk. Future enumerators (heap-based exact top-k, approximate retrieval) slot into `walkCandidates` without touching scoring.
+Future graph priors (Katz-style, SimRank, precomputed embeddings) slot in by replacing
+`dagRandomWalkInfluence`'s output, not by touching the walk. Future enumerators (heap-based exact
+top-k, approximate retrieval) slot into `walkCandidates` without touching scoring.
 
-### F2 — Stop-at-k isn't real without monotone priority or a sound heuristic *(Observed; high confidence)*
+### F2 — Stop-at-k isn't real without monotone priority or a sound heuristic _(Observed; high confidence)_
 
-Saved as durable session memory (`feedback_stop_at_k_requires_monotone_priority.md`). Any future PR proposing "PFS for stop-at-k" over composite scoring must first show the priority is monotone along edges. For our `composeScore`, no.
+Saved as durable session memory (`feedback_stop_at_k_requires_monotone_priority.md`). Any future PR
+proposing "PFS for stop-at-k" over composite scoring must first show the priority is monotone along
+edges. For our `composeScore`, no.
 
-Legitimate paths to real stop-at-k: (a) restrict priority to a monotone axis (graph-only), (b) precompute per-node scores offline so retrieval is heap-top-k over a set, (c) derive an admissible upper bound tight enough to prune (we don't have one).
+Legitimate paths to real stop-at-k: (a) restrict priority to a monotone axis (graph-only), (b)
+precompute per-node scores offline so retrieval is heap-top-k over a set, (c) derive an admissible
+upper bound tight enough to prune (we don't have one).
 
-### F3 — Influence signal is measurably different from hop decay; whether better is untested *(Observed mechanism; unvalidated fitness; medium confidence)*
+### F3 — Influence signal is measurably different from hop decay; whether better is untested _(Observed mechanism; unvalidated fitness; medium confidence)_
 
 **Revised from high to medium** after review feedback.
 
-Mechanism is observed: the fanout-fixture test on the same snapshot returns `[analyst-a, analyst-b, analyst-c, planner]` under hop decay and `[planner, analyst-a, analyst-b, analyst-c]` under influence. Planner (3-way merge target from the reviewer) outranks direct-predecessor analysts because α² · 3 / 3 = α² > α/3.
+Mechanism is observed: the fanout-fixture test on the same snapshot returns
+`[analyst-a, analyst-b, analyst-c, planner]` under hop decay and
+`[planner, analyst-a, analyst-b, analyst-c]` under influence. Planner (3-way merge target from the
+reviewer) outranks direct-predecessor analysts because α² · 3 / 3 = α² > α/3.
 
-**The open question is fitness for purpose.** If the reviewer's job is to scrutinize what the analysts wrote, the analysts are the nodes whose content matters. Ranking planner above them under `limit = k` pushes content-bearing nodes off the list — the opposite of what we want.
+**The open question is fitness for purpose.** If the reviewer's job is to scrutinize what the
+analysts wrote, the analysts are the nodes whose content matters. Ranking planner above them under
+`limit = k` pushes content-bearing nodes off the list — the opposite of what we want.
 
-Mitigation in the current code: `retrieveAncestorAnalystBranches` (used by `runReviewStage` / `runRewriterStage`) filters via `analystBranchExtractor`, so non-analyst nodes drop out before scoring. Within the filtered slot, influence and hop-decay both rank equal-distance sibling analysts identically. The risk is concentrated on the *tool-driven* reviewer recall path where the model chooses the routing filter; if it omits one, planner-type nodes can outrank content nodes.
+Mitigation in the current code: `retrieveAncestorAnalystBranches` (used by `runReviewStage` /
+`runRewriterStage`) filters via `analystBranchExtractor`, so non-analyst nodes drop out before
+scoring. Within the filtered slot, influence and hop-decay both rank equal-distance sibling analysts
+identically. The risk is concentrated on the _tool-driven_ reviewer recall path where the model
+chooses the routing filter; if it omits one, planner-type nodes can outrank content nodes.
 
-**What would downgrade this from "risk" to "demonstrated improvement":** a held-out set of reviewer queries comparing top-k under influence vs hop-decay under a rubric of "did the retrieved fragments let the reviewer detect a real concern?"
+**What would downgrade this from "risk" to "demonstrated improvement":** a held-out set of reviewer
+queries comparing top-k under influence vs hop-decay under a rubric of "did the retrieved fragments
+let the reviewer detect a real concern?"
 
-### F4 — "Memory strategy" isn't stage-role-keyed; it's `(role, wire-topology)`-keyed *(Observed; high confidence)*
+### F4 — "Memory strategy" isn't stage-role-keyed; it's `(role, wire-topology)`-keyed _(Observed; high confidence)_
 
-**Sharpened from original framing.** The original DIG-539 framing was "every review-shaped stage uses Markov prefill." Reality: every review-shaped stage has to ask what its Markov boundary actually is, and the answer depends on wire topology, not stage name.
+**Sharpened from original framing.** The original DIG-539 framing was "every review-shaped stage
+uses Markov prefill." Reality: every review-shaped stage has to ask what its Markov boundary
+actually is, and the answer depends on wire topology, not stage name.
 
-`runReviewStage` and `runRewriterStage` share the "reviewer" stage role but sit in a wire where their Markov boundary is a merge node, not analyst branches. `retrieveAncestorAnalystBranches` is a hand-rolled instance of what the general abstraction wants to be: "walk past my Markov boundary to nodes of type X."
+`runReviewStage` and `runRewriterStage` share the "reviewer" stage role but sit in a wire where
+their Markov boundary is a merge node, not analyst branches. `retrieveAncestorAnalystBranches` is a
+hand-rolled instance of what the general abstraction wants to be: "walk past my Markov boundary to
+nodes of type X."
 
-**Implication:** there's no such thing as a generic stage-role-keyed memory strategy. If a third stage needs a custom ancestor-walker, that's the signal to promote memory-strategy resolution into wire-structural arguments — e.g. `memory = topological { past-boundary = merge; upstream-of-type = "analyst"; … }` rather than preset names. Watch-item; not yet urgent.
+**Implication:** there's no such thing as a generic stage-role-keyed memory strategy. If a third
+stage needs a custom ancestor-walker, that's the signal to promote memory-strategy resolution into
+wire-structural arguments — e.g.
+`memory = topological { past-boundary = merge; upstream-of-type = "analyst"; … }` rather than preset
+names. Watch-item; not yet urgent.
 
-### F5 — Agent-facing retrieval surface is now behaviour-honest *(Observed; high confidence)*
+### F5 — Agent-facing retrieval surface is now behaviour-honest _(Observed; high confidence)_
 
-Before this round: the nudge said "use `queryText`" but the scorer returned zero; the generic extractor failed on `WireValueSet`-shaped outputs. Both silently degraded retrieval under a limit. After `2e0f73b4`: token-jaccard is the default scorer (pluggable), both envelope shapes peel correctly, and tests pin both behaviours.
+Before this round: the nudge said "use `queryText`" but the scorer returned zero; the generic
+extractor failed on `WireValueSet`-shaped outputs. Both silently degraded retrieval under a limit.
+After `2e0f73b4`: token-jaccard is the default scorer (pluggable), both envelope shapes peel
+correctly, and tests pin both behaviours.
 
-### F6 — Tuning priorities (revised order) *(Inferred; medium confidence)*
+### F6 — Tuning priorities (revised order) _(Inferred; medium confidence)_
 
 **Reordered from original memo** after review feedback.
 
-1. **Semantic scorer.** `tokenJaccard` is a baseline, not a serious retrieval mechanism. Swapping for embedding-based scoring is probably where the retrieval-quality ceiling actually sits. Pluggable via `qSemanticScorer`; no API change needed to swap.
-2. **Preset catalog openness.** `resolveWalkSpecPreset` is a closed case-of over four named presets. Wire authors can't define new presets without a Haskell change. If custom per-wire memory shapes proliferate, this is where authoring friction shows up.
-3. **Influence cache.** Tool-loop reviewer calls `cortex_memory_query` repeatedly within one stage; each call recomputes the influence map. Memoise on `MemoryHandle`. This is a latency concern, not a ranking-quality concern.
-4. **Damping factor α.** Hardcoded at 0.85. On a DAG with max hop distance 2–6, α^5 = 0.44 at default — α mostly shifts decay sharpness rather than flipping orderings. Probably a distraction compared to (1).
+1. **Semantic scorer.** `tokenJaccard` is a baseline, not a serious retrieval mechanism. Swapping
+   for embedding-based scoring is probably where the retrieval-quality ceiling actually sits.
+   Pluggable via `qSemanticScorer`; no API change needed to swap.
+2. **Preset catalog openness.** `resolveWalkSpecPreset` is a closed case-of over four named presets.
+   Wire authors can't define new presets without a Haskell change. If custom per-wire memory shapes
+   proliferate, this is where authoring friction shows up.
+3. **Influence cache.** Tool-loop reviewer calls `cortex_memory_query` repeatedly within one stage;
+   each call recomputes the influence map. Memoise on `MemoryHandle`. This is a latency concern, not
+   a ranking-quality concern.
+4. **Damping factor α.** Hardcoded at 0.85. On a DAG with max hop distance 2–6, α^5 = 0.44 at
+   default — α mostly shifts decay sharpness rather than flipping orderings. Probably a distraction
+   compared to (1).
 
-### F7 — Architecture alignment with DIG-488/490 is concrete at the `qExtractor` seam *(Observed; medium confidence)*
+### F7 — Architecture alignment with DIG-488/490 is concrete at the `qExtractor` seam _(Observed; medium confidence)_
 
-The typed-artifact / topology-bounded-retrieval direction asks downstream nodes
-to bind slices of upstream artifacts rather than receiving whole payloads. The
-memory system is the retrieval half of that direction. The `qExtractor` hook is
-the integration point.
+The typed-artifact / topology-bounded-retrieval direction asks downstream nodes to bind slices of
+upstream artifacts rather than receiving whole payloads. The memory system is the retrieval half of
+that direction. The `qExtractor` hook is the integration point.
 
 **Concrete sketch.** The `Query` type already carries a pluggable extractor:
 
@@ -202,55 +302,80 @@ projectionExtractor projection sliceFields raw = do
     }
 ```
 
-Where `ArtifactProjection a slice` is the typed lens the DIG-488 plan wants to introduce (one full artifact, many narrow projections), and `SliceFields` carries the same three axes the scorer + router already consume. The full artifact stays in `msNodeOutputs`; only the projected slice enters the match record.
+Where `ArtifactProjection a slice` is the typed lens the DIG-488 plan wants to introduce (one full
+artifact, many narrow projections), and `SliceFields` carries the same three axes the scorer +
+router already consume. The full artifact stays in `msNodeOutputs`; only the projected slice enters
+the match record.
 
 **What needs to exist for this to land:**
 
 - `Cortex.Wire.Value` (or a new `Cortex.Artifact`) exposes `ArtifactProjection` as a type.
-- `.cr` grammar lets a `memory = topological { … }` declaration name a projection on the retrieved nodes — e.g. `projection = "analyst_headline"`.
+- `.cr` grammar lets a `memory = topological { … }` declaration name a projection on the retrieved
+  nodes — e.g. `projection = "analyst_headline"`.
 - `Cortex.Pulse.Memory.Tool` resolves the projection name at query time and builds the extractor.
 
-None of this touches the query pipeline, the scorer, the walk, or the influence computation. The abstraction boundary F1 gives us is exactly the place DIG-488 integration slots in.
+None of this touches the query pipeline, the scorer, the walk, or the influence computation. The
+abstraction boundary F1 gives us is exactly the place DIG-488 integration slots in.
 
 ## 5. What we'd undo if we could
 
-Honest retrospective: given what we know now, we'd skip the DIG-538 v1 PFS implementation entirely and jump straight to the enumerate-then-sort + random-walk influence shape. The PFS detour cost one full review cycle and left behind three regression tests that exist only because of the mistake.
+Honest retrospective: given what we know now, we'd skip the DIG-538 v1 PFS implementation entirely
+and jump straight to the enumerate-then-sort + random-walk influence shape. The PFS detour cost one
+full review cycle and left behind three regression tests that exist only because of the mistake.
 
-What the detour *did* produce that was worth keeping: the three regression tests themselves (now pinning correctness invariants future refactors will need), and the `Frontier` / `MinFrontier` / `MaxFrontier` abstractions in `Cortex.Graph.Search` (unused by memory but useful for other search problems). Net-positive on the extraction, net-negative on the round-trip cost.
+What the detour _did_ produce that was worth keeping: the three regression tests themselves (now
+pinning correctness invariants future refactors will need), and the `Frontier` / `MinFrontier` /
+`MaxFrontier` abstractions in `Cortex.Graph.Search` (unused by memory but useful for other search
+problems). Net-positive on the extraction, net-negative on the round-trip cost.
 
-The retained lesson: *don't add a user-facing knob (`WalkAlgorithm`) when the design intent is really a scoring change.* Enumeration and scoring are orthogonal axes; conflating them produces APIs that look flexible but aren't.
+The retained lesson: _don't add a user-facing knob (`WalkAlgorithm`) when the design intent is
+really a scoring change._ Enumeration and scoring are orthogonal axes; conflating them produces APIs
+that look flexible but aren't.
 
 ## 6. Honest statements of uncertainty
 
-- **Influence-vs-hop ranking quality is untested on real reviewer transcripts.** Merge-vs-chain is mathematically correct; whether it produces *better reviews* is unvalidated.
-- **Bidirectional `max`-merge is a judgment call.** Other reasonable choices: sum (total attention), min (conservative), per-direction maps exposed separately. `max` mirrors BFS's `min`-merge shape for hop distance — aesthetic, not derived from a use case.
-- **α = 0.85 is the standard PageRank default and not validated for this domain.** See F6 for why this is probably a distraction.
-- **The biggest quality lever is almost certainly semantic scorer sophistication, not graph axis tuning.** Swapping `tokenJaccard` for an embedding model would dominate any improvement from α tuning or influence-vs-hop.
-- **F4's "watch-item" may already be triggered.** If DIG-488/490's typed-artifact future means more stages with merge-gated Markov boundaries, the "memory strategy parameterised by wire-structural arguments" evolution could be forced sooner than expected.
+- **Influence-vs-hop ranking quality is untested on real reviewer transcripts.** Merge-vs-chain is
+  mathematically correct; whether it produces _better reviews_ is unvalidated.
+- **Bidirectional `max`-merge is a judgment call.** Other reasonable choices: sum (total attention),
+  min (conservative), per-direction maps exposed separately. `max` mirrors BFS's `min`-merge shape
+  for hop distance — aesthetic, not derived from a use case.
+- **α = 0.85 is the standard PageRank default and not validated for this domain.** See F6 for why
+  this is probably a distraction.
+- **The biggest quality lever is almost certainly semantic scorer sophistication, not graph axis
+  tuning.** Swapping `tokenJaccard` for an embedding model would dominate any improvement from α
+  tuning or influence-vs-hop.
+- **F4's "watch-item" may already be triggered.** If DIG-488/490's typed-artifact future means more
+  stages with merge-gated Markov boundaries, the "memory strategy parameterised by wire-structural
+  arguments" evolution could be forced sooner than expected.
 
 ## 7. Prioritised next steps
 
 ### Act now
 
-- **None blocking.** Current state is correct, tested, internally coherent. The negative lessons and the `qExtractor` integration sketch are captured above.
+- **None blocking.** Current state is correct, tested, internally coherent. The negative lessons and
+  the `qExtractor` integration sketch are captured above.
 
 ### Design next
 
-- **Retrieval-quality A/B harness.** Held-out reviewer query set; top-k under influence vs hop-decay under a judgment rubric. Block the "influence is better" claim on this.
+- **Retrieval-quality A/B harness.** Held-out reviewer query set; top-k under influence vs hop-decay
+  under a judgment rubric. Block the "influence is better" claim on this.
 - **Semantic scorer upgrade.** `tokenJaccard` → embedding-based. Biggest likely quality lever.
-- **Influence cache on `MemoryHandle`.** Tool-loop reviewer makes repeated calls within one stage; memoise.
+- **Influence cache on `MemoryHandle`.** Tool-loop reviewer makes repeated calls within one stage;
+  memoise.
 
 ### Write up
 
 - Two ADRs split out of this memo:
-  - *Enumeration and scoring are orthogonal axes* (positive lesson from F1).
-  - *Stop-at-k requires monotone priority* (negative lesson from F2).
+  - _Enumeration and scoring are orthogonal axes_ (positive lesson from F1).
+  - _Stop-at-k requires monotone priority_ (negative lesson from F2).
 - Update any paper-drafts that still describe hop-count as the graph axis.
 
 ### Parked
 
-- A\* / monotone-priority stop-at-k. Requires domain structure we don't have. Revisit only if substrate sizes grow by ≥10× and full-cone scoring becomes a hotspot.
-- User-selectable `GraphPrior`. Add if/when we have a second prior that's observably useful for distinct stage kinds.
+- A\* / monotone-priority stop-at-k. Requires domain structure we don't have. Revisit only if
+  substrate sizes grow by ≥10× and full-cone scoring becomes a hotspot.
+- User-selectable `GraphPrior`. Add if/when we have a second prior that's observably useful for
+  distinct stage kinds.
 
 ---
 
@@ -258,10 +383,24 @@ The retained lesson: *don't add a user-facing knob (`WalkAlgorithm`) when the de
 
 The memo above reflects the revised stance. The deltas from the original draft, with attribution:
 
-- **F3 downgraded high → medium.** "Different is not better." The original memo treated ordering change as evidence of improvement; it's only evidence that the new axis is doing something. Fitness for purpose requires an eval harness, flagged as "Design next."
-- **F4 sharpened.** Original framing was "stage-specific calibration required" (tuning concern). Revised framing: there is no stage-role-keyed memory strategy that is correct across wires — the strategy is a `(role, topology)` function. `retrieveAncestorAnalystBranches` is evidence that the right long-term abstraction may be memory strategies parameterised by wire-structural relationships, not preset names.
-- **F6 reordered.** Original priority put α tuning near the top; revised ranks semantic scorer > preset catalog > cache > α. On DAGs with bounded hop distance, α mostly shifts decay sharpness rather than flipping orderings; `tokenJaccard` → embeddings is where the ranking-quality ceiling actually sits.
-- **F7 earned.** Original memo asserted DIG-488/490 alignment without showing mechanism. This revision includes the `qExtractor` typed-projection sketch (§4 F7) so the alignment claim is a demonstration, not an assertion.
-- **New §5: What we'd undo if we could.** Template improvement for future research memos — explicit cost-accounting of iteration dead ends, because "the detour happened" is how future-me remembers it was considered and rejected with receipts.
+- **F3 downgraded high → medium.** "Different is not better." The original memo treated ordering
+  change as evidence of improvement; it's only evidence that the new axis is doing something.
+  Fitness for purpose requires an eval harness, flagged as "Design next."
+- **F4 sharpened.** Original framing was "stage-specific calibration required" (tuning concern).
+  Revised framing: there is no stage-role-keyed memory strategy that is correct across wires — the
+  strategy is a `(role, topology)` function. `retrieveAncestorAnalystBranches` is evidence that the
+  right long-term abstraction may be memory strategies parameterised by wire-structural
+  relationships, not preset names.
+- **F6 reordered.** Original priority put α tuning near the top; revised ranks semantic scorer >
+  preset catalog > cache > α. On DAGs with bounded hop distance, α mostly shifts decay sharpness
+  rather than flipping orderings; `tokenJaccard` → embeddings is where the ranking-quality ceiling
+  actually sits.
+- **F7 earned.** Original memo asserted DIG-488/490 alignment without showing mechanism. This
+  revision includes the `qExtractor` typed-projection sketch (§4 F7) so the alignment claim is a
+  demonstration, not an assertion.
+- **New §5: What we'd undo if we could.** Template improvement for future research memos — explicit
+  cost-accounting of iteration dead ends, because "the detour happened" is how future-me remembers
+  it was considered and rejected with receipts.
 
-The reviewer's core thesis — *"different" is not "better"* — is the most load-bearing correction and shaped the F3 downgrade.
+The reviewer's core thesis — _"different" is not "better"_ — is the most load-bearing correction and
+shaped the F3 downgrade.

--- a/docs/Research-notes/Runtime/index.md
+++ b/docs/Research-notes/Runtime/index.md
@@ -8,17 +8,18 @@ sidebar:
 
 # Research Notes - Runtime
 
-Execution-layer research synthesis: Pulse, graph execution, rewrites, and
-memory.
+Execution-layer research synthesis: Pulse, graph execution, rewrites, and memory.
 
 ## Notes
 
-| Date | Title |
-|---|---|
+| Date       | Title                                                                                            |
+| ---------- | ------------------------------------------------------------------------------------------------ |
 | 2026-04-24 | [Topological Memory - Iteration Synthesis](2026-04-24-topological-memory-iteration-synthesis.md) |
 
 ## Related
 
 - [../index.md](../index.md) - research-notes landing.
-- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) - Pulse architecture chapter.
-- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md) - rewrites chapter.
+- [../../Architecture/06-pulse-runtime.md](../../Architecture/06-pulse-runtime.md) - Pulse
+  architecture chapter.
+- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md) -
+  rewrites chapter.

--- a/docs/Research-notes/Wire/2026-04-23-wire-composition-sugar.md
+++ b/docs/Research-notes/Wire/2026-04-23-wire-composition-sugar.md
@@ -1,6 +1,8 @@
 ---
 title: "Wire Composition Sugar: Operators, Templates, Lambdas, Combinator Executors"
-description: Speculative evaluation of composition-level reuse mechanisms for Wire beyond the v1 Mokhov algebra. Not a spec proposal; preserved as design backlog.
+description:
+  Speculative evaluation of composition-level reuse mechanisms for Wire beyond the v1 Mokhov
+  algebra. Not a spec proposal; preserved as design backlog.
 date: 2026-04-23
 status: research
 related:
@@ -14,16 +16,24 @@ related:
 
 ## Context
 
-The Wire grammar ships with two graph operators (`<>` overlay and `=>` connect) plus tuples, and one reuse primitive at the node level: partial nodes with `//` merge (§5.3 of the spec). Deliberately small. Deliberately Mokhov-algebraic.
+The Wire grammar ships with two graph operators (`<>` overlay and `=>` connect) plus tuples, and one
+reuse primitive at the node level: partial nodes with `//` merge (§5.3 of the spec). Deliberately
+small. Deliberately Mokhov-algebraic.
 
 Two classes of reuse are naturally expressible in v1:
 
-- **Node-level reuse** — "same executor archetype, different config." Covered by partial nodes + `//`. The flagship example's `analyst_base // { prompt = ... }` is the canonical pattern.
+- **Node-level reuse** — "same executor archetype, different config." Covered by partial nodes +
+  `//`. The flagship example's `analyst_base // { prompt = ... }` is the canonical pattern.
 - **One-off composed wires** — `let thesis = planner => analyst => reviewer;` binds a specific wire.
 
-What v1 does *not* have is **composition-level reuse** — "same topology, different node participants." Patterns like zip, scatter-gather, or pipeline-with-review are expressible today only by writing them out for each instance. This note evaluates the design space for adding composition-level reuse, concludes that none of it is load-bearing for v1, and preserves the thinking so the question doesn't have to be rediscovered.
+What v1 does _not_ have is **composition-level reuse** — "same topology, different node
+participants." Patterns like zip, scatter-gather, or pipeline-with-review are expressible today only
+by writing them out for each instance. This note evaluates the design space for adding
+composition-level reuse, concludes that none of it is load-bearing for v1, and preserves the
+thinking so the question doesn't have to be rediscovered.
 
-Scope of this note: speculative design backlog, not a spec proposal. Spec stays tight around the Mokhov algebra. Anything here is admissible later without invalidating v1 wires.
+Scope of this note: speculative design backlog, not a spec proposal. Spec stays tight around the
+Mokhov algebra. Anything here is admissible later without invalidating v1 wires.
 
 ## Four Candidate Mechanisms
 
@@ -33,14 +43,25 @@ Proposed in early jam sessions: sugar operators for fanout, fanin, star, clique.
 
 Evaluated:
 
-- **`=<<` fanout.** Redundant with `source => (a, b, c)`, which already cross-product-matches source's outputs to each tuple element's inputs on contract. `=<<` would add a glyph with no semantic gain.
-- **`>>=` fanin.** Mirror of `=<<`. `(a, b, c) => aggregator` with list-valued `<- [C]` already covers it. Arity distinguishes list-input aggregation from singular-input arity error.
-- **`<*>` star.** The applicative analogy does not port to directed dataflow. The only semantics not already covered are bidirectional hub-and-spoke, which introduces cycles through every spoke and breaks DAG. Scatter-gather is already `source => middle => sink`, one chain.
-- **`</>` clique.** All-to-all in a directed graph produces `n(n-1)` edges and a cycle between every pair. Useful for gossip/all-reduce patterns; Wire is not targeting those. Almost always a smell in typed dataflow; prefer an aggregator node.
+- **`=<<` fanout.** Redundant with `source => (a, b, c)`, which already cross-product-matches
+  source's outputs to each tuple element's inputs on contract. `=<<` would add a glyph with no
+  semantic gain.
+- **`>>=` fanin.** Mirror of `=<<`. `(a, b, c) => aggregator` with list-valued `<- [C]` already
+  covers it. Arity distinguishes list-input aggregation from singular-input arity error.
+- **`<*>` star.** The applicative analogy does not port to directed dataflow. The only semantics not
+  already covered are bidirectional hub-and-spoke, which introduces cycles through every spoke and
+  breaks DAG. Scatter-gather is already `source => middle => sink`, one chain.
+- **`</>` clique.** All-to-all in a directed graph produces `n(n-1)` edges and a cycle between every
+  pair. Useful for gossip/all-reduce patterns; Wire is not targeting those. Almost always a smell in
+  typed dataflow; prefer an aggregator node.
 
-**Verdict:** zero added expressiveness for all four. Operators have compounding cost (LLM rewriter action space, reader load, precedence decisions). Hard reject for v1 and later.
+**Verdict:** zero added expressiveness for all four. Operators have compounding cost (LLM rewriter
+action space, reader load, precedence decisions). Hard reject for v1 and later.
 
-The one pattern that *is* notationally awkward today is **zip / pairwise** — `(a, b) => (c, d)` means cross-product (four edges); pairwise `a => c, b => d` is `(a => c) <> (b => d)` written out. Linear growth with arity. If any operator were to justify itself, it'd be zip. But zip is better served by templates or a combinator executor than by a new graph operator.
+The one pattern that _is_ notationally awkward today is **zip / pairwise** — `(a, b) => (c, d)`
+means cross-product (four edges); pairwise `a => c, b => d` is `(a => c) <> (b => d)` written out.
+Linear growth with arity. If any operator were to justify itself, it'd be zip. But zip is better
+served by templates or a combinator executor than by a new graph operator.
 
 ### 2. Templates with Holes
 
@@ -54,7 +75,8 @@ template zip(a, b, c, d) = (a => c) <> (b => d);
 let my_wire = zip(planner, analyst, gatherer, merge);
 ```
 
-Invocation expands to the base algebra at compile time. Fixed arity. No first-class "template value" exists; templates cannot be passed around, stored, or returned.
+Invocation expands to the base algebra at compile time. Fixed arity. No first-class "template value"
+exists; templates cannot be passed around, stored, or returned.
 
 Roughly C-macro or Scheme `syntax-rules` in scope. Cheap to add:
 
@@ -63,15 +85,21 @@ Roughly C-macro or Scheme `syntax-rules` in scope. Cheap to add:
 - Invocation-as-call syntax.
 - No type-level machinery needed (body is closed over the graph algebra).
 
-**Unlocks:** named known-arity composition patterns. Zip, scatter-gather, pipeline-with-review, error-routing wrapper, etc. — whatever the production wires repeat.
+**Unlocks:** named known-arity composition patterns. Zip, scatter-gather, pipeline-with-review,
+error-routing wrapper, etc. — whatever the production wires repeat.
 
-**Does not unlock:** variable-arity patterns (templates are arity-fixed), higher-order composition (no first-class template values).
+**Does not unlock:** variable-arity patterns (templates are arity-fixed), higher-order composition
+(no first-class template values).
 
-**Restriction proposal:** if added, restrict template bodies to **graph-algebra expressions only** — `<>`, `=>`, parameters, other templates. No record operations, no string concat, no conditional logic. Keeps the action space bounded and inspectable; same design pressure as "closed alphabets, open composition."
+**Restriction proposal:** if added, restrict template bodies to **graph-algebra expressions only** —
+`<>`, `=>`, parameters, other templates. No record operations, no string concat, no conditional
+logic. Keeps the action space bounded and inspectable; same design pressure as "closed alphabets,
+open composition."
 
 ### 3. Full Lambdas
 
-First-class functions over wires. `let zip = \(a, b, c, d) -> (a => c) <> (b => d);` — bind a function value, invoke via application.
+First-class functions over wires. `let zip = \(a, b, c, d) -> (a => c) <> (b => d);` — bind a
+function value, invoke via application.
 
 Bigger jump than templates:
 
@@ -83,17 +111,29 @@ Bigger jump than templates:
 
 **Unlocks beyond templates:**
 
-1. **Variable-arity combinators.** `fold_overlay : [Wire] -> Wire = foldl (<>) ()`. Templates cannot express this — they need one definition per arity. A planner that emits `N` section briefs and needs `N` corresponding workers wired to one aggregator is currently awkward; with lambdas + list operations it is direct.
+1. **Variable-arity combinators.** `fold_overlay : [Wire] -> Wire = foldl (<>) ()`. Templates cannot
+   express this — they need one definition per arity. A planner that emits `N` section briefs and
+   needs `N` corresponding workers wired to one aggregator is currently awkward; with lambdas + list
+   operations it is direct.
 
-2. **Composable structural transformers.** Wire-to-wire functions composed via `∘`: `wrap_with_retry ∘ add_error_sink ∘ base_thesis`. Each transformer is a value; you store them in lists, apply them conditionally. Templates give you one transformer at a time, not composition of transformers.
+2. **Composable structural transformers.** Wire-to-wire functions composed via `∘`:
+   `wrap_with_retry ∘ add_error_sink ∘ base_thesis`. Each transformer is a value; you store them in
+   lists, apply them conditionally. Templates give you one transformer at a time, not composition of
+   transformers.
 
-3. **LLM rewriter abstraction (speculative).** A rewriter that notices "I keep wiring this 4-node pattern" could *emit a lambda definition* capturing the pattern, then use the lambda name in subsequent rewrites. This is compositional compression — a qualitatively different rewriter behavior from "edit nodes and edges." Adjacent to the rewrite materialization plan and Paper 3 (graph substitution semantics). Speculative; unproven.
+3. **LLM rewriter abstraction (speculative).** A rewriter that notices "I keep wiring this 4-node
+   pattern" could _emit a lambda definition_ capturing the pattern, then use the lambda name in
+   subsequent rewrites. This is compositional compression — a qualitatively different rewriter
+   behavior from "edit nodes and edges." Adjacent to the rewrite materialization plan and Paper 3
+   (graph substitution semantics). Speculative; unproven.
 
-**Does not unlock:** anything not already unlockable by templates when arity is known at compile time.
+**Does not unlock:** anything not already unlockable by templates when arity is known at compile
+time.
 
 ### 4. Registered Combinator Executors
 
-Instead of Wire-language sugar, register specific composition patterns as executors in the Cortex alphabet. `@combinator.zip`, `@combinator.fan_out_n`, etc.
+Instead of Wire-language sugar, register specific composition patterns as executors in the Cortex
+alphabet. `@combinator.zip`, `@combinator.fan_out_n`, etc.
 
 Sketch (hypothetical):
 
@@ -107,9 +147,13 @@ node zip_pair :
 = @combinator.zip {};
 ```
 
-**Catch:** this requires Wire-typed ports or a universal `Graph` contract — both deferred in v1 (§13 "Universal runtime contract `Graph C`"). It also introduces *compile-time evaluation* of executors, which is a real semantic shift from today's "executors run at evaluation time."
+**Catch:** this requires Wire-typed ports or a universal `Graph` contract — both deferred in v1 (§13
+"Universal runtime contract `Graph C`"). It also introduces _compile-time evaluation_ of executors,
+which is a real semantic shift from today's "executors run at evaluation time."
 
-**Trade-off:** uses the existing alphabet mechanism (fits the design rule "Wire composes registered authority; Haskell owns what the authority means"), but introduces a second role for executors — structural expansion alongside value production. One mechanism, two semantics.
+**Trade-off:** uses the existing alphabet mechanism (fits the design rule "Wire composes registered
+authority; Haskell owns what the authority means"), but introduces a second role for executors —
+structural expansion alongside value production. One mechanism, two semantics.
 
 ## Analysis
 
@@ -118,16 +162,24 @@ Three questions decide each:
 **What's the trigger that promotes it from speculative to necessary?**
 
 - **Operators:** none foreseeable. Reject permanently.
-- **Templates:** the first time a production wire or rewrite proposal repeats a known-arity composition pattern enough times that inlining feels painful. Probably arrives with DIG-478 or similar dynamic-rewrite work.
-- **Lambdas:** the first time a planner-driven rewrite needs variable-arity wiring (N workers wired generically), or the first time the rewriter wants to factor a discovered pattern into a named abstraction.
+- **Templates:** the first time a production wire or rewrite proposal repeats a known-arity
+  composition pattern enough times that inlining feels painful. Probably arrives with DIG-478 or
+  similar dynamic-rewrite work.
+- **Lambdas:** the first time a planner-driven rewrite needs variable-arity wiring (N workers wired
+  generically), or the first time the rewriter wants to factor a discovered pattern into a named
+  abstraction.
 - **Combinator executors:** requires universal `Graph` contract landing first. Until then, blocked.
 
 **What's the cost?**
 
-- **Operators:** low per operator, compounding. Each one expands LLM rewriter action space and reader load permanently.
-- **Templates:** moderate. One new top-level form, restricted body, parse-time expansion. Rewriter just sees the expansion.
-- **Lambdas:** high. Full function language under Wire. Inference story. Closure semantics. Type system implications.
-- **Combinator executors:** moderate-high. Unlocks structural-expansion-at-compile-time, which affects evaluation model.
+- **Operators:** low per operator, compounding. Each one expands LLM rewriter action space and
+  reader load permanently.
+- **Templates:** moderate. One new top-level form, restricted body, parse-time expansion. Rewriter
+  just sees the expansion.
+- **Lambdas:** high. Full function language under Wire. Inference story. Closure semantics. Type
+  system implications.
+- **Combinator executors:** moderate-high. Unlocks structural-expansion-at-compile-time, which
+  affects evaluation model.
 
 **What does the rewriter have to learn?**
 
@@ -138,14 +190,19 @@ Three questions decide each:
 
 ## Recommendation
 
-**Hold the line at v1's Mokhov algebra.** No operator sugar, no templates, no lambdas, no combinator executors in v1.
+**Hold the line at v1's Mokhov algebra.** No operator sugar, no templates, no lambdas, no combinator
+executors in v1.
 
 Watch for these pressure signals:
 
-1. **Known-arity composition repetition** in production wires or rewrite proposals. If it starts happening, templates are the right answer — cheap, bounded.
-2. **Variable-arity wiring requirement** from planner-driven rewrites. Lambdas become the right answer — but only this specific case justifies them.
-3. **Rewriter pattern-compression behavior** in agent work. If a rewriter starts "wanting" to name patterns it discovers, lambdas become interesting for a different reason. Speculative.
-4. **Universal Graph contract** landing for other reasons. Combinator executors become admissible as a by-product; evaluate then.
+1. **Known-arity composition repetition** in production wires or rewrite proposals. If it starts
+   happening, templates are the right answer — cheap, bounded.
+2. **Variable-arity wiring requirement** from planner-driven rewrites. Lambdas become the right
+   answer — but only this specific case justifies them.
+3. **Rewriter pattern-compression behavior** in agent work. If a rewriter starts "wanting" to name
+   patterns it discovers, lambdas become interesting for a different reason. Speculative.
+4. **Universal Graph contract** landing for other reasons. Combinator executors become admissible as
+   a by-product; evaluate then.
 
 Until one of those fires concretely, each mechanism stays in the backlog.
 
@@ -155,19 +212,30 @@ Three observations worth preserving:
 
 ### Lambdas are not pure sugar; templates are
 
-Templates expand at parse time. Everything they can express is a fixed-arity composition. Lambdas can express combinators over variable-arity lists of wires. The "templates are to lambdas what partial nodes are to full functions" framing is correct: templates buy ~80% of ergonomic wins at ~20% of conceptual cost, but the remaining 20% is real, not cosmetic.
+Templates expand at parse time. Everything they can express is a fixed-arity composition. Lambdas
+can express combinators over variable-arity lists of wires. The "templates are to lambdas what
+partial nodes are to full functions" framing is correct: templates buy ~80% of ergonomic wins at
+~20% of conceptual cost, but the remaining 20% is real, not cosmetic.
 
 ### The rewriter abstraction case is speculative but interesting
 
-A rewriter that can emit `let foo = \(...) -> ...` and use it later is doing something qualitatively different from a rewriter that only edits topology. It is compressing its own output. If research on Cortex rewriting (rewrite materialization plan / Paper 3) moves toward abstraction-emitting rewriters, lambdas become a design requirement, not a convenience.
+A rewriter that can emit `let foo = \(...) -> ...` and use it later is doing something qualitatively
+different from a rewriter that only edits topology. It is compressing its own output. If research on
+Cortex rewriting (rewrite materialization plan / Paper 3) moves toward abstraction-emitting
+rewriters, lambdas become a design requirement, not a convenience.
 
 ### "Closed alphabets, open composition" can be extended without operators
 
-The current action space is `(alphabet, composition) → wire`. Adding templates keeps the alphabet closed (executors and contracts registered externally) but expands the composition side with named patterns. Adding lambdas does the same but with first-class functions. Neither violates the design rule; both extend it. What does violate the rule: operators. Each new operator enlarges the closed side of the equation.
+The current action space is `(alphabet, composition) → wire`. Adding templates keeps the alphabet
+closed (executors and contracts registered externally) but expands the composition side with named
+patterns. Adding lambdas does the same but with first-class functions. Neither violates the design
+rule; both extend it. What does violate the rule: operators. Each new operator enlarges the closed
+side of the equation.
 
 ## Appendix — The Zip Problem in Detail
 
-The pairwise-composition case deserves a concrete trace because it is the most commonly-cited motivation for added sugar.
+The pairwise-composition case deserves a concrete trace because it is the most commonly-cited
+motivation for added sugar.
 
 **Current v1 expression:**
 
@@ -191,13 +259,20 @@ Sixteen edges (4×4). This is what `=>` means; it is not the same as zip.
 
 **Candidate sugar mechanisms:**
 
-- Operator `~~` or similar: `(a1, a2, a3, a4) ~~> (b1, b2, b3, b4)`. Dedicated pairwise operator. Rejected for reasons above.
-- Template: `template zip4(a1, a2, a3, a4, b1, b2, b3, b4) = (a1=>b1) <> (a2=>b2) <> (a3=>b3) <> (a4=>b4);`. Arity-specific; one template per arity.
-- Lambda: `let zip = \lefts rights -> foldl (<>) () (zipWith (=>) lefts rights);`. Variable-arity. Requires lambdas + list operations + `zipWith` as a registered combinator.
+- Operator `~~` or similar: `(a1, a2, a3, a4) ~~> (b1, b2, b3, b4)`. Dedicated pairwise operator.
+  Rejected for reasons above.
+- Template:
+  `template zip4(a1, a2, a3, a4, b1, b2, b3, b4) = (a1=>b1) <> (a2=>b2) <> (a3=>b3) <> (a4=>b4);`.
+  Arity-specific; one template per arity.
+- Lambda: `let zip = \lefts rights -> foldl (<>) () (zipWith (=>) lefts rights);`. Variable-arity.
+  Requires lambdas + list operations + `zipWith` as a registered combinator.
 - Combinator executor: `@combinator.zip`. Requires universal Graph contract.
 
-**Observation:** the zip problem only appears painful when you want variable-arity zip. Fixed-arity zip is one overlay chain; the pattern is obvious and short. If variable-arity zip becomes a production requirement, it is a lambda-level question, not an operator-level one.
+**Observation:** the zip problem only appears painful when you want variable-arity zip. Fixed-arity
+zip is one overlay chain; the pattern is obvious and short. If variable-arity zip becomes a
+production requirement, it is a lambda-level question, not an operator-level one.
 
 ---
 
-*This note is speculative backlog. No v1 spec change is proposed. Revisit when one of the four pressure signals fires.*
+_This note is speculative backlog. No v1 spec change is proposed. Revisit when one of the four
+pressure signals fires._

--- a/docs/Research-notes/Wire/index.md
+++ b/docs/Research-notes/Wire/index.md
@@ -8,17 +8,17 @@ sidebar:
 
 # Research Notes - Wire
 
-Wire-layer research synthesis retained because it still feeds current language
-design.
+Wire-layer research synthesis retained because it still feeds current language design.
 
 ## Notes
 
-| Date | Title |
-|---|---|
+| Date       | Title                                                                                                                |
+| ---------- | -------------------------------------------------------------------------------------------------------------------- |
 | 2026-04-23 | [Wire composition sugar - operators, templates, lambdas, combinator executors](2026-04-23-wire-composition-sugar.md) |
 
 ## Related
 
 - [../index.md](../index.md) - research-notes landing.
 - [../../Reference/Wire/](../../Reference/Wire/) - normative Wire language reference.
-- [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) - Wire substrate architecture.
+- [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) - Wire substrate
+  architecture.

--- a/docs/Research-notes/index.md
+++ b/docs/Research-notes/index.md
@@ -1,6 +1,8 @@
 ---
 title: Cortex Research Notes
-description: Dated Cortex research synthesis retained when it still explains current canon or live research threads.
+description:
+  Dated Cortex research synthesis retained when it still explains current canon or live research
+  threads.
 sidebar:
   label: Research notes
   order: 7
@@ -8,20 +10,16 @@ sidebar:
 
 # Cortex Research Notes
 
-Research notes are dated artifacts. They are not canonical specs, and they are
-not a permanent store for every issue-era synthesis. Retain notes that still
-explain current Cortex architecture, publication work, or active research
-questions.
+Research notes are dated artifacts. They are not canonical specs, and they are not a permanent store
+for every issue-era synthesis. Retain notes that still explain current Cortex architecture,
+publication work, or active research questions.
 
 ## Scope Subdirectories
 
-- **[Foundation/](Foundation/)** - formalism, algebraic structure, and
-  coordination boundaries.
-- **[Runtime/](Runtime/)** - Pulse runtime, graph execution, rewrites, and
-  memory.
+- **[Foundation/](Foundation/)** - formalism, algebraic structure, and coordination boundaries.
+- **[Runtime/](Runtime/)** - Pulse runtime, graph execution, rewrites, and memory.
 - **[Wire/](Wire/)** - Wire language design and source-language semantics.
-- **[Applications/](Applications/)** - downstream use cases and workflow
-  patterns.
+- **[Applications/](Applications/)** - downstream use cases and workflow patterns.
 
 ## What Belongs Here
 
@@ -33,17 +31,15 @@ questions.
 
 - Stale PR handoffs.
 - Superseded grammar snapshots.
-- Issue-specific migration notes whose surviving claims now live in canonical
-  architecture, reference, or ADR docs.
+- Issue-specific migration notes whose surviving claims now live in canonical architecture,
+  reference, or ADR docs.
 - Consumer-specific product strategy that belongs under `Consumers/`.
 
 ## Template
 
-Use [../Templates/research-memo.md](../Templates/research-memo.md) for new
-notes.
+Use [../Templates/research-memo.md](../Templates/research-memo.md) for new notes.
 
 ## Related
 
-- [../Architecture/](../Architecture/) - canonical chapters the research notes
-  feed into.
+- [../Architecture/](../Architecture/) - canonical chapters the research notes feed into.
 - [../Publications/](../Publications/) - formal write-ups the notes support.

--- a/docs/Roadmap/Archive/index.md
+++ b/docs/Roadmap/Archive/index.md
@@ -10,6 +10,6 @@ sidebar:
 
 No archived roadmap docs are currently retained.
 
-Archive docs are for superseded proposals that still explain why the current
-system looks the way it does. Stale issue-era plans and obsolete grammar
-snapshots should be removed once canonical reference docs replace them.
+Archive docs are for superseded proposals that still explain why the current system looks the way it
+does. Stale issue-era plans and obsolete grammar snapshots should be removed once canonical
+reference docs replace them.

--- a/docs/Roadmap/Completed/index.md
+++ b/docs/Roadmap/Completed/index.md
@@ -10,6 +10,6 @@ sidebar:
 
 No completed initiative docs are currently retained.
 
-Completed docs should stay in the tree only when they help readers understand
-the current architecture. Otherwise, the current architecture, reference, or ADR
-should carry the surviving idea.
+Completed docs should stay in the tree only when they help readers understand the current
+architecture. Otherwise, the current architecture, reference, or ADR should carry the surviving
+idea.

--- a/docs/Roadmap/Epics/index.md
+++ b/docs/Roadmap/Epics/index.md
@@ -10,10 +10,9 @@ sidebar:
 
 No active epic docs are currently retained.
 
-Use this directory only for multi-PR initiatives that are still useful as a
-current coordination surface. Once an epic ships or is superseded, either
-replace it with canonical Architecture/reference material or move a concise
-historical record to `Completed/` or `Archive/`.
+Use this directory only for multi-PR initiatives that are still useful as a current coordination
+surface. Once an epic ships or is superseded, either replace it with canonical
+Architecture/reference material or move a concise historical record to `Completed/` or `Archive/`.
 
 ## Template
 

--- a/docs/Roadmap/Plans/index.md
+++ b/docs/Roadmap/Plans/index.md
@@ -8,17 +8,17 @@ sidebar:
 
 # Cortex Plans
 
-| Plan | Kind | Status |
-|---|---|---|
-| [Lean mechanization](lean-mechanization.md) | Research plan | Proposed |
+| Plan                                                                            | Kind          | Status   |
+| ------------------------------------------------------------------------------- | ------------- | -------- |
+| [Lean mechanization](lean-mechanization.md)                                     | Research plan | Proposed |
 | [Rewrite materialization and recovery](rewrite-materialization-and-recovery.md) | Research plan | Proposed |
 
 ## Template
 
-Use the [implementation-plan template](../../Templates/implementation-plan.md)
-as the baseline when the plan is implementation-facing. Research plans should
-keep the same frontmatter discipline and clear scope, but may replace delivery
-slices with theorem obligations, evidence targets, and open proof debt.
+Use the [implementation-plan template](../../Templates/implementation-plan.md) as the baseline when
+the plan is implementation-facing. Research plans should keep the same frontmatter discipline and
+clear scope, but may replace delivery slices with theorem obligations, evidence targets, and open
+proof debt.
 
 ## Related
 

--- a/docs/Roadmap/Plans/lean-mechanization.md
+++ b/docs/Roadmap/Plans/lean-mechanization.md
@@ -12,23 +12,20 @@ related:
 
 # Lean Mechanization Research Plan
 
-**Status:** proposed
-**Scope:** machine-checked support for the fixed-topology staged-reduction core
+**Status:** proposed **Scope:** machine-checked support for the fixed-topology staged-reduction core
 used by Papers 1 and 2
 
 ## Summary
 
-This plan turns the fixed-topology staged-reduction core into a Lean 4
-mechanization target. The goal is not end-to-end workflow correctness or
-replayed I/O equivalence. The goal is to mechanize the structural safety
-contract the runtime actually relies on: commutative accumulation of node-local
-facts, idempotent failure closure, deterministic classification, and recovery
-safety after persisted-prefix crashes.
+This plan turns the fixed-topology staged-reduction core into a Lean 4 mechanization target. The
+goal is not end-to-end workflow correctness or replayed I/O equivalence. The goal is to mechanize
+the structural safety contract the runtime actually relies on: commutative accumulation of
+node-local facts, idempotent failure closure, deterministic classification, and recovery safety
+after persisted-prefix crashes.
 
-The central artifact is an explicit `WellFormedGraphState` structure, exposed
-under the published `wellFormedGraphState` predicate name, for normalized,
-closed states. Without that predicate, Paper 1's recovery claim and Paper 2's
-algebraic presentation remain too rhetorical.
+The central artifact is an explicit `WellFormedGraphState` structure, exposed under the published
+`wellFormedGraphState` predicate name, for normalized, closed states. Without that predicate, Paper
+1's recovery claim and Paper 2's algebraic presentation remain too rhetorical.
 
 ## Core Definitions
 
@@ -57,8 +54,8 @@ structure WellFormedGraphState (G : DAG) (s : GraphState) : Prop where
   frontierBridge : frontierBridge G s
 ```
 
-Here `frontierBridge` means proof-level `readyNodes G s` coincides with the
-runtime-style direct-predecessor frontier `directReadyNodes G s`.
+Here `frontierBridge` means proof-level `readyNodes G s` coincides with the runtime-style
+direct-predecessor frontier `directReadyNodes G s`.
 
 ## Theorem Stack
 
@@ -137,9 +134,8 @@ theorem persistence_safety
   wellFormedGraphState G sRecovered
 ```
 
-This is the load-bearing theorem for the crash-recovery model. It should match
-Paper 1's structural persistence-safety claim and Paper 2's recovery theorem in
-intent.
+This is the load-bearing theorem for the crash-recovery model. It should match Paper 1's structural
+persistence-safety claim and Paper 2's recovery theorem in intent.
 
 ### Tier 5: Classification exhaustiveness
 
@@ -151,8 +147,8 @@ theorem classifyClosedGraphState_exhaustive_of_wellFormed
   ...
 ```
 
-The classifier sits above recovery: well-formed recovered states can resume,
-settle, or suspend, but they cannot enter the stuck diagnostic branch.
+The classifier sits above recovery: well-formed recovered states can resume, settle, or suspend, but
+they cannot enter the stuck diagnostic branch.
 
 ## Explicit Non-Goals
 
@@ -163,8 +159,8 @@ Do not expand this plan into:
 - dynamic graph rewriting correctness
 - operator-facing persistence semantics
 
-Those belong either to assumptions outside the fixed-topology kernel or to the
-separate rewrite-materialization track.
+Those belong either to assumptions outside the fixed-topology kernel or to the separate
+rewrite-materialization track.
 
 ## Suggested Lean Module Structure
 
@@ -184,15 +180,16 @@ DurableTask/
     Safety.lean
 ```
 
-`Validity.lean` should appear early, not as an afterthought. The point of this
-plan is to make valid graph state a first-class theorem object.
+`Validity.lean` should appear early, not as an afterthought. The point of this plan is to make valid
+graph state a first-class theorem object.
 
 ## Expected Challenges
 
 - Finite DAG representation may need an adapter from the runtime's relation-style graph model.
 - Closure idempotence is the hardest proof burden in the current stack.
 - `Waiting(signal)` complicates any local status order because waiting carries data.
-- Output ownership is two-sided in the fixed-topology kernel: outputs must appear only where statuses own them, and completed/rewritten statuses must carry outputs.
+- Output ownership is two-sided in the fixed-topology kernel: outputs must appear only where
+  statuses own them, and completed/rewritten statuses must carry outputs.
 
 ## Relationship to the Paper Set
 
@@ -219,6 +216,9 @@ This plan provides three concrete benefits:
 
 ## Related
 
-- [../../Publications/Paper-1-staged-reduction/](../../Publications/Paper-1-staged-reduction/) — runtime-grounded fixed-topology paper.
-- [../../Publications/Paper-2-algebraic-foundations/](../../Publications/Paper-2-algebraic-foundations/) — algebraic companion paper.
-- [rewrite-materialization-and-recovery.md](rewrite-materialization-and-recovery.md) — separate plan for dynamic topology.
+- [../../Publications/Paper-1-staged-reduction/](../../Publications/Paper-1-staged-reduction/) —
+  runtime-grounded fixed-topology paper.
+- [../../Publications/Paper-2-algebraic-foundations/](../../Publications/Paper-2-algebraic-foundations/)
+  — algebraic companion paper.
+- [rewrite-materialization-and-recovery.md](rewrite-materialization-and-recovery.md) — separate plan
+  for dynamic topology.

--- a/docs/Roadmap/Plans/rewrite-materialization-and-recovery.md
+++ b/docs/Roadmap/Plans/rewrite-materialization-and-recovery.md
@@ -1,6 +1,8 @@
 ---
 title: Rewrite Materialization and Recovery Research Plan
-description: Research plan for dynamic graph rewriting, materialization boundaries, and recovery semantics in durable execution.
+description:
+  Research plan for dynamic graph rewriting, materialization boundaries, and recovery semantics in
+  durable execution.
 sidebar:
   label: Rewrite materialization
   order: 4
@@ -13,26 +15,23 @@ related:
 
 # Rewrite Materialization and Recovery Research Plan
 
-**Status:** proposed
-**Scope:** runtime-grounded rewrite admission, materialization, and recovery
+**Status:** proposed **Scope:** runtime-grounded rewrite admission, materialization, and recovery
 semantics beyond the fixed-topology core
 
 ## Summary
 
-This plan is the runtime-grounded companion to Paper 3's substitution theory.
-It studies topology-changing durable execution in which a running stage may
-propose a structured rewrite of the future execution graph. Papers 1 and 2
-cover the fixed-topology kernel; they do not cover the case where accumulation,
-closure, and recovery are computed over a graph that may change mid-run.
+This plan is the runtime-grounded companion to Paper 3's substitution theory. It studies
+topology-changing durable execution in which a running stage may propose a structured rewrite of the
+future execution graph. Papers 1 and 2 cover the fixed-topology kernel; they do not cover the case
+where accumulation, closure, and recovery are computed over a graph that may change mid-run.
 
-The plan therefore centers on a stronger execution machine with an explicit
-materialization boundary and iterative control loop over materialized graph
-state. The focus is recovery semantics, not just rewrite syntax.
+The plan therefore centers on a stronger execution machine with an explicit materialization boundary
+and iterative control loop over materialized graph state. The focus is recovery semantics, not just
+rewrite syntax.
 
 ## Why This Is Separate
 
-Topology-changing execution is not a minor extension of the fixed-topology
-theorem.
+Topology-changing execution is not a minor extension of the fixed-topology theorem.
 
 Once a rewrite is admitted:
 
@@ -46,8 +45,8 @@ The theory also needs to distinguish:
 - the planned or compiled graph artifact describing what obligations may arise
 - the materialized execution state describing what this run has actually reached
 
-This is why the runtime rewrite story belongs in a plan of its own rather than
-as a subsection of the fixed-topology papers.
+This is why the runtime rewrite story belongs in a plan of its own rather than as a subsection of
+the fixed-topology papers.
 
 ## Rewrite-Capable Machine
 
@@ -68,10 +67,11 @@ flowchart TD
 
 Key rule:
 
-- an admitted rewrite must be materialized before the runtime may conclude completion, suspension, or stuckness from the old topology
+- an admitted rewrite must be materialized before the runtime may conclude completion, suspension,
+  or stuckness from the old topology
 
-The back-edge above is a runtime control loop, not a graph cycle. Each
-materialized topology epoch is still a DAG.
+The back-edge above is a runtime control loop, not a graph cycle. Each materialized topology epoch
+is still a DAG.
 
 ## Durable Identity Model
 
@@ -82,8 +82,8 @@ The rewrite-capable runtime needs distinct identities for:
 - `StageActionId` — executable identity used for hydration and retry validation
 - `stageId` — semantic stage label only
 
-The plan should explain why these identities must stay distinct and what fails
-when `stageId` is overloaded as both semantic and executable identity.
+The plan should explain why these identities must stay distinct and what fails when `stageId` is
+overloaded as both semantic and executable identity.
 
 ## Persistence and Materialization
 
@@ -116,8 +116,8 @@ The current shipped rejection policy is intentionally narrow:
 
 - invalid or over-budget rewrites fail fast with a structured diagnostic
 
-Configurable fallback or planner-visible rejection handling is future work, not
-part of the current contract.
+Configurable fallback or planner-visible rejection handling is future work, not part of the current
+contract.
 
 ## Proof Obligations
 
@@ -129,8 +129,7 @@ The plan centers on the new proof burdens:
 4. dataflow preservation for output-preserving rewrite modes
 5. admitted-rewrite-before-termination correctness
 
-The fixed-topology theorem can be reused only inside a single materialized
-topology epoch.
+The fixed-topology theorem can be reused only inside a single materialized topology epoch.
 
 ## Boundary to Process Migration
 
@@ -139,9 +138,8 @@ Local graph substitution and non-local workflow migration should remain distinct
 - local rewrites substitute a bounded node region and continue
 - migration reinterprets already executed structure, history, or state mapping
 
-That boundary matters because future planner- or operator-driven graph surgery
-may stop being "just another rewrite constructor" and become a process-migration
-problem instead.
+That boundary matters because future planner- or operator-driven graph surgery may stop being "just
+another rewrite constructor" and become a process-migration problem instead.
 
 ## Relationship to the Paper Set
 
@@ -149,10 +147,11 @@ problem instead.
 - **Lean mechanization plan** — machine-checked support for the fixed-topology core
 - **Paper 2** — algebraic theory of the fixed-topology core and extension boundary
 - **This plan** — rewrite-capable execution, materialization, and recovery semantics
-- **Paper 3** — graph substitution semantics, compiled artifacts, and the implementation-independent layering above this runtime track
+- **Paper 3** — graph substitution semantics, compiled artifacts, and the implementation-independent
+  layering above this runtime track
 
-This split keeps the fixed-topology theorem honest while giving rewriting
-enough room to be treated seriously.
+This split keeps the fixed-topology theorem honest while giving rewriting enough room to be treated
+seriously.
 
 ## Deferred Work
 
@@ -162,10 +161,14 @@ The following are explicitly outside the current shipped and theory contract:
 - configurable rewrite rejection fallback instead of fail-fast only
 - richer operator-facing graph visualization and rewrite provenance
 - hierarchical child workflows with explicit sub-budget assignment
-- integrity witnesses stronger than the current watermark model, such as materialized-graph checksums
+- integrity witnesses stronger than the current watermark model, such as materialized-graph
+  checksums
 
 ## Related
 
-- [../../Publications/Paper-2-algebraic-foundations/](../../Publications/Paper-2-algebraic-foundations/) — fixed-topology algebra and extension boundary.
-- [../../Publications/Paper-3-graph-substitution-semantics/](../../Publications/Paper-3-graph-substitution-semantics/) — implementation-independent substitution theory.
-- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md) — canonical runtime architecture chapter.
+- [../../Publications/Paper-2-algebraic-foundations/](../../Publications/Paper-2-algebraic-foundations/)
+  — fixed-topology algebra and extension boundary.
+- [../../Publications/Paper-3-graph-substitution-semantics/](../../Publications/Paper-3-graph-substitution-semantics/)
+  — implementation-independent substitution theory.
+- [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md)
+  — canonical runtime architecture chapter.

--- a/docs/Roadmap/index.md
+++ b/docs/Roadmap/index.md
@@ -1,6 +1,8 @@
 ---
 title: Cortex Roadmap
-description: Active Cortex engineering and research plans, with selective history for retained completed or archived work.
+description:
+  Active Cortex engineering and research plans, with selective history for retained completed or
+  archived work.
 sidebar:
   label: Roadmap
   order: 4
@@ -8,32 +10,30 @@ sidebar:
 
 # Cortex Roadmap
 
-The roadmap keeps current work discoverable. It is not a permanent dump for
-issue snapshots, PR handoffs, or migration-era planning notes.
+The roadmap keeps current work discoverable. It is not a permanent dump for issue snapshots, PR
+handoffs, or migration-era planning notes.
 
 ## Tracks
 
 - **[Plans/](Plans/)** - focused implementation or research plans.
 - **[Epics/](Epics/)** - long-running initiatives when an active epic exists.
-- **[Completed/](Completed/)** - shipped initiatives retained because they still
-  explain current architecture.
+- **[Completed/](Completed/)** - shipped initiatives retained because they still explain current
+  architecture.
 - **[Archive/](Archive/)** - superseded proposals retained selectively.
 
 ## Current Plans
 
-- **[Lean mechanization](Plans/lean-mechanization.md)** - machine-checked support
-  for the fixed-topology core.
+- **[Lean mechanization](Plans/lean-mechanization.md)** - machine-checked support for the
+  fixed-topology core.
 - **[Rewrite materialization and recovery](Plans/rewrite-materialization-and-recovery.md)** -
   runtime-grounded rewrite and recovery semantics.
 
 ## Retention Rule
 
-When a plan stops explaining current work, remove it or replace it with a short
-current plan. Do not preserve stale issue-era plans merely because they once
-existed.
+When a plan stops explaining current work, remove it or replace it with a short current plan. Do not
+preserve stale issue-era plans merely because they once existed.
 
 ## Templates
 
 Use the [roadmap-epic template](../Templates/roadmap-epic.md) or
-[implementation-plan template](../Templates/implementation-plan.md) for new
-roadmap docs.
+[implementation-plan template](../Templates/implementation-plan.md) for new roadmap docs.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,6 +1,8 @@
 ---
 title: Cortex Glossary
-description: Definitions of Wire and Cortex terms readers will encounter across the docs. Normative definitions live in Reference/terminology.md; this page is a quick-reference pointer.
+description:
+  Definitions of Wire and Cortex terms readers will encounter across the docs. Normative definitions
+  live in Reference/terminology.md; this page is a quick-reference pointer.
 sidebar:
   label: Glossary
   order: 4
@@ -9,65 +11,62 @@ sidebar:
 # Cortex Glossary
 
 Quick-reference terms. Normative and complete definitions live in
-[Reference/terminology.md](Reference/terminology.md); this page exists for
-casual lookup and orientation.
+[Reference/terminology.md](Reference/terminology.md); this page exists for casual lookup and
+orientation.
 
 ## Core substrate
 
 - **Cortex** — the standalone AI substrate described in these docs.
-- **Algebra** — the pure topology and relation layer: vertices, edges, overlay,
-  connect, and law-bearing graph operations.
-- **Wire** — the source language for authoring executable topology. Its compiled
-  circuit form is the artifact Pulse executes. Grammar:
-  [Reference/Wire/grammar.md](Reference/Wire/grammar.md).
+- **Algebra** — the pure topology and relation layer: vertices, edges, overlay, connect, and
+  law-bearing graph operations.
+- **Wire** — the source language for authoring executable topology. Its compiled circuit form is the
+  artifact Pulse executes. Grammar: [Reference/Wire/grammar.md](Reference/Wire/grammar.md).
 - **Pulse** — the durable runtime that executes Circuits. See
   [Architecture/06-pulse-runtime.md](Architecture/06-pulse-runtime.md).
-- **Capability** — external authority surfaces available to execution: models,
-  tools, providers, and their neutral request/record types. Not the same as a
-  Nous activation bundle, formerly called a Nous capability bundle.
-- **Artifact** — generic durable outputs, provenance, metadata, rendering, and
-  artifact host boundaries.
-- **Cortex.Nous** — the structured reasoning library above the runtime
-  substrate. It owns reusable LLM-shaped catalogs, not runtime authority.
-- **Cortex.Nous.Archetypes** — the canonical epistemological archetype catalog:
-  Logos, Sophia, Techne, Episteme, Kritikos, Themis, and Poiesis.
-- **Cortex.Nous.Thought** — one bounded model-mediated cognitive evaluation bound
-  to a graph node; not a durable persona.
-- **Cortex.Nous.Memory** — cognitive memory: retrieval, ranking, packing,
-  compaction, source selection, topological context, and memory tools.
-- **Cortex.Nous.Patterns** — planned reusable reasoning-program catalogs such as
-  the DeepReport extraction target.
-- **Logos** — the `Cortex.Nous.Archetypes.Logos` archetype for discursive
-  reason, argument, and symbolic reasoning.
-- **Nous activation bundle** — the operational implementation of an archetype:
-  prompt discipline, retrieval corpus, embedding spaces, tools, memory policy,
-  evaluation criteria, and runtime contract.
+- **Capability** — external authority surfaces available to execution: models, tools, providers, and
+  their neutral request/record types. Not the same as a Nous activation bundle, formerly called a
+  Nous capability bundle.
+- **Artifact** — generic durable outputs, provenance, metadata, rendering, and artifact host
+  boundaries.
+- **Cortex.Nous** — the structured reasoning library above the runtime substrate. It owns reusable
+  LLM-shaped catalogs, not runtime authority.
+- **Cortex.Nous.Archetypes** — the canonical epistemological archetype catalog: Logos, Sophia,
+  Techne, Episteme, Kritikos, Themis, and Poiesis.
+- **Cortex.Nous.Thought** — one bounded model-mediated cognitive evaluation bound to a graph node;
+  not a durable persona.
+- **Cortex.Nous.Memory** — cognitive memory: retrieval, ranking, packing, compaction, source
+  selection, topological context, and memory tools.
+- **Cortex.Nous.Patterns** — planned reusable reasoning-program catalogs such as the DeepReport
+  extraction target.
+- **Logos** — the `Cortex.Nous.Archetypes.Logos` archetype for discursive reason, argument, and
+  symbolic reasoning.
+- **Nous activation bundle** — the operational implementation of an archetype: prompt discipline,
+  retrieval corpus, embedding spaces, tools, memory policy, evaluation criteria, and runtime
+  contract.
 
 ## Wire language
 
 - **Contract** — a named typed interface that flows through a port.
 - **Port** — a slot on a node, typed by a contract. Input (`<-`) or output (`->`). May be labeled.
-- **Port key** — `(direction, contract, label)`, the identity tuple `=>`
-  matches on.
+- **Port key** — `(direction, contract, label)`, the identity tuple `=>` matches on.
 - **Label** — part of a port's routing identity, not a cosmetic name.
 - **Node** — an executor application pinned to a port signature.
 - **Executor** — a registered recipe that turns inputs into outputs.
 - **Partial node** — a configured executor value with no ports pinned yet.
 - **Sum group** — output-port form `-> A | B` where exactly one variant fires.
-- **Wire value** — a node, a composed graph expression, or a port-determined
-  partial node in graph position.
+- **Wire value** — a node, a composed graph expression, or a port-determined partial node in graph
+  position.
 - **Port-boundary** — a wire's currently unconnected input and output ports.
-- **File-return expression** — the last expression in a `.wire` file, which
-  becomes the file's value.
-- **Evaluation-boundary check** — the runnable-wire gate: every singular input
-  must be connected exactly once.
+- **File-return expression** — the last expression in a `.wire` file, which becomes the file's
+  value.
+- **Evaluation-boundary check** — the runnable-wire gate: every singular input must be connected
+  exactly once.
 
 ## Composition
 
 - **`<>` overlay** — set union of nodes and edges.
 - **`=>` connect** — port-key-matched edge addition over boundaries.
-- **`//` merge** — right-biased shallow record merge; also applies to
-  partial-node configs.
+- **`//` merge** — right-biased shallow record merge; also applies to partial-node configs.
 - **`++` concat** — string and list concatenation.
 - **`|` sum** — output-port mutual-exclusion constructor.
 - **`@` application** — executor application to config: `@qualified.name { ... }`.
@@ -76,27 +75,24 @@ casual lookup and orientation.
 
 - **Envelope** — the runtime carrier for a value:
   `{ contract, mediaType, producer, value, provenance }`.
-- **Payload kind** — the runtime category of a contract's value:
-  `json`, `markdown`, `text`, `table`, or `artifact_ref`.
-- **Contract registry** — the authoritative contract definitions used for
-  validation, decoding, and rendering.
+- **Payload kind** — the runtime category of a contract's value: `json`, `markdown`, `text`,
+  `table`, or `artifact_ref`.
+- **Contract registry** — the authoritative contract definitions used for validation, decoding, and
+  rendering.
 - **Provenance** — the runtime record of where a value came from.
 - **Rewrite** — a bounded topology edit admitted during runtime. See
   [Architecture/07-rewrites-and-materialization.md](Architecture/07-rewrites-and-materialization.md).
 - **Gas** — structural-change budget consumed by rewrites.
-- **Topological memory** — `Cortex.Nous.Memory` context built from settled
-  upstream Pulse state.
+- **Topological memory** — `Cortex.Nous.Memory` context built from settled upstream Pulse state.
 
 ## Doc kinds
 
-- **Canonical chapter** — `NN-*` file under `Architecture/`. Part of the
-  architecture book.
+- **Canonical chapter** — `NN-*` file under `Architecture/`. Part of the architecture book.
 - **Reference** — normative spec under `Reference/`. Consultable, rule-precise.
 - **ADR** — `NNNN-*` file under `ADRs/`. One committed design decision.
 - **Epic** — long-running engineering initiative in `Roadmap/Epics/`.
 - **Plan** — implementation plan under `Roadmap/Plans/`.
-- **Research note** — dated synthesis/design memo under
-  `Research-notes/{scope}/`.
+- **Research note** — dated synthesis/design memo under `Research-notes/{scope}/`.
 - **Experiment** — dated smoke test or dogfood under `Experiments/{scope}/`.
 - **Handoff** — dated transition note under `Handoffs/`.
 - **Manuscript** — paper under `Publications/paper-N-*/manuscript.md`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 ---
 title: Cortex Documentation
-description: "Cortex as an upstream AI substrate: algebraic topology, Wire authoring, Pulse execution, controlled rewrites, artifacts, provenance, Nous cognition, and downstream bindings."
+description:
+  "Cortex as an upstream AI substrate: algebraic topology, Wire authoring, Pulse execution,
+  controlled rewrites, artifacts, provenance, Nous cognition, and downstream bindings."
 sidebar:
   label: Cortex
   order: 2
@@ -8,46 +10,45 @@ sidebar:
 
 # Cortex Documentation
 
-Cortex is a standalone Haskell substrate for graph-shaped AI systems. It gives
-you algebraic topology, a small language for authoring workflows, a durable
-runtime for executing them, and artifact/provenance surfaces for explaining what
-happened.
+Cortex is a standalone Haskell substrate for graph-shaped AI systems. It gives you algebraic
+topology, a small language for authoring workflows, a durable runtime for executing them, and
+artifact/provenance surfaces for explaining what happened.
 
-The boundary is deliberate: Cortex owns reusable mechanics; downstream products
-own domain semantics, policy, tools, operators, transport, and persistence.
+The boundary is deliberate: Cortex owns reusable mechanics; downstream products own domain
+semantics, policy, tools, operators, transport, and persistence.
 
 ## What Cortex Does
 
-| Capability | What it gives you |
-|---|---|
-| **Wire authoring** | A real `.wire` language for composing registered executors into typed dataflow graphs. |
-| **Algebra and Wire semantics** | Pure graph algebra plus validated executable topology before a run starts. |
-| **Pulse execution** | Durable graph execution with checkpoints, signals, run events, cancellation, retry, and inspection. |
-| **Controlled rewrites** | Runtime topology changes are proposals admitted through explicit rewrite rules and budgets. |
-| **Nous memory** | Thoughts can query and pack settled upstream graph state without turning memory into hidden mutable state. |
-| **Artifacts and provenance** | Structured outputs carry stable artifact-local provenance instead of relying on generated prose. |
-| **Cortex.Nous** | A structured reasoning library above the substrate with canonical archetypes and reusable patterns. |
-| **Host-action boundary** | Product-specific side effects stay behind authenticated, idempotent host APIs. |
+| Capability                     | What it gives you                                                                                          |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| **Wire authoring**             | A real `.wire` language for composing registered executors into typed dataflow graphs.                     |
+| **Algebra and Wire semantics** | Pure graph algebra plus validated executable topology before a run starts.                                 |
+| **Pulse execution**            | Durable graph execution with checkpoints, signals, run events, cancellation, retry, and inspection.        |
+| **Controlled rewrites**        | Runtime topology changes are proposals admitted through explicit rewrite rules and budgets.                |
+| **Nous memory**                | Thoughts can query and pack settled upstream graph state without turning memory into hidden mutable state. |
+| **Artifacts and provenance**   | Structured outputs carry stable artifact-local provenance instead of relying on generated prose.           |
+| **Cortex.Nous**                | A structured reasoning library above the substrate with canonical archetypes and reusable patterns.        |
+| **Host-action boundary**       | Product-specific side effects stay behind authenticated, idempotent host APIs.                             |
 
 ## System Layers
 
-| Layer | Responsibility | Primary artifact |
-|---|---|---|
-| **Algebra** | Pure topology laws: vertices, edges, overlay, connect, DAG validation. | Graph/relation algebra |
-| **Wire** | Source language, contracts, compiled circuit form, and runtime envelopes. | `.wire` source and compiled circuit |
-| **Pulse** | Durable execution of compiled circuits. | Run state and events |
-| **Capability** | External authority surfaces: models, tools, providers. | Registered authority |
-| **Artifact** | Durable outputs, provenance, rendering, host boundary. | Artifact IR and metadata |
-| **Nous** | Model-mediated cognition, memory, and reusable reasoning patterns. | Thoughts and patterns |
+| Layer          | Responsibility                                                            | Primary artifact                    |
+| -------------- | ------------------------------------------------------------------------- | ----------------------------------- |
+| **Algebra**    | Pure topology laws: vertices, edges, overlay, connect, DAG validation.    | Graph/relation algebra              |
+| **Wire**       | Source language, contracts, compiled circuit form, and runtime envelopes. | `.wire` source and compiled circuit |
+| **Pulse**      | Durable execution of compiled circuits.                                   | Run state and events                |
+| **Capability** | External authority surfaces: models, tools, providers.                    | Registered authority                |
+| **Artifact**   | Durable outputs, provenance, rendering, host boundary.                    | Artifact IR and metadata            |
+| **Nous**       | Model-mediated cognition, memory, and reusable reasoning patterns.        | Thoughts and patterns               |
 
-The core rule: **Wire composes registered authority; implementations own what
-that authority means.** Wire references registered executors, contracts, tools,
-prompts, memory strategies, and wiring. It does not invent host authority.
+The core rule: **Wire composes registered authority; implementations own what that authority
+means.** Wire references registered executors, contracts, tools, prompts, memory strategies, and
+wiring. It does not invent host authority.
 
 ## Wire Is The Front Door
 
-Wire is not pseudocode. It is the source language Cortex uses to describe
-workflow topology over a closed executor alphabet.
+Wire is not pseudocode. It is the source language Cortex uses to describe workflow topology over a
+closed executor alphabet.
 
 ```wire
 contract Topic;
@@ -68,8 +69,8 @@ node publish : <- Draft -> ReportArtifactRef = @artifact.report {};
 plan => write => publish
 ```
 
-The same source is compiled into a graph-shaped executable artifact. Pulse then
-executes the materialized graph and records run state, events, and artifacts.
+The same source is compiled into a graph-shaped executable artifact. Pulse then executes the
+materialized graph and records run state, events, and artifacts.
 
 ```mermaid
 flowchart LR
@@ -88,67 +89,61 @@ flowchart LR
 
 ## Architectural Ideas
 
-- **Algebraic topology is the semantic object.** Cortex treats graph structure as
-  execution structure, not as a visualization over a hidden linear plan.
-- **Authority is closed.** Wire composes registered executors and contracts; it
-  cannot invent host tools, side effects, or domain semantics.
-- **Adaptation is admitted, not arbitrary.** Rewrites change topology only after
-  runtime validation, budgeting, and materialization.
-- **Runtime and host stay separate.** Pulse owns durable execution; hosts own
-  domain mutation and product policy through host actions.
-- **Artifacts explain themselves.** Provenance is attached to structured
-  artifact nodes before rendering, so explanation does not depend on brittle
-  text spans.
+- **Algebraic topology is the semantic object.** Cortex treats graph structure as execution
+  structure, not as a visualization over a hidden linear plan.
+- **Authority is closed.** Wire composes registered executors and contracts; it cannot invent host
+  tools, side effects, or domain semantics.
+- **Adaptation is admitted, not arbitrary.** Rewrites change topology only after runtime validation,
+  budgeting, and materialization.
+- **Runtime and host stay separate.** Pulse owns durable execution; hosts own domain mutation and
+  product policy through host actions.
+- **Artifacts explain themselves.** Provenance is attached to structured artifact nodes before
+  rendering, so explanation does not depend on brittle text spans.
 
 ## Read First
 
-1. **[Architecture overview](Architecture/01-overview.md)** - system frame and
-   ownership boundary.
-2. **[Ownership and boundaries](Architecture/02-ownership-and-boundaries.md)** -
-   what belongs in Cortex versus a downstream product.
-3. **[Wire language](Architecture/05-wire-language.md)** - how source programs
-   describe executable topology.
-4. **[Wire grammar](Reference/Wire/grammar.md)** - the normative language
-   surface.
-5. **[Pulse runtime](Architecture/06-pulse-runtime.md)** - durable execution,
-   events, signals, retries, and host actions.
-6. **[Rewrites and materialization](Architecture/07-rewrites-and-materialization.md)** -
-   controlled topology evolution.
-7. **[Artifacts and provenance](Architecture/08-artifacts-and-provenance.md)** -
-   structured outputs and explanation.
-8. **[Nous reasoning library](Architecture/09-nous-reasoning-library.md)** -
-   archetypes and reusable reasoning patterns above the substrate.
+1. **[Architecture overview](Architecture/01-overview.md)** - system frame and ownership boundary.
+2. **[Ownership and boundaries](Architecture/02-ownership-and-boundaries.md)** - what belongs in
+   Cortex versus a downstream product.
+3. **[Wire language](Architecture/05-wire-language.md)** - how source programs describe executable
+   topology.
+4. **[Wire grammar](Reference/Wire/grammar.md)** - the normative language surface.
+5. **[Pulse runtime](Architecture/06-pulse-runtime.md)** - durable execution, events, signals,
+   retries, and host actions.
+6. **[Rewrites and materialization](Architecture/07-rewrites-and-materialization.md)** - controlled
+   topology evolution.
+7. **[Artifacts and provenance](Architecture/08-artifacts-and-provenance.md)** - structured outputs
+   and explanation.
+8. **[Nous reasoning library](Architecture/09-nous-reasoning-library.md)** - archetypes and reusable
+   reasoning patterns above the substrate.
 
 ## Explore The Canon
 
 - **[Architecture/](Architecture/)** - conceptual chapters for the substrate.
-- **[Reference/](Reference/)** - normative specifications for Wire, Pulse,
-  rewrites, terminology, and contributor workflow.
+- **[Reference/](Reference/)** - normative specifications for Wire, Pulse, rewrites, terminology,
+  and contributor workflow.
 - **[ADRs/](ADRs/)** - numbered architecture decisions.
-- **[Publications/](Publications/)** - formal paper drafts, figures, and
-  publication roadmap.
-- **[Consumers/](Consumers/)** - downstream binding examples after the core
-  model is clear.
+- **[Publications/](Publications/)** - formal paper drafts, figures, and publication roadmap.
+- **[Consumers/](Consumers/)** - downstream binding examples after the core model is clear.
 
 ## Working Artifacts
 
 - **[Roadmap/](Roadmap/)** - active research and implementation plans.
-- **[Research-notes/](Research-notes/)** - dated synthesis notes that are still
-  useful as design archaeology.
+- **[Research-notes/](Research-notes/)** - dated synthesis notes that are still useful as design
+  archaeology.
 - **[Experiments/](Experiments/)** - dated smoke tests and dogfood runs.
-- **[Handoffs/](Handoffs/)** - contributor or work-phase handoffs when one is
-  current enough to keep in the tree.
+- **[Handoffs/](Handoffs/)** - contributor or work-phase handoffs when one is current enough to keep
+  in the tree.
 - **[Templates/](Templates/)** - frontmatter and section shapes for new docs.
 
 ## Consumer Examples
 
-Consumer docs show how a downstream system can bind Cortex to product-specific
-policy, tools, artifacts, and operator surfaces. They are examples, not
-prerequisites for understanding Cortex. Generic rules belong in architecture,
-reference, or ADR docs.
+Consumer docs show how a downstream system can bind Cortex to product-specific policy, tools,
+artifacts, and operator surfaces. They are examples, not prerequisites for understanding Cortex.
+Generic rules belong in architecture, reference, or ADR docs.
 
 ## Source Of Truth
 
-When docs and implementation disagree, the implementation is authoritative until
-the docs are reconciled. Canonical docs should still avoid repo-layout details
-unless a page is specifically about migration or implementation planning.
+When docs and implementation disagree, the implementation is authoritative until the docs are
+reconciled. Canonical docs should still avoid repo-layout details unless a page is specifically
+about migration or implementation planning.

--- a/docs/map.md
+++ b/docs/map.md
@@ -8,62 +8,56 @@ sidebar:
 
 # Cortex Docs Map
 
-A one-page orientation to the documentation tree. When in doubt about where a
-new doc belongs, start here.
+A one-page orientation to the documentation tree. When in doubt about where a new doc belongs, start
+here.
 
 ## By Kind
 
-| Kind | Where | Lifetime | Dated? |
-|---|---|---|---|
-| Canonical architecture chapter | [Architecture/](Architecture/) | Long-term canon | No |
-| Normative specification | [Reference/](Reference/) | Long-term canon | No |
-| Architecture decision record | [ADRs/](ADRs/) | Permanent | No |
-| Downstream consumer binding | [Consumers/{consumer}.md](Consumers/) | Long-term per consumer | No |
-| Active roadmap plan | [Roadmap/Plans/](Roadmap/Plans/) | Active until completed or superseded | No |
-| Active roadmap epic | [Roadmap/Epics/](Roadmap/Epics/) | Active while retained | No |
-| Completed initiative | [Roadmap/Completed/](Roadmap/Completed/) | Historical, retained selectively | No |
-| Archived idea | [Roadmap/Archive/](Roadmap/Archive/) | Historical, retained selectively | No |
-| Paper manuscript and figures | [Publications/paper-N-*/](Publications/) | Published-once | No |
-| Paper notes and ideas | [Publications/Notes/](Publications/Notes/) | Working | No |
-| Research or synthesis memo | [Research-notes/{scope}/](Research-notes/) | Historical, retained selectively | Yes |
-| Experiment or smoke test | [Experiments/{scope}/](Experiments/) | Historical, retained selectively | Yes |
-| Handoff note | [Handoffs/](Handoffs/) | Temporary historical record | Yes |
-| Template | [Templates/](Templates/) | Long-term canon | No |
+| Kind                           | Where                                      | Lifetime                             | Dated? |
+| ------------------------------ | ------------------------------------------ | ------------------------------------ | ------ |
+| Canonical architecture chapter | [Architecture/](Architecture/)             | Long-term canon                      | No     |
+| Normative specification        | [Reference/](Reference/)                   | Long-term canon                      | No     |
+| Architecture decision record   | [ADRs/](ADRs/)                             | Permanent                            | No     |
+| Downstream consumer binding    | [Consumers/{consumer}.md](Consumers/)      | Long-term per consumer               | No     |
+| Active roadmap plan            | [Roadmap/Plans/](Roadmap/Plans/)           | Active until completed or superseded | No     |
+| Active roadmap epic            | [Roadmap/Epics/](Roadmap/Epics/)           | Active while retained                | No     |
+| Completed initiative           | [Roadmap/Completed/](Roadmap/Completed/)   | Historical, retained selectively     | No     |
+| Archived idea                  | [Roadmap/Archive/](Roadmap/Archive/)       | Historical, retained selectively     | No     |
+| Paper manuscript and figures   | [Publications/paper-N-\*/](Publications/)  | Published-once                       | No     |
+| Paper notes and ideas          | [Publications/Notes/](Publications/Notes/) | Working                              | No     |
+| Research or synthesis memo     | [Research-notes/{scope}/](Research-notes/) | Historical, retained selectively     | Yes    |
+| Experiment or smoke test       | [Experiments/{scope}/](Experiments/)       | Historical, retained selectively     | Yes    |
+| Handoff note                   | [Handoffs/](Handoffs/)                     | Temporary historical record          | Yes    |
+| Template                       | [Templates/](Templates/)                   | Long-term canon                      | No     |
 
 ## By Question
 
-**Where do I document a settled architecture decision?** Use `ADRs/` with the
-next `NNNN-` number.
+**Where do I document a settled architecture decision?** Use `ADRs/` with the next `NNNN-` number.
 
-**Where do I write up the Wire grammar surface?** Use `Reference/Wire/`.
-Canonical language rules live in reference docs, not research notes.
+**Where do I write up the Wire grammar surface?** Use `Reference/Wire/`. Canonical language rules
+live in reference docs, not research notes.
 
-**Where do I document runtime architecture?** Use
-`Architecture/06-pulse-runtime.md` for the stable model and
-`Architecture/07-rewrites-and-materialization.md` for topology evolution.
+**Where do I document runtime architecture?** Use `Architecture/06-pulse-runtime.md` for the stable
+model and `Architecture/07-rewrites-and-materialization.md` for topology evolution.
 
-**Where does downstream-specific design belong?** Start with
-`Consumers/{consumer}.md`. Consumer docs may contain concrete product bindings;
-Cortex architecture should stay consumer-independent. Create a consumer
-subdirectory only when a public binding grows beyond one page.
+**Where does downstream-specific design belong?** Start with `Consumers/{consumer}.md`. Consumer
+docs may contain concrete product bindings; Cortex architecture should stay consumer-independent.
+Create a consumer subdirectory only when a public binding grows beyond one page.
 
-**Where does an implementation plan go?** Use `Roadmap/Plans/` while it is
-active. Move or delete it when it ships, is superseded, or stops explaining the
-current plan.
+**Where does an implementation plan go?** Use `Roadmap/Plans/` while it is active. Move or delete it
+when it ships, is superseded, or stops explaining the current plan.
 
-**Where do dated synthesis notes go?** Use `Research-notes/` under the right
-scope. Keep only notes that still explain the current canon or a live research
-thread.
+**Where do dated synthesis notes go?** Use `Research-notes/` under the right scope. Keep only notes
+that still explain the current canon or a live research thread.
 
 ## Canonical Docs Versus Dated Artifacts
 
-Canonical docs are edited to remain current. They should frame Cortex as an
-independent upstream substrate and use downstream products only as examples.
+Canonical docs are edited to remain current. They should frame Cortex as an independent upstream
+substrate and use downstream products only as examples.
 
-Dated artifacts preserve reasoning from a point in time. They are retained only
-when they still help explain the current system. Stale PR handoffs,
-issue-specific migration plans, and superseded research snapshots should be
-removed instead of preserved by default.
+Dated artifacts preserve reasoning from a point in time. They are retained only when they still help
+explain the current system. Stale PR handoffs, issue-specific migration plans, and superseded
+research snapshots should be removed instead of preserved by default.
 
 ## Related
 

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -1,6 +1,7 @@
 ---
 title: Cortex Taxonomy
-description: How Cortex concepts are classified. Layers, roles, artifacts, and the relationships between them.
+description:
+  How Cortex concepts are classified. Layers, roles, artifacts, and the relationships between them.
 sidebar:
   label: Taxonomy
   order: 5
@@ -12,8 +13,8 @@ Glossary ([glossary.md](glossary.md)) defines terms one at a time. This page sho
 
 ## Layers
 
-Cortex separates six canonical roots. Arrows here show operational relationships,
-not import or dependency direction:
+Cortex separates six canonical roots. Arrows here show operational relationships, not import or
+dependency direction:
 
 ```mermaid
 flowchart TD
@@ -31,97 +32,92 @@ flowchart TD
     N -- "emits outputs as" --> R
 ```
 
-Algebra is the pure substrate Wire authors over. Wire owns the compiled circuit
-form. Pulse executes compiled circuits durably. Capability exposes external
-authority. Artifact owns durable outputs and provenance. Nous owns
-model-mediated cognition.
+Algebra is the pure substrate Wire authors over. Wire owns the compiled circuit form. Pulse executes
+compiled circuits durably. Capability exposes external authority. Artifact owns durable outputs and
+provenance. Nous owns model-mediated cognition.
 
 ## Roles a value can play
 
 A single Wire value often wears multiple hats. The roles are:
 
-| Role | What it is | Examples |
-|---|---|---|
-| **Executor** | Registered recipe. Turns config + inputs into outputs. Referenced via `@name`. | `@llm.analyst`, `@artifact.log`, `@cortex.report_run`, `@pure` |
-| **Partial node** | Executor applied to config, no ports pinned. `let`-bindable, `//`-mergeable. | `@llm.gatherer { memory = topological { preset = "analyst" }; }` |
-| **Node** | Partial node with ports pinned. Has boundary. Has identity. | `node analyst : <- EvidenceBundle -> AnalysisFragment | ExecutorError = @llm.analyst { prompt = "..."; };` |
-| **Composed wire** | Result of applying a graph operator. Has a derived boundary. | `planner => gatherer => analyst` |
-| **Runtime wrapper** | A node whose role is to host a whole wire and provide runtime services. | `@cortex.report_run { title = ...; }` |
+| Role                | What it is                                                                     | Examples                                                         |
+| ------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------- | -------------------------------------------------- |
+| **Executor**        | Registered recipe. Turns config + inputs into outputs. Referenced via `@name`. | `@llm.analyst`, `@artifact.log`, `@cortex.report_run`, `@pure`   |
+| **Partial node**    | Executor applied to config, no ports pinned. `let`-bindable, `//`-mergeable.   | `@llm.gatherer { memory = topological { preset = "analyst" }; }` |
+| **Node**            | Partial node with ports pinned. Has boundary. Has identity.                    | `node analyst : <- EvidenceBundle -> AnalysisFragment            | ExecutorError = @llm.analyst { prompt = "..."; };` |
+| **Composed wire**   | Result of applying a graph operator. Has a derived boundary.                   | `planner => gatherer => analyst`                                 |
+| **Runtime wrapper** | A node whose role is to host a whole wire and provide runtime services.        | `@cortex.report_run { title = ...; }`                            |
 
-The leading `@` marks the executor-authority boundary. It stages a registered
-executor with pure config data; it does not run the executor. See
+The leading `@` marks the executor-authority boundary. It stages a registered executor with pure
+config data; it does not run the executor. See
 [Reference/Wire/executors-and-alphabet.md](Reference/Wire/executors-and-alphabet.md).
 
 ## Artifacts a contract can carry
 
 Every contract declares a **payload kind** that selects validation and rendering:
 
-| Payload kind | Shape | Examples |
-|---|---|---|
-| `json` | Structured domain object | `AssetRef`, `AssetSet`, `ReportFragment` |
-| `markdown` | Lintable markdown text | `FinalReport`, `MarkdownSection` |
-| `text` | Minimal-structure text | `SearchQuery`, `PromptNote` |
-| `table` | Row/column typed data | `PriceSeries`, `CorrelationMatrix` |
-| `artifact_ref` | Reference to a persisted blob | `WorkbookRef`, `ReportArtifactRef` |
+| Payload kind   | Shape                         | Examples                                 |
+| -------------- | ----------------------------- | ---------------------------------------- |
+| `json`         | Structured domain object      | `AssetRef`, `AssetSet`, `ReportFragment` |
+| `markdown`     | Lintable markdown text        | `FinalReport`, `MarkdownSection`         |
+| `text`         | Minimal-structure text        | `SearchQuery`, `PromptNote`              |
+| `table`        | Row/column typed data         | `PriceSeries`, `CorrelationMatrix`       |
+| `artifact_ref` | Reference to a persisted blob | `WorkbookRef`, `ReportArtifactRef`       |
 
 ## Namespaces
 
 Cortex has a small closed set of globally-ambient namespaces:
 
-| Namespace | Registered where | Referenced in Wire how |
-|---|---|---|
-| **Executor alphabet** | External registry (`Cortex.Capability.*` + consumers) | `@qualified.name` |
-| **Contract namespace** | Contract registry + `contract X;` assertions | bare `Name` in port signatures |
-| **Tool registry** | External registry | bare `name` inside config `tools = [...]` |
-| **Config constructors** | Executor config schemas | `qualified.name { ... }` inside config values |
+| Namespace               | Registered where                                      | Referenced in Wire how                        |
+| ----------------------- | ----------------------------------------------------- | --------------------------------------------- |
+| **Executor alphabet**   | External registry (`Cortex.Capability.*` + consumers) | `@qualified.name`                             |
+| **Contract namespace**  | Contract registry + `contract X;` assertions          | bare `Name` in port signatures                |
+| **Tool registry**       | External registry                                     | bare `name` inside config `tools = [...]`     |
+| **Config constructors** | Executor config schemas                               | `qualified.name { ... }` inside config values |
 
-Beyond these four, every name is local: introduced by `let`, `node`, or `import`.
-The executor alphabet is authority-bearing; ordinary config constructors are
-not. The syntax distinction is the leading `@`.
+Beyond these four, every name is local: introduced by `let`, `node`, or `import`. The executor
+alphabet is authority-bearing; ordinary config constructors are not. The syntax distinction is the
+leading `@`.
 
 ## Nous archetypes and patterns
 
-`Cortex.Nous` adds reusable LLM-shaped catalogs above the substrate.
-`Cortex.Nous.Archetypes` classifies modes of cognition, `Cortex.Nous.Thought`
-names one bounded model-mediated node evaluation, `Cortex.Nous.Memory` owns
-cognitive context construction, and `Cortex.Nous.Patterns` names reusable
-reasoning programs. None of these grants executor authority or creates new
-runtime registries.
+`Cortex.Nous` adds reusable LLM-shaped catalogs above the substrate. `Cortex.Nous.Archetypes`
+classifies modes of cognition, `Cortex.Nous.Thought` names one bounded model-mediated node
+evaluation, `Cortex.Nous.Memory` owns cognitive context construction, and `Cortex.Nous.Patterns`
+names reusable reasoning programs. None of these grants executor authority or creates new runtime
+registries.
 
-| Archetype | Role |
-|---|---|
-| `Cortex.Nous.Archetypes.Logos` | Discursive reason, argument, symbolic reasoning |
-| `Cortex.Nous.Archetypes.Sophia` | Wisdom, judgment, synthesis |
-| `Cortex.Nous.Archetypes.Techne` | Craft, engineering, implementation |
-| `Cortex.Nous.Archetypes.Episteme` | Knowledge, evidence, research |
-| `Cortex.Nous.Archetypes.Kritikos` | Criticism, adversarial review |
-| `Cortex.Nous.Archetypes.Themis` | Audit, law, correctness, constraints |
-| `Cortex.Nous.Archetypes.Poiesis` | Creative generation, composition |
+| Archetype                         | Role                                            |
+| --------------------------------- | ----------------------------------------------- |
+| `Cortex.Nous.Archetypes.Logos`    | Discursive reason, argument, symbolic reasoning |
+| `Cortex.Nous.Archetypes.Sophia`   | Wisdom, judgment, synthesis                     |
+| `Cortex.Nous.Archetypes.Techne`   | Craft, engineering, implementation              |
+| `Cortex.Nous.Archetypes.Episteme` | Knowledge, evidence, research                   |
+| `Cortex.Nous.Archetypes.Kritikos` | Criticism, adversarial review                   |
+| `Cortex.Nous.Archetypes.Themis`   | Audit, law, correctness, constraints            |
+| `Cortex.Nous.Archetypes.Poiesis`  | Creative generation, composition                |
 
 Each archetype may have an operational activation bundle at
-`Cortex.Nous.Archetypes.<Archetype>.Activation`. The archetype is the semantic
-definition; the activation bundle is the concrete set of prompt discipline,
-retrieval corpus, embedding spaces, tool surface, memory policy, evaluation
-criteria, and runtime contract. Thought frames compose one or more archetype
-activations.
+`Cortex.Nous.Archetypes.<Archetype>.Activation`. The archetype is the semantic definition; the
+activation bundle is the concrete set of prompt discipline, retrieval corpus, embedding spaces, tool
+surface, memory policy, evaluation criteria, and runtime contract. Thought frames compose one or
+more archetype activations.
 
-`Cortex.Nous.Patterns.DeepReport` is the planned extraction target for reusable
-deep-report reasoning contracts, ports, templates, prompts, memory presets, and
-evaluation policy.
+`Cortex.Nous.Patterns.DeepReport` is the planned extraction target for reusable deep-report
+reasoning contracts, ports, templates, prompts, memory presets, and evaluation policy.
 
 ## Doc-kind taxonomy
 
 Docs are classified on two axes:
 
-| | Stable canon | Dated artifacts |
-|---|---|---|
-| **Canonical authority** | `Architecture/`, `Reference/`, `ADRs/` | none |
-| **Project working** | `Roadmap/Epics/`, `Roadmap/Plans/` | `Research-notes/` |
-| **Historical** | `Roadmap/Completed/`, `Roadmap/Archive/` | `Experiments/`, `Handoffs/` |
+|                         | Stable canon                             | Dated artifacts             |
+| ----------------------- | ---------------------------------------- | --------------------------- |
+| **Canonical authority** | `Architecture/`, `Reference/`, `ADRs/`   | none                        |
+| **Project working**     | `Roadmap/Epics/`, `Roadmap/Plans/`       | `Research-notes/`           |
+| **Historical**          | `Roadmap/Completed/`, `Roadmap/Archive/` | `Experiments/`, `Handoffs/` |
 
 Cross-cutting canon: `Templates/`, `index.md`, `map.md`, `glossary.md`, `taxonomy.md`
-Consumer-specific: `Consumers/{consumer}.md`, or `Consumers/{consumer}/` for a
-larger public binding
+Consumer-specific: `Consumers/{consumer}.md`, or `Consumers/{consumer}/` for a larger public binding
 Papers: `Publications/paper-N-*/`
 
 ## Related

--- a/editors/helix/README.md
+++ b/editors/helix/README.md
@@ -1,11 +1,12 @@
 # Helix integration for tree-sitter-wire
 
-Configures Helix to recognize `.wire` files, fetch and build the tree-sitter grammar, and apply highlights/folds/indents.
+Configures Helix to recognize `.wire` files, fetch and build the tree-sitter grammar, and apply
+highlights/folds/indents.
 
 ## Install
 
-1. Append the contents of `languages.toml` here to `~/.config/helix/languages.toml`.
-   Edit the `[[grammar]]` `source.path` to point at your local checkout of `editors/tree-sitter-wire/`.
+1. Append the contents of `languages.toml` here to `~/.config/helix/languages.toml`. Edit the
+   `[[grammar]]` `source.path` to point at your local checkout of `editors/tree-sitter-wire/`.
 
 2. Copy the query files from the canonical source into Helix's runtime directory:
 
@@ -14,7 +15,9 @@ Configures Helix to recognize `.wire` files, fetch and build the tree-sitter gra
    cp editors/tree-sitter-wire/queries/*.scm ~/.config/helix/runtime/queries/wire/
    ```
 
-   There is intentionally no `editors/helix/queries/` duplicate — the queries at `editors/tree-sitter-wire/queries/` are the single source of truth, so Helix and Neovim can never drift out of sync.
+   There is intentionally no `editors/helix/queries/` duplicate — the queries at
+   `editors/tree-sitter-wire/queries/` are the single source of truth, so Helix and Neovim can never
+   drift out of sync.
 
 3. Fetch and build the grammar:
 
@@ -24,8 +27,8 @@ Configures Helix to recognize `.wire` files, fetch and build the tree-sitter gra
    ```
 
 4. Restart Helix. Open a checked-in fixture such as
-   `test/fixtures/wire-v1/thesis-parallel-claim-branches.wire`, or any local
-   `.wire` file; highlighting should render immediately.
+   `test/fixtures/wire-v1/thesis-parallel-claim-branches.wire`, or any local `.wire` file;
+   highlighting should render immediately.
 
 ## Query locations Helix reads
 

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -30,13 +30,16 @@ The repo exposes `nixvimModules.default` at the flake level. In your nixvim conf
 ```
 
 What you get:
+
 - Tree-sitter grammar package (`tree-sitter-wire`) added to `plugins.treesitter.grammarPackages`
 - `.wire` extension → `wire` filetype
 - `highlights.scm` / `folds.scm` / `indents.scm` installed into the nvim runtime
 
 No further config needed — open any `.wire` file and highlighting, folds, and indent kick in.
 
-The module lives at `nix/modules/nixvim-wire.nix` and is safe to import even into configs that manage treesitter differently: it only *adds* to `grammarPackages` and never force-enables treesitter itself.
+The module lives at `nix/modules/nixvim-wire.nix` and is safe to import even into configs that
+manage treesitter differently: it only _adds_ to `grammarPackages` and never force-enables
+treesitter itself.
 
 ## 2. Raw nix package (home-manager, custom nvim setup, overlay)
 
@@ -50,7 +53,8 @@ packages.tree-sitter-wire         # $out/parser (the .so file)
 packages.tree-sitter-wire-plugin  # $out/parser/wire.so + $out/queries/wire/*.scm
 ```
 
-Use `tree-sitter-wire-plugin` in home-manager's `programs.neovim.plugins` or any place that accepts vim plugins.
+Use `tree-sitter-wire-plugin` in home-manager's `programs.neovim.plugins` or any place that accepts
+vim plugins.
 
 ## 3. Manual nvim-treesitter install (non-nix setups)
 
@@ -90,9 +94,8 @@ cp editors/tree-sitter-wire/queries/*.scm ~/.config/nvim/queries/wire/
 
 ## Verification (all paths)
 
-Open a checked-in fixture such as
-`test/fixtures/wire-v1/thesis-parallel-claim-branches.wire`, or any local
-`.wire` file:
+Open a checked-in fixture such as `test/fixtures/wire-v1/thesis-parallel-claim-branches.wire`, or
+any local `.wire` file:
 
 - Keywords highlight (`contract`, `node`, `let`, `import`, `from`, `select`)
 - Contract types (capitalized identifiers after `<-` / `->`) highlight distinctly

--- a/editors/tree-sitter-wire/README.md
+++ b/editors/tree-sitter-wire/README.md
@@ -1,10 +1,10 @@
 # tree-sitter-wire
 
-Tree-sitter grammar for the Cortex **Wire** DSL. Checked-in examples
-and regression fixtures use `.wire` files under `test/fixtures/wire-v1/`.
+Tree-sitter grammar for the Cortex **Wire** DSL. Checked-in examples and regression fixtures use
+`.wire` files under `test/fixtures/wire-v1/`.
 
-Source of truth for the syntax: `docs/Reference/Wire/grammar.md`.
-The production parser is `src/Cortex/Wire/V1/Parser.hs`.
+Source of truth for the syntax: `docs/Reference/Wire/grammar.md`. The production parser is
+`src/Cortex/Wire/V1/Parser.hs`.
 
 ## What's here
 
@@ -74,7 +74,8 @@ tree-sitter parse path/to/file.wire
 ./test/parse-fixtures.sh
 ```
 
-The generated `src/parser.c`, `src/grammar.json`, `src/node-types.json`, and `src/tree_sitter/parser.h` are checked in by convention so consumers don't need the CLI.
+The generated `src/parser.c`, `src/grammar.json`, `src/node-types.json`, and
+`src/tree_sitter/parser.h` are checked in by convention so consumers don't need the CLI.
 
 ## Editor integrations
 
@@ -86,12 +87,17 @@ See the sibling directories:
 
 ## Known Divergences From The V1 Parser
 
-This grammar is deliberately a *parseable superset* of what the Megaparsec parser accepts, except where editor recovery benefits from accepting incomplete buffers:
+This grammar is deliberately a _parseable superset_ of what the Megaparsec parser accepts, except
+where editor recovery benefits from accepting incomplete buffers:
 
-- **Identifiers do not accept `:`.** The grammar uses `[A-Za-z_][A-Za-z0-9_\-]*` so port labels like `<- input: Contract` disambiguate cleanly. Values like `"SPY:US"` remain string literals.
-- **Semantic checks are out of scope.** Tree-sitter accepts syntactically valid records, lists, executor applications, and graph expressions even when the compiler would reject unknown contracts, unknown executors, bad port contracts, or invalid runtime config.
+- **Identifiers do not accept `:`.** The grammar uses `[A-Za-z_][A-Za-z0-9_\-]*` so port labels like
+  `<- input: Contract` disambiguate cleanly. Values like `"SPY:US"` remain string literals.
+- **Semantic checks are out of scope.** Tree-sitter accepts syntactically valid records, lists,
+  executor applications, and graph expressions even when the compiler would reject unknown
+  contracts, unknown executors, bad port contracts, or invalid runtime config.
 
-Outside these points, every production form accepted by the V1 parser should parse here. Regression coverage lives in `test/corpus/v1.txt` and `test/parse-fixtures.sh`.
+Outside these points, every production form accepted by the V1 parser should parse here. Regression
+coverage lives in `test/corpus/v1.txt` and `test/parse-fixtures.sh`.
 
 ## License
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -2,7 +2,10 @@
 
 Syntax highlighting + auto-indent + comment handling for `.wire` files.
 
-This uses a TextMate grammar (the default VS Code tokenizer). It doesn't wire up tree-sitter directly — VS Code doesn't natively support tree-sitter grammars yet. The tree-sitter grammar in the sibling `tree-sitter-wire/` directory is still the authoritative spec and powers Neovim/Helix; this extension is the pragmatic VS Code fallback.
+This uses a TextMate grammar (the default VS Code tokenizer). It doesn't wire up tree-sitter
+directly — VS Code doesn't natively support tree-sitter grammars yet. The tree-sitter grammar in the
+sibling `tree-sitter-wire/` directory is still the authoritative spec and powers Neovim/Helix; this
+extension is the pragmatic VS Code fallback.
 
 ## Install (local, for development)
 
@@ -36,8 +39,10 @@ code --install-extension cortex-wire-0.1.0.vsix
 ## What's covered
 
 - **Comments**: `#` line + `/* */` block, with `Ctrl+/` and `Ctrl+Shift+A` toggling
-- **Keywords**: `node`, `circuit`, `meta`, `use`, `if`, `else`, `between`, `connect`, `path`, `fanout`, `fanin`, `clique`, `signal`, roles (`act`/`await`/`emit`)
-- **Record fields**: `role`, `executor`, `prompt`, `config`, `tools`, `ports`, `timeout`, `retry`, `stepBudget`, `maxOutputTokens`, `on`, `kind`, `to`, `label`
+- **Keywords**: `node`, `circuit`, `meta`, `use`, `if`, `else`, `between`, `connect`, `path`,
+  `fanout`, `fanin`, `clique`, `signal`, roles (`act`/`await`/`emit`)
+- **Record fields**: `role`, `executor`, `prompt`, `config`, `tools`, `ports`, `timeout`, `retry`,
+  `stepBudget`, `maxOutputTokens`, `on`, `kind`, `to`, `label`
 - **Graph operators**: `=>`, `<>`, `<-`, `->`
 - **Strings** (including escape sequences), integers, `true`/`false`/`null`
 - **Contracts**: capitalized identifiers after `<-`/`->` or in type positions
@@ -47,7 +52,9 @@ code --install-extension cortex-wire-0.1.0.vsix
 
 ## What's NOT covered (vs the tree-sitter grammar)
 
-- Contract alternatives bracketed sets (`<- [A B]`) get shallower highlighting because TextMate can't easily model the enclosing rule
+- Contract alternatives bracketed sets (`<- [A B]`) get shallower highlighting because TextMate
+  can't easily model the enclosing rule
 - No incremental parse tree — this is pattern-based, not AST-based
 
-For the full experience (incremental parsing, AST queries, folding per precise rule) use Neovim or Helix with the tree-sitter grammar in `editors/tree-sitter-wire/`.
+For the full experience (incremental parsing, AST queries, folding per precise rule) use Neovim or
+Helix with the tree-sitter grammar in `editors/tree-sitter-wire/`.

--- a/flake.lock
+++ b/flake.lock
@@ -734,11 +734,11 @@
         "tree-sitter-json": "tree-sitter-json"
       },
       "locked": {
-        "lastModified": 1777338485,
-        "narHash": "sha256-251l19oovwXSa5pJpNdksCvrrOXonGPodkSR0TbogXg=",
+        "lastModified": 1777342849,
+        "narHash": "sha256-eiqNbFOoTOHKuJVbGtIO39YVTdLETQRbJlcv1BQ3IIo=",
         "owner": "Digimuoto",
         "repo": "repo-docs",
-        "rev": "f783db9adb5667134e822d614346cff8f2f0145a",
+        "rev": "f6d01bfe842083adda58a63abf7e36fb99fa0830",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -734,11 +734,11 @@
         "tree-sitter-json": "tree-sitter-json"
       },
       "locked": {
-        "lastModified": 1777333278,
-        "narHash": "sha256-V9n49DPwttzdqYz1PjmjsCsSsRh7kj2ScPDw1BvgO4Q=",
+        "lastModified": 1777338485,
+        "narHash": "sha256-251l19oovwXSa5pJpNdksCvrrOXonGPodkSR0TbogXg=",
         "owner": "Digimuoto",
         "repo": "repo-docs",
-        "rev": "99581a3052f3fc09c2b835deea5b9f4494baf494",
+        "rev": "f783db9adb5667134e822d614346cff8f2f0145a",
         "type": "github"
       },
       "original": {

--- a/justfile
+++ b/justfile
@@ -67,6 +67,16 @@ lint:
     @echo "🔍 Running HLint..."
     nix run .#lint-haskell
 
+# Run strict Lean theory lint checks
+lean-lint:
+    @echo "🔍 Running Lean lint..."
+    nix run .#lean-lint
+
+# Run strict Markdown/docs lint checks
+docs-lint:
+    @echo "🔍 Running docs lint..."
+    nix run .#docs-lint
+
 # ============================================================================
 # DOCUMENTATION SITE
 # ============================================================================

--- a/nix/ci/default.nix
+++ b/nix/ci/default.nix
@@ -23,6 +23,24 @@
       '';
     };
 
+    lean-lint = pkgs.writeShellApplication {
+      name = "lean-lint";
+      runtimeInputs = [pkgs.python3];
+      text = ''
+        set -euo pipefail
+        exec python3 scripts/lean-lint
+      '';
+    };
+
+    docs-lint = pkgs.writeShellApplication {
+      name = "docs-lint";
+      runtimeInputs = [pkgs.python3];
+      text = ''
+        set -euo pipefail
+        exec python3 scripts/docs-lint
+      '';
+    };
+
     check-theory = pkgs.writeShellApplication {
       name = "check-theory";
       runtimeInputs = [pkgs.nix];
@@ -36,6 +54,8 @@
       name = "ci-check";
       runtimeInputs = [
         check-format
+        docs-lint
+        lean-lint
         lint-haskell
         check-theory
         pkgs.nix
@@ -51,11 +71,19 @@
         lint-haskell
         echo
 
-        echo "Step 3: Lean theory"
+        echo "Step 3: Lean lint"
+        lean-lint
+        echo
+
+        echo "Step 4: docs lint"
+        docs-lint
+        echo
+
+        echo "Step 5: Lean theory"
         check-theory
         echo
 
-        echo "Step 4: flake checks"
+        echo "Step 6: flake checks"
         nix flake check --print-build-logs
       '';
     };
@@ -64,6 +92,8 @@
       _check-format = check-format;
       _check-theory = check-theory;
       _ci-check = ci-check;
+      docs-lint = docs-lint;
+      lean-lint = lean-lint;
       lint-haskell = lint-haskell;
     };
 
@@ -90,6 +120,18 @@
         type = "app";
         program = "${lint-haskell}/bin/lint-haskell";
         meta.description = "Run HLint across Cortex Haskell sources";
+      };
+
+      lean-lint = {
+        type = "app";
+        program = "${lean-lint}/bin/lean-lint";
+        meta.description = "Run strict mechanical lint checks over Lean theory files";
+      };
+
+      docs-lint = {
+        type = "app";
+        program = "${docs-lint}/bin/docs-lint";
+        meta.description = "Run strict mechanical lint checks over Markdown docs";
       };
     };
   };

--- a/nix/ci/formatter.nix
+++ b/nix/ci/formatter.nix
@@ -11,6 +11,15 @@
         alejandra.enable = true; # Nix
         just.enable = true; # justfile
         ormolu.enable = true; # Haskell
+        prettier = {
+          enable = true; # Markdown
+          includes = ["*.md"];
+          settings = {
+            printWidth = 100;
+            proseWrap = "always";
+            tabWidth = 2;
+          };
+        };
       };
 
       settings = {
@@ -18,6 +27,9 @@
           excludes = [
             "nix/materialized/*"
             ".git/*"
+            "docs/Templates/*"
+            # Golden Markdown fixtures intentionally match renderer output.
+            "test/fixtures/ir/*"
             "theory/.lake/*"
             # Generated tree-sitter parser (do not reformat).
             "editors/*/src/parser.c"

--- a/nix/ci/pre-commit.nix
+++ b/nix/ci/pre-commit.nix
@@ -37,6 +37,16 @@
             files = "(^|/).+\\.(hs|lhs)$|(^|/)cortex\\.cabal$|(^|/)\\.hlint\\.yaml$";
           };
 
+          lean-lint = {
+            enable = true;
+            name = "lean-lint";
+            description = "Run strict Lean theory lint checks";
+            entry = "${config.packages.lean-lint}/bin/lean-lint";
+            language = "system";
+            pass_filenames = false;
+            files = "^theory/.*|^scripts/lean-lint$|^agents/skills/lean-code-style/.*|^nix/(lean\\.nix|ci/.*)$|^justfile$";
+          };
+
           lean-theory = {
             enable = true;
             name = "lean-theory";
@@ -45,6 +55,16 @@
             language = "system";
             pass_filenames = false;
             files = "^theory/.*\\.(lean|json)$|^theory/(lakefile\\.lean|lean-toolchain)$|^nix/lean\\.nix$";
+          };
+
+          docs-lint = {
+            enable = true;
+            name = "docs-lint";
+            description = "Run strict Markdown/docs lint checks";
+            entry = "${config.packages.docs-lint}/bin/docs-lint";
+            language = "system";
+            pass_filenames = false;
+            files = "^docs/.*|^scripts/docs-lint$|^agents/skills/doc-review.*|^nix/(docs\\.nix|ci/.*)$|^justfile$";
           };
         };
       };

--- a/scripts/docs-lint
+++ b/scripts/docs-lint
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Strict mechanical lint checks for Cortex Markdown documentation."""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+TODAY = dt.date.today()
+
+PUBLICATION_MANUSCRIPT_REQUIRED = {
+    "authors",
+    "date",
+    "description",
+    "kind",
+    "related",
+    "status",
+    "title",
+    "updated",
+}
+
+PUBLICATION_ARTIFACT_REQUIRED = {
+    "date",
+    "description",
+    "related",
+    "status",
+    "title",
+}
+
+STATUS_VALUES = {
+    "accepted",
+    "active",
+    "canonical",
+    "draft",
+    "final",
+    "historical",
+    "planned",
+    "proposed",
+    "published",
+    "research",
+    "superseded",
+}
+
+
+@dataclass
+class Document:
+    path: Path
+    text: str
+    frontmatter: dict[str, object]
+    body: str
+    body_start_line: int
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def iter_docs() -> list[Path]:
+    paths: list[Path] = []
+    for pattern in ("*.md", "*.mmd"):
+        for path in DOCS.rglob(pattern):
+            if "Templates" in path.relative_to(DOCS).parts:
+                continue
+            paths.append(path)
+    return sorted(paths)
+
+
+def strip_quotes(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, object], str, int, list[str]]:
+    errors: list[str] = []
+    if not text.startswith("---\n"):
+        return {}, text, 1, ["missing YAML frontmatter"]
+
+    lines = text.splitlines()
+    close_index = None
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            close_index = index
+            break
+
+    if close_index is None:
+        return {}, text, 1, ["unterminated YAML frontmatter"]
+
+    frontmatter: dict[str, object] = {}
+    key: str | None = None
+    for line in lines[1:close_index]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        list_match = re.match(r"\s+-\s+(.+)$", line)
+        if list_match and key:
+            frontmatter.setdefault(key, [])
+            if isinstance(frontmatter[key], list):
+                frontmatter[key].append(strip_quotes(list_match.group(1)))
+            continue
+        key_match = re.match(r"^([A-Za-z0-9_.-]+):(?:\s*(.*))?$", line)
+        if key_match:
+            key = key_match.group(1)
+            value = key_match.group(2) or ""
+            frontmatter[key] = strip_quotes(value) if value.strip() else []
+            continue
+        nested_match = re.match(r"\s+([A-Za-z0-9_.-]+):(?:\s*(.*))?$", line)
+        if nested_match and key:
+            frontmatter.setdefault(key, {})
+            if isinstance(frontmatter[key], dict):
+                nested_key = nested_match.group(1)
+                value = strip_quotes(nested_match.group(2) or "")
+                frontmatter[key][nested_key] = value
+            continue
+        continuation_match = re.match(r"\s+(.+)$", line)
+        if continuation_match and key:
+            value = strip_quotes(continuation_match.group(1))
+            current = frontmatter.get(key)
+            if current == []:
+                frontmatter[key] = value
+            elif isinstance(current, str):
+                frontmatter[key] = f"{current} {value}"
+            else:
+                errors.append(f"unexpected continuation for frontmatter key {key!r}: {line}")
+            continue
+        errors.append(f"unparsed frontmatter line: {line}")
+
+    body = "\n".join(lines[close_index + 1 :])
+    if text.endswith("\n"):
+        body += "\n"
+    return frontmatter, body, close_index + 2, errors
+
+
+def load_document(path: Path) -> Document:
+    text = path.read_text(encoding="utf-8")
+    frontmatter, body, body_start_line, parse_errors = parse_frontmatter(text)
+    document = Document(path, text, frontmatter, body, body_start_line)
+    setattr(document, "parse_errors", parse_errors)
+    return document
+
+
+def is_markdown(path: Path) -> bool:
+    return path.suffix == ".md"
+
+
+def is_publication(path: Path) -> bool:
+    return path.relative_to(DOCS).parts[:1] == ("Publications",)
+
+
+def is_publication_bundle(path: Path) -> bool:
+    parts = path.relative_to(DOCS).parts
+    return len(parts) >= 2 and parts[0] == "Publications" and parts[1].startswith("Paper-")
+
+
+def is_canonical(path: Path) -> bool:
+    parts = path.relative_to(DOCS).parts
+    if parts[0] in {"Architecture", "Reference", "Publications"}:
+        return True
+    return len(parts) == 1 and path.suffix == ".md"
+
+
+def parse_date(value: object) -> dt.date | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return dt.date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def slugify(heading: str) -> str:
+    heading = re.sub(r"<[^>]+>", "", heading)
+    heading = re.sub(r"`([^`]*)`", r"\1", heading)
+    heading = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", heading)
+    heading = heading.lower()
+    heading = re.sub(r"[^a-z0-9 _-]", "", heading)
+    heading = re.sub(r"\s+", "-", heading.strip())
+    return heading
+
+
+def headings(path: Path) -> set[str]:
+    if not path.exists() or path.suffix != ".md":
+        return set()
+
+    text = path.read_text(encoding="utf-8")
+    ids: set[str] = set(re.findall(r'<a\s+id=["\']([^"\']+)["\']', text))
+    in_fence = False
+    for line in text.splitlines():
+        if line.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        match = re.match(r"^(#{1,6})\s+(.+?)\s*#*\s*$", line)
+        if match:
+            ids.add(slugify(match.group(2)))
+    return ids
+
+
+def add(errors: list[str], path: Path, message: str, line: int | None = None) -> None:
+    location = rel(path) if line is None else f"{rel(path)}:{line}"
+    errors.append(f"{location}: {message}")
+
+
+def check_frontmatter(document: Document, errors: list[str]) -> None:
+    path = document.path
+    if not is_markdown(path):
+        return
+
+    for parse_error in getattr(document, "parse_errors"):
+        add(errors, path, parse_error, 1)
+
+    fm = document.frontmatter
+    for key in ("title", "description"):
+        if not fm.get(key):
+            add(errors, path, f"frontmatter is missing {key!r}", 1)
+
+    status = fm.get("status")
+    if isinstance(status, str) and status not in STATUS_VALUES:
+        add(errors, path, f"unknown status {status!r}", 1)
+
+    date = parse_date(fm.get("date"))
+    updated = parse_date(fm.get("updated"))
+    for key in ("date", "updated"):
+        if key in fm and parse_date(fm.get(key)) is None:
+            add(errors, path, f"{key!r} must be an ISO date", 1)
+    for key, value in (("date", date), ("updated", updated)):
+        if value and value > TODAY:
+            add(errors, path, f"{key!r} must not be in the future", 1)
+    if date and updated and updated < date:
+        add(errors, path, "'updated' must not be earlier than 'date'", 1)
+
+    if is_publication_bundle(path):
+        required = (
+            PUBLICATION_MANUSCRIPT_REQUIRED
+            if path.name == "manuscript.md"
+            else PUBLICATION_ARTIFACT_REQUIRED
+        )
+        for key in sorted(required - set(fm)):
+            add(errors, path, f"publication frontmatter is missing {key!r}", 1)
+        if path.name == "manuscript.md" and fm.get("kind") != "publication":
+            add(errors, path, "publication manuscripts must set kind: publication", 1)
+        if path.name == "manuscript.md" and not isinstance(fm.get("authors"), list):
+            add(errors, path, "publication manuscripts must use list-form authors", 1)
+
+
+def check_related(document: Document, errors: list[str]) -> None:
+    related = document.frontmatter.get("related")
+    if not isinstance(related, list):
+        return
+
+    for entry in related:
+        if not isinstance(entry, str):
+            continue
+        if entry.startswith("docs/"):
+            candidate = ROOT / entry
+        elif entry.startswith("./") or entry.startswith("../") or entry.endswith(".md"):
+            candidate = (document.path.parent / entry).resolve()
+        else:
+            continue
+        if not candidate.exists():
+            add(errors, document.path, f"related target does not exist: {entry}", 1)
+
+
+def check_publication_body(document: Document, errors: list[str]) -> None:
+    if not is_publication(document.path) or not is_markdown(document.path):
+        return
+
+    lines = document.body.splitlines()
+    h1_index = next((i for i, line in enumerate(lines) if line.startswith("# ")), None)
+    if h1_index is not None:
+        for offset, line in enumerate(lines[h1_index + 1 : h1_index + 8], start=h1_index + 2):
+            if re.match(r"\*\*(Authors?|Status|Venue|Date|Updated):\*\*", line):
+                add(
+                    errors,
+                    document.path,
+                    "publication metadata belongs in frontmatter, not below the H1",
+                    document.body_start_line + offset - 1,
+                )
+
+    for index, line in enumerate(lines):
+        if line.strip() == "## References":
+            next_index = index + 1
+            while next_index < len(lines) and not lines[next_index].strip():
+                next_index += 1
+            if next_index >= len(lines):
+                add(errors, document.path, "References section is empty", document.body_start_line + index)
+            elif not re.match(r"\d+\.\s+", lines[next_index]):
+                add(
+                    errors,
+                    document.path,
+                    "References section must start with a Markdown ordered list",
+                    document.body_start_line + next_index,
+                )
+        if re.match(r"\[[0-9]+\]\s+", line):
+            add(
+                errors,
+                document.path,
+                "reference entries must use Markdown ordered-list syntax",
+                document.body_start_line + index,
+            )
+
+
+def check_canonical_policy(document: Document, errors: list[str]) -> None:
+    if not is_canonical(document.path):
+        return
+
+    lines = document.text.splitlines()
+    for line_no, line in enumerate(lines, start=1):
+        if re.search(r"\bTrack\s+[0-9]+\b", line):
+            add(errors, document.path, "canonical docs must not use internal track numbers", line_no)
+        if re.search(r"\b(?:GitHub|PR)\s+#[0-9]+\b", line):
+            add(errors, document.path, "canonical docs must not cite transient issue or PR IDs", line_no)
+        if "Cortex Pulse" in line:
+            add(errors, document.path, "use the stable term 'Pulse runtime' in canonical docs", line_no)
+
+
+def check_markdown_links(document: Document, errors: list[str]) -> None:
+    if not is_markdown(document.path):
+        return
+
+    link_pattern = re.compile(r"(?<!!)\[[^\]]+\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+    current_headings: set[str] | None = None
+    heading_cache: dict[Path, set[str]] = {}
+
+    for match in link_pattern.finditer(document.text):
+        target = unquote(match.group(1))
+        if re.match(r"^[a-z][a-z0-9+.-]*:", target):
+            continue
+
+        line_no, _ = line_col(document.text, match.start())
+        path_part, _, anchor = target.partition("#")
+        if not path_part:
+            target_path = document.path
+        else:
+            target_path = (document.path.parent / path_part).resolve()
+
+        if path_part:
+            if target_path.is_dir():
+                target_file = target_path / "index.md"
+                if not target_file.exists():
+                    add(errors, document.path, f"local link target does not exist: {target}", line_no)
+                    continue
+            elif not target_path.exists():
+                add(errors, document.path, f"local link target does not exist: {target}", line_no)
+                continue
+            else:
+                target_file = target_path
+        else:
+            target_file = document.path
+
+        if anchor:
+            if target_file == document.path:
+                if current_headings is None:
+                    current_headings = headings(document.path)
+                anchor_headings = current_headings
+            else:
+                anchor_headings = heading_cache.setdefault(target_file, headings(target_file))
+            if anchor not in anchor_headings:
+                add(errors, document.path, f"local link anchor does not exist: {target}", line_no)
+
+
+def line_col(text: str, index: int) -> tuple[int, int]:
+    line = text.count("\n", 0, index) + 1
+    last_newline = text.rfind("\n", 0, index)
+    column = index + 1 if last_newline == -1 else index - last_newline
+    return line, column
+
+
+def mermaid_blocks(text: str) -> list[tuple[int, list[str]]]:
+    blocks: list[tuple[int, list[str]]] = []
+    in_mermaid = False
+    start_line = 0
+    current: list[str] = []
+
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if line.startswith("```mermaid"):
+            in_mermaid = True
+            start_line = line_no + 1
+            current = []
+            continue
+        if in_mermaid and line.startswith("```"):
+            blocks.append((start_line, current))
+            in_mermaid = False
+            continue
+        if in_mermaid:
+            current.append(line)
+    return blocks
+
+
+def check_mermaid_text(path: Path, text: str, errors: list[str]) -> None:
+    if path.suffix == ".mmd":
+        blocks = [(1, text.splitlines())]
+    else:
+        blocks = mermaid_blocks(text)
+
+    for start_line, lines in blocks:
+        for offset, line in enumerate(lines):
+            line_no = start_line + offset
+            if "lint: allow semantic" in line:
+                continue
+            if re.search(r"\bclassDef\b.*\bfill:", line):
+                add(errors, path, "Mermaid cosmetic classDef fill is not allowed", line_no)
+            if re.search(r"\bstyle\b.*\bfill:", line):
+                add(errors, path, "Mermaid inline fill styling is not allowed", line_no)
+            if re.search(r"\blinkStyle\b", line):
+                add(errors, path, "Mermaid linkStyle is not allowed in canonical diagrams", line_no)
+
+
+def check_whitespace(path: Path, text: str, errors: list[str]) -> None:
+    for line_no, line in enumerate(text.splitlines(keepends=True), start=1):
+        content = line[:-1] if line.endswith("\n") else line
+        if content.endswith("\r"):
+            add(errors, path, "carriage return is not allowed", line_no)
+        if content.rstrip(" \t") != content:
+            add(errors, path, "trailing whitespace", line_no)
+
+
+def main() -> int:
+    if not DOCS.exists():
+        print("docs-lint: docs/ not found", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+    paths = iter_docs()
+    documents = [load_document(path) if path.suffix == ".md" else None for path in paths]
+
+    for path, document in zip(paths, documents):
+        text = path.read_text(encoding="utf-8")
+        check_whitespace(path, text, errors)
+        check_mermaid_text(path, text, errors)
+        if document is None:
+            continue
+        check_frontmatter(document, errors)
+        check_related(document, errors)
+        check_publication_body(document, errors)
+        check_canonical_policy(document, errors)
+        check_markdown_links(document, errors)
+
+    if errors:
+        print("docs-lint failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+
+    print(f"docs-lint: checked {len(paths)} docs/Markdown artifacts")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lean-lint
+++ b/scripts/lean-lint
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Strict mechanical lint checks for Cortex Lean theory files."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+THEORY = ROOT / "theory"
+MAX_LINE_LENGTH = 100
+
+BANNED_CODE_WORDS = {
+    "admit",
+    "axiom",
+    "constant",
+    "partial",
+    "sorry",
+    "unsafe",
+}
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def lean_files() -> list[Path]:
+    return sorted(
+        path
+        for path in THEORY.rglob("*.lean")
+        if ".lake" not in path.parts and path.is_file()
+    )
+
+
+def strip_comments_and_strings(source: str) -> str:
+    """Preserve coordinates while replacing Lean comments and strings by spaces."""
+
+    out: list[str] = []
+    i = 0
+    block_depth = 0
+    in_string = False
+
+    while i < len(source):
+        char = source[i]
+        nxt = source[i : i + 2]
+
+        if block_depth:
+            if nxt == "/-":
+                block_depth += 1
+                out.append("  ")
+                i += 2
+            elif nxt == "-/":
+                block_depth -= 1
+                out.append("  ")
+                i += 2
+            else:
+                out.append("\n" if char == "\n" else " ")
+                i += 1
+            continue
+
+        if in_string:
+            if char == "\\" and i + 1 < len(source):
+                out.append("  ")
+                i += 2
+            elif char == '"':
+                in_string = False
+                out.append(" ")
+                i += 1
+            else:
+                out.append("\n" if char == "\n" else " ")
+                i += 1
+            continue
+
+        if nxt == "--":
+            while i < len(source) and source[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+
+        if nxt == "/-":
+            block_depth = 1
+            out.append("  ")
+            i += 2
+            continue
+
+        if char == '"':
+            in_string = True
+            out.append(" ")
+            i += 1
+            continue
+
+        out.append(char)
+        i += 1
+
+    return "".join(out)
+
+
+def line_col(text: str, index: int) -> tuple[int, int]:
+    line = text.count("\n", 0, index) + 1
+    last_newline = text.rfind("\n", 0, index)
+    column = index + 1 if last_newline == -1 else index - last_newline
+    return line, column
+
+
+def add_match_errors(
+    errors: list[str],
+    path: Path,
+    text: str,
+    pattern: str,
+    message: str,
+) -> None:
+    for match in re.finditer(pattern, text, flags=re.MULTILINE):
+        line, column = line_col(text, match.start())
+        errors.append(f"{rel(path)}:{line}:{column}: {message}: {match.group(0)!r}")
+
+
+def check_file(path: Path, errors: list[str]) -> None:
+    source = path.read_text(encoding="utf-8")
+
+    for line_no, line in enumerate(source.splitlines(keepends=True), start=1):
+        content = line[:-1] if line.endswith("\n") else line
+        if content.endswith("\r"):
+            errors.append(f"{rel(path)}:{line_no}: carriage return is not allowed")
+        if content.rstrip(" \t") != content:
+            errors.append(f"{rel(path)}:{line_no}: trailing whitespace")
+        if len(content) > MAX_LINE_LENGTH:
+            errors.append(
+                f"{rel(path)}:{line_no}: line is {len(content)} columns "
+                f"(max {MAX_LINE_LENGTH})"
+            )
+
+    code = strip_comments_and_strings(source)
+    banned_words = "|".join(sorted(BANNED_CODE_WORDS))
+    add_match_errors(
+        errors,
+        path,
+        code,
+        rf"\b({banned_words})\b",
+        "trusted-base/debt keyword is banned in Lean code",
+    )
+    add_match_errors(
+        errors,
+        path,
+        code,
+        r"set_option\s+linter\.[A-Za-z0-9_.]+\s+false",
+        "linter suppression is banned",
+    )
+    add_match_errors(
+        errors,
+        path,
+        code,
+        r"set_option\s+autoImplicit\s+true",
+        "autoImplicit must not be re-enabled",
+    )
+    add_match_errors(
+        errors,
+        path,
+        code,
+        r"\|\s*_\s*=>",
+        "wildcard match arms on Lean ADTs are banned",
+    )
+
+
+def module_name(path: Path) -> str:
+    without_suffix = path.relative_to(THEORY).with_suffix("")
+    return ".".join(without_suffix.parts)
+
+
+def check_umbrella_imports(errors: list[str]) -> None:
+    cortex = THEORY / "Cortex.lean"
+    lakefile = THEORY / "lakefile.lean"
+    modules = {
+        module_name(path)
+        for path in (THEORY / "Cortex").rglob("*.lean")
+        if path.is_file() and ".lake" not in path.parts
+    }
+
+    cortex_text = cortex.read_text(encoding="utf-8")
+    cortex_imports = set(re.findall(r"^import\s+([A-Za-z0-9_.]+)\s*$", cortex_text, re.M))
+    missing = sorted(modules - cortex_imports)
+    for mod in missing:
+        errors.append(f"{rel(cortex)}: missing umbrella import for {mod}")
+
+    lake_text = lakefile.read_text(encoding="utf-8")
+    lake_roots = set(re.findall(r"`([A-Za-z0-9_.]+)", lake_text))
+    expected_roots = {"Cortex", *modules}
+    missing_roots = sorted(expected_roots - lake_roots)
+    for mod in missing_roots:
+        errors.append(f"{rel(lakefile)}: root list is missing {mod}")
+
+
+def main() -> int:
+    if not THEORY.exists():
+        print("lean-lint: theory/ not found", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+    files = lean_files()
+
+    for path in files:
+        check_file(path, errors)
+    check_umbrella_imports(errors)
+
+    if errors:
+        print("lean-lint failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+
+    print(f"lean-lint: checked {len(files)} Lean files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/theory/README.md
+++ b/theory/README.md
@@ -1,150 +1,123 @@
 # Cortex theory
 
-Lean 4 mechanization of the Cortex substrate. This directory builds as
-its own Lake project (`lakefile.lean`, `lean-toolchain`) and is wired
-into the repo's nix flake under `packages.cortex-theory` via
-`nix/lean.nix`.
+Lean 4 mechanization of the Cortex substrate. This directory builds as its own Lake project
+(`lakefile.lean`, `lean-toolchain`) and is wired into the repo's nix flake under
+`packages.cortex-theory` via `nix/lean.nix`.
 
-The point of having a Lean track at all is to turn the substrate
-guarantees from prose into proof:
+The point of having a Lean track at all is to turn the substrate guarantees from prose into proof:
 
 - Wire / Graph laws aren't conventions — they're theorems.
-- Pulse frontier safety isn't a code review property — it's a
-  mechanized invariant.
-- Rewrite admission isn't a runtime check we hope is correct — it's
-  a soundness theorem we discharge.
-- Pulse determinism modulo external sparks is the audit-trail
-  property that makes runs replayable.
+- Pulse frontier safety isn't a code review property — it's a mechanized invariant.
+- Rewrite admission isn't a runtime check we hope is correct — it's a soundness theorem we
+  discharge.
+- Pulse determinism modulo external sparks is the audit-trail property that makes runs replayable.
 
-Together these put the substrate's correctness story under
-machine-checked assurance, leaving the LLM-driven layers above as the
-"untrusted user" of a "trusted system". The agent layer remains
+Together these put the substrate's correctness story under machine-checked assurance, leaving the
+LLM-driven layers above as the "untrusted user" of a "trusted system". The agent layer remains
 stochastic; the substrate it runs on does not.
 
 ## Tracks
 
-The five tracks are sketched below. Each track begins as an explicit
-obligation surface; completed slices replace scaffold assumptions with
-theorems, while unfinished tracks keep proof debt visible.
+The five tracks are sketched below. Each track begins as an explicit obligation surface; completed
+slices replace scaffold assumptions with theorems, while unfinished tracks keep proof debt visible.
 
 ### Track 1 — Graph algebra (Mokhov)
 
-`Cortex.Graph.Core` defines the inductive `Graph α` with constructors
-`empty`, `vertex`, `overlay`, `connect`. `Cortex.Graph.Relation`
-defines the finite relation denotation used by the Haskell
-`toRelation` implementation and proves the Mokhov laws on that
-denotation with mathlib `Finset`s. `Cortex.Graph.Laws` now exposes the
-AST-facing laws as theorems over denotational equality (`GraphEq`),
-because raw syntax trees are not definitionally equal. The next quotient
-step (`Cortex.Graph.Quotient`, TODO) can lift those denotational laws to
-ordinary equality on a quotient carrier.
+`Cortex.Graph.Core` defines the inductive `Graph α` with constructors `empty`, `vertex`, `overlay`,
+`connect`. `Cortex.Graph.Relation` defines the finite relation denotation used by the Haskell
+`toRelation` implementation and proves the Mokhov laws on that denotation with mathlib `Finset`s.
+`Cortex.Graph.Laws` now exposes the AST-facing laws as theorems over denotational equality
+(`GraphEq`), because raw syntax trees are not definitionally equal. The next quotient step
+(`Cortex.Graph.Quotient`, TODO) can lift those denotational laws to ordinary equality on a quotient
+carrier.
 
-**Headline obligation:** `connect_decomposition`
-(`g · h · k = g · h ⊕ g · k ⊕ h · k`). This is what licenses circuit
-simplification and the executor's compatibility-edge derivation. The
-relation-level theorem now exists; the remaining obligation is lifting it
-through graph equivalence.
+**Headline obligation:** `connect_decomposition` (`g · h · k = g · h ⊕ g · k ⊕ h · k`). This is what
+licenses circuit simplification and the executor's compatibility-edge derivation. The relation-level
+theorem now exists; the remaining obligation is lifting it through graph equivalence.
 
 ### Track 2 — Fixed-topology Pulse kernel
 
-`Cortex.Pulse.DAG`, `State`, `Fact`, `Frontier`, `Closure`, `Validity`,
-and `Recovery` model the Paper 1 fixed-topology staged-reduction kernel.
-The current model is extensional: a finite node type, an edge-derived DAG
-reachability relation, abstract payloads, node-local facts,
-reachability-level readiness, direct-predecessor runtime readiness,
-topology-domain validity, and failure closure over the DAG. It avoids
-runtime UUID/database shapes and keeps payload and failure details
-abstract.
+`Cortex.Pulse.DAG`, `State`, `Fact`, `Frontier`, `Closure`, `Validity`, and `Recovery` model the
+Paper 1 fixed-topology staged-reduction kernel. The current model is extensional: a finite node
+type, an edge-derived DAG reachability relation, abstract payloads, node-local facts,
+reachability-level readiness, direct-predecessor runtime readiness, topology-domain validity, and
+failure closure over the DAG. It avoids runtime UUID/database shapes and keeps payload and failure
+details abstract.
 
 Mechanized results now include:
 
 - `frontier_only_ready`: frontier membership implies readiness.
-- `frontier_antichain`: frontier nodes are mutually incomparable by
-  strict reachability.
-- `NodeResult.applyNodeFact_comm`: node-local facts for distinct nodes
-  commute.
-- `NodeResult.applyNodeFacts_perm_invariant`: disjoint-key fact folds
-  are invariant under list permutation.
+- `frontier_antichain`: frontier nodes are mutually incomparable by strict reachability.
+- `NodeResult.applyNodeFact_comm`: node-local facts for distinct nodes commute.
+- `NodeResult.applyNodeFacts_perm_invariant`: disjoint-key fact folds are invariant under list
+  permutation.
 - `propagateFailure_extensive`: propagation preserves failed nodes.
-- `propagateFailure_monotone`: failure propagation is monotone over
-  pointwise failure-growth.
-- `propagateFailure_failureClosureComplete`: one propagation pass closes
-  failure over propagatable descendants.
-- `propagateFailure_preserves_topologyDomain`: propagation preserves the
-  absence of off-topology durable state.
-- `propagateFailure_preserves_outputsRespectStatuses`: propagation
-  preserves output ownership.
-- `propagateFailure_preserves_outputsCompleteForStatuses`: propagation
-  preserves required outputs for completed and rewritten nodes.
+- `propagateFailure_monotone`: failure propagation is monotone over pointwise failure-growth.
+- `propagateFailure_failureClosureComplete`: one propagation pass closes failure over propagatable
+  descendants.
+- `propagateFailure_preserves_topologyDomain`: propagation preserves the absence of off-topology
+  durable state.
+- `propagateFailure_preserves_outputsRespectStatuses`: propagation preserves output ownership.
+- `propagateFailure_preserves_outputsCompleteForStatuses`: propagation preserves required outputs
+  for completed and rewritten nodes.
 - `propagateFailure_idempotent`: failure propagation is idempotent.
-- `directReady_sound`: executable direct-predecessor readiness implies
-  proof-level reachability readiness under causal-history closure.
-- `readyNodes_eq_directReadyNodes`: proof and runtime frontiers coincide
-  under closure and causal-history invariants.
-- `NodeResult.Admissible`: node facts must target the topology and come
-  from the executable frontier before preservation theorems apply.
-- `frontierFacts_recovered_wellFormedGraphState`: admissible fact folds
-  become structurally well-formed again after recovery normalization and
-  failure closure.
-- `persistence_safety`: recovered states are structurally well-formed,
-  conditional on explicit persisted topology-domain, output ownership,
-  output-completeness, and causal-history preconditions that recovery
-  preserves.
-- `classifyClosedGraphState_exhaustive_of_wellFormed`: well-formed
-  closed states classify into failed, progressing, completed, or
-  suspended branches.
-- `classifyGraphState_not_stuck_of_wellFormed`: well-formed states
-  cannot classify as stuck after the runtime closure step.
+- `directReady_sound`: executable direct-predecessor readiness implies proof-level reachability
+  readiness under causal-history closure.
+- `readyNodes_eq_directReadyNodes`: proof and runtime frontiers coincide under closure and
+  causal-history invariants.
+- `NodeResult.Admissible`: node facts must target the topology and come from the executable frontier
+  before preservation theorems apply.
+- `frontierFacts_recovered_wellFormedGraphState`: admissible fact folds become structurally
+  well-formed again after recovery normalization and failure closure.
+- `persistence_safety`: recovered states are structurally well-formed, conditional on explicit
+  persisted topology-domain, output ownership, output-completeness, and causal-history preconditions
+  that recovery preserves.
+- `classifyClosedGraphState_exhaustive_of_wellFormed`: well-formed closed states classify into
+  failed, progressing, completed, or suspended branches.
+- `classifyGraphState_not_stuck_of_wellFormed`: well-formed states cannot classify as stuck after
+  the runtime closure step.
 
 The Paper 1 Lean-Haskell modeling boundary is documented in
-`docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md`.
-Remaining obligations include Haskell-side establishment of the
-persisted recovery preconditions and quotient lifting for the graph
-algebra laws.
+`docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md`. Remaining obligations include
+Haskell-side establishment of the persisted recovery preconditions and quotient lifting for the
+graph algebra laws.
 
 ### Track 3 — Rewrite soundness
 
-`Cortex.Wire.Rewrite` sketches the admission predicate from
-`src/Cortex/Pulse/Rewrite.hs`. The current Lean surface is
-proof-carrying rather than vacuous: an admitted `Rewrite` carries
-preservation evidence for graph acyclicity, the caller-supplied contract
-predicate, and positive budget consumption. Remaining obligations:
+`Cortex.Wire.Rewrite` sketches the admission predicate from `src/Cortex/Pulse/Rewrite.hs`. The
+current Lean surface is proof-carrying rather than vacuous: an admitted `Rewrite` carries
+preservation evidence for graph acyclicity, the caller-supplied contract predicate, and positive
+budget consumption. Remaining obligations:
 
 - connect those proof-carrying certificates to the Haskell admission path;
-- instantiate the contract predicate from the Wire `@` registry boundary
-  model: every materialized executor node must come from a registered
-  executor reference, validated pure config, declared or derivable ports,
-  known contracts, explicit purity/effect metadata, and explicit host
-  authority;
-- lift local positive-cost consumption to a full rewrite-chain
-  termination proof.
+- instantiate the contract predicate from the Wire `@` registry boundary model: every materialized
+  executor node must come from a registered executor reference, validated pure config, declared or
+  derivable ports, known contracts, explicit purity/effect metadata, and explicit host authority;
+- lift local positive-cost consumption to a full rewrite-chain termination proof.
 
-This is the "sandbox by proof" story for dynamic graph rewriting.
-Rewrites may transform topology, but they cannot invent new `@` executor
-authority outside the registry boundary documented in
+This is the "sandbox by proof" story for dynamic graph rewriting. Rewrites may transform topology,
+but they cannot invent new `@` executor authority outside the registry boundary documented in
 `docs/Reference/Wire/executors-and-alphabet.md`.
 
 ### Track 4 — Provider / spark abstraction (TODO)
 
-A formal model of `Cortex.Capability.Model.Client` and its
-`spark`-shaped contract: an external call returns
-`Either CallError Result`. Discharging this lets us state determinism
-modulo sparks without hand-waving over LLM nondeterminism.
+A formal model of `Cortex.Capability.Model.Client` and its `spark`-shaped contract: an external call
+returns `Either CallError Result`. Discharging this lets us state determinism modulo sparks without
+hand-waving over LLM nondeterminism.
 
 ### Track 5 — Substrate / consumer boundary (TODO)
 
-Per ADR 0015, the Cortex runtime never imports the structured
-reasoning library or any consumer module. A Lean encoding of the
-import graph as a strict partial order makes this enforceable
+Per ADR 0015, the Cortex runtime never imports the structured reasoning library or any consumer
+module. A Lean encoding of the import graph as a strict partial order makes this enforceable
 mechanically rather than by code review.
 
-Track 5 sits inside the substrate proof; Track 4 sits between the
-substrate and external nondeterminism.
+Track 5 sits inside the substrate proof; Track 4 sits between the substrate and external
+nondeterminism.
 
 ## Build
 
-The Lean toolchain version lives in `lean-toolchain` (currently
-`leanprover/lean4:v4.29.0`). The standard Lake commands work:
+The Lean toolchain version lives in `lean-toolchain` (currently `leanprover/lean4:v4.29.0`). The
+standard Lake commands work:
 
 ```
 cd theory
@@ -162,24 +135,22 @@ nix build .#cortex-theory
 just lean-check
 ```
 
-For direct Lake workflows, `nix develop` still provides a working Lean
-toolchain in the repo shell. The repo's pre-commit hook checks theory
-changes through the flake surface (`nix build .#cortex-theory`) so that
-local commits and CI agree on the Lean gate.
+For direct Lake workflows, `nix develop` still provides a working Lean toolchain in the repo shell.
+The repo's pre-commit hook checks theory changes through the flake surface
+(`nix build .#cortex-theory`) so that local commits and CI agree on the Lean gate.
 
 ## Status
 
-| Track | Statements | Proved | Axiomatized |
-|---|---|---|---|
-| 1a. Graph relation semantics | finite relation denotation + Mokhov laws | relation-level laws | none |
-| 1b. Graph denotational AST laws | AST laws over graph equivalence | denotational law surface | none |
-| 1c. Graph quotient laws | lifted quotient equality laws | pending | none |
-| 2. Fixed-topology Pulse kernel | edge-derived DAG/state/fact/frontier/closure/recovery/classification surface | frontier antichain, direct/runtime frontier bridge, fact commutativity, admissible fact recovery, closure idempotence, topology-domain/output/volatile-state/causal preservation, structural recovery predicate, classification exhaustiveness | none |
-| 3. Rewrite soundness | proof-carrying rewrite certificate | acyclicity/contract/budget projections | none |
-| 4. Provider / sparks | — | — | not started |
-| 5. Substrate / consumer boundary | — | — | not started |
+| Track                            | Statements                                                                   | Proved                                                                                                                                                                                                                                         | Axiomatized |
+| -------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| 1a. Graph relation semantics     | finite relation denotation + Mokhov laws                                     | relation-level laws                                                                                                                                                                                                                            | none        |
+| 1b. Graph denotational AST laws  | AST laws over graph equivalence                                              | denotational law surface                                                                                                                                                                                                                       | none        |
+| 1c. Graph quotient laws          | lifted quotient equality laws                                                | pending                                                                                                                                                                                                                                        | none        |
+| 2. Fixed-topology Pulse kernel   | edge-derived DAG/state/fact/frontier/closure/recovery/classification surface | frontier antichain, direct/runtime frontier bridge, fact commutativity, admissible fact recovery, closure idempotence, topology-domain/output/volatile-state/causal preservation, structural recovery predicate, classification exhaustiveness | none        |
+| 3. Rewrite soundness             | proof-carrying rewrite certificate                                           | acyclicity/contract/budget projections                                                                                                                                                                                                         | none        |
+| 4. Provider / sparks             | —                                                                            | —                                                                                                                                                                                                                                              | not started |
+| 5. Substrate / consumer boundary | —                                                                            | —                                                                                                                                                                                                                                              | not started |
 
-Discharging the remaining obligations is the actual work. The scaffold's
-job is to make the obligation graph compile and run end-to-end so that
-proof debt is visible and each abstract certificate or predicate can be
-connected to executable Cortex code.
+Discharging the remaining obligations is the actual work. The scaffold's job is to make the
+obligation graph compile and run end-to-end so that proof debt is visible and each abstract
+certificate or predicate can be connected to executable Cortex code.


### PR DESCRIPTION
## Summary
Add deterministic linting and formatting gates for Cortex Lean theory and Markdown documentation.

## Implemented
- Added `scripts/lean-lint` plus `just lean-lint` and Nix app/package wiring.
- Added `scripts/docs-lint` plus `just docs-lint` and Nix app/package wiring.
- Wired Lean/docs linting into local `just ci-check`, pre-commit hooks, and GitHub Actions.
- Added Markdown formatting through treefmt/prettier with 100-column prose wrapping and `docs/Templates` excluded.
- Updated Lean/doc review skills so the machine-enforced layer is explicit.
- Fixed the current baseline: frontmatter parsing, local links/anchors, publication note index, Mermaid cosmetic fills, canonical issue/PR references, and Pulse terminology.
- Formatted Markdown corpus under the new formatter.

## Validation
- [x] `just lean-lint`
- [x] `just docs-lint`
- [x] `just fmt-check`
- [x] `just lean-check`
- [x] `just docs-check`
- [x] `just ci-check`

## Checklist
- [x] Implementation complete
- [x] No allowlist or grandfathering file introduced
- [x] Ready for review

## Issues
Closes #68
Closes #69
