### PR TITLE
feat: lift GraphEq laws to quotient carrier

### DIFF
--- a/theory/Cortex.lean
+++ b/theory/Cortex.lean
@@ -2,6 +2,7 @@
 import Cortex.Graph.Core
 import Cortex.Graph.Relation
 import Cortex.Graph.Laws
+import Cortex.Graph.Quotient
 
 -- Track 2 — Pulse runtime, fixed-topology kernel
 import Cortex.Pulse.DAG

--- a/theory/Cortex/Graph/Laws.lean
+++ b/theory/Cortex/Graph/Laws.lean
@@ -18,8 +18,8 @@ modulo the finite relation denotation defined in
 
 The page defines denotational graph equality, proves Mokhov's unit and
 algebraic laws as theorems, and restates selected laws for the `+` and
-`*` operator surface. A later quotient module can lift these facts to
-ordinary equality on a quotient carrier.
+`*` operator surface. `Cortex.Graph.Quotient` packages this relation as
+the setoid for the `AlgGraph` quotient carrier.
 
 ## Status
 
@@ -35,7 +35,7 @@ ordinary equality on a quotient carrier.
 | `connect_distrib_overlay_right`        | theorem       |
 | `connect_decomposition`                | theorem       |
 
-The remaining Track 1 obligation is quotient lifting.
+The quotient law surface lives in `Cortex.Graph.Quotient`.
 
 ## References
 
@@ -138,7 +138,7 @@ Same denotational laws re-expressed against the Lean operator surface
 notation.
 -/
 
-theorem overlay_comm_plus {α : Type} [DecidableEq α] (g h : Graph α) :
+theorem overlay_comm_add {α : Type} [DecidableEq α] (g h : Graph α) :
     GraphEq (g + h) (h + g) :=
   overlay_comm g h
 

