### PR TITLE
feat: prove Wire planner construction admission

### DIFF
--- a/docs/Reference/rewrites.md
+++ b/docs/Reference/rewrites.md
@@ -70,9 +70,9 @@ definitions outside the fragment, and any cycle in the resulting materialized gr
 
 New node ids inside a spec are deterministic and namespaced by their parent anchor (for example
 `planner:repair_branch_1:step_1`). Deterministic namespacing is required so identity is stable
-across replay. Local node ids inside the inserted spec must not contain the namespace delimiter `:`.
-After namespacing, inserted node ids must also be fresh against the current topology; a proposal
-that would collide with an existing node is rejected before planning continues.
+across replay. Local node ids inside the inserted spec must be non-empty and must not contain the
+namespace delimiter `:`. After namespacing, inserted node ids must also be fresh against the current
+topology; a proposal that would collide with an existing node is rejected before planning continues.
 
 ### 1.3 Deferred forms
 

--- a/src/Cortex/Pulse/PlanHydration.hs
+++ b/src/Cortex/Pulse/PlanHydration.hs
@@ -185,8 +185,9 @@ renderRewriteValidationError errs = T.intercalate "; " (fmap renderOne errs)
         "Rewrite entry nodes are outside the inserted topology: " <> showNodeIds nodes
       RewritePlanningIssue (RewriteExitNodesOutsideTopology nodes) ->
         "Rewrite exit nodes are outside the inserted topology: " <> showNodeIds nodes
-      RewritePlanningIssue (RewriteLocalNodeIdsContainNamespaceDelimiter nodes) ->
-        "Rewrite local node ids must not contain namespace delimiter ':': " <> showNodeIds nodes
+      RewritePlanningIssue (RewriteInvalidLocalNodeIds nodes) ->
+        "Rewrite local node ids must be non-empty and must not contain namespace delimiter ':': "
+          <> showNodeIds nodes
       RewritePlanningIssue (RewriteNamespacedNodeCollision nodes) ->
         "Rewrite namespaced nodes collide with existing topology: " <> showNodeIds nodes
       RewritePlanningIssue (RewriteOrphanNodes nodes) ->

--- a/src/Cortex/Pulse/Rewrite.hs
+++ b/src/Cortex/Pulse/Rewrite.hs
@@ -191,7 +191,7 @@ data RewritePlanningError a
   | RewriteDuplicateExitNodes [a]
   | RewriteEntryNodesOutsideTopology [a]
   | RewriteExitNodesOutsideTopology [a]
-  | RewriteLocalNodeIdsContainNamespaceDelimiter [a]
+  | RewriteInvalidLocalNodeIds [a]
   | RewriteNamespacedNodeCollision [a]
   | RewriteOrphanNodes [a]
   deriving stock (Eq, Show, Generic)
@@ -394,16 +394,17 @@ validateNamespaceDiscipline ::
   Either [RewritePlanningError NodeId] ()
 validateNamespaceDiscipline topology anchor spec =
   let localNodes = relVertices spec.sgsTopology
-      badLocalNodes = Set.toList (Set.filter nodeIdHasNamespaceDelimiter localNodes)
+      badLocalNodes = Set.toList (Set.filter nodeIdInvalidLocalSegment localNodes)
       namespacedNodes = Set.map (namespaceNodeId anchor) localNodes
       collisions = Set.toList (Set.intersection namespacedNodes (relVertices topology))
       errors =
-        [RewriteLocalNodeIdsContainNamespaceDelimiter badLocalNodes | not (null badLocalNodes)]
+        [RewriteInvalidLocalNodeIds badLocalNodes | not (null badLocalNodes)]
           <> [RewriteNamespacedNodeCollision collisions | not (null collisions)]
    in if null errors then Right () else Left errors
 
-nodeIdHasNamespaceDelimiter :: NodeId -> Bool
-nodeIdHasNamespaceDelimiter (NodeId nodeId) = T.singleton ':' `T.isInfixOf` nodeId
+nodeIdInvalidLocalSegment :: NodeId -> Bool
+nodeIdInvalidLocalSegment (NodeId nodeId) =
+  T.null nodeId || T.singleton ':' `T.isInfixOf` nodeId
 
 validateRewriteAnchor ::
   Relation NodeId ->

--- a/test/Cortex/Pulse/GraphRewriteSpec.hs
+++ b/test/Cortex/Pulse/GraphRewriteSpec.hs
@@ -267,9 +267,21 @@ spec = do
 
         case planGraphRewrite rewrite initialTopo initialDefs of
           Left errs ->
-            errs `shouldContain` [RewriteLocalNodeIdsContainNamespaceDelimiter [NodeId "sub:1"]]
+            errs `shouldContain` [RewriteInvalidLocalNodeIds [NodeId "sub:1"]]
           Right _ ->
             expectationFailure "Expected namespace-delimiter local node id to be rejected"
+
+      it "rejects empty local inserted node ids" $ do
+        let subTopo = toRelation (Vertex (NodeId "") :: Graph NodeId)
+            subDefs = Map.fromList [(NodeId "", mkDef Sub1)]
+            spec' = SubgraphSpec subTopo subDefs [NodeId ""] [NodeId ""]
+            rewrite = AppendAfter (NodeId "b") spec'
+
+        case planGraphRewrite rewrite initialTopo initialDefs of
+          Left errs ->
+            errs `shouldContain` [RewriteInvalidLocalNodeIds [NodeId ""]]
+          Right _ ->
+            expectationFailure "Expected empty local node id to be rejected"
 
       it "rejects namespaced inserted nodes that collide with the current topology" $ do
         let collisionNode = NodeId "b:sub1"

--- a/theory/Cortex.lean
+++ b/theory/Cortex.lean
@@ -18,6 +18,7 @@ import Cortex.Wire.Registry
 import Cortex.Wire.Rewrite
 import Cortex.Wire.Admission
 import Cortex.Wire.Planner
+import Cortex.Wire.Planner.Construction
 
 /-!
 ## Overview

