### PR TITLE
feat: mechanize Wire runtime admission bridge

### DIFF
--- a/docs/Architecture/07-rewrites-and-materialization.md
+++ b/docs/Architecture/07-rewrites-and-materialization.md
@@ -59,9 +59,11 @@ are recognized future forms but not part of the admitted alphabet.
 
 A `SubgraphSpec` is a self-contained fragment: local topology, stage definitions for every local
 node, explicit entry nodes where inbound edges attach, explicit exit nodes where outbound edges
-continue. Validation rejects missing definitions, orphan nodes, definitions outside the fragment,
-and any cycle in the resulting materialized graph. New nodes receive deterministic ids namespaced by
-their parent (`planner:repair_branch_1:step_1`), keeping identity stable across replay.
+continue. Entry and exit declarations are serialized lists but semantically sets, so duplicates are
+invalid. Validation rejects duplicate entry/exit nodes, missing definitions, orphan nodes,
+definitions outside the fragment, and any cycle in the resulting materialized graph. New nodes
+receive deterministic ids namespaced by their parent (`planner:repair_branch_1:step_1`), keeping
+identity stable across replay.
 
 Stages signal rewrites via a richer outcome:
 
@@ -85,18 +87,19 @@ effect class) is deferred. The five dimensions:
 
 ```haskell
 data RewriteBudget = RewriteBudget
-  { rbAddedNodesMax    :: Int  -- nodes added
-  , rbAddedEdgesMax    :: Int  -- edges added
-  , rbAddedDepthMax    :: Int  -- depth added below any anchor
-  , rbFrontierDeltaMax :: Int  -- peak frontier breadth delta
-  , rbRewriteOpsMax    :: Int  -- admitted rewrite operations
+  { rbAddedNodesMax    :: Natural  -- nodes added
+  , rbAddedEdgesMax    :: Natural  -- edges added
+  , rbAddedDepthMax    :: Natural  -- depth added below any anchor
+  , rbFrontierDeltaMax :: Natural  -- peak frontier breadth delta
+  , rbRewriteOpsMax    :: Natural  -- admitted rewrite operations
   }
 ```
 
-Each admitted rewire consumes a `RewriteCost` computed statically from its `SubgraphSpec`; admission
-draws only against remaining budget. Runaway planner elaboration becomes a runtime impossibility
-rather than a prompt-discipline problem. Gas is visible in run history: operators can inspect
-remaining budget, each rewrite's cost, and the rewire that exhausted a dimension.
+Each admitted rewire consumes a natural-valued `RewriteCost` computed statically from its
+`SubgraphSpec`; admission draws only against remaining budget. Negative serialized values are
+invalid before admission. Runaway planner elaboration becomes a runtime impossibility rather than a
+prompt-discipline problem. Gas is visible in run history: operators can inspect remaining budget,
+each rewrite's cost, and the rewire that exhausted a dimension.
 
 ## Admission policy
 
@@ -108,8 +111,10 @@ Admission is the runtime's gate. A proposal is admitted only when every check pa
    the port-semantic rules of [Chapter 05](./05-wire-language.md). Singular and list-valued inputs
    obey the same arity rules at the rewire boundary as at compile time.
 3. **Topology validity.** The post-application materialized graph remains a DAG. The anchor exists
-   in the current topology and definition map. Entry/exit sets are non-empty where the rewrite form
-   requires them. No orphans, no dangling references.
+   in the current topology and definition map. Entry/exit sets are non-empty and duplicate-free
+   where the rewrite form requires them. Definition-domain updates follow the anchor disposition:
+   replacement deletes the anchor definition before overlaying inserted definitions; retention and
+   append keep the old domain and overlay inserted definitions. No orphans, no dangling references.
 4. **Resource bounds.** Estimated `RewriteCost` fits within the remaining budget on every dimension.
 5. **Runtime policy.** The anchor, the run, and the task type permit rewrites of this form. Planner
    nodes may be restricted to a subset of the algebra.
@@ -131,6 +136,10 @@ reduce node-local facts concurrently over the current frontier. Rewrite admissio
 is the coordinated phase where topology-changing proposals are checked against the ambient graph,
 the remaining budget, and the other proposals in flight. The phase boundary therefore separates
 coordination-friendly fact reduction from coordinated topology change.
+
+The proof contract leads the implementation. The runtime admission path must construct the same
+natural budget vectors, duplicate-free entry/exit sets, topology-diff facts, and definition-domain
+update shape used by the mechanized rewrite model, or reject the proposal before materialization.
 
 ## Materialization
 

--- a/docs/Reference/rewrites.md
+++ b/docs/Reference/rewrites.md
@@ -64,8 +64,9 @@ A `SubgraphSpec` is a self-contained fragment carrying:
 - an explicit **entry set** where inbound edges attach,
 - an explicit **exit set** where outbound edges continue.
 
-Validation rejects missing definitions, orphan nodes, definitions outside the fragment, and any
-cycle in the resulting materialized graph.
+Entry and exit declarations are serialized as lists but are semantically sets. Duplicate entry or
+exit nodes are invalid. Validation rejects duplicates, missing definitions, orphan nodes,
+definitions outside the fragment, and any cycle in the resulting materialized graph.
 
 New node ids inside a spec are deterministic and namespaced by their parent anchor (for example
 `planner:repair_branch_1:step_1`). Deterministic namespacing is required so identity is stable
@@ -102,16 +103,17 @@ construction.
 
 ```haskell
 data RewriteBudget = RewriteBudget
-  { rbAddedNodesMax    :: Int  -- nodes added
-  , rbAddedEdgesMax    :: Int  -- edges added
-  , rbAddedDepthMax    :: Int  -- depth added below any anchor
-  , rbFrontierDeltaMax :: Int  -- peak frontier breadth delta
-  , rbRewriteOpsMax    :: Int  -- admitted rewrite operations
+  { rbAddedNodesMax    :: Natural  -- nodes added
+  , rbAddedEdgesMax    :: Natural  -- edges added
+  , rbAddedDepthMax    :: Natural  -- depth added below any anchor
+  , rbFrontierDeltaMax :: Natural  -- peak frontier breadth delta
+  , rbRewriteOpsMax    :: Natural  -- admitted rewrite operations
   }
 ```
 
-Gas is **structural-change only** in v1. Semantic weighting (latency, cost class, effect class) is
-not part of the budget and is deferred to a future ADR.
+Gas dimensions are natural quantities. Negative serialized values are invalid and fail before
+admission. Gas is **structural-change only** in v1. Semantic weighting (latency, cost class, effect
+class) is not part of the budget and is deferred to a future ADR.
 
 ### 3.2 `RewriteCost`
 
@@ -125,6 +127,10 @@ Each admitted rewrite consumes a `RewriteCost` computed **statically** from its 
 
 Admission draws only against remaining budget on every dimension. A proposal whose cost exceeds any
 dimension is rejected with `rewrite_budget_exceeded`; no partial consumption.
+
+The proof contract is the leader here: runtime `RewriteBudget` and `RewriteCost` use the same
+natural-vector shape as the mechanized rewrite-admission model, and runtime validation rejects list
+or JSON shapes that cannot denote the proof-side sets and natural numbers.
 
 ### 3.3 Budget visibility
 
@@ -145,8 +151,11 @@ Admission is the runtime's gate. A proposal is admitted only when **every** chec
    the port-semantic rules of [chapter 05](../Architecture/05-wire-language.md). Singular and
    list-valued inputs obey the same arity rules at the rewrite boundary as at compile time.
 3. **Topology validity.** The post-application materialized graph remains a DAG. The anchor exists
-   in the current topology and definition map. Entry and exit sets are non-empty where the rewrite
-   form requires them. No orphans, no dangling references.
+   in the current topology and definition map. Entry and exit sets are non-empty and duplicate-free
+   where the rewrite form requires them. Definition-domain updates follow the anchor disposition:
+   replacing an anchor deletes its definition before overlaying inserted definitions; retaining or
+   appending keeps the old domain and overlays inserted definitions. No orphans, no dangling
+   references.
 4. **Resource bounds.** Estimated `RewriteCost` fits within the remaining budget on every dimension
    (§3.2).
 5. **Runtime policy.** The anchor, the run, and the task type permit rewrites of this form. Planner

--- a/docs/Reference/terminology.md
+++ b/docs/Reference/terminology.md
@@ -39,13 +39,13 @@ Each layer owns a specific set of terms. This page groups them by layer.
 ### Core forms
 
 | Term              | Definition                                                                                                                                                          |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Contract**      | A named typed interface that flows through a port. Ambient in a global namespace. Carries a payload kind.                                                           |
 | **Node**          | A pinned executor application with a port signature. Declared via `node name : <ports> = @executor { config };`. Has identity; reused references are the same node. |
 | **Port**          | A slot on a node, typed by a contract. Input (`<-`) or output (`->`). May be labeled.                                                                               |
 | **Port key**      | The identity tuple `(direction, contract, label)` that `=>` matches on. Absent-label is a distinct key, not a wildcard.                                             |
 | **Label**         | Part of a port's identity for routing, not a decoration. Labeled ports match only identically-labeled partners.                                                     |
-| **Sum group**     | Output port form `-> A                                                                                                                                              | B` with mutual-exclusion metadata: exactly one variant fires per evaluation. |
+| **Sum group**     | Output port form `-> A \| B` with mutual-exclusion metadata: exactly one variant fires per evaluation.                                                              |
 | **Partial node**  | Staged value `@executor { config }` with no ports pinned yet. `let`-bindable, `//`-mergeable, pinnable via `node` declaration.                                      |
 | **Wire value**    | Any value of wire kind: node, composed graph expression, or (in graph position with port-determined executor) a partial node.                                       |
 | **Port-boundary** | A wire's unconnected input and output ports. The surface `=>` operates on.                                                                                          |
