### PR TITLE
feat: mechanize Wire registry rewrite proofs

### DIFF
--- a/theory/Cortex.lean
+++ b/theory/Cortex.lean
@@ -14,6 +14,7 @@ import Cortex.Pulse.Recovery
 import Cortex.Pulse.Classify
 
 -- Track 3 — Wire rewrite soundness
+import Cortex.Wire.Registry
 import Cortex.Wire.Rewrite
 
 /-!
@@ -33,5 +34,5 @@ check that every proof track remains importable together.
 
 The imported tracks are the theorem split: `Cortex.Graph.*` for algebra,
 `Cortex.Pulse.*` for fixed-topology runtime safety, and
-`Cortex.Wire.*` for rewrite admission.
+`Cortex.Wire.*` for registry-boundary and rewrite admission.
 -/

--- a/theory/Cortex/Wire/Registry.lean
+++ b/theory/Cortex/Wire/Registry.lean
@@ -1,0 +1,307 @@
+import Cortex.Graph.Laws
+import Mathlib.Data.Finset.Basic
+
+/-!
+## Overview
+
+Proof-facing model of the Wire executor registry boundary.
+
+## Context
+
+Wire syntax can stage executor authority with `@qualified.name { config }`.
+That expression is pure: it does not run the executor. Before a staged
+executor can become a materialized graph node, the registry must establish
+that the executor exists, the config is valid, ports and contracts are
+known, endpoint contracts are compatible, effect metadata is known, output
+validation is known, and host authority is explicit.
+
+This module turns those documented obligations into a reusable Lean
+predicate. It intentionally remains abstract over executor names, config
+values, contract identifiers, and host authority tokens; the Haskell
+compiler and registry are responsible for producing concrete witnesses.
+The predicates here are therefore a proof boundary, not a replacement for
+the runtime correspondence theorem that must connect them to the executable
+admission path. A registry with trivial predicates can satisfy this abstract
+model; the load-bearing claim is the later theorem that the Haskell registry
+constructs only these witnesses from real schema, contract, policy, and host
+authority checks.
+
+## Theorem Split
+
+The page defines port boundaries, registry entries, staged executor nodes,
+node-level admission, edge-level endpoint admission, graph-level registry
+boundary validity, and transport of the boundary across denotational graph
+equality.
+-/
+
+namespace Cortex.Wire
+
+open Cortex.Graph
+
+/-! ## Registry Model -/
+
+/-- `EffectClass` names the coarse purity/effect category declared by the registry. -/
+inductive EffectClass : Type where
+  | pure
+  | impure
+  | hostEffecting
+  | modelMediated
+  deriving DecidableEq, Repr
+
+/-- `PortBoundary contract` is the registry-declared contract surface for a node. -/
+structure PortBoundary (contract : Type) [DecidableEq contract] where
+  /-- Contracts accepted by the materialized node's input boundary. -/
+  inputs : Finset contract
+  /-- Contracts produced by the materialized node's output boundary. -/
+  outputs : Finset contract
+
+namespace PortBoundary
+
+/-- `contracts boundary` is the full contract surface declared for a materialized node. -/
+def contracts {contract : Type} [DecidableEq contract] (boundary : PortBoundary contract) :
+    Finset contract :=
+  boundary.inputs ∪ boundary.outputs
+
+end PortBoundary
+
+/-- `RegistryEntry` is the authority record attached to one registered executor. -/
+structure RegistryEntry (config contract authority : Type) [DecidableEq contract] where
+  /-- Configuration records for this executor must pass its registry schema. -/
+  configValid : config → Prop
+  /-- The registry can declare or derive the port boundary for this config. -/
+  ports : config → PortBoundary contract
+  /-- The configured executor has enough port information to become a graph node. -/
+  portsDeclaredOrDerivable : config → Prop
+  /-- The executor's purity/effect class is explicit registry metadata. -/
+  effectClass : EffectClass
+  /-- The registry has a validation rule for each declared output contract. -/
+  outputValidationKnown : config → Prop
+  /-- Host permissions for this executor invocation are explicit. -/
+  hostAuthorityExplicit : authority → Prop
+
+/-- `ExecutorRegistry` resolves executor names to registry entries. -/
+structure ExecutorRegistry
+    (executor config contract authority : Type)
+    [DecidableEq contract] where
+  /-- Lookup in the closed executor alphabet. `none` means the executor is not registered. -/
+  resolve : executor → Option (RegistryEntry config contract authority)
+  /-- The registry's closed contract vocabulary. -/
+  contractKnown : contract → Prop
+  /-- Endpoint compatibility for a source output contract and target input contract. -/
+  contractsCompatible : contract → contract → Prop
+  /-- Effect classes admitted by the runtime policy represented by this registry. -/
+  effectClassKnown : EffectClass → Prop
+
+/-- `StagedExecutorNode` is the pure result of applying `@` to config data. -/
+structure StagedExecutorNode (executor config authority : Type) where
+  /-- Qualified executor identity from the closed registry alphabet. -/
+  executor : executor
+  /-- Pure configuration data staged with the executor. -/
+  config : config
+  /-- Host-authority token selected by the registry or binding layer. -/
+  authority : authority
+
+/-! ## Admission Predicates -/
+
+/-- `nodeAdmittedBy registry node` records the registry obligations for one staged node. -/
+def nodeAdmittedBy
+    {executor config contract authority : Type}
+    [DecidableEq contract]
+    (registry : ExecutorRegistry executor config contract authority)
+    (node : StagedExecutorNode executor config authority) :
+    Prop :=
+  ∃ entry : RegistryEntry config contract authority,
+    registry.resolve node.executor = some entry ∧
+    entry.configValid node.config ∧
+    entry.portsDeclaredOrDerivable node.config ∧
+    (∀ contract,
+      contract ∈ (entry.ports node.config).contracts →
+        registry.contractKnown contract) ∧
+    registry.effectClassKnown entry.effectClass ∧
+    entry.outputValidationKnown node.config ∧
+    entry.hostAuthorityExplicit node.authority
+
+/-- `edgeAdmittedBy registry source target` records endpoint compatibility for one graph edge. -/
+def edgeAdmittedBy
+    {executor config contract authority : Type}
+    [DecidableEq contract]
+    (registry : ExecutorRegistry executor config contract authority)
+    (source target : StagedExecutorNode executor config authority) :
+    Prop :=
+  ∃ sourceEntry targetEntry : RegistryEntry config contract authority,
+    registry.resolve source.executor = some sourceEntry ∧
+    registry.resolve target.executor = some targetEntry ∧
+    ∃ outputContract inputContract : contract,
+      outputContract ∈ (sourceEntry.ports source.config).outputs ∧
+      inputContract ∈ (targetEntry.ports target.config).inputs ∧
+      registry.contractKnown outputContract ∧
+      registry.contractKnown inputContract ∧
+      registry.contractsCompatible outputContract inputContract
+
+/-- `registryVerticesAdmitted registry g` says every graph vertex is registry-admitted. -/
+def registryVerticesAdmitted
+    {executor config contract authority : Type}
+    [DecidableEq contract]
+    [DecidableEq (StagedExecutorNode executor config authority)]
+    (registry : ExecutorRegistry executor config contract authority)
+    (g : Graph (StagedExecutorNode executor config authority)) :
+    Prop :=
+  ∀ node,
+    node ∈ (denote g).vertices →
+      nodeAdmittedBy registry node
+
+/-- `registryEdgesAdmitted registry g` says every graph edge has compatible endpoints. -/
+def registryEdgesAdmitted
+    {executor config contract authority : Type}
+    [DecidableEq contract]
+    [DecidableEq (StagedExecutorNode executor config authority)]
+    (registry : ExecutorRegistry executor config contract authority)
+    (g : Graph (StagedExecutorNode executor config authority)) :
+    Prop :=
+  ∀ source target,
+    (source, target) ∈ (denote g).edges →
+      edgeAdmittedBy registry source target
+
+/-- `registryBoundary registry g` is the graph-level Wire registry admission predicate. -/
+def registryBoundary
+    {executor config contract authority : Type}
+    [DecidableEq contract]
+    [DecidableEq (StagedExecutorNode executor config authority)]
+    (registry : ExecutorRegistry executor config contract authority)
+    (g : Graph (StagedExecutorNode executor config authority)) :
+    Prop :=
+  registryVerticesAdmitted registry g ∧ registryEdgesAdmitted registry g
+
+/-! ## Admission Projections -/
+
+section AdmissionProjections
+
+variable {executor config contract authority : Type}
+variable [DecidableEq contract]
+variable {registry : ExecutorRegistry executor config contract authority}
+variable {node : StagedExecutorNode executor config authority}
+
+/-- `nodeAdmittedBy_executor_exists` extracts the closed-alphabet lookup witness. -/
+theorem nodeAdmittedBy_executor_exists
+    (hAdmitted : nodeAdmittedBy registry node) :
+    ∃ entry : RegistryEntry config contract authority,
+      registry.resolve node.executor = some entry := by
+  rcases hAdmitted with
+    ⟨entry, hResolve, _hConfig, _hPorts, _hContracts, _hEffect, _hOutput, _hHost⟩
+  exact ⟨entry, hResolve⟩
+
+/-- `nodeAdmittedBy_configValid` extracts the config-schema obligation. -/
+theorem nodeAdmittedBy_configValid
+    (hAdmitted : nodeAdmittedBy registry node) :
+    ∃ entry : RegistryEntry config contract authority,
+      registry.resolve node.executor = some entry ∧ entry.configValid node.config := by
+  rcases hAdmitted with
+    ⟨entry, hResolve, hConfig, _hPorts, _hContracts, _hEffect, _hOutput, _hHost⟩
+  exact ⟨entry, hResolve, hConfig⟩
+
+/-- `nodeAdmittedBy_portsDeclared` extracts the port-boundary obligation. -/
+theorem nodeAdmittedBy_portsDeclared
+    (hAdmitted : nodeAdmittedBy registry node) :
+    ∃ entry : RegistryEntry config contract authority,
+      registry.resolve node.executor = some entry ∧
+        entry.portsDeclaredOrDerivable node.config := by
+  rcases hAdmitted with
+    ⟨entry, hResolve, _hConfig, hPorts, _hContracts, _hEffect, _hOutput, _hHost⟩
+  exact ⟨entry, hResolve, hPorts⟩
+
+/-- `nodeAdmittedBy_contractsKnown` extracts the contract-vocabulary obligation. -/
+theorem nodeAdmittedBy_contractsKnown
+    (hAdmitted : nodeAdmittedBy registry node) :
+    ∃ entry : RegistryEntry config contract authority,
+      registry.resolve node.executor = some entry ∧
+        ∀ contract,
+          contract ∈ (entry.ports node.config).contracts →
+            registry.contractKnown contract := by
+  rcases hAdmitted with
+    ⟨entry, hResolve, _hConfig, _hPorts, hContracts, _hEffect, _hOutput, _hHost⟩
+  exact ⟨entry, hResolve, hContracts⟩
+
+/-- `nodeAdmittedBy_effectClassKnown` extracts the effect-class policy obligation. -/
+theorem nodeAdmittedBy_effectClassKnown
+    (hAdmitted : nodeAdmittedBy registry node) :
+    ∃ entry : RegistryEntry config contract authority,
+      registry.resolve node.executor = some entry ∧
+        registry.effectClassKnown entry.effectClass := by
+  rcases hAdmitted with
+    ⟨entry, hResolve, _hConfig, _hPorts, _hContracts, hEffect, _hOutput, _hHost⟩
+  exact ⟨entry, hResolve, hEffect⟩
+
+/-- `nodeAdmittedBy_outputValidationKnown` extracts the output-validation obligation. -/
+theorem nodeAdmittedBy_outputValidationKnown
+    (hAdmitted : nodeAdmittedBy registry node) :
+    ∃ entry : RegistryEntry config contract authority,
+      registry.resolve node.executor = some entry ∧
+        entry.outputValidationKnown node.config := by
+  rcases hAdmitted with
+    ⟨entry, hResolve, _hConfig, _hPorts, _hContracts, _hEffect, hOutput, _hHost⟩
+  exact ⟨entry, hResolve, hOutput⟩
+
+/-- `nodeAdmittedBy_hostAuthorityExplicit` extracts the host-authority obligation. -/
+theorem nodeAdmittedBy_hostAuthorityExplicit
+    (hAdmitted : nodeAdmittedBy registry node) :
+    ∃ entry : RegistryEntry config contract authority,
+      registry.resolve node.executor = some entry ∧
+        entry.hostAuthorityExplicit node.authority := by
+  rcases hAdmitted with
+    ⟨entry, hResolve, _hConfig, _hPorts, _hContracts, _hEffect, _hOutput, hHost⟩
+  exact ⟨entry, hResolve, hHost⟩
+
+end AdmissionProjections
+
+/-! ## Boundary Projections -/
+
+section BoundaryProjections
+
+variable {executor config contract authority : Type}
+variable [DecidableEq contract]
+variable [DecidableEq (StagedExecutorNode executor config authority)]
+variable {registry : ExecutorRegistry executor config contract authority}
+variable {g h : Graph (StagedExecutorNode executor config authority)}
+
+/-- `registryBoundary_vertices` extracts graph-wide vertex admission. -/
+theorem registryBoundary_vertices
+    (hBoundary : registryBoundary registry g) :
+    registryVerticesAdmitted registry g :=
+  hBoundary.1
+
+/-- `registryBoundary_edges` extracts graph-wide endpoint compatibility. -/
+theorem registryBoundary_edges
+    (hBoundary : registryBoundary registry g) :
+    registryEdgesAdmitted registry g :=
+  hBoundary.2
+
+/-! ## Graph Equality Transport -/
+
+/-- Registry-boundary validity transports across denotational graph equality. -/
+theorem registryBoundary_of_graphEq
+    (hEq : GraphEq g h)
+    (hBoundary : registryBoundary registry g) :
+    registryBoundary registry h := by
+  have hDenote : denote g = denote h := hEq
+  rcases hBoundary with ⟨hVerticesBoundary, hEdgesBoundary⟩
+  constructor
+  · intro node hNode
+    have hVertices : (denote h).vertices = (denote g).vertices := by
+      rw [hDenote]
+    exact hVerticesBoundary node (by simpa [hVertices] using hNode)
+  · intro source target hEdge
+    have hEdges : (denote h).edges = (denote g).edges := by
+      rw [hDenote]
+    exact hEdgesBoundary source target (by simpa [hEdges] using hEdge)
+
+/-- Registry-boundary validity is invariant under denotational graph equality. -/
+theorem registryBoundary_graphEq_iff
+    (hEq : GraphEq g h) :
+    registryBoundary registry g ↔ registryBoundary registry h := by
+  constructor
+  · exact registryBoundary_of_graphEq hEq
+  · exact registryBoundary_of_graphEq hEq.symm
+
+end BoundaryProjections
+
+end Cortex.Wire