--- a/theory/Cortex/Graph/Relation.lean
+++ b/theory/Cortex/Graph/Relation.lean
@@ -180,4 +180,108 @@ theorem denote_connect_decomposition (g h k : Graph α) :
           (Graph.connect h k)) :=
   Relation.connect_decomposition (denote g) (denote h) (denote k)
 
+/-! ## Relation Realization -/
+
+/-- `Relation.EdgeEndpointsInVertices r` says each edge endpoint appears in the vertex set. -/
+def Relation.EdgeEndpointsInVertices (relation : Relation α) : Prop :=
+  ∀ edge, edge ∈ relation.edges → edge.1 ∈ relation.vertices ∧ edge.2 ∈ relation.vertices
+
+/-- `graphOfVertices vertices` is the edge-free graph containing the listed vertices. -/
+def graphOfVertices : List α → Graph α
+  | [] => Graph.empty
+  | vertex :: rest => Graph.overlay (Graph.vertex vertex) (graphOfVertices rest)
+
+/-- `graphOfEdges edges` is the overlay of singleton-edge graphs for the listed edges. -/
+def graphOfEdges : List (α × α) → Graph α
+  | [] => Graph.empty
+  | edge :: rest => Graph.overlay (Graph.edge edge.1 edge.2) (graphOfEdges rest)
+
+/-- `graphOfRelation relation` chooses a non-extractable graph representative for a relation. -/
+noncomputable def graphOfRelation (relation : Relation α) : Graph α :=
+  Graph.overlay (graphOfVertices relation.vertices.toList) (graphOfEdges relation.edges.toList)
+
+/-- Denotation of `graphOfVertices` is exactly the listed vertices and no edges. -/
+theorem denote_graphOfVertices (vertices : List α) :
+    denote (graphOfVertices vertices) =
+      { vertices := vertices.toFinset, edges := ∅ } := by
+  induction vertices with
+  | nil =>
+      ext x <;> simp [graphOfVertices, denote_empty, Relation.empty]
+  | cons vertex rest ih =>
+      rw [graphOfVertices, denote_overlay, ih]
+      ext x <;> simp [Relation.overlay, Relation.vertex, denote_vertex, List.toFinset_cons]
+
+/-- Denotation of `graphOfEdges` contains each listed edge and its endpoints. -/
+theorem denote_graphOfEdges (edges : List (α × α)) :
+    denote (graphOfEdges edges) =
+      { vertices := (edges.map Prod.fst).toFinset ∪ (edges.map Prod.snd).toFinset
+        edges := edges.toFinset } := by
+  induction edges with
+  | nil =>
+      ext x <;> simp [graphOfEdges, denote_empty, Relation.empty]
+  | cons edge rest ih =>
+      rw [graphOfEdges, denote_overlay, ih]
+      ext x
+      · simp
+          [ Relation.overlay
+          , Graph.edge
+          , Relation.connect
+          , Relation.vertex
+          , Relation.cross
+          , denote_vertex
+          , denote_connect
+          , List.toFinset_cons
+          , or_comm
+          , or_left_comm
+          ]
+      · simp
+          [ Relation.overlay
+          , Graph.edge
+          , Relation.connect
+          , Relation.vertex
+          , Relation.cross
+          , denote_vertex
+          , denote_connect
+          , List.toFinset_cons
+          ]
+
+/-- A relation with all edge endpoints in its vertex set has a graph representative. -/
+theorem denote_graphOfRelation
+    {relation : Relation α}
+    (hEndpoints : Relation.EdgeEndpointsInVertices relation) :
+    denote (graphOfRelation relation) = relation := by
+  unfold graphOfRelation
+  rw [denote_overlay, denote_graphOfVertices, denote_graphOfEdges]
+  apply Relation.ext
+  · apply Finset.ext
+    intro vertex
+    simp only
+      [ Relation.overlay
+      , Finset.mem_union
+      , List.mem_toFinset
+      , Finset.mem_toList
+      , List.mem_map
+      ]
+    constructor
+    · intro hVertex
+      rcases hVertex with hVertex | hEndpoint
+      · exact hVertex
+      · rcases hEndpoint with hSource | hTarget
+        · rcases hSource with ⟨edge, hEdge, rfl⟩
+          exact (hEndpoints edge hEdge).1
+        · rcases hTarget with ⟨edge, hEdge, rfl⟩
+          exact (hEndpoints edge hEdge).2
+    · intro hVertex
+      exact Or.inl hVertex
+  · apply Finset.ext
+    intro edge
+    simp only
+      [ Relation.overlay
+      , Finset.mem_union
+      , List.mem_toFinset
+      , Finset.mem_toList
+      , Finset.notMem_empty
+      , false_or
+      ]
+
 end Cortex.Graph