@@ -60,12 +60,12 @@ Each layer owns a specific set of terms. This page groups them by layer.
 
 ### Value operators
 
-| Term                | Definition                                                                                   |
-| ------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| **`//` merge**      | Right-biased shallow record merge. Applies to records and to partial-node configs.           |
-| **`++` concat**     | String and list concatenation.                                                               |
-| \*\*`               | ` sum constructor\*\*                                                                        | Output-port mutual-exclusion form; distinct grammar construct, not pure sugar. |
-| **`@` application** | Executor application to a config record: `@qualified.name { ... }`. Produces a partial node. |
+| Term                     | Definition                                                                                   |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| **`//` merge**           | Right-biased shallow record merge. Applies to records and to partial-node configs.           |
+| **`++` concat**          | String and list concatenation.                                                               |
+| **`\|` sum constructor** | Output-port mutual-exclusion form; distinct grammar construct, not pure sugar.               |
+| **`@` application**      | Executor application to a config record: `@qualified.name { ... }`. Produces a partial node. |
 
 ### File-level forms
 
@@ -100,6 +100,7 @@ Each layer owns a specific set of terms. This page groups them by layer.
 | **Rewire**                    | A bounded runtime topology modification over a live Circuit. Subject to vocabulary, endpoint-compatibility, topology, and resource (gas) bounds. Modules: `Cortex.Pulse.Rewrite` plus the Wire compiler.       |
 | **Realized circuit**          | The concrete Circuit topology that existed after admitted rewires during a run. A runtime artifact, not a grammar construct.                                                                                   |
 | **Gas**                       | The structural-change budget consumed by rewires: nodes added, edges added, depth, frontier breadth, rewrite operations.                                                                                       |
+| **Proof contract**            | A mechanized safety surface whose terms lead runtime implementation. Haskell admission code must either construct values satisfying the proof contract or reject the input before it reaches that boundary.    |
 | **Topological memory**        | A node-addressable accumulated context from upstream evaluations. Declared on the node, consumed at evaluation time. Canonical home: `Cortex.Nous.Memory.Topological`; Pulse supplies the settled event state. |
 | **Frontier**                  | The set of graph nodes ready to execute at a given point. Pulse schedules over the frontier.                                                                                                                   |
 
@@ -107,6 +108,9 @@ Each layer owns a specific set of terms. This page groups them by layer.
 
 - **Wire composes registered authority.** Wire source references registered nodes, contract IDs,
   prompts, and wiring. It does not invent executors, tools, payload types, or domain authority.
+- **Theory names safety obligations.** Where a mechanized proof contract exists, the proof-side
+  vocabulary is normative. Runtime code enforces that shape at admission and persistence boundaries;
+  it does not weaken the contract to fit convenient implementation types.
 - **Haskell owns what the authority means.** Executors, contracts, codecs, payload kinds, and
   registry schemas are Haskell-defined and live outside Wire.
 - **Product concepts stay downstream.** Launch fields, report sections, model-policy choices,

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -32,21 +32,22 @@ flowchart TD
     N -- "emits outputs as" --> R
 ```
 
-Algebra is the pure substrate Wire authors over. Wire owns the compiled circuit form. Pulse executes
-compiled circuits durably. Capability exposes external authority. Artifact owns durable outputs and
+Algebra is the pure substrate Wire authors over. Mechanized theory names the safety contracts that
+runtime implementation must enforce. Wire owns the compiled circuit form. Pulse executes compiled
+circuits durably. Capability exposes external authority. Artifact owns durable outputs and
 provenance. Nous owns model-mediated cognition.
 
 ## Roles a value can play
 
 A single Wire value often wears multiple hats. The roles are:
 
-| Role                | What it is                                                                     | Examples                                                         |
-| ------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------- | -------------------------------------------------- |
-| **Executor**        | Registered recipe. Turns config + inputs into outputs. Referenced via `@name`. | `@llm.analyst`, `@artifact.log`, `@cortex.report_run`, `@pure`   |
-| **Partial node**    | Executor applied to config, no ports pinned. `let`-bindable, `//`-mergeable.   | `@llm.gatherer { memory = topological { preset = "analyst" }; }` |
-| **Node**            | Partial node with ports pinned. Has boundary. Has identity.                    | `node analyst : <- EvidenceBundle -> AnalysisFragment            | ExecutorError = @llm.analyst { prompt = "..."; };` |
-| **Composed wire**   | Result of applying a graph operator. Has a derived boundary.                   | `planner => gatherer => analyst`                                 |
-| **Runtime wrapper** | A node whose role is to host a whole wire and provide runtime services.        | `@cortex.report_run { title = ...; }`                            |
+| Role                | What it is                                                                     | Examples                                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| **Executor**        | Registered recipe. Turns config + inputs into outputs. Referenced via `@name`. | `@llm.analyst`, `@artifact.log`, `@cortex.report_run`, `@pure`                                              |
+| **Partial node**    | Executor applied to config, no ports pinned. `let`-bindable, `//`-mergeable.   | `@llm.gatherer { memory = topological { preset = "analyst" }; }`                                            |
+| **Node**            | Partial node with ports pinned. Has boundary. Has identity.                    | `node analyst : <- EvidenceBundle -> AnalysisFragment \| ExecutorError = @llm.analyst { prompt = "..."; };` |
+| **Composed wire**   | Result of applying a graph operator. Has a derived boundary.                   | `planner => gatherer => analyst`                                                                            |
+| **Runtime wrapper** | A node whose role is to host a whole wire and provide runtime services.        | `@cortex.report_run { title = ...; }`                                                                       |
 
 The leading `@` marks the executor-authority boundary. It stages a registered executor with pure
 config data; it does not run the executor. See