--- a/theory/Cortex/Graph/Quotient.lean
+++ b/theory/Cortex/Graph/Quotient.lean
@@ -1,0 +1,320 @@
+import Cortex.Graph.Laws
+
+/-!
+## Overview
+
+Quotient carrier for Mokhov's algebraic graph laws.
+
+## Context
+
+`Cortex.Graph.Core.Graph` is the raw expression syntax. Its constructors
+remember how a graph was written, so algebraic identities such as
+`overlay empty g = g` are false as raw AST equality. `Cortex.Graph.Laws`
+therefore exposes the law surface through `GraphEq`, equality of finite
+relation denotations.
+
+This module packages that relation as a quotient carrier, `AlgGraph`.
+On `AlgGraph`, Mokhov's laws hold as ordinary Lean equality while raw
+`Graph` remains available for syntax-directed recursion, compilation,
+and expression metrics.
+
+The module is intentionally proof infrastructure. Existing Pulse and
+Wire modules continue to use raw `Graph` and `GraphEq` until a proof
+needs quotient-level rewriting.
+
+## Theorem Split
+
+The page first proves `GraphEq` is an equivalence and that `overlay` and
+`connect` respect it. It then defines the quotient carrier, lifts the
+graph operations, and restates Mokhov's law set with `=`.
+-/
+
+namespace Cortex.Graph
+
+variable {α : Type} [DecidableEq α]
+
+/-! ## GraphEq Setoid -/
+
+namespace GraphEq
+
+/-- `GraphEq` is reflexive. -/
+theorem refl (g : Graph α) :
+    GraphEq g g :=
+  rfl
+
+/-- `GraphEq` is symmetric. -/
+theorem symm {g h : Graph α}
+    (hEq : GraphEq g h) :
+    GraphEq h g :=
+  Eq.symm hEq
+
+/-- `GraphEq` is transitive. -/
+theorem trans {g h k : Graph α}
+    (hLeft : GraphEq g h)
+    (hRight : GraphEq h k) :
+    GraphEq g k :=
+  Eq.trans hLeft hRight
+
+/-- `overlay` respects denotational equality in both arguments. -/
+theorem overlay {g g' h h' : Graph α}
+    (hLeft : GraphEq g g')
+    (hRight : GraphEq h h') :
+    GraphEq (Graph.overlay g h) (Graph.overlay g' h') := by
+  show
+    Cortex.Graph.denote (Graph.overlay g h) =
+      Cortex.Graph.denote (Graph.overlay g' h')
+  simp only [denote_overlay]
+  rw [
+    show Cortex.Graph.denote g = Cortex.Graph.denote g' from hLeft,
+    show Cortex.Graph.denote h = Cortex.Graph.denote h' from hRight,
+  ]
+
+/-- `connect` respects denotational equality in both arguments. -/
+theorem connect {g g' h h' : Graph α}
+    (hLeft : GraphEq g g')
+    (hRight : GraphEq h h') :
+    GraphEq (Graph.connect g h) (Graph.connect g' h') := by
+  show
+    Cortex.Graph.denote (Graph.connect g h) =
+      Cortex.Graph.denote (Graph.connect g' h')
+  simp only [denote_connect]
+  rw [
+    show Cortex.Graph.denote g = Cortex.Graph.denote g' from hLeft,
+    show Cortex.Graph.denote h = Cortex.Graph.denote h' from hRight,
+  ]
+
+end GraphEq
+
+/-- `graphSetoid α` identifies raw graph expressions with the same denotation. -/
+def graphSetoid (α : Type) [DecidableEq α] : Setoid (Graph α) where
+  r := GraphEq
+  iseqv :=
+    { refl := GraphEq.refl
+      symm := GraphEq.symm
+      trans := GraphEq.trans }
+
+/-! ## Quotient Carrier -/
+
+/-- `AlgGraph α` is the algebraic graph carrier modulo denotational equality. -/
+def AlgGraph (α : Type) [DecidableEq α] : Type :=
+  Quotient (graphSetoid α)
+
+namespace AlgGraph
+
+/-- Embed a raw graph expression into the quotient carrier. -/
+def ofGraph (g : Graph α) : AlgGraph α :=
+  Quotient.mk (graphSetoid α) g
+
+/-- Raw `GraphEq` is exactly equality after embedding into `AlgGraph`. -/
+theorem ofGraph_eq_iff {g h : Graph α} :
+    ofGraph g = ofGraph h ↔ GraphEq g h :=
+  Quotient.eq
+
+/-- Turn a raw `GraphEq` proof into quotient equality. -/
+theorem eq_of_graphEq {g h : Graph α}
+    (hEq : GraphEq g h) :
+    ofGraph g = ofGraph h :=
+  Quotient.sound hEq
+
+/-- Recover raw `GraphEq` from quotient equality between embedded expressions. -/
+theorem graphEq_of_eq {g h : Graph α}
+    (hEq : ofGraph g = ofGraph h) :
+    GraphEq g h :=
+  Quotient.exact hEq
+
+/-- Denote a quotient graph by lifting `Cortex.Graph.denote` from raw graph syntax. -/
+def denote : AlgGraph α → Relation α :=
+  Quotient.lift Cortex.Graph.denote (fun _ _ hEq => hEq)
+
+@[simp]
+theorem denote_ofGraph (g : Graph α) :
+    denote (ofGraph g) = Cortex.Graph.denote g :=
+  rfl
+
+/-- Quotient equality is equality of denotations. -/
+theorem eq_iff_denote_eq (g h : AlgGraph α) :
+    g = h ↔ denote g = denote h := by
+  refine Quotient.inductionOn₂ g h ?_
+  intro rawG rawH
+  change ofGraph rawG = ofGraph rawH ↔ Cortex.Graph.denote rawG = Cortex.Graph.denote rawH
+  exact ofGraph_eq_iff
+
+/-! ## Lifted Operations -/
+
+/-- Empty algebraic graph. -/
+def empty : AlgGraph α :=
+  ofGraph Graph.empty
+
+/-- Singleton-vertex algebraic graph. -/
+def vertex (v : α) : AlgGraph α :=
+  ofGraph (Graph.vertex v)
+
+/-- Algebraic overlay, lifted from raw graph expressions. -/
+def overlay : AlgGraph α → AlgGraph α → AlgGraph α :=
+  Quotient.lift₂
+    (fun g h => ofGraph (Graph.overlay g h))
+    (fun _ _ _ _ hLeft hRight =>
+      Quotient.sound (GraphEq.overlay hLeft hRight))
+
+/-- Algebraic connect, lifted from raw graph expressions. -/
+def connect : AlgGraph α → AlgGraph α → AlgGraph α :=
+  Quotient.lift₂
+    (fun g h => ofGraph (Graph.connect g h))
+    (fun _ _ _ _ hLeft hRight =>
+      Quotient.sound (GraphEq.connect hLeft hRight))
+
+instance : Add (AlgGraph α) where
+  add := overlay
+
+instance : Mul (AlgGraph α) where
+  mul := connect
+
+@[simp]
+theorem overlay_ofGraph (g h : Graph α) :
+    overlay (ofGraph g) (ofGraph h) = ofGraph (Graph.overlay g h) :=
+  rfl
+
+@[simp]
+theorem connect_ofGraph (g h : Graph α) :
+    connect (ofGraph g) (ofGraph h) = ofGraph (Graph.connect g h) :=
+  rfl
+
+@[simp]
+theorem denote_empty :
+    denote (α := α) empty = Relation.empty :=
+  rfl
+
+@[simp]
+theorem denote_vertex (v : α) :
+    denote (vertex v) = Relation.vertex v :=
+  rfl
+
+@[simp]
+theorem denote_overlay (g h : AlgGraph α) :
+    denote (overlay g h) = Relation.overlay (denote g) (denote h) := by
+  refine Quotient.inductionOn₂ g h ?_
+  intro rawG rawH
+  rfl
+
+@[simp]
+theorem denote_connect (g h : AlgGraph α) :
+    denote (connect g h) = Relation.connect (denote g) (denote h) := by
+  refine Quotient.inductionOn₂ g h ?_
+  intro rawG rawH
+  rfl
+
+/-! ## Mokhov Laws as Quotient Equality -/
+
+/-- `empty` is a left identity for quotient overlay. -/
+theorem overlay_empty_left (g : AlgGraph α) :
+    overlay empty g = g := by
+  apply (eq_iff_denote_eq _ _).2
+  simp only [denote_overlay, denote_empty]
+  exact Relation.overlay_empty_left (denote g)
+
+/-- `empty` is a right identity for quotient overlay. -/
+theorem overlay_empty_right (g : AlgGraph α) :
+    overlay g empty = g := by
+  apply (eq_iff_denote_eq _ _).2
+  simp only [denote_overlay, denote_empty]
+  exact Relation.overlay_empty_right (denote g)
+
+/-- `empty` is a two-sided identity for quotient overlay. -/
+theorem overlay_empty (g : AlgGraph α) :
+    overlay empty g = g ∧ overlay g empty = g :=
+  ⟨overlay_empty_left g, overlay_empty_right g⟩
+
+/-- `empty` is a left identity for quotient connect. -/
+theorem connect_empty_left (g : AlgGraph α) :
+    connect empty g = g := by
+  apply (eq_iff_denote_eq _ _).2
+  simp only [denote_connect, denote_empty]
+  exact Relation.connect_empty_left (denote g)
+
+/-- `empty` is a right identity for quotient connect. -/
+theorem connect_empty_right (g : AlgGraph α) :
+    connect g empty = g := by
+  apply (eq_iff_denote_eq _ _).2
+  simp only [denote_connect, denote_empty]
+  exact Relation.connect_empty_right (denote g)
+
+/-- `empty` is a two-sided identity for quotient connect. -/
+theorem connect_empty (g : AlgGraph α) :
+    connect empty g = g ∧ connect g empty = g :=
+  ⟨connect_empty_left g, connect_empty_right g⟩
+
+/-- Quotient overlay is commutative. Mokhov Theorem 1. -/
+theorem overlay_comm (g h : AlgGraph α) :
+    overlay g h = overlay h g := by
+  apply (eq_iff_denote_eq _ _).2
+  simp only [denote_overlay]
+  exact Relation.overlay_comm (denote g) (denote h)
+
+/-- Quotient overlay is associative. Mokhov Theorem 2. -/
+theorem overlay_assoc (g h k : AlgGraph α) :
+    overlay (overlay g h) k = overlay g (overlay h k) := by
+  apply (eq_iff_denote_eq _ _).2
+  simp only [denote_overlay]
+  exact Relation.overlay_assoc (denote g) (denote h) (denote k)
+
+/-- Quotient connect is associative. Mokhov Theorem 4. -/
+theorem connect_assoc (g h k : AlgGraph α) :
+    connect (connect g h) k = connect g (connect h k) := by
+  apply (eq_iff_denote_eq _ _).2
+  simp only [denote_connect]
+  exact Relation.connect_assoc (denote g) (denote h) (denote k)
+
+/-- Quotient connect distributes over overlay on the left. Mokhov Theorem 6. -/
+theorem connect_distrib_overlay_left (g h k : AlgGraph α) :
+    connect g (overlay h k) =
+      overlay (connect g h) (connect g k) := by
+  apply (eq_iff_denote_eq _ _).2
+  simp only [denote_connect, denote_overlay]
+  exact
+    Relation.connect_distrib_overlay_left
+      (denote g)
+      (denote h)
+      (denote k)
+
+/-- Quotient connect distributes over overlay on the right. -/
+theorem connect_distrib_overlay_right (g h k : AlgGraph α) :
+    connect (overlay g h) k =
+      overlay (connect g k) (connect h k) := by
+  apply (eq_iff_denote_eq _ _).2
+  simp only [denote_connect, denote_overlay]
+  exact
+    Relation.connect_distrib_overlay_right
+      (denote g)
+      (denote h)
+      (denote k)
+
+/-- Quotient connect decomposition. Mokhov Theorem 8. -/
+theorem connect_decomposition (g h k : AlgGraph α) :
+    connect (connect g h) k =
+      overlay
+        (overlay (connect g h) (connect g k))
+        (connect h k) := by
+  apply (eq_iff_denote_eq _ _).2
+  simp only [denote_connect, denote_overlay]
+  exact Relation.connect_decomposition (denote g) (denote h) (denote k)
+
+/-! ## Operator Restatements -/
+
+/-- Quotient overlay commutativity through the `+` notation. -/
+theorem overlay_comm_add (g h : AlgGraph α) :
+    g + h = h + g :=
+  overlay_comm g h
+
+/-- Quotient connect associativity through the `*` notation. -/
+theorem connect_assoc_mul (g h k : AlgGraph α) :
+    g * h * k = g * (h * k) :=
+  connect_assoc g h k
+
+/-- Quotient connect decomposition through the `+` and `*` notation. -/
+theorem connect_decomposition_mul (g h k : AlgGraph α) :
+    g * h * k = (g * h) + (g * k) + (h * k) :=
+  connect_decomposition g h k
+
+end AlgGraph
+
+end Cortex.Graph

--- a/theory/Main.lean
+++ b/theory/Main.lean
@@ -21,7 +21,7 @@ proof tracks imported by the root module.
 
 def main : IO Unit := do
   IO.println "Cortex theory — Lean 4 mechanization (scaffold)"
-  IO.println "  Track 1 (Graph algebra) ......... import Cortex.Graph.Core / Laws"
+  IO.println "  Track 1 (Graph algebra) ......... import Cortex.Graph.Quotient"
   IO.println "  Track 2 (Pulse kernel) .......... import Cortex.Pulse.Classify"
   IO.println "  Track 3 (Wire rewrite) .......... import Cortex.Wire.Planner.Construction"
   IO.println ""

--- a/theory/README.md
+++ b/theory/README.md
@@ -27,13 +27,13 @@ slices replace scaffold assumptions with theorems, while unfinished tracks keep 
 `connect`. `Cortex.Graph.Relation` defines the finite relation denotation used by the Haskell
 `toRelation` implementation and proves the Mokhov laws on that denotation with mathlib `Finset`s.
 `Cortex.Graph.Laws` now exposes the AST-facing laws as theorems over denotational equality
-(`GraphEq`), because raw syntax trees are not definitionally equal. The next quotient step
-(`Cortex.Graph.Quotient`, TODO) can lift those denotational laws to ordinary equality on a quotient
-carrier.
+(`GraphEq`), because raw syntax trees are not definitionally equal. `Cortex.Graph.Quotient` defines
+`AlgGraph α`, the quotient of raw graph expressions by `GraphEq`, and lifts the same laws to
+ordinary equality on that algebraic carrier.
 
 **Headline obligation:** `connect_decomposition` (`g · h · k = g · h ⊕ g · k ⊕ h · k`). This is what
 licenses circuit simplification and the executor's compatibility-edge derivation. The relation-level
-theorem now exists; the remaining obligation is lifting it through graph equivalence.
+theorem, denotational AST theorem, and quotient-equality theorem now exist.
 
 ### Track 2 — Fixed-topology Pulse kernel
 
@@ -79,8 +79,7 @@ Mechanized results now include:
 
 The Paper 1 Lean-Haskell modeling boundary is documented in
 `docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md`. Remaining obligations include
-Haskell-side establishment of the persisted recovery preconditions and quotient lifting for the
-graph algebra laws.
+Haskell-side establishment of the persisted recovery preconditions.
 
 ### Track 3 — Rewrite soundness
 
@@ -215,7 +214,7 @@ The repo's pre-commit hook checks theory changes through the flake surface
 | -------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | 1a. Graph relation semantics     | finite relation denotation + Mokhov laws                                                | relation-level laws                                                                                                                                                                                                                            | none        |
 | 1b. Graph denotational AST laws  | AST laws over graph equivalence                                                         | denotational law surface                                                                                                                                                                                                                       | none        |
-| 1c. Graph quotient laws          | lifted quotient equality laws                                                           | pending                                                                                                                                                                                                                                        | none        |
+| 1c. Graph quotient laws          | lifted quotient equality laws                                                           | `AlgGraph` quotient carrier, lifted operations, quotient equality bridge, Mokhov laws as `=`                                                                                                                                                   | none        |
 | 2. Fixed-topology Pulse kernel   | edge-derived DAG/state/fact/frontier/closure/recovery/classification surface            | frontier antichain, direct/runtime frontier bridge, fact commutativity, admissible fact recovery, closure idempotence, topology-domain/output/volatile-state/causal preservation, structural recovery predicate, classification exhaustiveness | none        |
 | 3. Rewrite soundness             | registry-boundary model + proof-carrying rewrite certificate + runtime admission bridge | node/edge registry predicates, runtime planning predicates, acyclicity/contract/budget projections, admitted planned-delta bridge, chain-level preservation, step bound by rewrite-operation budget                                            | none        |
 | 4. Provider / sparks             | —                                                                                       | —                                                                                                                                                                                                                                              | not started |

--- a/theory/lakefile.lean
+++ b/theory/lakefile.lean
@@ -30,6 +30,7 @@ lean_lib «Cortex» where
     `Cortex.Graph.Core,
     `Cortex.Graph.Relation,
     `Cortex.Graph.Laws,
+    `Cortex.Graph.Quotient,
     `Cortex.Pulse.DAG,
     `Cortex.Pulse.State,
     `Cortex.Pulse.Fact,


### PR DESCRIPTION
## Summary

Add a quotient graph carrier for Mokhov graph laws so downstream proofs can use ordinary Lean equality over algebraic graphs while preserving the raw `Graph` AST for syntax-directed recursion and compilation.

## Implemented

- [x] Add `Cortex.Graph.Quotient` with the `GraphEq` setoid and `AlgGraph` quotient carrier.
- [x] Lift `empty`, `vertex`, `overlay`, and `connect` through quotient compatibility proofs.
- [x] Prove Mokhov laws as ordinary equality on the quotient carrier.
- [x] Add raw-AST bridge lemmas between `GraphEq` and quotient equality.
- [x] Wire the new module into `theory/lakefile.lean`, `theory/Cortex.lean`, and theory docs.

## Layer

`Cortex.Graph` / Lean theory. This is proof infrastructure only; it does not change Haskell runtime behavior.

## Validation

- [x] `just lean-lint`
- [x] `just lean-check`
- [x] `just lean-build`
- [x] `just fmt-check`
- [x] `just docs-check`
- [x] `just check-commit-provenance origin/main..HEAD`

## Checklist

- [x] Implementation complete
- [x] Tests/proof coverage added or updated
- [x] `just lean-check` passes locally
- [x] Ready for review

## Issue

Closes #90