--- a/theory/Cortex/Wire/Planner/Construction.lean
+++ b/theory/Cortex/Wire/Planner/Construction.lean
@@ -1,0 +1,684 @@
+import Cortex.Wire.Planner
+import Mathlib.Data.List.Basic
+
+/-!
+## Overview
+
+Runtime-shaped construction for Wire rewrite admission.
+
+## Context
+
+`Cortex.Wire.Planner` names the proof contract established by executable
+planning. This module moves one step closer to the runtime: it defines a
+concrete namespaced-node model, constructs a proof-side planned delta from
+the relation-level planner model, and proves that the constructed delta
+supplies the bulk of `RuntimePlannerConstruction`.
+
+The theorem surface remains denotational. The constructed graph topology is a
+non-extractable `Graph` representative for the finite planned relation;
+correctness is stated as `denote topology = plannedFinalRelation ...`, not
+raw AST equality. The executable runtime computes its own topology and must
+establish denotational equality to this representative.
+
+## Theorem Split
+
+The page first records relation endpoint-closure lemmas needed to realize
+planned relations as graphs. It then defines runtime-style namespaced node ids
+and finally constructs planned deltas whose topology, diff sets, definitions,
+entry/exit sets, and costs are definitionally tied to the planner model.
+-/
+
+namespace Cortex.Wire
+
+open Cortex.Graph
+
+/-! ## Runtime-Style Node Namespacing -/
+
+/-- `RuntimeNodeId` models executable node ids as namespace segments.
+
+The Haskell runtime serializes the same shape as colon-delimited `Text`.
+Keeping segments structured in Lean makes delimiter-freedom explicit: a local
+inserted id is a single non-empty segment containing no reserved delimiter, and
+namespacing appends that segment below the anchor path. Fixed-anchor
+injectivity is the only namespace theorem carried by the policy; disjointness
+across different anchors is established by per-rewrite freshness against the
+current topology. -/
+structure RuntimeNodeId where
+  /-- Namespace path segments. -/
+  segments : List String
+  deriving DecidableEq, Repr
+
+namespace RuntimeNodeId
+
+/-- Runtime namespace delimiter mirrored from the Haskell `NodeId` encoding. -/
+def namespaceDelimiter : Char :=
+  ':'
+
+/-- `segmentAllowed segment` mirrors the executable local-node syntax check. -/
+def segmentAllowed (segment : String) : Prop :=
+  segment.isEmpty = false ∧ segment.contains namespaceDelimiter = false
+
+/-- A local inserted node id is one non-empty segment with no namespace delimiter. -/
+def localAllowed (node : RuntimeNodeId) : Prop :=
+  ∃ segment, node.segments = [segment] ∧ segmentAllowed segment
+
+/-- Namespace a local inserted node under an anchor. -/
+def namespaceNode (anchor localNode : RuntimeNodeId) : RuntimeNodeId :=
+  { segments := anchor.segments ++ localNode.segments }
+
+/-- Fixed-anchor namespacing is injective. -/
+theorem namespaceNode_injective (anchor : RuntimeNodeId) :
+    Function.Injective (namespaceNode anchor) := by
+  intro left right hNamespaced
+  cases left with
+  | mk leftSegments =>
+      cases right with
+      | mk rightSegments =>
+          cases anchor with
+          | mk anchorSegments =>
+              have hSegments :
+                  anchorSegments ++ leftSegments = anchorSegments ++ rightSegments :=
+                congrArg RuntimeNodeId.segments hNamespaced
+              have hLocalSegments : leftSegments = rightSegments :=
+                List.append_right_injective anchorSegments hSegments
+              cases hLocalSegments
+              rfl
+
+/-- The concrete runtime namespace policy for structured node ids. -/
+def namespacePolicy : RuntimeNamespacePolicy RuntimeNodeId :=
+  { namespaceNode := namespaceNode
+    localAllowed := localAllowed
+    namespaceNode_injective := namespaceNode_injective }
+
+end RuntimeNodeId
+
+/-! ## Relation Endpoint Closure -/
+
+section EndpointClosure
+
+variable {node : Type}
+variable [DecidableEq node]
+
+/-- Relation overlay preserves endpoint closure. -/
+theorem relation_edgeEndpoints_overlay
+    {left right : Relation node}
+    (hLeft : Relation.EdgeEndpointsInVertices left)
+    (hRight : Relation.EdgeEndpointsInVertices right) :
+    Relation.EdgeEndpointsInVertices (Relation.overlay left right) := by
+  intro edge hEdge
+  simp only [Relation.overlay, Finset.mem_union] at hEdge ⊢
+  rcases hEdge with hEdge | hEdge
+  · exact ⟨Or.inl (hLeft edge hEdge).1, Or.inl (hLeft edge hEdge).2⟩
+  · exact ⟨Or.inr (hRight edge hEdge).1, Or.inr (hRight edge hEdge).2⟩
+
+/-- Relation connect preserves endpoint closure. -/
+theorem relation_edgeEndpoints_connect
+    {left right : Relation node}
+    (hLeft : Relation.EdgeEndpointsInVertices left)
+    (hRight : Relation.EdgeEndpointsInVertices right) :
+    Relation.EdgeEndpointsInVertices (Relation.connect left right) := by
+  intro edge hEdge
+  simp only [Relation.connect, Relation.cross, Finset.mem_union, Finset.mem_product] at hEdge ⊢
+  rcases hEdge with hOldEdge | hCross
+  · rcases hOldEdge with hEdge | hEdge
+    · exact ⟨Or.inl (hLeft edge hEdge).1, Or.inl (hLeft edge hEdge).2⟩
+    · exact ⟨Or.inr (hRight edge hEdge).1, Or.inr (hRight edge hEdge).2⟩
+  · exact ⟨Or.inl hCross.1, Or.inr hCross.2⟩
+
+/-- Denotations of graph expressions are endpoint-closed relations. -/
+theorem denote_edgeEndpointsInVertices (g : Graph node) :
+    Relation.EdgeEndpointsInVertices (denote g) := by
+  induction g with
+  | empty =>
+      intro edge hEdge
+      simp only [denote_empty, Relation.empty, Finset.notMem_empty] at hEdge
+  | vertex vertex =>
+      intro edge hEdge
+      simp only [denote_vertex, Relation.vertex, Finset.notMem_empty] at hEdge
+  | overlay left right left_ih right_ih =>
+      rw [denote_overlay]
+      exact relation_edgeEndpoints_overlay left_ih right_ih
+  | connect left right left_ih right_ih =>
+      rw [denote_connect]
+      exact relation_edgeEndpoints_connect left_ih right_ih
+
+/-- Removing one vertex and its incident edges preserves endpoint closure. -/
+theorem relation_edgeEndpoints_removeVertex
+    {relation : Relation node}
+    {vertex : node}
+    (hRelation : Relation.EdgeEndpointsInVertices relation) :
+    Relation.EdgeEndpointsInVertices (removeVertexFromRelation relation vertex) := by
+  intro edge hEdge
+  simp only [removeVertexFromRelation, Finset.mem_filter, Finset.mem_erase] at hEdge ⊢
+  rcases hEdge with ⟨hOldEdge, hSourceNe, hTargetNe⟩
+  exact ⟨⟨hSourceNe, (hRelation edge hOldEdge).1⟩, ⟨hTargetNe, (hRelation edge hOldEdge).2⟩⟩
+
+/-- Removing outgoing edges preserves endpoint closure. -/
+theorem relation_edgeEndpoints_removeOutgoing
+    {relation : Relation node}
+    {vertex : node}
+    (hRelation : Relation.EdgeEndpointsInVertices relation) :
+    Relation.EdgeEndpointsInVertices (removeOutgoingFromRelation relation vertex) := by
+  intro edge hEdge
+  simp only [removeOutgoingFromRelation, Finset.mem_filter] at hEdge ⊢
+  exact hRelation edge hEdge.1
+
+/-- Adding edges while also adding their endpoints preserves endpoint closure. -/
+theorem relation_edgeEndpoints_addEdges
+    {relation : Relation node}
+    {edges : Finset (node × node)}
+    (hRelation : Relation.EdgeEndpointsInVertices relation) :
+    Relation.EdgeEndpointsInVertices (addEdgesToRelation relation edges) := by
+  intro edge hEdge
+  simp only [addEdgesToRelation, Finset.mem_union] at hEdge ⊢
+  rcases hEdge with hOldEdge | hAddedEdge
+  · exact
+      ⟨ Or.inl (Or.inl (hRelation edge hOldEdge).1)
+      , Or.inl (Or.inl (hRelation edge hOldEdge).2)
+      ⟩
+  · exact
+      ⟨ Or.inl (Or.inr (Finset.mem_image.mpr ⟨edge, hAddedEdge, rfl⟩))
+      , Or.inr (Finset.mem_image.mpr ⟨edge, hAddedEdge, rfl⟩)
+      ⟩
+
+/-- The relation-level planner construction always produces an endpoint-closed relation. -/
+theorem plannedFinalRelation_edgeEndpointsInVertices
+    (context : Graph node)
+    (rewrite : GraphRewrite node) :
+    Relation.EdgeEndpointsInVertices (plannedFinalRelation context rewrite) := by
+  cases rewrite with
+  | expandNode anchor mode spec =>
+      cases mode with
+      | replaceNode =>
+          simp only
+            [ plannedFinalRelation
+            , GraphRewrite.anchor
+            , GraphRewrite.spec
+            , GraphRewrite.anchorDisposition
+            ]
+          exact
+            relation_edgeEndpoints_addEdges
+              (relation_edgeEndpoints_addEdges
+                (relation_edgeEndpoints_overlay
+                  (relation_edgeEndpoints_removeVertex (denote_edgeEndpointsInVertices context))
+                  (denote_edgeEndpointsInVertices spec.topology)))
+      | retainNodeAsEnvelope =>
+          simp only
+            [ plannedFinalRelation
+            , GraphRewrite.anchor
+            , GraphRewrite.spec
+            , GraphRewrite.anchorDisposition
+            ]
+          exact
+            relation_edgeEndpoints_addEdges
+              (relation_edgeEndpoints_addEdges
+                (relation_edgeEndpoints_overlay
+                  (relation_edgeEndpoints_removeOutgoing (denote_edgeEndpointsInVertices context))
+                  (denote_edgeEndpointsInVertices spec.topology)))
+  | appendAfter anchor spec =>
+      simp only
+        [ plannedFinalRelation
+        , GraphRewrite.anchor
+        , GraphRewrite.spec
+        , GraphRewrite.anchorDisposition
+        ]
+      exact
+        relation_edgeEndpoints_addEdges
+          (relation_edgeEndpoints_addEdges
+            (relation_edgeEndpoints_overlay
+              (relation_edgeEndpoints_removeOutgoing (denote_edgeEndpointsInVertices context))
+              (denote_edgeEndpointsInVertices spec.topology)))
+
+end EndpointClosure
+
+/-! ## Anchor Membership -/
+
+section AnchorMembership
+
+variable {node : Type}
+variable [DecidableEq node]
+
+/-- Acyclic source topologies have no direct self-loop at the rewrite anchor. -/
+theorem anchor_noSelfLoop_of_acyclic
+    {context : Graph node}
+    {anchor : node}
+    (hSourceAcyclic : Acyclic context) :
+    (anchor, anchor) ∉ (denote context).edges := by
+  intro hLoop
+  exact hSourceAcyclic anchor (GraphPath.direct hLoop)
+
+/-- Without a self-loop, an anchor is not its own direct predecessor. -/
+theorem anchor_not_mem_predecessorsOf_of_noSelfLoop
+    {relation : Relation node}
+    {anchor : node}
+    (hNoSelfLoop : (anchor, anchor) ∉ relation.edges) :
+    anchor ∉ predecessorsOf relation anchor := by
+  intro hPred
+  simp only [predecessorsOf, Finset.mem_image, Finset.mem_filter] at hPred
+  rcases hPred with ⟨edge, hEdge, hSource⟩
+  rcases edge with ⟨source, target⟩
+  simp only at hSource
+  subst source
+  simp only at hEdge
+  rw [hEdge.2] at hEdge
+  exact hNoSelfLoop hEdge.1
+
+/-- Without a self-loop, an anchor is not its own direct successor. -/
+theorem anchor_not_mem_successorsOf_of_noSelfLoop
+    {relation : Relation node}
+    {anchor : node}
+    (hNoSelfLoop : (anchor, anchor) ∉ relation.edges) :
+    anchor ∉ successorsOf relation anchor := by
+  intro hSucc
+  simp only [successorsOf, Finset.mem_image, Finset.mem_filter] at hSucc
+  rcases hSucc with ⟨edge, hEdge, hTarget⟩
+  rcases edge with ⟨source, target⟩
+  simp only at hTarget
+  subst target
+  simp only at hEdge
+  rw [hEdge.2] at hEdge
+  exact hNoSelfLoop hEdge.1
+
+/-- A replacement rewrite removes the anchor when the old topology has no anchor self-loop. -/
+theorem anchor_not_mem_plannedFinalRelation_replace
+    {context : Graph node}
+    {anchor : node}
+    {spec : SubgraphSpec node}
+    (hAnchorIn : anchor ∈ (denote context).vertices)
+    (hNoSelfLoop : (anchor, anchor) ∉ (denote context).edges)
+    (hFresh :
+      ∀ mappedNode,
+        mappedNode ∈ (denote spec.topology).vertices →
+          mappedNode ∉ (denote context).vertices)
+    (hEntryInside : NodesInside spec.entryNodes spec.topology)
+    (hExitInside : NodesInside spec.exitNodes spec.topology) :
+    anchor ∉
+      (plannedFinalRelation context
+        (GraphRewrite.expandNode anchor ExpansionMode.replaceNode spec)).vertices := by
+  intro hFinal
+  simp only
+    [ plannedFinalRelation
+    , GraphRewrite.anchor
+    , GraphRewrite.spec
+    , GraphRewrite.anchorDisposition
+    , removeVertexFromRelation
+    , addEdgesToRelation
+    , Relation.overlay
+    , Finset.mem_union
+    , Finset.mem_erase
+    , Finset.mem_image
+    , Finset.mem_product
+    ] at hFinal
+  rcases hFinal with (((hBaseOrInserted | hEntrySource) | hEntryTarget) | hExitSource) |
+    hExitTarget
+  · rcases hBaseOrInserted with hBase | hInserted
+    · exact hBase.1 rfl
+    · exact hFresh anchor hInserted hAnchorIn
+  · rcases hEntrySource with ⟨edge, hEdge, hSource⟩
+    rcases edge with ⟨source, _entry⟩
+    simp only at hSource
+    have hPred : anchor ∈ predecessorsOf (denote context) anchor := by
+      simpa only [hSource] using hEdge.1
+    exact anchor_not_mem_predecessorsOf_of_noSelfLoop hNoSelfLoop hPred
+  · rcases hEntryTarget with ⟨edge, hEdge, hEntry⟩
+    rcases edge with ⟨_source, entry⟩
+    simp only at hEntry
+    have hEntryOld : entry ∈ (denote context).vertices := by
+      rw [hEntry]
+      exact hAnchorIn
+    exact hFresh entry (hEntryInside entry hEdge.2) hEntryOld
+  · rcases hExitSource with ⟨edge, hEdge, hExit⟩
+    rcases edge with ⟨exit, _successor⟩
+    simp only at hExit
+    have hExitOld : exit ∈ (denote context).vertices := by
+      rw [hExit]
+      exact hAnchorIn
+    exact hFresh exit (hExitInside exit hEdge.1) hExitOld
+  · rcases hExitTarget with ⟨edge, hEdge, hSuccessor⟩
+    rcases edge with ⟨_exit, successor⟩
+    simp only at hSuccessor
+    have hSucc : anchor ∈ successorsOf (denote context) anchor := by
+      simpa only [hSuccessor] using hEdge.2
+    exact anchor_not_mem_successorsOf_of_noSelfLoop hNoSelfLoop hSucc
+
+/-- A retained-envelope rewrite keeps the anchor in the planned final relation. -/
+theorem anchor_mem_plannedFinalRelation_retain
+    {context : Graph node}
+    {anchor : node}
+    {spec : SubgraphSpec node}
+    (hAnchorIn : anchor ∈ (denote context).vertices) :
+    anchor ∈
+      (plannedFinalRelation context
+        (GraphRewrite.expandNode anchor ExpansionMode.retainNodeAsEnvelope spec)).vertices := by
+  simp only
+    [ plannedFinalRelation
+    , GraphRewrite.anchor
+    , GraphRewrite.spec
+    , GraphRewrite.anchorDisposition
+    , removeOutgoingFromRelation
+    , addEdgesToRelation
+    , Relation.overlay
+    , Finset.mem_union
+    ]
+  exact Or.inl (Or.inl (Or.inl (Or.inl (Or.inl hAnchorIn))))
+
+/-- An append-after rewrite keeps the anchor in the planned final relation. -/
+theorem anchor_mem_plannedFinalRelation_append
+    {context : Graph node}
+    {anchor : node}
+    {spec : SubgraphSpec node}
+    (hAnchorIn : anchor ∈ (denote context).vertices) :
+    anchor ∈
+      (plannedFinalRelation context (GraphRewrite.appendAfter anchor spec)).vertices := by
+  simp only
+    [ plannedFinalRelation
+    , GraphRewrite.anchor
+    , GraphRewrite.spec
+    , GraphRewrite.anchorDisposition
+    , removeOutgoingFromRelation
+    , addEdgesToRelation
+    , Relation.overlay
+    , Finset.mem_union
+    ]
+  exact Or.inl (Or.inl (Or.inl (Or.inl (Or.inl hAnchorIn))))
+
+end AnchorMembership
+
+/-! ## Constructed Planned Delta -/
+
+section ConstructedDelta
+
+variable {node : Type}
+variable [DecidableEq node]
+
+/-- Relation computed by the runtime-shaped planner after namespacing. -/
+def constructedFinalRelation
+    (policy : RuntimeNamespacePolicy node)
+    (context : PlanningContext node)
+    (rawRewrite : GraphRewrite node) :
+    Relation node :=
+  plannedFinalRelation context.topology (runtimePlannerRewrite policy rawRewrite)
+
+/-- Graph representative for the constructed final relation. -/
+noncomputable def constructedFinalTopology
+    (policy : RuntimeNamespacePolicy node)
+    (context : PlanningContext node)
+    (rawRewrite : GraphRewrite node) :
+    Graph node :=
+  graphOfRelation (constructedFinalRelation policy context rawRewrite)
+
+/-- The constructed final topology denotes the relation-level planner output. -/
+theorem denote_constructedFinalTopology
+    (policy : RuntimeNamespacePolicy node)
+    (context : PlanningContext node)
+    (rawRewrite : GraphRewrite node) :
+    denote (constructedFinalTopology policy context rawRewrite) =
+      constructedFinalRelation policy context rawRewrite := by
+  unfold constructedFinalTopology constructedFinalRelation
+  exact
+    denote_graphOfRelation
+      (plannedFinalRelation_edgeEndpointsInVertices
+        context.topology
+        (runtimePlannerRewrite policy rawRewrite))
+
+/-- Planned delta obtained by the runtime-shaped construction equations. -/
+noncomputable def constructedPlannedRewriteDelta
+    (policy : RuntimeNamespacePolicy node)
+    (context : PlanningContext node)
+    (rawRewrite : GraphRewrite node)
+    (insertedDepth : Nat) :
+    PlannedRewriteDelta node :=
+  let rewrite := runtimePlannerRewrite policy rawRewrite
+  let finalRelation := constructedFinalRelation policy context rawRewrite
+  let oldRelation := denote context.topology
+  let newNodes := relationAddedNodes oldRelation finalRelation
+  let addedEdges := relationAddedEdges oldRelation finalRelation
+  { topology := constructedFinalTopology policy context rawRewrite
+    definitions := plannedFinalDefinitions context rewrite
+    newNodes := newNodes
+    removedNodes := relationRemovedNodes oldRelation finalRelation
+    addedEdges := addedEdges
+    entryNodes := rewrite.spec.entryNodes
+    exitNodes := rewrite.spec.exitNodes
+    anchorNode := rawRewrite.anchor
+    anchorDisposition := rewrite.anchorDisposition
+    cost :=
+      { addedNodes := newNodes.card
+        addedEdges := addedEdges.card
+        addedDepth :=
+          match rewrite.anchorDisposition with
+          | RewriteAnchorDisposition.removed => insertedDepth - 1
+          | RewriteAnchorDisposition.retained => insertedDepth
+        frontierDelta := rewrite.spec.entryNodes.card - 1
+        rewriteOps := 1 } }
+
+/-- The constructed delta records anchor identity and derives anchor membership facts. -/
+theorem constructedPlannedRewriteDelta_anchorMatches
+    {policy : RuntimeNamespacePolicy node}
+    {context : PlanningContext node}
+    {rawRewrite : GraphRewrite node}
+    {insertedDepth : Nat}
+    (hDiscipline :
+      NamespaceDiscipline
+        policy.localAllowed
+        (policy.namespaceNode rawRewrite.anchor)
+        context
+        rawRewrite.spec)
+    (hAnchorInTopology : rawRewrite.anchor ∈ (denote context.topology).vertices)
+    (hSourceAcyclic : Acyclic context.topology)
+    (hRawSubgraphValid : rawRewrite.spec.Valid) :
+    RuntimeAnchorMatches
+      policy
+      rawRewrite
+      (constructedPlannedRewriteDelta policy context rawRewrite insertedDepth) := by
+  have hAnchorNoSelfLoop :
+      (rawRewrite.anchor, rawRewrite.anchor) ∉ (denote context.topology).edges :=
+    anchor_noSelfLoop_of_acyclic hSourceAcyclic
+  have hNamespacedValid : (runtimePlannerRewrite policy rawRewrite).spec.Valid := by
+    simp only [runtimePlannerRewrite, namespaceGraphRewrite_spec]
+    exact
+      namespaceSubgraphSpec_preserves_valid
+        (policy.namespaceNode_injective rawRewrite.anchor)
+        hRawSubgraphValid
+  have hFresh :
+      ∀ mappedNode,
+        mappedNode ∈ (denote (runtimePlannerRewrite policy rawRewrite).spec.topology).vertices →
+          mappedNode ∉ (denote context.topology).vertices := by
+    rw [runtimePlannerRewrite, namespaceGraphRewrite_spec]
+    exact namespaceSubgraphSpec_fresh_against_context hDiscipline
+  refine
+    { anchorNode_eq := by
+        simp only [constructedPlannedRewriteDelta]
+      anchorDisposition_eq := by
+        simp only [constructedPlannedRewriteDelta]
+      removed_absent := ?_
+      retained_present := ?_ }
+  · intro hRemoved
+    simp only [constructedPlannedRewriteDelta] at hRemoved ⊢
+    rw [denote_constructedFinalTopology]
+    cases rawRewrite with
+    | expandNode anchor mode spec =>
+        cases mode with
+        | replaceNode =>
+            exact
+              anchor_not_mem_plannedFinalRelation_replace
+                hAnchorInTopology
+                hAnchorNoSelfLoop
+                hFresh
+                hNamespacedValid.entryNodesInside
+                hNamespacedValid.exitNodesInside
+        | retainNodeAsEnvelope =>
+            cases hRemoved
+    | appendAfter anchor spec =>
+        cases hRemoved
+  · intro hRetained
+    simp only [constructedPlannedRewriteDelta] at hRetained ⊢
+    rw [denote_constructedFinalTopology]
+    cases rawRewrite with
+    | expandNode anchor mode spec =>
+        cases mode with
+        | replaceNode =>
+            cases hRetained
+        | retainNodeAsEnvelope =>
+            exact anchor_mem_plannedFinalRelation_retain hAnchorInTopology
+    | appendAfter anchor spec =>
+        exact anchor_mem_plannedFinalRelation_append hAnchorInTopology
+
+/-- Runtime validation inputs not computed by the pure construction equations. -/
+structure RuntimeConstructionValidation
+    (policy : RuntimeNamespacePolicy node)
+    (context : PlanningContext node)
+    (rawRewrite : GraphRewrite node)
+    (insertedDepth : Nat) :
+    Prop where
+  /-- The runtime namespace validator accepted local syntax and freshness. -/
+  namespaceDiscipline :
+    NamespaceDiscipline
+      policy.localAllowed
+      (policy.namespaceNode rawRewrite.anchor)
+      context
+      rawRewrite.spec
+  /-- The raw anchor exists in the current topology. -/
+  anchorInTopology : rawRewrite.anchor ∈ (denote context.topology).vertices
+  /-- The raw anchor has a current definition. -/
+  anchorHasDefinition : rawRewrite.anchor ∈ context.definitions
+  /-- The current topology is already a DAG before planning starts. -/
+  sourceAcyclic : Acyclic context.topology
+  /-- The raw inserted subgraph passed runtime subgraph validation. -/
+  rawSubgraphValid : rawRewrite.spec.Valid
+  /-- Runtime longest-path computation agrees with the proof-side inserted-depth witness. -/
+  insertedDepthMatches :
+    LongestInsertedPathNodeCount
+      (runtimePlannerRewrite policy rawRewrite).spec
+      insertedDepth
+  /-- The final definition domain exactly covers final topology vertices. -/
+  finalDefinitionsCover :
+    DefinitionCoverage
+      (constructedPlannedRewriteDelta policy context rawRewrite insertedDepth).topology
+      (constructedPlannedRewriteDelta policy context rawRewrite insertedDepth).definitions
+  /-- The runtime validated the final topology as acyclic. -/
+  finalAcyclic :
+    Acyclic (constructedPlannedRewriteDelta policy context rawRewrite insertedDepth).topology
+
+/-- The concrete construction equations establish `RuntimePlannerConstruction`. -/
+theorem constructedPlannedRewriteDelta_runtimePlannerConstruction
+    {policy : RuntimeNamespacePolicy node}
+    {context : PlanningContext node}
+    {rawRewrite : GraphRewrite node}
+    {insertedDepth : Nat}
+    (hValidation :
+      RuntimeConstructionValidation policy context rawRewrite insertedDepth) :
+    RuntimePlannerConstruction
+      policy
+      context
+      rawRewrite
+      (constructedPlannedRewriteDelta policy context rawRewrite insertedDepth) := by
+  refine
+    { namespaceDiscipline := hValidation.namespaceDiscipline
+      anchorInTopology := hValidation.anchorInTopology
+      anchorHasDefinition := hValidation.anchorHasDefinition
+      rawSubgraphValid := hValidation.rawSubgraphValid
+      anchorMatches :=
+        constructedPlannedRewriteDelta_anchorMatches
+          hValidation.namespaceDiscipline
+          hValidation.anchorInTopology
+          hValidation.sourceAcyclic
+          hValidation.rawSubgraphValid
+      deltaMatches := ?_
+      costMatches := ?_
+      finalDefinitionsCover := hValidation.finalDefinitionsCover
+      finalAcyclic := hValidation.finalAcyclic }
+  · refine
+      { topology_eq := ?_
+        entryNodes_eq := ?_
+        exitNodes_eq := ?_
+        newNodes_eq := ?_
+        removedNodes_eq := ?_
+        addedEdges_eq := ?_
+        definitions_eq := ?_ }
+    · exact denote_constructedFinalTopology policy context rawRewrite
+    · simp only [constructedPlannedRewriteDelta]
+    · simp only [constructedPlannedRewriteDelta]
+    · simp only
+        [ constructedPlannedRewriteDelta
+        , constructedFinalRelation
+        , denote_constructedFinalTopology
+        ]
+    · simp only
+        [ constructedPlannedRewriteDelta
+        , constructedFinalRelation
+        , denote_constructedFinalTopology
+        ]
+    · simp only
+        [ constructedPlannedRewriteDelta
+        , constructedFinalRelation
+        , denote_constructedFinalTopology
+        ]
+    · simp only [constructedPlannedRewriteDelta]
+  · refine
+      { addedNodes_eq := ?_
+        addedEdges_eq := ?_
+        addedDepth_eq := ?_
+        entryNodes_runtimeList := ?_
+        rewriteOps_eq := ?_ }
+    · simp only [constructedPlannedRewriteDelta]
+    · simp only [constructedPlannedRewriteDelta]
+    · refine ⟨insertedDepth, hValidation.insertedDepthMatches, ?_⟩
+      rfl
+    · let entryNodes :=
+        (constructedPlannedRewriteDelta policy context rawRewrite insertedDepth).entryNodes
+      refine ⟨entryNodes.toList, ?_, ?_⟩
+      · exact
+          ⟨ Finset.nodup_toList _
+          , Finset.toList_toFinset _
+          ⟩
+      · have hEntryCard :
+            entryNodes.card = entryNodes.toList.length :=
+          RuntimeNodeListMatches.card_eq_length
+            ⟨Finset.nodup_toList _, Finset.toList_toFinset _⟩
+        change entryNodes.card - 1 = entryNodes.toList.length - 1
+        rw [hEntryCard]
+    · simp only [constructedPlannedRewriteDelta]
+
+/-- Concrete construction plus budget admission gives an abstract admissible rewrite. -/
+theorem constructedPlannedRewriteDelta_admissible
+    {policy : RuntimeNamespacePolicy node}
+    {context : PlanningContext node}
+    {rawRewrite : GraphRewrite node}
+    {insertedDepth : Nat}
+    {budget remaining : RewriteBudget}
+    {contractOk : Graph node → Prop}
+    (hValidation :
+      RuntimeConstructionValidation policy context rawRewrite insertedDepth)
+    (hAdmitted :
+      AdmittedRewriteDelta
+        budget
+        (constructedPlannedRewriteDelta policy context rawRewrite insertedDepth)
+        remaining)
+    (hContracts :
+      ∀ g,
+        denote g = denote context.topology →
+          contractOk g →
+            contractOk
+              (constructedPlannedRewriteDelta
+                policy
+                context
+                rawRewrite
+                insertedDepth).topology) :
+    admissible
+      ((constructedPlannedRewriteDelta policy context rawRewrite insertedDepth).toRewrite
+        context.topology
+        (plannedRewriteSafety_of_checks
+          (runtimePlannerConstruction_planGraphRewriteChecks
+            (constructedPlannedRewriteDelta_runtimePlannerConstruction hValidation))
+          hContracts))
+      context.topology
+      budget :=
+  runtimePlannerConstruction_admissible
+    (constructedPlannedRewriteDelta_runtimePlannerConstruction hValidation)
+    hAdmitted
+    hContracts
+
+end ConstructedDelta
+
+end Cortex.Wire