--- a/theory/Cortex/Wire/Rewrite.lean
+++ b/theory/Cortex/Wire/Rewrite.lean
@@ -1,4 +1,5 @@
-import Cortex.Graph.Relation
+import Cortex.Wire.Registry
+import Mathlib.Data.Nat.Basic
 
 /-!
 ## Overview
@@ -14,24 +15,29 @@ The Haskell side (`src/Cortex/Pulse/Rewrite.hs`,
 file mechanizes the proof-carrying shape expected of admitted rewrites:
 an accepted rewrite must carry evidence that it preserves graph
 acyclicity, preserves the contract-boundary predicate supplied by the
-caller, and consumes positive budget.
+caller, and consumes positive rewrite-operation budget inside the same
+five-dimensional budget shape used by the runtime.
 
 ## Context
 
-This module is a tracked scaffold. It names real predicates for rewrite
-admission without pretending the dynamic rewrite story is already fully
-mechanized or connected to the Haskell implementation.
+This module names real predicates for rewrite admission without pretending
+the dynamic rewrite story is already fully connected to the Haskell
+implementation. The current proof surface now includes both local
+admission projections and chain-level preservation/termination facts.
 
 ## Theorem Split
 
 The page defines graph-level paths, the abstract rewrite certificate,
-the admission predicate, and theorem projections from the certificate.
+the five-dimensional rewrite budget, the admission predicate, theorem
+projections from the certificate, and rewrite chains bounded by remaining
+rewrite-operation budget.
 
 ## Roadmap
 
 1. Connect `Rewrite` certificates to the Haskell admission path.
-2. Instantiate `contractOk` from the registry boundary model.
-3. Lift the budget-consumption projection to rewrite chains.
+2. Connect registry-boundary witnesses to the Haskell compiler and registry.
+3. Model the remaining `planGraphRewrite` checks: anchor existence,
+   entry/exit non-emptiness, orphan-freedom, and runtime policy.
 4. Connect the graph path predicate to the runtime topology integrity
    witness from ADR 0009.
 
@@ -58,18 +64,112 @@ inductive GraphPath {α : Type} [DecidableEq α] (g : Graph α) : α → α → 
 def Acyclic {α : Type} [DecidableEq α] (g : Graph α) : Prop :=
   ∀ node : α, ¬ GraphPath g node node
 
-/-- `Rewrite α` is a partial function on graphs. The full Haskell shape
+/-- `RewriteCost` mirrors the runtime's structural rewrite-cost dimensions. -/
+structure RewriteCost where
+  /-- Number of nodes added by the admitted rewrite. -/
+  addedNodes : Nat
+  /-- Number of edges added by the admitted rewrite. -/
+  addedEdges : Nat
+  /-- Depth added below the rewrite anchor. -/
+  addedDepth : Nat
+  /-- Peak frontier-width delta introduced by the rewrite. -/
+  frontierDelta : Nat
+  /-- Number of admitted rewrite operations consumed by this rewrite. -/
+  rewriteOps : Nat
+  deriving DecidableEq, Repr
+
+/-- `RewriteBudget` mirrors the runtime's remaining structural rewrite budget. -/
+structure RewriteBudget where
+  /-- Remaining node additions. -/
+  addedNodes : Nat
+  /-- Remaining edge additions. -/
+  addedEdges : Nat
+  /-- Remaining depth below anchors. -/
+  addedDepth : Nat
+  /-- Remaining peak frontier-width delta. -/
+  frontierDelta : Nat
+  /-- Remaining admitted rewrite operations. -/
+  rewriteOps : Nat
+  deriving DecidableEq, Repr
+
+namespace RewriteCost
+
+/-- `fitsIn cost budget` means every structural cost dimension fits the remaining budget. -/
+def fitsIn (cost : RewriteCost) (budget : RewriteBudget) : Prop :=
+  cost.addedNodes ≤ budget.addedNodes ∧
+    cost.addedEdges ≤ budget.addedEdges ∧
+      cost.addedDepth ≤ budget.addedDepth ∧
+        cost.frontierDelta ≤ budget.frontierDelta ∧
+          cost.rewriteOps ≤ budget.rewriteOps
+
+end RewriteCost
+
+namespace RewriteBudget
+
+/-- `le left right` is fieldwise comparison for remaining rewrite budgets. -/
+def le (left right : RewriteBudget) : Prop :=
+  left.addedNodes ≤ right.addedNodes ∧
+    left.addedEdges ≤ right.addedEdges ∧
+      left.addedDepth ≤ right.addedDepth ∧
+        left.frontierDelta ≤ right.frontierDelta ∧
+          left.rewriteOps ≤ right.rewriteOps
+
+/-- `consume budget cost` mirrors runtime subtraction after a cost fits the budget. -/
+def consume (budget : RewriteBudget) (cost : RewriteCost) : RewriteBudget :=
+  { addedNodes := budget.addedNodes - cost.addedNodes
+    addedEdges := budget.addedEdges - cost.addedEdges
+    addedDepth := budget.addedDepth - cost.addedDepth
+    frontierDelta := budget.frontierDelta - cost.frontierDelta
+    rewriteOps := budget.rewriteOps - cost.rewriteOps }
+
+/-- `consume_le` records that budget consumption never replenishes any dimension. -/
+theorem consume_le (budget : RewriteBudget) (cost : RewriteCost) :
+    (consume budget cost).le budget := by
+  constructor
+  · exact Nat.sub_le _ _
+  · constructor
+    · exact Nat.sub_le _ _
+    · constructor
+      · exact Nat.sub_le _ _
+      · constructor
+        · exact Nat.sub_le _ _
+        · exact Nat.sub_le _ _
+
+/-- `le_trans` composes fieldwise budget comparison. -/
+theorem le_trans
+    {left middle right : RewriteBudget}
+    (hLeft : left.le middle)
+    (hRight : middle.le right) :
+    left.le right := by
+  rcases hLeft with ⟨hLeftNodes, hLeftEdges, hLeftDepth, hLeftFrontier, hLeftOps⟩
+  rcases hRight with ⟨hRightNodes, hRightEdges, hRightDepth, hRightFrontier, hRightOps⟩
+  exact
+    ⟨ _root_.le_trans hLeftNodes hRightNodes
+    , _root_.le_trans hLeftEdges hRightEdges
+    , _root_.le_trans hLeftDepth hRightDepth
+    , _root_.le_trans hLeftFrontier hRightFrontier
+    , _root_.le_trans hLeftOps hRightOps
+    ⟩
+
+/-- `le_refl` is reflexivity for fieldwise budget comparison. -/
+theorem le_refl (budget : RewriteBudget) : budget.le budget :=
+  ⟨le_rfl, le_rfl, le_rfl, le_rfl, le_rfl⟩
+
+end RewriteBudget
+
+/-- `Rewrite α` is an option-valued graph transformer. The full Haskell shape
 carries provenance and concrete contract metadata; this proof shape keeps
-the transformation, a positive budget cost, and the preservation evidence
-that an admitted rewrite must supply. -/
+the transformation, a structural budget cost, and the preservation evidence
+that an admitted rewrite must supply. The rewrite-operation dimension is
+strictly positive so chain length is bounded by `rewriteOps`. -/
 structure Rewrite (α : Type) [DecidableEq α] (contractOk : Graph α → Prop) where
   /-- `apply` is the transformation. `none` means "this rewrite does not apply
       to this graph". -/
   apply : Graph α → Option (Graph α)
-  /-- `cost` is the fixed budget cost of attempting this rewrite. -/
-  cost  : Nat
-  /-- `cost_positive` ensures every accepted rewrite consumes budget. -/
-  cost_positive : 0 < cost
+  /-- `cost` is the fixed structural budget cost of admitting this rewrite. -/
+  cost : RewriteCost
+  /-- `rewriteOps_positive` ensures every accepted rewrite consumes operation budget. -/
+  rewriteOps_positive : 0 < cost.rewriteOps
   /-- `preserves_acyclic` is the graph-safety certificate for this rewrite. -/
   preserves_acyclic :
     ∀ {g g' : Graph α}, apply g = some g' → Acyclic g → Acyclic g'
@@ -79,11 +179,14 @@ structure Rewrite (α : Type) [DecidableEq α] (contractOk : Graph α → Prop) 
 
 /-! ## Admission Predicate -/
 
+section RewriteProofs
+
+variable {α : Type}
+variable [DecidableEq α]
+variable {contractOk : Graph α → Prop}
+
 /-- `applicable r g` says the rewrite produces a candidate graph. -/
 def applicable
-    {α : Type}
-    [DecidableEq α]
-    {contractOk : Graph α → Prop}
     (r : Rewrite α contractOk)
     (g : Graph α) : Prop :=
   ∃ g' : Graph α, r.apply g = some g'
@@ -93,13 +196,10 @@ def applicable
 The acyclicity and contract-boundary obligations live in the `Rewrite`
 certificate, so an admissible rewrite cannot be constructed without them. -/
 def admissible
-    {α : Type}
-    [DecidableEq α]
-    {contractOk : Graph α → Prop}
     (r : Rewrite α contractOk)
     (g : Graph α)
-    (budget : Nat) : Prop :=
-  r.cost ≤ budget ∧ applicable r g
+    (budget : RewriteBudget) : Prop :=
+  r.cost.fitsIn budget ∧ applicable r g
 
 /-! ## Soundness Obligations -/
 
@@ -108,12 +208,9 @@ def admissible
 If `g` is acyclic and `r` is admissible at `g`, then `r.apply g`
 (when defined) is acyclic. -/
 theorem admissible_preserves_acyclic
-    {α : Type}
-    [DecidableEq α]
-    {contractOk : Graph α → Prop}
     (r : Rewrite α contractOk)
     {g g' : Graph α}
-    {budget : Nat}
+    {budget : RewriteBudget}
     (_hAdmissible : admissible r g budget)
     (hApply : r.apply g = some g')
     (hAcyclic : Acyclic g) :
@@ -127,32 +224,189 @@ every port still references a registered contract, and every cross-fragment
 edge is still typed-compatible. The concrete predicate is supplied as
 `contractOk` until the registry mechanization lands. -/
 theorem admissible_preserves_contracts
-    {α : Type}
-    [DecidableEq α]
-    {contractOk : Graph α → Prop}
     (r : Rewrite α contractOk)
     {g g' : Graph α}
-    {budget : Nat}
+    {budget : RewriteBudget}
     (_hAdmissible : admissible r g budget)
     (hApply : r.apply g = some g')
     (hContracts : contractOk g) :
     contractOk g' :=
   r.preserves_contracts hApply hContracts
 
-/-- `apply_admissible_terminates` records the local budget-decrease obligation.
+/-- `admissible_rewriteOps_bounds` extracts the local operation-budget facts.
 
-A full chain termination proof will induct over remaining budget; the
-local fact needed for that induction is that each admissible rewrite has
-positive cost bounded by the current budget. -/
-theorem apply_admissible_terminates
-    {α : Type}
-    [DecidableEq α]
-    {contractOk : Graph α → Prop}
+A chain-length proof uses this local fact to show every admitted step consumes at least one
+rewrite operation and never exceeds the current operation budget. -/
+theorem admissible_rewriteOps_bounds
     (r : Rewrite α contractOk)
     (g : Graph α)
-    (budget : Nat)
+    (budget : RewriteBudget)
     (hAdmissible : admissible r g budget) :
-    0 < r.cost ∧ r.cost ≤ budget :=
-  ⟨r.cost_positive, hAdmissible.1⟩
+    0 < r.cost.rewriteOps ∧ r.cost.rewriteOps ≤ budget.rewriteOps :=
+  ⟨r.rewriteOps_positive, hAdmissible.1.2.2.2.2⟩
+
+end RewriteProofs
+
+/-! ## Registry Boundary Instantiation -/
+
+section RegistryBoundary
+
+variable {executor config contract authority : Type}
+variable [DecidableEq contract]
+variable [DecidableEq (StagedExecutorNode executor config authority)]
+
+/-- `admissible_preserves_registryBoundary` instantiates `contractOk` with the Wire registry
+boundary model.
+
+An admitted rewrite over staged executor nodes cannot leave the closed executor alphabet unless its
+rewrite certificate also proves the registry boundary for the produced graph. -/
+theorem admissible_preserves_registryBoundary
+    (registry : ExecutorRegistry executor config contract authority)
+    (r :
+      Rewrite
+        (StagedExecutorNode executor config authority)
+        (registryBoundary registry))
+    {g g' : Graph (StagedExecutorNode executor config authority)}
+    {budget : RewriteBudget}
+    (hAdmissible : admissible r g budget)
+    (hApply : r.apply g = some g')
+    (hBoundary : registryBoundary registry g) :
+    registryBoundary registry g' :=
+  admissible_preserves_contracts r hAdmissible hApply hBoundary
+
+end RegistryBoundary
+
+/-! ## Rewrite Chains -/
+
+section RewriteChains
+
+variable {α : Type}
+variable [DecidableEq α]
+variable {contractOk : Graph α → Prop}
+
+/-- `RewriteChain g budget gFinal finalBudget steps` is a finite sequence of admitted rewrites.
+
+Each step applies one rewrite, subtracts its structural cost from the remaining budget, and
+continues from the produced graph. The `steps` index makes the operation-budget termination bound
+explicit. The index order is: current graph, current budget, final graph, final budget, steps. -/
+inductive RewriteChain
+    (contractOk : Graph α → Prop) :
+    Graph α → RewriteBudget → Graph α → RewriteBudget → Nat → Prop where
+  | done {g : Graph α} {budget : RewriteBudget} :
+      RewriteChain contractOk g budget g budget 0
+  | step
+      {g g' gFinal : Graph α}
+      {budget budgetAfter finalBudget : RewriteBudget}
+      {steps : Nat}
+      (r : Rewrite α contractOk)
+      (hAdmissible : admissible r g budget)
+      (hApply : r.apply g = some g')
+      (hBudgetAfter : budgetAfter = budget.consume r.cost)
+      (tail : RewriteChain contractOk g' budgetAfter gFinal finalBudget steps) :
+      RewriteChain contractOk g budget gFinal finalBudget (Nat.succ steps)
+
+private theorem rewrite_step_budget_bound
+    {steps : Nat}
+    {budget budgetAfter : RewriteBudget}
+    {rewriteCost : RewriteCost}
+    (hSteps : steps ≤ budgetAfter.rewriteOps)
+    (hBudgetAfter : budgetAfter = budget.consume rewriteCost)
+    (hOpsPositive : 0 < rewriteCost.rewriteOps)
+    (hOpsBound : rewriteCost.rewriteOps ≤ budget.rewriteOps) :
+    Nat.succ steps ≤ budget.rewriteOps := by
+  have hOneLeCost : 1 ≤ rewriteCost.rewriteOps := Nat.succ_le_of_lt hOpsPositive
+  have hStepBound : Nat.succ steps ≤ budgetAfter.rewriteOps + 1 := by
+    simpa [Nat.succ_eq_add_one] using Nat.succ_le_succ hSteps
+  have hBudgetAfterBound : budgetAfter.rewriteOps + 1 ≤ budget.rewriteOps := by
+    rw [hBudgetAfter, RewriteBudget.consume]
+    calc
+      budget.rewriteOps - rewriteCost.rewriteOps + 1 ≤
+          budget.rewriteOps - rewriteCost.rewriteOps + rewriteCost.rewriteOps :=
+        Nat.add_le_add_left hOneLeCost _
+      _ = budget.rewriteOps := Nat.sub_add_cancel hOpsBound
+  exact _root_.le_trans hStepBound hBudgetAfterBound
+
+/-- `rewriteChain_steps_le_rewriteOps` bounds chain length by operation budget. -/
+theorem rewriteChain_steps_le_rewriteOps
+    {g gFinal : Graph α}
+    {budget finalBudget : RewriteBudget}
+    {steps : Nat}
+    (hChain : RewriteChain contractOk g budget gFinal finalBudget steps) :
+    steps ≤ budget.rewriteOps := by
+  induction hChain with
+  | done =>
+      exact Nat.zero_le _
+  | step r hAdmissible _hApply hBudgetAfter _tail ih =>
+      exact
+        rewrite_step_budget_bound
+          ih
+          hBudgetAfter
+          r.rewriteOps_positive
+          hAdmissible.1.2.2.2.2
+
+/-- `rewriteChain_finalBudget_le_initial` records that rewrite chains never replenish budget. -/
+theorem rewriteChain_finalBudget_le_initial
+    {g gFinal : Graph α}
+    {budget finalBudget : RewriteBudget}
+    {steps : Nat}
+    (hChain : RewriteChain contractOk g budget gFinal finalBudget steps) :
+    finalBudget.le budget := by
+  induction hChain with
+  | done =>
+      exact RewriteBudget.le_refl _
+  | step r _hAdmissible _hApply hBudgetAfter _tail ih =>
+      rw [hBudgetAfter] at ih
+      exact RewriteBudget.le_trans ih (RewriteBudget.consume_le _ r.cost)
+
+/-- `rewriteChain_preserves_acyclic` lifts acyclicity preservation to rewrite chains. -/
+theorem rewriteChain_preserves_acyclic
+    {g gFinal : Graph α}
+    {budget finalBudget : RewriteBudget}
+    {steps : Nat}
+    (hChain : RewriteChain contractOk g budget gFinal finalBudget steps)
+    (hAcyclic : Acyclic g) :
+    Acyclic gFinal := by
+  induction hChain with
+  | done =>
+      exact hAcyclic
+  | step r hAdmissible hApply _hBudgetAfter _tail ih =>
+      exact ih (admissible_preserves_acyclic r hAdmissible hApply hAcyclic)
+
+/-- `rewriteChain_preserves_contracts` lifts contract preservation to rewrite chains. -/
+theorem rewriteChain_preserves_contracts
+    {g gFinal : Graph α}
+    {budget finalBudget : RewriteBudget}
+    {steps : Nat}
+    (hChain : RewriteChain contractOk g budget gFinal finalBudget steps)
+    (hContracts : contractOk g) :
+    contractOk gFinal := by
+  induction hChain with
+  | done =>
+      exact hContracts
+  | step r hAdmissible hApply _hBudgetAfter _tail ih =>
+      exact ih (admissible_preserves_contracts r hAdmissible hApply hContracts)
+
+end RewriteChains
+
+/-- `rewriteChain_preserves_registryBoundary` lifts registry-boundary preservation to chains. -/
+theorem rewriteChain_preserves_registryBoundary
+    {executor config contract authority : Type}
+    [DecidableEq contract]
+    [DecidableEq (StagedExecutorNode executor config authority)]
+    (registry : ExecutorRegistry executor config contract authority)
+    {g gFinal : Graph (StagedExecutorNode executor config authority)}
+    {budget finalBudget : RewriteBudget}
+    {steps : Nat}
+    (hChain :
+      RewriteChain
+        (registryBoundary registry)
+        g
+        budget
+        gFinal
+        finalBudget
+        steps)
+    (hBoundary : registryBoundary registry g) :
+    registryBoundary registry gFinal :=
+  rewriteChain_preserves_contracts hChain hBoundary
 
 end Cortex.Wire

--- a/theory/Main.lean
+++ b/theory/Main.lean
@@ -23,6 +23,6 @@ def main : IO Unit := do
   IO.println "Cortex theory — Lean 4 mechanization (scaffold)"
   IO.println "  Track 1 (Graph algebra) ......... import Cortex.Graph.Core / Laws"
   IO.println "  Track 2 (Pulse kernel) .......... import Cortex.Pulse.Classify"
-  IO.println "  Track 3 (Rewrite soundness) ..... import Cortex.Wire.Rewrite"
+  IO.println "  Track 3 (Wire rewrite) .......... import Cortex.Wire.Registry / Rewrite"
   IO.println ""
   IO.println "Open obligations: see `theory/README.md`."

--- a/theory/README.md
+++ b/theory/README.md
@@ -84,19 +84,23 @@ graph algebra laws.
 
 ### Track 3 — Rewrite soundness
 
-`Cortex.Wire.Rewrite` sketches the admission predicate from `src/Cortex/Pulse/Rewrite.hs`. The
-current Lean surface is proof-carrying rather than vacuous: an admitted `Rewrite` carries
-preservation evidence for graph acyclicity, the caller-supplied contract predicate, and positive
-budget consumption. Remaining obligations:
+`Cortex.Wire.Registry` models the `@` executor boundary as pure staging of registered authority:
+executor lookup, config validation, registry-wide contract vocabulary, endpoint compatibility,
+effect-class policy, output validation, and host authority. `Cortex.Wire.Rewrite` sketches the
+admission predicate from `src/Cortex/Pulse/Rewrite.hs`. The current Lean surface is proof-carrying
+rather than vacuous: an admitted `Rewrite` carries preservation evidence for graph acyclicity, the
+caller-supplied contract predicate, and consumption of the five-dimensional runtime rewrite budget.
+Chain-level theorems now lift those local certificates across finite rewrite sequences and bound the
+number of admitted steps by the initial remaining rewrite-operation budget. Remaining obligations:
 
 - connect those proof-carrying certificates to the Haskell admission path;
-- instantiate the contract predicate from the Wire `@` registry boundary model: every materialized
-  executor node must come from a registered executor reference, validated pure config, declared or
-  derivable ports, known contracts, explicit purity/effect metadata, and explicit host authority;
-- lift local positive-cost consumption to a full rewrite-chain termination proof.
+- connect registry-boundary witnesses to the Haskell compiler and registry;
+- model anchor existence, entry/exit non-emptiness, orphan-freedom, and runtime policy checks from
+  `planGraphRewrite`;
+- connect the abstract chain model to durable materialization order and lineage.
 
 This is the "sandbox by proof" story for dynamic graph rewriting. Rewrites may transform topology,
-but they cannot invent new `@` executor authority outside the registry boundary documented in
+but chain-level preservation requires them to stay inside the registry boundary documented in
 `docs/Reference/Wire/executors-and-alphabet.md`.
 
 ### Track 4 — Provider / spark abstraction (TODO)
@@ -147,7 +151,7 @@ The repo's pre-commit hook checks theory changes through the flake surface
 | 1b. Graph denotational AST laws  | AST laws over graph equivalence                                              | denotational law surface                                                                                                                                                                                                                       | none        |
 | 1c. Graph quotient laws          | lifted quotient equality laws                                                | pending                                                                                                                                                                                                                                        | none        |
 | 2. Fixed-topology Pulse kernel   | edge-derived DAG/state/fact/frontier/closure/recovery/classification surface | frontier antichain, direct/runtime frontier bridge, fact commutativity, admissible fact recovery, closure idempotence, topology-domain/output/volatile-state/causal preservation, structural recovery predicate, classification exhaustiveness | none        |
-| 3. Rewrite soundness             | proof-carrying rewrite certificate                                           | acyclicity/contract/budget projections                                                                                                                                                                                                         | none        |
+| 3. Rewrite soundness             | registry-boundary model + proof-carrying rewrite certificate                 | node/edge registry predicates, acyclicity/contract/budget projections, chain-level preservation, step bound by rewrite-operation budget                                                                                                        | none        |
 | 4. Provider / sparks             | —                                                                            | —                                                                                                                                                                                                                                              | not started |
 | 5. Substrate / consumer boundary | —                                                                            | —                                                                                                                                                                                                                                              | not started |
 

--- a/theory/lakefile.lean
+++ b/theory/lakefile.lean
@@ -38,6 +38,7 @@ lean_lib «Cortex» where
     `Cortex.Pulse.Validity,
     `Cortex.Pulse.Recovery,
     `Cortex.Pulse.Classify,
+    `Cortex.Wire.Registry,
     `Cortex.Wire.Rewrite
   ]
 


### PR DESCRIPTION
## Summary

Mechanizes the first real Track 3 Wire rewrite proof surface: staged executor registry authority, graph-level registry-boundary validity, five-dimensional rewrite budgets, and chain-level preservation for proof-carrying rewrites.

## What Changed

- Added `Cortex.Wire.Registry` for the `@qualified.name { config }` executor boundary.
- Modeled registry admission as pure staged authority: executor lookup, config validity, registry-wide contract vocabulary, endpoint compatibility, effect-class policy, output validation, and explicit host authority.
- Split registry validity into vertex admission and edge endpoint admission, with transport across graph denotational equality.
- Extended `Cortex.Wire.Rewrite` with runtime-shaped `RewriteCost` / `RewriteBudget` records.
- Added proof-carrying rewrite certificates for acyclicity and contract-boundary preservation.
- Added `RewriteChain` with per-step budget consumption and chain-level preservation theorems.
- Wired the new module into the Lean root, Lake roots, smoke output, and `theory/README.md`.

## Proven Theorem Surface

Given admitted, proof-carrying rewrites:

- chain length is bounded by initial `rewriteOps` budget;
- final budget is fieldwise no greater than initial budget;
- acyclicity is preserved across rewrite chains;
- caller-supplied contract predicates are preserved across rewrite chains;
- Wire registry-boundary validity is preserved across rewrite chains.

## Remaining Bridge Work

This PR proves the abstract Lean side. The runtime correspondence remains explicit future work:

- connect Haskell `planGraphRewrite` / admission results to these Lean certificates;
- connect registry-boundary witnesses to the Haskell compiler and registry;
- model anchor existence, entry/exit non-emptiness, orphan-freedom, runtime policy, provenance, and materialization order.

## Validation

- `just lean-lint`
- `just lean-build`
- `just lean-check`
- `just fmt-check`
- `git diff --check`
- `just check-commit-provenance origin/main..HEAD`

Closes #72