--- a/flake.lock
+++ b/flake.lock
@@ -734,11 +734,11 @@
         "tree-sitter-json": "tree-sitter-json"
       },
       "locked": {
-        "lastModified": 1777342849,
-        "narHash": "sha256-eiqNbFOoTOHKuJVbGtIO39YVTdLETQRbJlcv1BQ3IIo=",
+        "lastModified": 1777377945,
+        "narHash": "sha256-beBpEk7R9Z12WS5ZJ2s83nEVXMT3sd+xLpu2bBkbhL4=",
         "owner": "Digimuoto",
         "repo": "repo-docs",
-        "rev": "f6d01bfe842083adda58a63abf7e36fb99fa0830",
+        "rev": "6252f4e13f8db140f6716706a06684b3fc2738b5",
         "type": "github"
       },
       "original": {

--- a/scripts/docs-lint
+++ b/scripts/docs-lint
@@ -414,6 +414,104 @@ def check_mermaid_text(path: Path, text: str, errors: list[str]) -> None:
                 add(errors, path, "Mermaid linkStyle is not allowed in canonical diagrams", line_no)
 
 
+def split_table_row(line: str) -> list[str]:
+    line = line.strip()
+    if line.startswith("|"):
+        line = line[1:]
+    if line.endswith("|") and not line.endswith("\\|"):
+        line = line[:-1]
+
+    cells: list[str] = []
+    current: list[str] = []
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if char == "\\" and index + 1 < len(line) and line[index + 1] == "|":
+            current.append("\\|")
+            index += 2
+            continue
+        if char == "|":
+            cells.append("".join(current))
+            current = []
+            index += 1
+            continue
+        current.append(char)
+        index += 1
+    cells.append("".join(current))
+    return cells
+
+
+SEPARATOR_CELL = re.compile(r"^\s*:?-{2,}:?\s*$")
+
+
+def check_table_shape(path: Path, text: str, errors: list[str]) -> None:
+    if not is_markdown(path):
+        return
+
+    lines = text.splitlines()
+    in_fence = False
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if line.startswith("```"):
+            in_fence = not in_fence
+            index += 1
+            continue
+        if in_fence:
+            index += 1
+            continue
+
+        stripped = line.strip()
+        if not (stripped.startswith("|") and stripped.endswith("|")):
+            index += 1
+            continue
+        if index + 1 >= len(lines):
+            index += 1
+            continue
+
+        next_stripped = lines[index + 1].strip()
+        if not (next_stripped.startswith("|") and next_stripped.endswith("|")):
+            index += 1
+            continue
+
+        sep_cells = split_table_row(next_stripped)
+        if not sep_cells or not all(SEPARATOR_CELL.match(cell) for cell in sep_cells):
+            index += 1
+            continue
+
+        expected = len(sep_cells)
+        header_cells = split_table_row(stripped)
+        if len(header_cells) != expected:
+            add(
+                errors,
+                path,
+                f"table header has {len(header_cells)} cells, separator has {expected}",
+                index + 1,
+            )
+
+        body = index + 2
+        while body < len(lines):
+            body_line = lines[body]
+            if body_line.startswith("```"):
+                break
+            body_stripped = body_line.strip()
+            if not (body_stripped.startswith("|") and body_stripped.endswith("|")):
+                break
+            if SEPARATOR_CELL.match(body_stripped.strip("|").strip()):
+                break
+            body_cells = split_table_row(body_stripped)
+            if len(body_cells) != expected:
+                add(
+                    errors,
+                    path,
+                    f"table row has {len(body_cells)} cells, separator has {expected}",
+                    body + 1,
+                )
+            body += 1
+
+        index = body
+
+
 def check_whitespace(path: Path, text: str, errors: list[str]) -> None:
     for line_no, line in enumerate(text.splitlines(keepends=True), start=1):
         content = line[:-1] if line.endswith("\n") else line
@@ -435,6 +533,7 @@ def main() -> int:
     for path, document in zip(paths, documents):
         text = path.read_text(encoding="utf-8")
         check_whitespace(path, text, errors)
+        check_table_shape(path, text, errors)
         check_mermaid_text(path, text, errors)
         if document is None:
             continue

--- a/src/Cortex/Pulse/Executor/Events.hs
+++ b/src/Cortex/Pulse/Executor/Events.hs
@@ -38,6 +38,7 @@ import Data.Int (Int64)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.UUID (UUID)
+import Numeric.Natural (Natural)
 import Platform.Observability.Fields
   ( ObsEventCode (ObsEventCode),
     ObsFields,
@@ -139,9 +140,9 @@ data FailrunInfo = FailrunInfo
 -- | Info for a successfully admitted rewrite.
 data RewriteAdmissionInfo = RewriteAdmissionInfo
   { raiRewriteId :: Int64,
-    raiCostNodes :: Int,
-    raiCostEdges :: Int,
-    raiRewriteOpsRemaining :: Int
+    raiCostNodes :: Natural,
+    raiCostEdges :: Natural,
+    raiRewriteOpsRemaining :: Natural
   }
   deriving stock (Show)
 

--- a/src/Cortex/Pulse/PlanHydration.hs
+++ b/src/Cortex/Pulse/PlanHydration.hs
@@ -173,6 +173,10 @@ renderRewriteValidationError errs = T.intercalate "; " (fmap renderOne errs)
         "Rewrite subgraph must declare at least one entry node"
       RewritePlanningIssue RewriteExitNodesMissing ->
         "Rewrite subgraph must declare at least one exit node"
+      RewritePlanningIssue (RewriteDuplicateEntryNodes nodes) ->
+        "Rewrite subgraph declares duplicate entry nodes: " <> showNodeIds nodes
+      RewritePlanningIssue (RewriteDuplicateExitNodes nodes) ->
+        "Rewrite subgraph declares duplicate exit nodes: " <> showNodeIds nodes
       RewritePlanningIssue (RewriteEntryNodesOutsideTopology nodes) ->
         "Rewrite entry nodes are outside the inserted topology: " <> showNodeIds nodes
       RewritePlanningIssue (RewriteExitNodesOutsideTopology nodes) ->

--- a/src/Cortex/Pulse/Rewrite.hs
+++ b/src/Cortex/Pulse/Rewrite.hs
@@ -53,7 +53,10 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
 
+-- | A rewrite fragment. Entry and exit lists are the serialized form of proof-side sets;
+-- validation rejects duplicates before planning.
 data SubgraphSpec a def = SubgraphSpec
   { sgsTopology :: Relation a,
     sgsDefinitions :: Map a def,
@@ -75,22 +78,26 @@ data GraphRewrite a def
   deriving stock (Eq, Show, Generic, Functor)
   deriving anyclass (FromJSON, ToJSON)
 
+-- | Remaining structural rewrite budget. Dimensions are natural quantities, matching the
+-- proof-side `RewriteBudget`.
 data RewriteBudget = RewriteBudget
-  { rbAddedNodesMax :: !Int,
-    rbAddedEdgesMax :: !Int,
-    rbAddedDepthMax :: !Int,
-    rbFrontierDeltaMax :: !Int,
-    rbRewriteOpsMax :: !Int
+  { rbAddedNodesMax :: !Natural,
+    rbAddedEdgesMax :: !Natural,
+    rbAddedDepthMax :: !Natural,
+    rbFrontierDeltaMax :: !Natural,
+    rbRewriteOpsMax :: !Natural
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
+-- | Structural rewrite cost. A cost is a proof-side natural vector, so negative costs are rejected
+-- at JSON decoding and cannot reach budget admission.
 data RewriteCost = RewriteCost
-  { rcAddedNodes :: !Int,
-    rcAddedEdges :: !Int,
-    rcAddedDepth :: !Int,
-    rcFrontierDelta :: !Int,
-    rcRewriteOps :: !Int
+  { rcAddedNodes :: !Natural,
+    rcAddedEdges :: !Natural,
+    rcAddedDepth :: !Natural,
+    rcFrontierDelta :: !Natural,
+    rcRewriteOps :: !Natural
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -108,8 +115,8 @@ data BudgetDimension
 -- | A single exceeded dimension with the requested and remaining values.
 data ExceededDimension = ExceededDimension
   { edDimension :: !BudgetDimension,
-    edRequested :: !Int,
-    edRemaining :: !Int
+    edRequested :: !Natural,
+    edRemaining :: !Natural
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -129,8 +136,8 @@ budgetFraction ctx dim =
       remaining = lookupDimension dim ctx.bcRemainingBudget
    in if initial == 0 then 0 else fromIntegral remaining / fromIntegral initial
 
--- | Extract the integer value for a budget dimension from a 'RewriteBudget'.
-lookupDimension :: BudgetDimension -> RewriteBudget -> Int
+-- | Extract the natural value for a budget dimension from a 'RewriteBudget'.
+lookupDimension :: BudgetDimension -> RewriteBudget -> Natural
 lookupDimension DimAddedNodes = rbAddedNodesMax
 lookupDimension DimAddedEdges = rbAddedEdgesMax
 lookupDimension DimAddedDepth = rbAddedDepthMax
@@ -177,6 +184,8 @@ data RewritePlanningError a
   | RewriteDefinitionsOutsideTopology [a]
   | RewriteEntryNodesMissing
   | RewriteExitNodesMissing
+  | RewriteDuplicateEntryNodes [a]
+  | RewriteDuplicateExitNodes [a]
   | RewriteEntryNodesOutsideTopology [a]
   | RewriteExitNodesOutsideTopology [a]
   | RewriteOrphanNodes [a]
@@ -295,10 +304,10 @@ planGraphRewrite rewrite topology defs = case rewrite of
             RewriteAnchorRetained -> insertedDepthNodes
           cost =
             RewriteCost
-              { rcAddedNodes = Set.size newNodes,
-                rcAddedEdges = Set.size addedEdges,
-                rcAddedDepth = addedDepth,
-                rcFrontierDelta = max 0 (length spec'.sgsEntryNodes - 1),
+              { rcAddedNodes = fromIntegral (Set.size newNodes),
+                rcAddedEdges = fromIntegral (Set.size addedEdges),
+                rcAddedDepth = fromIntegral addedDepth,
+                rcFrontierDelta = fromIntegral (max 0 (length spec'.sgsEntryNodes - 1)),
                 rcRewriteOps = 1
               }
        in PlannedRewriteDelta
@@ -347,6 +356,8 @@ validateSubgraphSpec spec =
       extraDefinitions = Set.toList (Set.difference definitionNodes insertedNodes)
       entryNodes = Set.fromList spec.sgsEntryNodes
       exitNodes = Set.fromList spec.sgsExitNodes
+      duplicateEntries = duplicateValues spec.sgsEntryNodes
+      duplicateExits = duplicateValues spec.sgsExitNodes
       badEntries = Set.toList (Set.difference entryNodes insertedNodes)
       badExits = Set.toList (Set.difference exitNodes insertedNodes)
       reachableFromEntries =
@@ -363,6 +374,8 @@ validateSubgraphSpec spec =
             [RewriteDefinitionsOutsideTopology extraDefinitions | not (null extraDefinitions)],
             [RewriteEntryNodesMissing | null spec.sgsEntryNodes],
             [RewriteExitNodesMissing | null spec.sgsExitNodes],
+            [RewriteDuplicateEntryNodes duplicateEntries | not (null duplicateEntries)],
+            [RewriteDuplicateExitNodes duplicateExits | not (null duplicateExits)],
             [RewriteEntryNodesOutsideTopology badEntries | not (null badEntries)],
             [RewriteExitNodesOutsideTopology badExits | not (null badExits)],
             [RewriteOrphanNodes orphanNodes | not (null orphanNodes)]
@@ -371,6 +384,17 @@ validateSubgraphSpec spec =
         Left err -> Left (RewriteInvalidTopology err : errors)
         Right () ->
           if null errors then Right () else Left errors
+
+duplicateValues :: (Ord a) => [a] -> [a]
+duplicateValues = reverse . go Set.empty Set.empty []
+  where
+    go _seen _emitted acc [] = acc
+    go seen emitted acc (value : values)
+      | Set.member value emitted = go seen emitted acc values
+      | Set.member value seen =
+          go seen (Set.insert value emitted) (value : acc) values
+      | otherwise =
+          go (Set.insert value seen) emitted acc values
 
 -- | Longest path node count from any entry to any exit in the subgraph.
 --

--- a/test/Cortex/Pulse/GraphRewriteSpec.hs
+++ b/test/Cortex/Pulse/GraphRewriteSpec.hs
@@ -39,6 +39,7 @@ import Cortex.Pulse.Rewrite
     RewriteBudget (..),
     RewriteBudgetError (..),
     RewriteCost (..),
+    RewritePlanningError (..),
     SubgraphSpec (..),
     admitRewriteDelta,
     admittedRemainingBudget,
@@ -232,6 +233,31 @@ spec = do
           Right _ ->
             expectationFailure "Expected append with missing anchor definition to be rejected"
 
+    describe "rewrite validation" $ do
+      it "rejects duplicate entry nodes before planning a rewrite" $ do
+        let subTopo = toRelation (edge (NodeId "sub1") (NodeId "sub2") :: Graph NodeId)
+            subDefs = Map.fromList [(NodeId "sub1", mkDef Sub1), (NodeId "sub2", mkDef Sub2)]
+            spec' = SubgraphSpec subTopo subDefs [NodeId "sub1", NodeId "sub1"] [NodeId "sub2"]
+            rewrite = AppendAfter (NodeId "b") spec'
+
+        case planGraphRewrite rewrite initialTopo initialDefs of
+          Left errs ->
+            errs `shouldContain` [RewriteDuplicateEntryNodes [NodeId "sub1"]]
+          Right _ ->
+            expectationFailure "Expected duplicate entry nodes to be rejected"
+
+      it "rejects duplicate exit nodes before planning a rewrite" $ do
+        let subTopo = toRelation (edge (NodeId "sub1") (NodeId "sub2") :: Graph NodeId)
+            subDefs = Map.fromList [(NodeId "sub1", mkDef Sub1), (NodeId "sub2", mkDef Sub2)]
+            spec' = SubgraphSpec subTopo subDefs [NodeId "sub1"] [NodeId "sub2", NodeId "sub2"]
+            rewrite = AppendAfter (NodeId "b") spec'
+
+        case planGraphRewrite rewrite initialTopo initialDefs of
+          Left errs ->
+            errs `shouldContain` [RewriteDuplicateExitNodes [NodeId "sub2"]]
+          Right _ ->
+            expectationFailure "Expected duplicate exit nodes to be rejected"
+
     describe "rewrite budgeting" $ do
       it "computes structural rewrite cost and decrements remaining budget pointwise" $ do
         let subTopo = toRelation (edge (NodeId "sub1") (NodeId "sub2") :: Graph NodeId)
@@ -349,6 +375,38 @@ spec = do
             dims = exceededDimensions budgetErr
         fmap (\d -> (edDimension d, edRequested d, edRemaining d)) dims
           `shouldBe` [(DimAddedNodes, 4, 2), (DimAddedDepth, 2, 1)]
+
+      it "rejects serialized negative rewrite costs before admission" $ do
+        let negativeCostJson =
+              Aeson.object
+                [ "rcAddedNodes" Aeson..= (-1 :: Int),
+                  "rcAddedEdges" Aeson..= (0 :: Int),
+                  "rcAddedDepth" Aeson..= (0 :: Int),
+                  "rcFrontierDelta" Aeson..= (0 :: Int),
+                  "rcRewriteOps" Aeson..= (0 :: Int)
+                ]
+
+        case Aeson.fromJSON negativeCostJson :: Aeson.Result RewriteCost of
+          Aeson.Error _err -> pure ()
+          Aeson.Success cost ->
+            expectationFailure $
+              "Expected negative rewrite cost to fail JSON decoding, got: " <> show cost
+
+      it "rejects serialized negative rewrite budgets before runtime use" $ do
+        let negativeBudgetJson =
+              Aeson.object
+                [ "rbAddedNodesMax" Aeson..= (-1 :: Int),
+                  "rbAddedEdgesMax" Aeson..= (0 :: Int),
+                  "rbAddedDepthMax" Aeson..= (0 :: Int),
+                  "rbFrontierDeltaMax" Aeson..= (0 :: Int),
+                  "rbRewriteOpsMax" Aeson..= (0 :: Int)
+                ]
+
+        case Aeson.fromJSON negativeBudgetJson :: Aeson.Result RewriteBudget of
+          Aeson.Error _err -> pure ()
+          Aeson.Success budget ->
+            expectationFailure $
+              "Expected negative rewrite budget to fail JSON decoding, got: " <> show budget
 
   describe "buildStageTemplateRegistry" $ do
     let mkDynDef nid templateId =

--- a/theory/Cortex.lean
+++ b/theory/Cortex.lean
@@ -16,6 +16,7 @@ import Cortex.Pulse.Classify
 -- Track 3 — Wire rewrite soundness
 import Cortex.Wire.Registry
 import Cortex.Wire.Rewrite
+import Cortex.Wire.Admission
 
 /-!
 ## Overview

--- a/theory/Cortex/Wire/Admission.lean
+++ b/theory/Cortex/Wire/Admission.lean
@@ -1,0 +1,639 @@
+import Cortex.Wire.Rewrite
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Prod
+
+/-!
+## Overview
+
+Runtime-admission bridge for Wire rewrites.
+
+## Context
+
+`Cortex.Wire.Rewrite` proves safety for proof-carrying rewrites: if a
+rewrite carries preservation certificates and consumes budget, then rewrite
+chains preserve the stated invariants. The Haskell runtime, however, admits
+rewrites through `planGraphRewrite`, `consumeRewriteBudget`, and
+`admitRewriteDelta`.
+
+This module names the proof-side shape of those runtime checks. It does not
+execute Haskell. Instead, it records the obligations an accepted planned
+rewrite must establish: the final topology must match the relation-level
+planner construction, relation-diff sets must agree with the final topology,
+anchor disposition must agree with the rewrite form, structural costs must
+match the planned delta, definition-domain updates must follow the runtime
+delete-or-retain formula, and budget admission must consume budget pointwise.
+Under those obligations, an accepted plan instantiates the abstract `Rewrite`
+certificate surface.
+
+## Theorem Split
+
+The page defines runtime-shaped rewrite inputs, subgraph validity, a
+relation-level planner model, planned rewrite checks, budget admission, and
+the bridge theorem from admitted planned deltas to abstract admissible
+rewrites.
+-/
+
+namespace Cortex.Wire
+
+open Cortex.Graph
+
+/-! ## Runtime-Shaped Inputs -/
+
+/-- `ExpansionMode` mirrors the runtime's node-expansion mode. -/
+inductive ExpansionMode : Type where
+  | replaceNode
+  | retainNodeAsEnvelope
+  deriving DecidableEq, Repr
+
+/-- `RewriteAnchorDisposition` records whether the anchor remains materialized. -/
+inductive RewriteAnchorDisposition : Type where
+  | removed
+  | retained
+  deriving DecidableEq, Repr
+
+/-- `SubgraphSpec node` is the proof-side shape of a proposed inserted subgraph. -/
+structure SubgraphSpec (node : Type) where
+  /-- Topology of the proposed inserted subgraph. -/
+  topology : Graph node
+  /-- Domain of the stage definitions supplied for the inserted subgraph. -/
+  definitions : Finset node
+  /-- Entry nodes exposed by the inserted subgraph. -/
+  entryNodes : Finset node
+  /-- Exit nodes exposed by the inserted subgraph. -/
+  exitNodes : Finset node
+
+/-- `GraphRewrite node` mirrors the runtime rewrite forms currently admitted. -/
+inductive GraphRewrite (node : Type) : Type where
+  | expandNode : node → ExpansionMode → SubgraphSpec node → GraphRewrite node
+  | appendAfter : node → SubgraphSpec node → GraphRewrite node
+
+namespace GraphRewrite
+
+/-- `anchor rewrite` is the node around which the runtime plans the rewrite. -/
+def anchor {node : Type} : GraphRewrite node → node
+  | GraphRewrite.expandNode anchorNode _mode _spec => anchorNode
+  | GraphRewrite.appendAfter anchorNode _spec => anchorNode
+
+/-- `spec rewrite` is the inserted subgraph proposed by the rewrite. -/
+def spec {node : Type} : GraphRewrite node → SubgraphSpec node
+  | GraphRewrite.expandNode _anchor _mode subgraph => subgraph
+  | GraphRewrite.appendAfter _anchor subgraph => subgraph
+
+/-- `anchorDisposition rewrite` mirrors the runtime anchor-retention decision. -/
+def anchorDisposition {node : Type} : GraphRewrite node → RewriteAnchorDisposition
+  | GraphRewrite.expandNode _anchor ExpansionMode.replaceNode _spec =>
+      RewriteAnchorDisposition.removed
+  | GraphRewrite.expandNode _anchor ExpansionMode.retainNodeAsEnvelope _spec =>
+      RewriteAnchorDisposition.retained
+  | GraphRewrite.appendAfter _anchor _spec =>
+      RewriteAnchorDisposition.retained
+
+end GraphRewrite
+
+/-! ## Relation-Level Planner Model
+
+This section transcribes the Haskell `planGraphRewrite` topology construction
+(`src/Cortex/Pulse/Rewrite.hs`) into a relation-level Lean model. The runtime
+plan proceeds in five stages:
+
+1. Resolve the anchor's predecessors and successors in the current topology.
+2. Form the base topology by either deleting the anchor (`replaceNode`) or
+   stripping its outgoing edges (`retainNodeAsEnvelope`, `appendAfter`).
+3. Overlay the inserted subgraph.
+4. Wire the entry sources to the inserted entry nodes. The entry source set is
+   the anchor's predecessors when the anchor is removed and the anchor itself
+   when the anchor is retained.
+5. Wire the inserted exit nodes to the anchor's successors.
+
+`plannedFinalRelation` carries out exactly those five stages on the relation
+denotation. The bridge theorem `topologyMatches` requires `delta.topology` to
+match this construction; `relationAddedNodes`, `relationRemovedNodes`, and
+`relationAddedEdges` recover the runtime `relationDiff` outputs from the same
+relation.
+
+The planner takes the inserted subgraph as already living in the final node
+namespace. The runtime obtains that shape through `namespaceSubgraph`; a later
+executable correspondence theorem must connect that function to this
+proof-side input.
+-/
+
+section PlannerRelation
+
+variable {node : Type}
+variable [DecidableEq node]
+
+/-- `predecessorsOf relation target` extracts direct predecessors of `target`. -/
+def predecessorsOf (relation : Relation node) (target : node) : Finset node :=
+  (relation.edges.filter (fun edge => edge.2 = target)).image Prod.fst
+
+/-- `successorsOf relation source` extracts direct successors of `source`. -/
+def successorsOf (relation : Relation node) (source : node) : Finset node :=
+  (relation.edges.filter (fun edge => edge.1 = source)).image Prod.snd
+
+/-- `removeVertexFromRelation relation vertex` removes a vertex and incident edges. -/
+def removeVertexFromRelation (relation : Relation node) (vertex : node) : Relation node :=
+  { vertices := relation.vertices.erase vertex
+    edges := relation.edges.filter (fun edge => edge.1 ≠ vertex ∧ edge.2 ≠ vertex) }
+
+/-- `removeOutgoingFromRelation relation vertex` removes all outgoing edges from a vertex. -/
+def removeOutgoingFromRelation (relation : Relation node) (vertex : node) : Relation node :=
+  { vertices := relation.vertices
+    edges := relation.edges.filter (fun edge => edge.1 ≠ vertex) }
+
+/-- `addEdgesToRelation relation edges` adds edges and their endpoint vertices. -/
+def addEdgesToRelation (relation : Relation node) (edges : Finset (node × node)) :
+    Relation node :=
+  { vertices := relation.vertices ∪ edges.image Prod.fst ∪ edges.image Prod.snd
+    edges := relation.edges ∪ edges }
+
+/-- `plannedFinalRelation context rewrite` mirrors the runtime topology construction.
+
+The subgraph is assumed to already live in the final node namespace. The Haskell
+planner obtains that shape through `namespaceSubgraph`; a later executable
+correspondence theorem must connect that function to this proof-side input. -/
+def plannedFinalRelation (context : Graph node) (rewrite : GraphRewrite node) :
+    Relation node :=
+  let oldRelation := denote context
+  let anchorNode := rewrite.anchor
+  let insertedRelation := denote rewrite.spec.topology
+  let predecessors := predecessorsOf oldRelation anchorNode
+  let successors := successorsOf oldRelation anchorNode
+  let baseRelation :=
+    match rewrite with
+    | GraphRewrite.expandNode _anchor ExpansionMode.replaceNode _spec =>
+        removeVertexFromRelation oldRelation anchorNode
+    | GraphRewrite.expandNode _anchor ExpansionMode.retainNodeAsEnvelope _spec =>
+        removeOutgoingFromRelation oldRelation anchorNode
+    | GraphRewrite.appendAfter _anchor _spec =>
+        removeOutgoingFromRelation oldRelation anchorNode
+  let withSubgraph := Relation.overlay baseRelation insertedRelation
+  let entrySources :=
+    match rewrite.anchorDisposition with
+    | RewriteAnchorDisposition.removed => predecessors
+    | RewriteAnchorDisposition.retained => {anchorNode}
+  let withEntries :=
+    addEdgesToRelation withSubgraph (entrySources ×ˢ rewrite.spec.entryNodes)
+  addEdgesToRelation withEntries (rewrite.spec.exitNodes ×ˢ successors)
+
+/-- Nodes added by moving from `oldRelation` to `newRelation`. -/
+def relationAddedNodes (oldRelation newRelation : Relation node) : Finset node :=
+  newRelation.vertices \ oldRelation.vertices
+
+/-- Nodes removed by moving from `oldRelation` to `newRelation`. -/
+def relationRemovedNodes (oldRelation newRelation : Relation node) : Finset node :=
+  oldRelation.vertices \ newRelation.vertices
+
+/-- Edges added by moving from `oldRelation` to `newRelation`. -/
+def relationAddedEdges
+    (oldRelation newRelation : Relation node) :
+    Finset (node × node) :=
+  newRelation.edges \ oldRelation.edges
+
+end PlannerRelation
+
+/-! ## Planning Predicates -/
+
+section PlanningPredicates
+
+variable {node : Type}
+variable [DecidableEq node]
+
+/-- `DefinitionCoverage topology definitions` says definitions exactly cover topology vertices. -/
+def DefinitionCoverage (topology : Graph node) (definitions : Finset node) : Prop :=
+  definitions = (denote topology).vertices
+
+/-- `NodesInside nodes topology` says every listed node appears in the topology. -/
+def NodesInside (nodes : Finset node) (topology : Graph node) : Prop :=
+  ∀ node, node ∈ nodes → node ∈ (denote topology).vertices
+
+/-- `ReachableOrSame g source target` matches runtime reachability, including the root itself. -/
+def ReachableOrSame (g : Graph node) (source target : node) : Prop :=
+  source = target ∨ GraphPath g source target
+
+/-- `OrphanFree spec` says each inserted node lies on an entry-to-exit path. -/
+def OrphanFree (spec : SubgraphSpec node) : Prop :=
+  ∀ node,
+    node ∈ (denote spec.topology).vertices →
+      (∃ entry, entry ∈ spec.entryNodes ∧ ReachableOrSame spec.topology entry node) ∧
+        ∃ exit, exit ∈ spec.exitNodes ∧ ReachableOrSame spec.topology node exit
+
+/-- `GraphPathNodeCount g source target count` counts vertices along a non-branching path. -/
+inductive GraphPathNodeCount (g : Graph node) : node → node → Nat → Prop where
+  | same {node : node} :
+      node ∈ (denote g).vertices →
+        GraphPathNodeCount g node node 1
+  | direct {source target : node} :
+      (source, target) ∈ (denote g).edges →
+        GraphPathNodeCount g source target 2
+  | cons {source next target : node} {count : Nat} :
+      (source, next) ∈ (denote g).edges →
+        GraphPathNodeCount g next target count →
+          GraphPathNodeCount g source target (count + 1)
+
+/-- `EntryExitPathNodeCount spec count` witnesses an entry-to-exit path with `count` nodes. -/
+def EntryExitPathNodeCount (spec : SubgraphSpec node) (count : Nat) : Prop :=
+  ∃ entry exit,
+    entry ∈ spec.entryNodes ∧
+      exit ∈ spec.exitNodes ∧
+        GraphPathNodeCount spec.topology entry exit count
+
+/-- `LongestInsertedPathNodeCount spec depth` mirrors the runtime inserted-depth computation. -/
+def LongestInsertedPathNodeCount (spec : SubgraphSpec node) (depth : Nat) : Prop :=
+  (∀ count, EntryExitPathNodeCount spec count → count ≤ depth) ∧
+    (depth = 0 ∨ EntryExitPathNodeCount spec depth)
+
+/-- `SubgraphSpec.Valid spec` collects the runtime's inserted-subgraph checks. -/
+structure SubgraphSpec.Valid (spec : SubgraphSpec node) : Prop where
+  /-- The inserted subgraph itself is acyclic. -/
+  acyclic : Acyclic spec.topology
+  /-- Inserted definitions exactly cover inserted topology nodes. -/
+  definitionsCover : DefinitionCoverage spec.topology spec.definitions
+  /-- Inserted subgraphs must expose at least one entry node. -/
+  entryNodesNonempty : spec.entryNodes.Nonempty
+  /-- Inserted subgraphs must expose at least one exit node. -/
+  exitNodesNonempty : spec.exitNodes.Nonempty
+  /-- Every entry node belongs to the inserted topology. -/
+  entryNodesInside : NodesInside spec.entryNodes spec.topology
+  /-- Every exit node belongs to the inserted topology. -/
+  exitNodesInside : NodesInside spec.exitNodes spec.topology
+  /-- Every inserted node is reachable from an entry and can reach an exit. -/
+  orphanFree : OrphanFree spec
+
+/-- `PlanningContext` is the current runtime topology plus definition domain. -/
+structure PlanningContext (node : Type) where
+  /-- Current materialized topology before the rewrite is applied. -/
+  topology : Graph node
+  /-- Domain of current stage definitions. -/
+  definitions : Finset node
+
+/-- `plannedFinalDefinitions context rewrite` mirrors the runtime definition-domain update.
+
+Replacing an anchor deletes its current definition before overlaying the inserted definitions.
+Retaining an anchor and appending after an anchor keep the old definition domain and overlay the
+inserted definitions. The inserted subgraph is assumed to already live in the final namespace. -/
+def plannedFinalDefinitions
+    (context : PlanningContext node)
+    (rewrite : GraphRewrite node) :
+    Finset node :=
+  match rewrite.anchorDisposition with
+  | RewriteAnchorDisposition.removed =>
+      context.definitions.erase rewrite.anchor ∪ rewrite.spec.definitions
+  | RewriteAnchorDisposition.retained =>
+      context.definitions ∪ rewrite.spec.definitions
+
+/-- `PlannedRewriteDelta` mirrors the runtime's planned rewrite output. -/
+structure PlannedRewriteDelta (node : Type) where
+  /-- Final topology after applying the planned rewrite. -/
+  topology : Graph node
+  /-- Final definition domain after applying the planned rewrite. -/
+  definitions : Finset node
+  /-- Nodes newly introduced by the planned rewrite. -/
+  newNodes : Finset node
+  /-- Nodes removed by the planned rewrite. -/
+  removedNodes : Finset node
+  /-- Edges newly introduced by the planned rewrite. -/
+  addedEdges : Finset (node × node)
+  /-- Entry nodes of the inserted subgraph after namespacing. -/
+  entryNodes : Finset node
+  /-- Exit nodes of the inserted subgraph after namespacing. -/
+  exitNodes : Finset node
+  /-- Anchor node that produced the rewrite. -/
+  anchorNode : node
+  /-- Whether the anchor remains in the final topology. -/
+  anchorDisposition : RewriteAnchorDisposition
+  /-- Structural cost computed for this rewrite. -/
+  cost : RewriteCost
+
+/-- `SubgraphContainedInFinal rewrite delta` records that the inserted subgraph was inserted. -/
+structure SubgraphContainedInFinal
+    (rewrite : GraphRewrite node)
+    (delta : PlannedRewriteDelta node) :
+    Prop where
+  /-- Every inserted vertex appears in the final topology. -/
+  verticesInside :
+    ∀ node,
+      node ∈ (denote rewrite.spec.topology).vertices →
+        node ∈ (denote delta.topology).vertices
+  /-- Every inserted edge appears in the final topology. -/
+  edgesInside :
+    ∀ edge,
+      edge ∈ (denote rewrite.spec.topology).edges →
+        edge ∈ (denote delta.topology).edges
+
+/-- `EntryExitMatches rewrite delta` ties delta entry/exit sets to the inserted subgraph. -/
+structure EntryExitMatches
+    (rewrite : GraphRewrite node)
+    (delta : PlannedRewriteDelta node) :
+    Prop where
+  /-- Delta entry nodes are exactly the inserted subgraph entry nodes. -/
+  entryNodes_eq : delta.entryNodes = rewrite.spec.entryNodes
+  /-- Delta exit nodes are exactly the inserted subgraph exit nodes. -/
+  exitNodes_eq : delta.exitNodes = rewrite.spec.exitNodes
+
+/-- `AnchorDispositionMatches rewrite delta` couples the runtime disposition to topology. -/
+structure AnchorDispositionMatches
+    (rewrite : GraphRewrite node)
+    (delta : PlannedRewriteDelta node) :
+    Prop where
+  /-- Delta disposition agrees with the rewrite form. -/
+  disposition_eq : delta.anchorDisposition = rewrite.anchorDisposition
+  /-- Removed anchors are absent from the final topology. -/
+  removed_absent :
+    delta.anchorDisposition = RewriteAnchorDisposition.removed →
+      rewrite.anchor ∉ (denote delta.topology).vertices
+  /-- Retained anchors remain in the final topology. -/
+  retained_present :
+    delta.anchorDisposition = RewriteAnchorDisposition.retained →
+      rewrite.anchor ∈ (denote delta.topology).vertices
+
+/-- `TopologyDiffMatches context delta` ties delta sets to the relation diff. -/
+structure TopologyDiffMatches
+    (context : PlanningContext node)
+    (delta : PlannedRewriteDelta node) :
+    Prop where
+  /-- New nodes are exactly final vertices absent from the old topology. -/
+  newNodes_eq :
+    delta.newNodes =
+      relationAddedNodes (denote context.topology) (denote delta.topology)
+  /-- Removed nodes are exactly old vertices absent from the final topology. -/
+  removedNodes_eq :
+    delta.removedNodes =
+      relationRemovedNodes (denote context.topology) (denote delta.topology)
+  /-- Added edges are exactly final edges absent from the old topology. -/
+  addedEdges_eq :
+    delta.addedEdges =
+      relationAddedEdges (denote context.topology) (denote delta.topology)
+
+/-- `DefinitionUpdateMatches context rewrite delta` ties definitions to the planner update. -/
+structure DefinitionUpdateMatches
+    (context : PlanningContext node)
+    (rewrite : GraphRewrite node)
+    (delta : PlannedRewriteDelta node) :
+    Prop where
+  /-- Final definition-domain keys match the runtime delete-or-retain update formula. -/
+  definitions_eq : delta.definitions = plannedFinalDefinitions context rewrite
+
+/-- `PlannedRewriteCostMatches rewrite delta` ties every budget dimension to the delta. -/
+structure PlannedRewriteCostMatches
+    (rewrite : GraphRewrite node)
+    (delta : PlannedRewriteDelta node) :
+    Prop where
+  /-- Added-node cost equals the relation-diff node count. -/
+  addedNodes_eq : delta.cost.addedNodes = delta.newNodes.card
+  /-- Added-edge cost equals the relation-diff edge count. -/
+  addedEdges_eq : delta.cost.addedEdges = delta.addedEdges.card
+  /-- Added-depth cost is computed from the inserted entry-to-exit longest path. -/
+  addedDepth_eq :
+    ∃ insertedDepth,
+      LongestInsertedPathNodeCount rewrite.spec insertedDepth ∧
+        delta.cost.addedDepth =
+          match delta.anchorDisposition with
+          | RewriteAnchorDisposition.removed => insertedDepth - 1
+          | RewriteAnchorDisposition.retained => insertedDepth
+  /-- Frontier delta is the number of inserted entries beyond the first. -/
+  frontierDelta_eq : delta.cost.frontierDelta = delta.entryNodes.card - 1
+  /-- Each planned graph rewrite consumes one rewrite-operation unit. -/
+  rewriteOps_eq : delta.cost.rewriteOps = 1
+
+/-- `PlanGraphRewriteChecks context rewrite delta` is the Lean-side runtime planning contract. -/
+structure PlanGraphRewriteChecks
+    (context : PlanningContext node)
+    (rewrite : GraphRewrite node)
+    (delta : PlannedRewriteDelta node) :
+    Prop where
+  /-- The delta records the rewrite anchor. -/
+  anchorMatches : delta.anchorNode = rewrite.anchor
+  /-- The anchor exists in the current topology. -/
+  anchorInTopology : rewrite.anchor ∈ (denote context.topology).vertices
+  /-- The anchor has a current stage definition. -/
+  anchorHasDefinition : rewrite.anchor ∈ context.definitions
+  /-- The inserted subgraph satisfies the runtime subgraph checks. -/
+  subgraphValid : rewrite.spec.Valid
+  /-- The final topology matches the proof-side relation-level planner construction. -/
+  topologyMatches :
+    denote delta.topology = plannedFinalRelation context.topology rewrite
+  /-- The inserted subgraph is present in the final topology. -/
+  subgraphContained : SubgraphContainedInFinal rewrite delta
+  /-- Delta entry/exit nodes are the inserted subgraph entry/exit nodes. -/
+  entryExitMatches : EntryExitMatches rewrite delta
+  /-- Delta anchor disposition agrees with the rewrite and final anchor membership. -/
+  anchorDispositionMatches : AnchorDispositionMatches rewrite delta
+  /-- Delta new/removed/added sets agree with relation-level topology diffs. -/
+  topologyDiffMatches : TopologyDiffMatches context delta
+  /-- Delta cost agrees with every structural budget dimension. -/
+  costMatches : PlannedRewriteCostMatches rewrite delta
+  /-- Delta definitions agree with the runtime delete-or-retain update formula. -/
+  definitionUpdateMatches : DefinitionUpdateMatches context rewrite delta
+  /-- The final topology has a definition for each materialized node and no extras. -/
+  finalDefinitionsCover : DefinitionCoverage delta.topology delta.definitions
+  /-- The runtime validates the final topology as acyclic. -/
+  finalAcyclic : Acyclic delta.topology
+
+end PlanningPredicates
+
+/-! ## Budget Admission -/
+
+section BudgetAdmission
+
+variable {node : Type}
+
+/-- `AdmittedRewriteDelta budget delta remaining` mirrors `admitRewriteDelta`. -/
+structure AdmittedRewriteDelta
+    (budget : RewriteBudget)
+    (delta : PlannedRewriteDelta node)
+    (remaining : RewriteBudget) :
+    Prop where
+  /-- The planned cost fits every remaining budget dimension. -/
+  fits : delta.cost.fitsIn budget
+  /-- The runtime returns the pointwise-decremented remaining budget. -/
+  remaining_eq : remaining = budget.consume delta.cost
+
+/-- Budget admission never replenishes any structural budget dimension. -/
+theorem admittedRewriteDelta_remaining_le_initial
+    {budget remaining : RewriteBudget}
+    {delta : PlannedRewriteDelta node}
+    (hAdmitted : AdmittedRewriteDelta budget delta remaining) :
+    remaining.le budget := by
+  rw [hAdmitted.remaining_eq]
+  exact RewriteBudget.consume_le budget delta.cost
+
+/-- Budget admission exposes the rewrite-operation bound needed by chain termination. -/
+theorem admittedRewriteDelta_rewriteOps_bound
+    {budget remaining : RewriteBudget}
+    {delta : PlannedRewriteDelta node}
+    (hAdmitted : AdmittedRewriteDelta budget delta remaining) :
+    delta.cost.rewriteOps ≤ budget.rewriteOps :=
+  hAdmitted.fits.2.2.2.2
+
+end BudgetAdmission
+
+/-! ## Bridge To Proof-Carrying Rewrites -/
+
+section Bridge
+
+variable {node : Type}
+variable [DecidableEq node]
+variable {contractOk : Graph node → Prop}
+
+/-- `PlannedRewriteSafety` supplies the non-structural certificate for a planned delta. -/
+structure PlannedRewriteSafety
+    (source : Graph node)
+    (delta : PlannedRewriteDelta node)
+    (contractOk : Graph node → Prop) :
+    Prop where
+  /-- The final topology is acyclic. Usually projected from `PlanGraphRewriteChecks`. -/
+  finalAcyclic : Acyclic delta.topology
+  /-- Caller-specific contract validity is preserved by this planned rewrite. -/
+  preservesContracts :
+    ∀ g, denote g = denote source → contractOk g → contractOk delta.topology
+  /-- The planned delta consumes at least one rewrite operation. -/
+  rewriteOpsPositive : 0 < delta.cost.rewriteOps
+
+/-- Planning checks provide the acyclicity and operation-budget parts of rewrite safety. -/
+theorem plannedRewriteSafety_of_checks
+    {context : PlanningContext node}
+    {rewrite : GraphRewrite node}
+    {delta : PlannedRewriteDelta node}
+    (hChecks : PlanGraphRewriteChecks context rewrite delta)
+    (hContracts :
+      ∀ g, denote g = denote context.topology → contractOk g → contractOk delta.topology) :
+    PlannedRewriteSafety context.topology delta contractOk := by
+  refine
+    { finalAcyclic := hChecks.finalAcyclic
+      preservesContracts := hContracts
+      rewriteOpsPositive := ?_ }
+  rw [hChecks.costMatches.rewriteOps_eq]
+  exact Nat.zero_lt_one
+
+namespace PlannedRewriteDelta
+
+/-- `toRewrite source delta safety` turns an accepted plan into a proof-carrying rewrite. -/
+def toRewrite
+    (source : Graph node)
+    (delta : PlannedRewriteDelta node)
+    (hSafety : PlannedRewriteSafety source delta contractOk) :
+    Rewrite node contractOk :=
+  { apply := fun g =>
+      if denote g = denote source then
+        some delta.topology
+      else
+        none
+    cost := delta.cost
+    rewriteOps_positive := hSafety.rewriteOpsPositive
+    preserves_acyclic := by
+      intro g g' hApply _hAcyclic
+      by_cases hSource : denote g = denote source
+      · simp [hSource] at hApply
+        cases hApply
+        exact hSafety.finalAcyclic
+      · simp [hSource] at hApply
+    preserves_contracts := by
+      intro g g' hApply hContracts
+      by_cases hSource : denote g = denote source
+      · simp [hSource] at hApply
+        cases hApply
+        exact hSafety.preservesContracts g hSource hContracts
+      · simp [hSource] at hApply }
+
+end PlannedRewriteDelta
+
+/-- The planned rewrite applies to the source topology it was planned against. -/
+theorem plannedRewrite_applicable
+    {source : Graph node}
+    {delta : PlannedRewriteDelta node}
+    {hSafety : PlannedRewriteSafety source delta contractOk} :
+    applicable (delta.toRewrite source hSafety) source := by
+  exact ⟨delta.topology, by simp [PlannedRewriteDelta.toRewrite]⟩
+
+/-- Admitted planned deltas instantiate the abstract `admissible` rewrite predicate. -/
+theorem admittedPlannedRewrite_admissible
+    {source : Graph node}
+    {budget remaining : RewriteBudget}
+    {delta : PlannedRewriteDelta node}
+    {hSafety : PlannedRewriteSafety source delta contractOk}
+    (hAdmitted : AdmittedRewriteDelta budget delta remaining) :
+    admissible (delta.toRewrite source hSafety) source budget :=
+  ⟨hAdmitted.fits, plannedRewrite_applicable⟩
+
+/-- Runtime planning checks plus budget admission give an abstract admissible rewrite. -/
+theorem planGraphRewriteChecks_admissible
+    {context : PlanningContext node}
+    {rewrite : GraphRewrite node}
+    {budget remaining : RewriteBudget}
+    {delta : PlannedRewriteDelta node}
+    (hChecks : PlanGraphRewriteChecks context rewrite delta)
+    (hAdmitted : AdmittedRewriteDelta budget delta remaining)
+    (hContracts :
+      ∀ g, denote g = denote context.topology → contractOk g → contractOk delta.topology) :
+    admissible
+      (delta.toRewrite context.topology (plannedRewriteSafety_of_checks hChecks hContracts))
+      context.topology
+      budget :=
+  admittedPlannedRewrite_admissible hAdmitted
+
+/-- Runtime planning checks expose the final DAG certificate used by rewrite safety. -/
+theorem planGraphRewriteChecks_final_acyclic
+    {context : PlanningContext node}
+    {rewrite : GraphRewrite node}
+    {delta : PlannedRewriteDelta node}
+    (hChecks : PlanGraphRewriteChecks context rewrite delta) :
+    Acyclic delta.topology :=
+  hChecks.finalAcyclic
+
+/-- Runtime planning checks expose the final topology construction equation. -/
+theorem planGraphRewriteChecks_topology_matches
+    {context : PlanningContext node}
+    {rewrite : GraphRewrite node}
+    {delta : PlannedRewriteDelta node}
+    (hChecks : PlanGraphRewriteChecks context rewrite delta) :
+    denote delta.topology = plannedFinalRelation context.topology rewrite :=
+  hChecks.topologyMatches
+
+/-- Runtime planning checks expose the relation-diff equations for delta sets. -/
+theorem planGraphRewriteChecks_topologyDiffMatches
+    {context : PlanningContext node}
+    {rewrite : GraphRewrite node}
+    {delta : PlannedRewriteDelta node}
+    (hChecks : PlanGraphRewriteChecks context rewrite delta) :
+    TopologyDiffMatches context delta :=
+  hChecks.topologyDiffMatches
+
+/-- Runtime planning checks expose the structural cost equations. -/
+theorem planGraphRewriteChecks_costMatches
+    {context : PlanningContext node}
+    {rewrite : GraphRewrite node}
+    {delta : PlannedRewriteDelta node}
+    (hChecks : PlanGraphRewriteChecks context rewrite delta) :
+    PlannedRewriteCostMatches rewrite delta :=
+  hChecks.costMatches
+
+/-- Runtime planning checks expose anchor-disposition agreement. -/
+theorem planGraphRewriteChecks_anchorDispositionMatches
+    {context : PlanningContext node}
+    {rewrite : GraphRewrite node}
+    {delta : PlannedRewriteDelta node}
+    (hChecks : PlanGraphRewriteChecks context rewrite delta) :
+    AnchorDispositionMatches rewrite delta :=
+  hChecks.anchorDispositionMatches
+
+/-- Runtime planning checks expose the exact definition-domain update equation. -/
+theorem planGraphRewriteChecks_definitionUpdateMatches
+    {context : PlanningContext node}
+    {rewrite : GraphRewrite node}
+    {delta : PlannedRewriteDelta node}
+    (hChecks : PlanGraphRewriteChecks context rewrite delta) :
+    DefinitionUpdateMatches context rewrite delta :=
+  hChecks.definitionUpdateMatches
+
+/-- Runtime planning checks expose final definitions as the planned update formula. -/
+theorem planGraphRewriteChecks_definitions_eq
+    {context : PlanningContext node}
+    {rewrite : GraphRewrite node}
+    {delta : PlannedRewriteDelta node}
+    (hChecks : PlanGraphRewriteChecks context rewrite delta) :
+    delta.definitions = plannedFinalDefinitions context rewrite :=
+  hChecks.definitionUpdateMatches.definitions_eq
+
+end Bridge
+
+end Cortex.Wire

--- a/theory/Main.lean
+++ b/theory/Main.lean
@@ -23,6 +23,6 @@ def main : IO Unit := do
   IO.println "Cortex theory — Lean 4 mechanization (scaffold)"
   IO.println "  Track 1 (Graph algebra) ......... import Cortex.Graph.Core / Laws"
   IO.println "  Track 2 (Pulse kernel) .......... import Cortex.Pulse.Classify"
-  IO.println "  Track 3 (Wire rewrite) .......... import Cortex.Wire.Registry / Rewrite"
+  IO.println "  Track 3 (Wire rewrite) .......... import Cortex.Wire.Admission"
   IO.println ""
   IO.println "Open obligations: see `theory/README.md`."

--- a/theory/README.md
+++ b/theory/README.md
@@ -86,17 +86,47 @@ graph algebra laws.
 
 `Cortex.Wire.Registry` models the `@` executor boundary as pure staging of registered authority:
 executor lookup, config validation, registry-wide contract vocabulary, endpoint compatibility,
-effect-class policy, output validation, and host authority. `Cortex.Wire.Rewrite` sketches the
-admission predicate from `src/Cortex/Pulse/Rewrite.hs`. The current Lean surface is proof-carrying
-rather than vacuous: an admitted `Rewrite` carries preservation evidence for graph acyclicity, the
-caller-supplied contract predicate, and consumption of the five-dimensional runtime rewrite budget.
-Chain-level theorems now lift those local certificates across finite rewrite sequences and bound the
-number of admitted steps by the initial remaining rewrite-operation budget. Remaining obligations:
+effect-class policy, output validation, and host authority. `Cortex.Wire.Rewrite` defines the
+proof-carrying rewrite certificate surface: an admitted `Rewrite` carries preservation evidence for
+graph acyclicity, the caller-supplied contract predicate, and consumption of the five-dimensional
+runtime rewrite budget. `Cortex.Wire.Admission` now models the proof-side bridge from
+`planGraphRewrite` and `admitRewriteDelta`: anchor existence, anchor definition coverage,
+inserted-subgraph validity, entry/exit non-emptiness, orphan-freedom, denotational equality to a
+relation-level final-topology construction, relation-diff equations, anchor-disposition coupling,
+structural cost equations for every budget dimension, the final definition-domain update equation,
+final-definition coverage, final acyclicity, and pointwise budget consumption.
 
-- connect those proof-carrying certificates to the Haskell admission path;
+Mechanized results now include:
+
+- `plannedRewriteSafety_of_checks`: runtime planning checks supply the acyclicity and positive
+  rewrite-operation parts of a proof-carrying rewrite.
+- `planGraphRewriteChecks_topology_matches`: planning checks expose the final-topology construction
+  equation.
+- `planGraphRewriteChecks_topologyDiffMatches`: planning checks expose relation-diff equations for
+  new nodes, removed nodes, and added edges.
+- `planGraphRewriteChecks_costMatches`: planning checks expose structural cost equations for added
+  nodes, added edges, inserted depth, frontier delta, and rewrite-operation budget.
+- `planGraphRewriteChecks_anchorDispositionMatches`: planning checks expose anchor-disposition
+  agreement and final anchor membership.
+- `planGraphRewriteChecks_definitions_eq`: planning checks expose the exact definition-domain update
+  formula for removed versus retained anchors.
+- `admittedRewriteDelta_remaining_le_initial`: budget admission never replenishes any structural
+  budget dimension.
+- `admittedRewriteDelta_rewriteOps_bound`: the runtime rewrite-operation bound is exposed for chain
+  termination.
+- `admittedPlannedRewrite_admissible`: an admitted planned delta instantiates the abstract
+  `admissible` predicate.
+- `planGraphRewriteChecks_admissible`: runtime planning checks plus budget admission produce an
+  abstract admissible rewrite.
+- `rewriteChain_preserves_acyclic`, `rewriteChain_preserves_contracts`,
+  `rewriteChain_preserves_registryBoundary`, `rewriteChain_steps_le_rewriteOps`, and
+  `rewriteChain_finalBudget_le_initial`: local rewrite certificates lift across finite chains.
+
+Remaining obligations:
+
+- connect the Lean relation-level planner and namespaced `SubgraphSpec` input to the executable
+  Haskell constructors in `planGraphRewrite`;
 - connect registry-boundary witnesses to the Haskell compiler and registry;
-- model anchor existence, entry/exit non-emptiness, orphan-freedom, and runtime policy checks from
-  `planGraphRewrite`;
 - connect the abstract chain model to durable materialization order and lineage.
 
 This is the "sandbox by proof" story for dynamic graph rewriting. Rewrites may transform topology,
@@ -145,15 +175,15 @@ The repo's pre-commit hook checks theory changes through the flake surface
 
 ## Status
 
-| Track                            | Statements                                                                   | Proved                                                                                                                                                                                                                                         | Axiomatized |
-| -------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 1a. Graph relation semantics     | finite relation denotation + Mokhov laws                                     | relation-level laws                                                                                                                                                                                                                            | none        |
-| 1b. Graph denotational AST laws  | AST laws over graph equivalence                                              | denotational law surface                                                                                                                                                                                                                       | none        |
-| 1c. Graph quotient laws          | lifted quotient equality laws                                                | pending                                                                                                                                                                                                                                        | none        |
-| 2. Fixed-topology Pulse kernel   | edge-derived DAG/state/fact/frontier/closure/recovery/classification surface | frontier antichain, direct/runtime frontier bridge, fact commutativity, admissible fact recovery, closure idempotence, topology-domain/output/volatile-state/causal preservation, structural recovery predicate, classification exhaustiveness | none        |
-| 3. Rewrite soundness             | registry-boundary model + proof-carrying rewrite certificate                 | node/edge registry predicates, acyclicity/contract/budget projections, chain-level preservation, step bound by rewrite-operation budget                                                                                                        | none        |
-| 4. Provider / sparks             | —                                                                            | —                                                                                                                                                                                                                                              | not started |
-| 5. Substrate / consumer boundary | —                                                                            | —                                                                                                                                                                                                                                              | not started |
+| Track                            | Statements                                                                              | Proved                                                                                                                                                                                                                                         | Axiomatized |
+| -------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| 1a. Graph relation semantics     | finite relation denotation + Mokhov laws                                                | relation-level laws                                                                                                                                                                                                                            | none        |
+| 1b. Graph denotational AST laws  | AST laws over graph equivalence                                                         | denotational law surface                                                                                                                                                                                                                       | none        |
+| 1c. Graph quotient laws          | lifted quotient equality laws                                                           | pending                                                                                                                                                                                                                                        | none        |
+| 2. Fixed-topology Pulse kernel   | edge-derived DAG/state/fact/frontier/closure/recovery/classification surface            | frontier antichain, direct/runtime frontier bridge, fact commutativity, admissible fact recovery, closure idempotence, topology-domain/output/volatile-state/causal preservation, structural recovery predicate, classification exhaustiveness | none        |
+| 3. Rewrite soundness             | registry-boundary model + proof-carrying rewrite certificate + runtime admission bridge | node/edge registry predicates, runtime planning predicates, acyclicity/contract/budget projections, admitted planned-delta bridge, chain-level preservation, step bound by rewrite-operation budget                                            | none        |
+| 4. Provider / sparks             | —                                                                                       | —                                                                                                                                                                                                                                              | not started |
+| 5. Substrate / consumer boundary | —                                                                                       | —                                                                                                                                                                                                                                              | not started |
 
 Discharging the remaining obligations is the actual work. The scaffold's job is to make the
 obligation graph compile and run end-to-end so that proof debt is visible and each abstract

--- a/theory/lakefile.lean
+++ b/theory/lakefile.lean
@@ -39,7 +39,8 @@ lean_lib «Cortex» where
     `Cortex.Pulse.Recovery,
     `Cortex.Pulse.Classify,
     `Cortex.Wire.Registry,
-    `Cortex.Wire.Rewrite
+    `Cortex.Wire.Rewrite,
+    `Cortex.Wire.Admission
   ]
 
 -- Smoke-test executable. Prints a build banner; useful for confirming


### PR DESCRIPTION
## Summary
Mechanizes the Wire runtime admission bridge between `planGraphRewrite` / `admitRewriteDelta` and the abstract proof-carrying `Rewrite` surface. The runtime boundary now bends to the proof model: rewrite costs and budgets are natural vectors, entry/exit declarations denote duplicate-free sets, and definition-domain updates follow the mechanized delete-or-retain formula.

## What changed
- Added `Cortex.Wire.Admission` with runtime-shaped rewrite inputs, planned deltas, subgraph validity, planning checks, and budget admission predicates.
- Added a proof-side relation-level planner model for anchor removal/retention, inserted subgraph overlay, entry rewiring, and exit rewiring.
- Tightened `PlanGraphRewriteChecks` so accepted deltas must carry final-topology equality, relation-diff equations, spec containment, entry/exit equality, anchor-disposition coupling, structural cost equations for every budget dimension, and exact definition-domain update equations.
- Aligned Haskell `RewriteBudget` and `RewriteCost` with Lean `Nat` by using `Natural`; negative serialized budgets/costs now fail decoding before admission.
- Hardened `Cortex.Pulse.Rewrite` so subgraph validation rejects duplicate entry/exit nodes before planning.
- Updated canonical terminology, rewrite reference, and architecture prose so theory/proof contracts lead the runtime vocabulary.
- Extended docs linting to catch malformed Markdown table shapes, including unescaped `|` examples in terminology tables.
- Bumped `repo-docs` to `6252f4e13f8db140f6716706a06684b3fc2738b5`.
- Proved admitted planned deltas instantiate the existing abstract `admissible` rewrite predicate.
- Wired the module into `import Cortex`, Lake roots, the smoke executable banner, and Wire theory docs.

## Theorem surface
- `plannedRewriteSafety_of_checks`
- `admittedRewriteDelta_remaining_le_initial`
- `admittedRewriteDelta_rewriteOps_bound`
- `admittedPlannedRewrite_admissible`
- `planGraphRewriteChecks_admissible`
- `planGraphRewriteChecks_final_acyclic`
- `planGraphRewriteChecks_topology_matches`
- `planGraphRewriteChecks_topologyDiffMatches`
- `planGraphRewriteChecks_costMatches`
- `planGraphRewriteChecks_anchorDispositionMatches`
- `planGraphRewriteChecks_definitionUpdateMatches`
- `planGraphRewriteChecks_definitions_eq`

## Remaining scope
- Connect the Lean relation-level planner and namespaced `SubgraphSpec` input to executable Haskell constructors in `planGraphRewrite`.
- Connect registry-boundary witnesses to the Haskell compiler and registry.
- Connect the abstract chain model to durable materialization order and lineage.

## Validation
- [x] `cd theory && lake env lean Cortex/Wire/Admission.lean`
- [x] `cd theory && lake build Cortex.Wire.Admission`
- [x] `cd theory && lake env lean Cortex.lean`
- [x] `just lean-lint`
- [x] `just lean-build`
- [x] `just lean-check`
- [x] `just fmt-check`
- [x] `just lint`
- [x] `just docs-lint`
- [x] `just docs-build`
- [x] `nix build .#cortex-tests`
- [x] `nix run .#cortex-tests -- --match GraphRewrite`
- [x] Lean forbidden-construct and heavy-tactic scans over Wire modules
- [x] `git diff --check`
- [x] `just check-commit-provenance origin/main..HEAD`

Note: `just test-match GraphRewrite` currently fails before package compilation in the ad hoc Cabal path because `postgresql-libpq-configure` cannot find `pg_config` in that shell; the flake-built test executable above passes the focused suite.

Closes #75.