--- a/theory/Main.lean
+++ b/theory/Main.lean
@@ -23,6 +23,6 @@ def main : IO Unit := do
   IO.println "Cortex theory — Lean 4 mechanization (scaffold)"
   IO.println "  Track 1 (Graph algebra) ......... import Cortex.Graph.Core / Laws"
   IO.println "  Track 2 (Pulse kernel) .......... import Cortex.Pulse.Classify"
-  IO.println "  Track 3 (Wire rewrite) .......... import Cortex.Wire.Planner"
+  IO.println "  Track 3 (Wire rewrite) .......... import Cortex.Wire.Planner.Construction"
   IO.println ""
   IO.println "Open obligations: see `theory/README.md`."

--- a/theory/README.md
+++ b/theory/README.md
@@ -97,7 +97,10 @@ structural cost equations for every budget dimension, the final definition-domai
 final-definition coverage, final acyclicity, and pointwise budget consumption. `Cortex.Wire.Planner`
 names the executable-planner correspondence boundary: subgraph namespacing, namespace discipline,
 the AST-to-relation mapping lemma, and the construction-to-checks theorem used to feed
-runtime-shaped planner equations into `PlanGraphRewriteChecks`.
+runtime-shaped planner equations into `PlanGraphRewriteChecks`. `Cortex.Wire.Planner.Construction`
+adds a proof-side planner construction: it realizes the relation-level final topology as a graph
+representative, computes delta diff sets and costs from that relation, and proves the constructed
+delta establishes the planner-construction bridge under the remaining runtime validation witnesses.
 
 Mechanized results now include:
 
@@ -138,14 +141,27 @@ Mechanized results now include:
   obligations.
 - `runtimePlannerConstruction_admissible`: runtime planner construction plus budget admission
   directly instantiates the abstract admissible-rewrite predicate.
+- `Relation.EdgeEndpointsInVertices`, `graphOfRelation`, and `denote_graphOfRelation`: endpoint-
+  closed finite relations can be realized by graph expressions without quotienting raw graph syntax.
+- `RuntimeNodeId.namespacePolicy`: structured namespace segments model the runtime `NodeId`
+  namespacing discipline with fixed-anchor injectivity and local-id syntax.
+- `plannedFinalRelation_edgeEndpointsInVertices`: the relation-level planner output is always
+  endpoint-closed, so it has a graph representative.
+- `constructedPlannedRewriteDelta_runtimePlannerConstruction`: the proof-side planner construction
+  computes the final topology, relation diffs, entry/exit sets, definition update, and structural
+  costs needed by `RuntimePlannerConstruction`; anchor absence for replacement rewrites is derived
+  from namespace freshness plus source-topology acyclicity.
+- `constructedPlannedRewriteDelta_admissible`: the constructed delta, runtime validation witnesses,
+  and budget admission instantiate the abstract admissible-rewrite predicate.
 - `rewriteChain_preserves_acyclic`, `rewriteChain_preserves_contracts`,
   `rewriteChain_preserves_registryBoundary`, `rewriteChain_steps_le_rewriteOps`, and
   `rewriteChain_finalBudget_le_initial`: local rewrite certificates lift across finite chains.
 
 Remaining obligations:
 
-- prove that the executable Haskell planner establishes the `RuntimePlannerConstruction` equations
-  now named in Lean, using the concrete `NodeId` namespace policy and duplicate-free runtime lists;
+- prove that the executable Haskell planner produces the `RuntimeConstructionValidation` witnesses
+  used by the constructed Lean delta, including source-topology acyclicity, current anchor
+  membership, final definition coverage, final acyclicity, and the inserted-depth computation;
 - connect registry-boundary witnesses to the Haskell compiler and registry;
 - connect the abstract chain model to durable materialization order and lineage.
 

--- a/theory/lakefile.lean
+++ b/theory/lakefile.lean
@@ -41,7 +41,8 @@ lean_lib «Cortex» where
     `Cortex.Wire.Registry,
     `Cortex.Wire.Rewrite,
     `Cortex.Wire.Admission,
-    `Cortex.Wire.Planner
+    `Cortex.Wire.Planner,
+    `Cortex.Wire.Planner.Construction
   ]
 
 -- Smoke-test executable. Prints a build banner; useful for confirming


### PR DESCRIPTION
## Summary
Prove that a concrete runtime-shaped Wire planner construction establishes the Lean `RuntimePlannerConstruction` contract and therefore feeds the existing admission theorem.

Layer: `Cortex.Wire` theory, with correspondence to `src/Cortex/Pulse/Rewrite.hs`. This stays in the substrate proof track; no Nous or consumer-layer concerns.

## Plan
- [ ] Add a graph-realization helper for finite relations, likely in `theory/Cortex/Graph/Relation.lean`:
  - construct a `Graph node` from a finite `Relation node`
  - prove `denote (graphOfRelation r) = r`
- [ ] Add a concrete runtime-style namespacing model, likely under `theory/Cortex/Wire/Planner/`:
  - structural `RuntimeNodeId` / local-id surface
  - local id syntax predicate or subtype
  - `namespaceNode anchor local`
  - fixed-anchor injectivity
  - freshness lemma from runtime collision check against old topology
- [ ] Add a runtime planner-construction relation/function mirroring `planGraphRewrite` enough to construct `PlannedRewriteDelta`:
  - final topology as `graphOfRelation (plannedFinalRelation ...)`
  - final definitions via `plannedFinalDefinitions`
  - new/removed/added relation-diff sets
  - entry/exit sets after namespacing
  - anchor disposition and anchor membership facts
  - five-dimensional cost fields, using the existing longest-path and duplicate-free entry-list witnesses
- [ ] Prove the construction yields `RuntimePlannerConstruction`.
- [ ] Derive `PlanGraphRewriteChecks` and `admissible` from the concrete construction.
- [ ] Update `theory/README.md` with the new proven surface and remaining obligations.

## Implementation Notes
- Source acyclicity should be an explicit construction precondition where needed to derive removed-anchor absence. Without it, self-loop countermodels can reintroduce the anchor through predecessor/successor wiring.
- Keep namespacing identity separate from future content-addressing identity. Namespacing proves topology freshness and parent-local provenance; content digests can be added later as materialization/provenance invariants.
- The cost proof should stay relational for this slice. Proving the executable Haskell longest-path algorithm is a later refinement; this PR should connect the planner construction to the existing `LongestInsertedPathNodeCount` witness surface.

## Checklist
- [ ] Implementation complete
- [ ] Theory docs updated
- [ ] `just lean-build` passes locally
- [ ] `just lean-check` passes locally
- [ ] Ready for review

## Issue
Closes #85