### PR TITLE
docs: publish haddock and typst manuscript pages

### DIFF
--- a/docs/Publications/Paper-1-staged-reduction/typst/manuscript.typ
+++ b/docs/Publications/Paper-1-staged-reduction/typst/manuscript.typ
@@ -1,0 +1,772 @@
+#import "../../_typst/cortex-paper.typ": cortex-paper
+
+#let horizontalrule = line(length: 100%)
+
+#show: cortex-paper
+
+= Staged Reduction for Durable Workflow Execution
+<staged-reduction-for-durable-workflow-execution>
+== Abstract
+<abstract>
+We present a durable workflow execution runtime organized as a staged
+pure reduction over fixed algebraic graph topology. Workers produce
+node-local outcomes from an immutable predecessor-complete snapshot. The
+coordinator applies results through three phases with distinct algebraic
+roles: #strong[accumulation] of commutative local facts,
+#strong[closure] under an idempotent failure-propagation operator, and
+#strong[classification] of the resulting state into a lifecycle
+decision. The central claim of the paper is intentionally narrow:
+incremental persistence is #strong[structurally safe] at any point
+during accumulation because recovery normalizes partially persisted
+state and re-closes it before any authoritative lifecycle decision is
+taken. We define the recovered-state validity contract explicitly and
+show how the three-phase decomposition explains both normal execution
+and crash recovery. The paper reports the design as implemented in the
+Pulse runtime, contrasts it with the failure modes of an earlier
+imperative runtime, and supports the implementation claims with
+property-based validation plus a proof sketch of the core structural
+argument. We do not claim end-to-end workflow correctness, outcome
+reproducibility for nondeterministic stages, or topology-changing
+rewrite correctness in this paper.
+
+== Artifact Status
+<artifact-status>
+The fixed-topology kernel is mechanized in Lean 4 under
+`theory/Cortex/Pulse/`; see #link("lean-mechanization.md") for the
+artifact mapping. The boundary between the Lean model and the live
+Haskell runtime is documented in #link("lean-haskell-boundary.md");.
+
+== 1. Introduction
+<1-introduction>
+Durable execution runtimes --- systems that execute long-running
+workflows with crash recovery, signal suspension, and audit trails ---
+must answer a fundamental question: when do you persist state, and what
+invariants does the persisted state satisfy?
+
+Event-sourced runtimes (Temporal \[1\], Azure Durable
+Functions \[2\]) replay workflow code from a command
+journal on crash. This achieves determinism but constrains workflow
+code: no randomness, no direct I/O, no threading. Checkpoint-based
+systems (Flink \[3\], derived from Chandy-Lamport
+\[4\]) snapshot operator state at barriers. DAG-based
+orchestrators (Airflow \[5\], Dagster
+\[6\]) track task instance status but typically treat
+the graph as scheduling metadata rather than as the semantic object that
+defines state transitions.
+
+We take a different approach. In our runtime, the algebraic graph
+topology is the source of the state-transition semantics. The execution
+frontier --- the set of nodes ready to execute --- is an antichain in
+the DAG\'s reachability order (Lemma 1). Workers execute from a common
+snapshot and produce pure result values. The coordinator applies results
+through a staged reduction:
+
++ #strong[Accumulate:] apply each worker\'s result as a commutative
+  point update to graph state.
++ #strong[Close:] propagate failure consequences through the topology
+  via an idempotent closure operator.
++ #strong[Classify:] determine whether the graph is progressing,
+  settled, suspended, or stuck.
+
+The architectural insight is that persistence boundaries align with
+algebraic phase boundaries. Because the closure operator is idempotent,
+the coordinator can persist at any point during accumulation --- even
+mid-frontier --- and recovery can normalize the partial state and
+re-close it before resuming. This removes the need for frontier-atomic
+persistence and makes incremental per-node persistence in the concurrent
+path safe by construction rather than by careful synchronization.
+
+=== 1.1 Context
+<11-context>
+The model is implemented in the Pulse runtime for graph-shaped AI and
+host-action workflows. Pulse manages workflows with 4-20 stages per
+plan, including stages that call external APIs, evaluate model
+responses, and execute multi-step host actions. The staged-reduction
+model replaced an earlier imperative design that used per-worker atomic
+state mutation and ad hoc recovery logic; that design produced persist
+races, duplicated failure propagation, and exception-handling ambiguity
+that motivated the redesign.
+
+=== 1.2 Assumptions and Scope
+<12-assumptions-and-scope>
+The algebra governs state transitions. It does not govern:
+
+- worker I/O (the side effects of stage execution)
+- persistence timing (when the coordinator writes to the database)
+- signal delivery protocol (when external signals arrive)
+- replay policy enforcement (whether irreversible stages may re-execute)
+- topology-changing graph rewriting
+
+These are coordinator responsibilities outside the pure reduction.
+
+Model assumptions:
+
+- finite DAG topology, validated at execution entry
+- node execution is opaque I/O that produces a closed `NodeOutcome`
+  value
+- persistence occurs at coordinator-defined points
+- signal suspension is a first-class node outcome inside the same
+  reduction
+
+Claim boundaries:
+
+- #strong[Claimed in this paper:] structural persistence safety for
+  fixed-topology execution
+- #strong[Not claimed in this paper:] end-to-end workflow correctness,
+  exact outcome reproducibility for nondeterministic stages, or
+  rewrite-capable execution
+
+When outcome reproducibility is discussed, it is conditional on a
+standard piecewise-determinism assumption: re-executed nodes observe the
+same predecessor-complete inputs and produce compatible results.
+Structural safety does not require that assumption; only outcome
+identity does.
+
+== 2. Background
+<2-background>
+=== 2.1 Algebraic Graphs
+<21-algebraic-graphs>
+Mokhov \[7\] introduces an algebraic graph with four
+constructors:
+
+```haskell
+data Graph a
+  = Empty
+  | Vertex a
+  | Overlay (Graph a) (Graph a)
+  | Connect (Graph a) (Graph a)
+
+instance Semigroup (Graph a) where (<>) = Overlay
+instance Monoid (Graph a) where mempty = Empty
+```
+
+Derived combinators build execution topologies declaratively (`edge`,
+`path`, `star`, `clique`). We lower graphs to a `Relation` with cached
+forward and reverse adjacency maps for efficient predecessor and
+successor queries. DAG validation runs at plan construction and again at
+execution entry.
+
+=== 2.2 Graph State
+<22-graph-state>
+For the fixed-topology core considered in this paper:
+
+```haskell
+data NodeStatus
+  = NodePending | NodeRunning | NodeCompleted
+  | NodeFailed  | NodeSkipped | NodeWaiting !Text
+
+data GraphState o = GraphState
+  { gsNodeStatuses :: !(Map NodeId NodeStatus)
+  , gsNodeOutputs  :: !(Map NodeId o)
+  }
+```
+
+A graph is:
+
+- #strong[settled] when no node is Pending or Running
+- #strong[terminal] when settled and either some node is Failed or all
+  nodes are Completed or Skipped
+- #strong[suspended] when at least one node is Waiting and no node is
+  ready
+
+The runtime also has rewrite-capable extensions, but they are
+intentionally out of scope for this paper\'s theorem path.
+
+== 3. The Staged Reduction
+<3-the-staged-reduction>
+```mermaid
+flowchart TB
+  subgraph Pure["Pure Graph Reduction"]
+    A["Node results"]
+    B["Accumulate"]
+    C["Close"]
+    D["Classify"]
+    A --> B --> C --> D
+  end
+
+  subgraph Runtime["Runtime Coordinator"]
+    E["Dispatch frontier"]
+    F["Mark run done"]
+    G["Persist and suspend"]
+    H["Diagnose and fail"]
+  end
+
+  D -->|Progressing| E
+  D -->|Settled| F
+  D -->|Suspended| G
+  D -->|Stuck| H
+```
+
+#emph[Figure 1.] The pure graph reduction (top) processes worker results
+through commutative accumulation, idempotent failure closure, and
+exhaustive lifecycle classification. The runtime coordinator (bottom)
+dispatches frontier work, persists state, and finalizes lifecycle
+outcomes from the classifier\'s verdict.
+
+=== 3.1 Frontier Computation
+<31-frontier-computation>
+The execution frontier is the set of Pending nodes whose predecessors
+are all Completed, Skipped, or Rewritten:
+
+```haskell
+readyNodes :: Relation NodeId -> GraphState o -> [NodeId]
+readyNodes rel state =
+  [ v | v <- Set.toList (relVertices rel)
+      , Map.lookup v (gsNodeStatuses state) == Just NodePending
+      , all (isCompletedOrSkipped state) (Set.toList (predecessors rel v))
+  ]
+```
+
+#strong[Lemma 1 (Frontier antichain).] The ready set forms an antichain
+under reachability.
+
+#emph[Proof.] Suppose frontier nodes $A$ and $B$ are comparable, so
+there is a directed path
+
+$ B = v_0 arrow.r v_1 arrow.r dots.h.c arrow.r v_k = A . $
+
+For $A$ to be ready, $v_(k - 1)$ must be `Completed`, `Skipped`, or
+`Rewritten`. Inducting backward, each $v_i$ for $1 lt.eq i < k$ must be
+`Completed`, `Skipped`, or `Rewritten`; in particular, $B$ must have one
+of those statuses. But frontier membership requires $B$ to be `Pending`.
+Contradiction.
+
+#strong[Consequence.] Frontier nodes update disjoint keys. Workers
+execute from the same predecessor-complete snapshot without sibling
+ordering dependence.
+
+=== 3.2 Node Outcomes and the Forward/Reset Partition
+<32-node-outcomes-and-the-forwardreset-partition>
+Workers produce a closed outcome type:
+
+```haskell
+data NodeOutcome
+  = OutcomeSucceeded Value
+  | OutcomeSkipped
+  | OutcomeSuspendedOn Text
+  | OutcomeNodeFailed FailureDetail
+  | OutcomeNodeTimedOut
+  | OutcomeNodeCancelled
+  | OutcomeNodeShutdown
+  | OutcomeNodeRunCancelled
+```
+
+The outcome type partitions into two classes with different algebraic
+roles:
+
+- #strong[forward outcomes] advance the node\'s status monotonically on
+  the status partial order
+- #strong[reset outcomes] revert the node to Pending and are explicitly
+  non-monotone
+
+Both classes commute for independent frontier nodes because they update
+disjoint keys. Only the forward fragment admits the stronger
+lattice-style monotonicity reading.
+
+=== 3.3 Phase 1: Accumulate
+<33-phase-1-accumulate>
+```haskell
+applyNodeFact :: NodeResult -> GraphState Value -> GraphState Value
+applyNodeFact (NodeResult nid outcome) gs = case outcome of
+  OutcomeSucceeded output ->
+    gs { gsNodeStatuses = Map.insert nid NodeCompleted ...
+       , gsNodeOutputs  = Map.insert nid output ... }
+  OutcomeNodeFailed _ ->
+    gs { gsNodeStatuses = Map.insert nid NodeFailed ... }
+  OutcomeNodeCancelled ->
+    gs { gsNodeStatuses = Map.insert nid NodePending ... }
+  ...
+```
+
+`applyNodeFact` updates only the node\'s own status and output. It does
+not propagate consequences.
+
+#strong[Lemma 2 (Disjoint-key accumulation commutativity).] For frontier
+results $r_A$ and $r_B$ from distinct frontier nodes $A$ and $B$,
+
+= \$\$ \\texttt{applyNodeFact}, r\_A \\circ \\texttt{applyNodeFact}, r\_B
+<-textttapplynodefact-r_a-circ-textttapplynodefact-r_b>
+\\texttt{applyNodeFact}, r\_B \\circ \\texttt{applyNodeFact}, r\_A. \$\$
+
+#emph[Proof.] `applyNodeFact` writes to `gsNodeStatuses` and
+`gsNodeOutputs` at key `nrNodeId` only. For distinct keys
+$k_1 eq.not k_2$,
+
+= \$\$ \\texttt{Map.insert},(k\_1, v\_1) \\circ \\texttt{Map.insert},(k\_2, v\_2)
+<-textttmapinsertk_1-v_1-circ-textttmapinsertk_2-v_2>
+\\texttt{Map.insert},(k\_2, v\_2) \\circ \\texttt{Map.insert},(k\_1,
+v\_1). \$\$
+
+This lemma is deliberately weaker than the shared-state commutativity
+results studied in LVars or CRDTs. Here we exploit disjoint-key point
+updates, not conflict resolution on a shared key.
+
+=== 3.4 Phase 2: Close
+<34-phase-2-close>
+```haskell
+propagateFailure :: Relation NodeId -> GraphState o -> GraphState o
+```
+
+`propagateFailure` marks all reachable Pending and Waiting descendants
+of Failed nodes as Failed. In the implementation, it behaves as a
+closure operator:
+
+- #strong[monotone:] more failures in imply more failures out
+- #strong[extensive:] failures are only added, never removed
+- #strong[idempotent:] applying closure twice yields the same result as
+  once
+
+Extensiveness, monotonicity, and idempotence are mechanized in Lean 4 as
+`propagateFailure_extensive`, `propagateFailure_monotone`, and
+`propagateFailure_idempotent` (see #link("lean-mechanization.md");).
+
+==== Definition 1 (Valid recovered graph state)
+<definition-1-valid-recovered-graph-state>
+Let $G$ be a fixed DAG and $g s$ a graph state after recovery
+normalization and closure. We say
+$"wellFormedGraphState" \( G \, g s \)$ holds iff:
+
++ $"dom" \( g s N o d e S t a t u s e s \) = V \( G \)$
++ $"dom" \( g s N o d e O u t p u t s \) subset.eq V \( G \)$
++ a node has an output iff its status is `NodeCompleted` or
+  `NodeRewritten`
++ no node is `NodeRunning` or `NodeInterrupted`
++ every `Pending` or `Waiting` descendant of a `Failed` node is itself
+  `Failed`
++ $mono("readyNodes") \( G \, g s \)$ is exactly the set of `Pending`
+  nodes all of whose predecessors are `Completed`, `Skipped`, or
+  `Rewritten`
+
+Items 5 and 6 are properties of the closed, normalized state used for
+classification and resume. Arbitrary mid-accumulation persisted
+snapshots need not satisfy them before normalization and closure.
+
+==== Proposition 1 (Structural persistence safety, conditional on closure laws)
+<proposition-1-structural-persistence-safety-conditional-on-closure-laws>
+Assuming the closure laws above, let $S$ be a frontier result set and
+let $S' subset.eq S$ be the prefix whose facts were durably persisted
+before a crash. Define:
+
+```haskell
+gsPersisted  = foldl' (flip applyNodeFact) gs0 S'
+gsRecovered  = propagateFailure G (resetRunningToPending gsPersisted)
+```
+
+Then `gsRecovered` is a valid recovered graph state. In particular,
+`readyNodes G gsRecovered` is a correct resume frontier from which
+execution may continue without corrupting graph structure.
+
+#emph[Proof sketch.] The proof obligation breaks into named parts:
+
++ #strong[Domain preservation.] `applyNodeFact` only updates keys
+  already present in the topology-indexed status and output maps, so
+  accumulation never introduces out-of-topology node ids.
++ #strong[Normalization.] `resetRunningToPending` preserves domains and
+  outputs while removing volatile `NodeRunning` and `NodeInterrupted`
+  markers that may remain after a crash.
++ #strong[Closure completeness.] `propagateFailure` preserves domains
+  and saturates all propagatable descendants of failed nodes,
+  establishing item 5 of Definition 1.
++ #strong[Frontier correctness.] `readyNodes` is an extensional test of
+  item 6: it selects exactly the Pending nodes whose predecessors are
+  Completed or Skipped.
++ #strong[Resume safety under additional facts.] When unpersisted nodes
+  re-execute, re-closing cannot invalidate already propagated failures
+  because closure is idempotent and monotone.
+
+The proposition is therefore a structural statement: the recovered graph
+state is normalized, closed, and schedulable. It does not prove that
+replayed worker I/O yields the same business result as the pre-crash
+execution.
+
+Proposition 1 is mechanized in Lean 4 as `persistence_safety` in
+`theory/Cortex/Pulse/Recovery.lean` (see
+#link("lean-mechanization.md");). The Lean theorem is conditional on
+persisted topology-domain, output-ownership, output-completeness, and
+causal-history preconditions, which the runtime must establish at the
+persistence boundary.
+
+=== 3.5 Phase 3: Classify
+<35-phase-3-classify>
+```haskell
+data StepResult
+  = Progressing (GraphState Value) [NodeId]
+  | Settled (GraphState Value) RunOutcome
+  | Suspended (GraphState Value)
+  | Stuck (GraphState Value) StuckDiagnostic
+
+classifyGraphState :: Relation NodeId -> GraphState Value -> StepResult
+classifyGraphState rel gs0 =
+  let gs = propagateFailure rel gs0
+      frontier = readyNodes rel gs
+  in case frontier of
+       (_:_) -> Progressing gs frontier
+       []    -> if allSettled rel gs
+                then Settled gs (if hasFailedNodes rel gs then OutcomeFailed else OutcomeCompleted)
+                else if hasWaitingNodes gs then Suspended gs
+                else Stuck gs (diagnoseStuck rel gs)
+```
+
+The four-way classification is exhaustive by construction:
+
+- non-empty frontier implies `Progressing`
+- otherwise, settled graphs are `Settled`
+- otherwise, waiting-without-frontier graphs are `Suspended`
+- everything else is `Stuck`
+
+The coordinator is a thin I/O interpreter over this pure classification.
+
+=== 3.6 Composition: Sequential and Concurrent
+<36-composition-sequential-and-concurrent>
+The three phases compose differently in the two execution strategies:
+
+- #strong[Sequential:] for each node in the frontier, accumulate one
+  fact, close, classify, persist, observe, maybe continue
+- #strong[Concurrent:] accumulate all facts, close once, classify once,
+  observe once
+
+Both converge to the same closed final state given the same `NodeResult`
+values. They differ only in observation schedule: the sequential path
+may observe intermediate classifications and short-circuit earlier,
+while the concurrent path defers observation to the batch boundary.
+
+The formal composition is:
+
+```haskell
+applyFrontierResults :: Relation NodeId -> [NodeResult] -> GraphState Value -> StepResult
+applyFrontierResults rel results gs =
+  classifyGraphState rel (foldl' (flip applyNodeFact) gs results)
+```
+
+#strong[Proposition 2 (Permutation invariance).] `applyFrontierResults`
+is invariant under permutation of `results`.
+
+#emph[Proof.] By Lemma 2, the accumulation fold is permutation-invariant
+for distinct-key frontier results. `propagateFailure` and
+`classifyGraphState` are deterministic functions of the accumulated
+state. QED.
+
+The Lean theorem `NodeResult.applyNodeFacts_perm_invariant` mechanizes
+the fold-level accumulation claim for distinct node keys.
+
+=== 3.7 Crash Recovery
+<37-crash-recovery>
+Recovery requires no event-log replay:
+
+```haskell
+gs0 <- readPersistedState
+gs1 <- resolveDeliveredSignals gs0
+let gs2 = resetRunningToPending gs1
+let step = classifyGraphState topology gs2
+```
+
+The persisted state may reflect a partially completed frontier: some
+nodes may already be Completed, some may still be Running, and some
+consequences of failure may not yet have been closed. Recovery
+normalizes this partial state and then re-enters the same pure reduction
+used during ordinary execution.
+
+=== 3.8 Signal Suspension
+<38-signal-suspension>
+Suspension flows through the same staged reduction. `OutcomeSuspendedOn`
+maps to `NodeWaiting` via `applyNodeFact`. When `classifyGraphState`
+finds waiting nodes and no frontier, the result is `Suspended`. Signal
+delivery records the payload and conditionally wakes the run. On resume,
+`resolveDeliveredSignals` transitions delivered waits into completed
+nodes with the signal payload as output.
+
+A run can have both waiting and progressing nodes simultaneously;
+suspension occurs only when no further progress is possible without
+signal delivery.
+
+=== 3.9 Worked Examples
+<39-worked-examples>
+==== 3.9.1 Normal completion on a diamond
+<391-normal-completion-on-a-diamond>
+Consider the DAG
+
+$ alpha arrow.r beta \, #h(2em) alpha arrow.r gamma \, #h(2em) beta arrow.r delta \, #h(2em) gamma arrow.r delta . $
+
+Initial state:
+
+- $alpha$ is `Pending`
+- $beta$ is `Pending`
+- $gamma$ is `Pending`
+- $delta$ is `Pending`
+
+Step 1:
+
+- the frontier is ${ alpha }$
+- worker returns `OutcomeSucceeded a`
+- accumulate writes $alpha$ as `Completed`, with `output(alpha) = a`
+- close is a no-op
+- classify yields `Progressing [beta, gamma]`
+
+Step 2:
+
+- $beta$ and $gamma$ run from the same predecessor-complete snapshot
+- workers return `OutcomeSucceeded b` and `OutcomeSucceeded c`
+- accumulate writes two disjoint-key updates; order does not matter by
+  Lemma 2
+- close is a no-op
+- classify yields `Progressing [delta]`
+
+Step 3:
+
+- worker returns `OutcomeSucceeded d`
+- accumulate writes $delta$ as `Completed`
+- close is a no-op
+- classify yields `Settled OutcomeCompleted`
+
+The example shows the main path of the staged reduction: local facts
+first, global consequences second, lifecycle decision last.
+
+==== 3.9.2 Mid-frontier crash and recovery
+<392-mid-frontier-crash-and-recovery>
+Use the same diamond after $alpha$ has already completed. The frontier
+is ${ beta \, gamma }$.
+
+Suppose:
+
+- $gamma$ finishes and its fact is persisted
+- $beta$ is still `Running`
+- the process crashes before the frontier is fully observed and closed
+
+Persisted pre-crash state:
+
+- $alpha$ is `Completed`
+- $gamma$ is `Completed`
+- $beta$ is `Running`
+- $delta$ is `Pending`
+
+Recovery performs:
+
++ `resetRunningToPending`, yielding $beta$ as `Pending`
++ `propagateFailure`, which is a no-op because no failure has been
+  persisted yet
++ `classifyGraphState`, which yields `Progressing [beta]`
+
+Now $beta$ re-executes and returns `OutcomeNodeFailed`. After
+accumulation and closure:
+
+- $beta$ is `Failed`
+- $delta$ is `Failed` by failure propagation
+- classify yields `Settled OutcomeFailed`
+
+If the crash had happened after $beta$\'s failure was persisted but
+before global observation, recovery would simply close the already
+persisted failure and classify the same settled failed state. The
+important point is not that the pre-crash and post-crash histories are
+textually identical; it is that the recovered state remains structurally
+valid and resumes from a correct frontier.
+
+== 4. Implementation
+<4-implementation>
+The current prototype comprises approximately 1100 lines of pure
+graph-reduction code plus approximately 1700 lines of runtime
+coordination code. The pure layer implements graph algebra, frontier
+computation, failure closure, and classification. The coordinator
+handles persistence, logging, cancellation, and worker scheduling.
+
+The concurrent path dispatches workers with bounded parallelism. The
+theory permits persistence at any coordinator-chosen prefix of
+accumulation; the current implementation still centralizes
+close-and-classify at the frontier observation boundary.
+
+Execution-entry DAG validation ensures cyclic topologies are rejected
+before any stage executes.
+
+=== 4.1 Property-Based Validation
+<41-property-based-validation>
+The implementation-level claims are backed by QuickCheck property tests
+on randomly generated DAGs:
+
+#figure(
+  align(center)[#table(
+    columns: 3,
+    align: (auto,auto,auto,),
+    table.header([Property], [Paper ref], [Test evidence],),
+    table.hline(),
+    [Frontier antichain (Lemma 1)], [§3.1], [No two `readyNodes` have a
+    reachability relationship],
+    [Disjoint-key commutativity (Lemma 2)], [§3.3], [`applyNodeFact`
+    commutes for pairs of distinct frontier nodes],
+    [Permutation invariance], [§3.6], [`applyFrontierResults` gives the
+    same result under `shuffle`],
+    [Closure idempotence], [§3.4], [`propagateFailure` applied twice
+    equals applied once],
+    [Closure extensiveness], [§3.4], [Failure count never decreases
+    after propagation],
+    [Closure monotonicity], [§3.4], [More failures in yields more
+    failures out],
+    [Recovery normalization], [§3.4, §3.7], [Partial frontier +
+    `resetRunningToPending` + classify yields a valid closed state],
+    [Sequential = batch], [§3.6], [Fold of single-element
+    `applyFrontierResults` matches batch application],
+  )]
+  , kind: table
+  )
+
+Several of these properties are now mechanized in Lean 4 --- frontier
+antichain, disjoint-key commutativity and fold permutation, closure
+extensiveness, monotonicity, idempotence, recovery normalization, and
+classification exhaustiveness --- and the artifacts are listed in
+#link("lean-mechanization.md");. The QuickCheck tests remain runtime
+evidence on the live Haskell implementation; they are not a substitute
+for the Lean proof surface.
+
+== 5. Failure Modes Addressed by the Redesign
+<5-failure-modes-addressed-by-the-redesign>
+The table below is a design-level comparison between the earlier
+imperative runtime and the staged-reduction model. It states which
+failure classes the redesign removes structurally; it is not a
+quantitative operational evaluation.
+
+#figure(
+  align(center)[#table(
+    columns: 3,
+    align: (auto,auto,auto,),
+    table.header([Failure mode], [Prior design], [Staged reduction],),
+    table.hline(),
+    [#strong[Persist race];], [Workers persist independently; stale
+    snapshots overwrite], [Coordinator-controlled partial persist;
+    recovery re-closes state],
+    [#strong[Interleaved mutation];], [Workers read and write shared
+    coordinator state], [Workers get immutable snapshots and return
+    values],
+    [#strong[Cancellation complexity];], [Monitor + terminal flags +
+    exception discrimination], [Cancelled workers produce `NodeResult`;
+    algebra handles reset],
+    [#strong[Failure propagation drift];], [Duplicated in worker paths
+    and collector logic], [Single `propagateFailure`, pure, tested
+    independently],
+    [#strong[Recovery ambiguity];], [Event log reconstruction or
+    frontier-atomic persist], [State normalization:
+    `resetRunningToPending` + close + classify],
+  )]
+  , kind: table
+  )
+
+== 6. Related Work
+<6-related-work>
+The accumulation lemma here is a disjoint-key commutativity result. It
+is related in spirit to lattice-based determinism (LVars
+\[8\]) and CRDTs \[10\], but
+substantially weaker: we do not solve shared-key merge semantics, only
+independent point updates. The analogy is architectural rather than
+technical identity.
+
+The CALM theorem \[11\] still provides a useful reading
+of the design. Accumulation is coordination-free, while lifecycle
+classification is a threshold observation that requires a barrier. The
+frontier boundary is therefore the coordination boundary.
+
+Petri-net work on concurrent processes \[9\] is relevant
+because the frontier is an antichain of concurrently enabled work, but
+again the correspondence is suggestive rather than complete. Our runtime
+uses a much narrower operational fragment.
+
+Henrio et al. \[12\] provide a recent mechanized
+account of layered confluence for actor systems. That is a useful
+comparison point for the worker-coordinator topology, but we do not
+derive our theorem from their framework here.
+
+Temporal \[1\] constrains workflow code to be
+deterministic; we constrain only the coordinator\'s reduction. Within
+Elnozahy et al.\'s recovery taxonomy \[13\], our
+approach is coordinated checkpointing at frontier barriers, justified by
+closure idempotence rather than by replay from a command log.
+
+Haxl \[14\] and the Par monad \[15\]
+exploit independence for deterministic parallelism; our contribution
+extends that design pressure to long-running durable tasks with crash
+recovery and signal suspension.
+
+== 7. Discussion
+<7-discussion>
+=== 7.1 Structural Safety Versus End-to-End Correctness
+<71-structural-safety-versus-end-to-end-correctness>
+The main theorem is intentionally a structural theorem. It says the
+recovered graph state is well-formed, closed, and schedulable. It does
+not say the application-level result is identical across crashes,
+because that depends on stage I/O semantics that the algebra does not
+govern.
+
+This is a deliberate design choice, not a hidden gap. The paper\'s
+contribution is to isolate the part of the system that can be reasoned
+about compositionally and test it against a precise contract.
+
+=== 7.2 Recovery Cost
+<72-recovery-cost>
+Frontier-wave replay may re-execute completed work on crash, which
+asynchronous snapshotting systems such as Flink can sometimes avoid. The
+trade-off is a much simpler coordinator model and a narrower persistence
+theorem. Incremental per-node persistence reduces the replay cost in
+practice because only work whose facts were not durably observed must
+re-run.
+
+=== 7.3 The Forward/Reset Boundary
+<73-the-forwardreset-boundary>
+The node-outcome type partitions into monotone forward outcomes and
+explicitly non-monotone reset outcomes. The monotone core admits the
+cleaner algebraic story. Reset outcomes commute only because they remain
+node-local. This boundary is the honest edge of the model and should
+remain explicit.
+
+=== 7.4 Boundary to Topology-Changing Execution
+<74-boundary-to-topology-changing-execution>
+Dynamic graph rewriting is no longer treated as part of this paper\'s
+theorem path. Once topology changes mid-run, the fixed-topology
+structural-safety theorem stated here is insufficient. Rewrite-capable
+execution needs an additional materialization boundary, durable identity
+story, and recovery theorem. That is now a separate paper track.
+
+== 8. Conclusion
+<8-conclusion>
+The central result is a staged pure reduction for fixed-topology durable
+workflow execution:
+
++ #strong[Accumulate] commutative local facts from workers.
++ #strong[Close] under an idempotent failure-propagation operator.
++ #strong[Classify] the resulting state into a lifecycle decision.
+
+The architectural insight is that persistence boundaries align with
+these algebraic phase boundaries. Incremental persistence during
+accumulation is structurally safe because recovery normalizes partial
+state and re-closes it before any authoritative lifecycle decision is
+taken.
+
+The runtime is not claimed correct because every worker interleaving is
+directly controlled. It is claimed structurally safe because worker
+results accumulate into a state that is normalized, closed, and
+classified by a pure algebra with explicit assumptions and boundaries.
+
+== References
+<references>
++ Temporal Technologies. #emph[Temporal];. #link("https://temporal.io")
++ Microsoft. #emph[Azure Durable Functions];.
+  #link("https://learn.microsoft.com/en-us/azure/azure-functions/durable/")
++ Carbone, P. et al. (2015). #emph[Lightweight Asynchronous Snapshots
+  for Distributed Dataflows];.
+  arXiv:#link("https://arxiv.org/abs/1506.08603")[1506.08603];.
++ Chandy, K. M., Lamport, L. (1985). #emph[Distributed Snapshots];. ACM
+  TOCS 3(1):63--75.
++ Apache Software Foundation. #emph[Apache Airflow];.
+  #link("https://airflow.apache.org")
++ Dagster Labs. #emph[Dagster];. #link("https://dagster.io")
++ Mokhov, A. (2017). #emph[Algebraic Graphs with Class];. Haskell 2017.
++ Kuper, L., Newton, R. (2013). #emph[LVars: Lattice-based Data
+  Structures for Deterministic Parallelism];. FHPC 2013.
++ Best, E., Devillers, R. (1987). #emph[Sequential and Concurrent
+  Behaviour in Petri Net Theory];. TCS 55:87--136.
++ Shapiro, M. et al. (2011). #emph[Conflict-free Replicated Data Types];.
+  SSS 2011.
++ Conway, N. et al. (2012). #emph[Logic and Lattices for Distributed
+  Programming];. SoCC 2012.
++ Henrio, L. et al. (2026). #emph[Layers of Confluence for Actors];. CPP
+  2026.
++ Elnozahy, E. et al. (2002). #emph[A Survey of Rollback-Recovery
+  Protocols];. ACM Computing Surveys 34(3):375--408.
++ Marlow, S. et al. (2014). #emph[There is No Fork];. ICFP 2014.
++ Marlow, S. et al. (2011). #emph[A Monad for Deterministic
+  Parallelism];. Haskell 2011.

--- a/docs/Publications/Paper-1-staged-reduction/typst/repo-docs-typst.json
+++ b/docs/Publications/Paper-1-staged-reduction/typst/repo-docs-typst.json
@@ -1,0 +1,11 @@
+{
+  "entry": "manuscript.typ",
+  "output": "manuscript.pdf",
+  "route": "Publications/Paper-1-staged-reduction/typeset-manuscript",
+  "title": "Paper 1 - Staged Reduction",
+  "description": "First-pass Typst PDF rendering of the staged reduction manuscript.",
+  "sidebar": {
+    "label": "Typeset PDF",
+    "order": 2
+  }
+}

--- a/docs/Publications/Paper-2-algebraic-foundations/typst/manuscript.typ
+++ b/docs/Publications/Paper-2-algebraic-foundations/typst/manuscript.typ
@@ -1,0 +1,392 @@
+#import "../../_typst/cortex-paper.typ": cortex-paper
+
+#let horizontalrule = line(length: 100%)
+
+#show: cortex-paper
+
+= Algebraic Foundations of Staged Durable Execution
+<algebraic-foundations-of-staged-durable-execution>
+== Abstract
+<abstract>
+We develop an algebraic account of durable workflow execution organized
+as a staged reduction: commutative fact accumulation, idempotent failure
+closure, and deterministic state classification. The core object is not
+a workflow program trace but a topology-indexed graph state together
+with a validity predicate for normalized, closed states. We separate
+three layers of obligation: algebraic facts about accumulation, closure,
+and classification; structural recovery theorems for fixed-topology
+execution; and external assumptions about worker I/O reproducibility.
+The result is a sharper statement of what the runtime proves, what it
+merely assumes, and what is deferred to mechanization. We also
+characterize the extension boundary: which changes preserve the staged
+reduction and which require a different machine. Topology-changing graph
+rewriting is treated as one such boundary and is excluded from the core
+theory of this paper.
+
+#horizontalrule
+
+== 1. Core Model
+<1-core-model>
+=== 1.1 Graphs, States, and Validity
+<11-graphs-states-and-validity>
+Let $G = \( V \, E \)$ be a finite DAG. A graph state consists of:
+
+- a total status map $s t a t u s : V arrow.r N o d e S t a t u s$
+- a partial output map $o u t p u t : V harpoon.rt V a l u e$
+
+For the fixed-topology core:
+
+$ N o d e S t a t u s = upright("Pending") divides upright("Running") divides upright("Completed") divides upright("Failed") divides upright("Skipped") divides upright("Waiting") \( s i g n a l \) $
+
+We distinguish three kinds of states:
+
+- #strong[mid-accumulation states];, which may still contain
+  $upright("Running")$
+- #strong[normalized states];, after `resetRunningToPending`
+- #strong[closed states];, after `propagateFailure`
+
+The main validity predicate is defined only on normalized, closed
+states.
+
+#strong[Definition 1 (`wellFormedGraphState`).]
+$"wellFormedGraphState" \( G \, s \)$ holds iff:
+
++ $"dom" \( s t a t u s \) = V$
++ $"dom" \( o u t p u t \) subset.eq V$
++ outputs appear exactly on statuses that semantically carry outputs
++ no node is $upright("Running")$ or $upright("Interrupted")$
++ every $upright("Pending")$ or $upright("Waiting")$ descendant of a
+  $upright("Failed")$ node is itself $upright("Failed")$
++ $"readyNodes" \( G \, s \)$ is extensionally equal to the readiness
+  predicate: nodes that are $upright("Pending")$ and whose predecessors
+  are all $upright("Completed")$, $upright("Skipped")$, or
+  $upright("Rewritten")$
+
+This definition is intentionally relative to fixed topology. Once
+topology changes, the validity contract must be enriched with
+materialization and identity invariants.
+
+=== 1.2 The Staged Machine
+<12-the-staged-machine>
+The fixed-topology runtime factors as:
+
+$ "reduce" \( G \, R \, s \) = "classify" \( G \, "close" \( G \, "accumulate" \( R \, s \) \) \) $
+
+Where:
+
+- `accumulate = foldl (flip applyNodeFact)`
+- `close = propagateFailure`
+- `classify = classifyGraphState`
+
+The execution model uses barriered frontier waves, but the algebraic
+core only sees a set of node-local facts and a topology-indexed state.
+
+#horizontalrule
+
+== 2. Algebraic Structure
+<2-algebraic-structure>
+=== 2.1 Accumulation as a Commutative Action
+<21-accumulation-as-a-commutative-action>
+Let `F` be the free commutative monoid of `NodeResult` values with
+distinct `NodeId`s. Distinctness is justified by the frontier antichain
+property.
+
+`applyNodeFact` induces a monoid action:
+
+$ "act" : F times G r a p h S t a t e arrow.r G r a p h S t a t e $
+
+$ "act" \( S \, s \) = "foldl" \( "flip" med a p p l y N o d e F a c t \, med s \, med S \) $
+
+The load-bearing property is not a deep join law on shared state. It is
+the more modest disjoint-key commutativity of point updates.
+
+#strong[Lemma 1 (disjoint-key commutativity).] If
+$r_1 . n i d eq.not r_2 . n i d$, then:
+
+= \$\$ applyNodeFact\\ r\_1\\ (applyNodeFact\\ r\_2\\ s)
+<-applynodefact-r_1-applynodefact-r_2-s>
+applyNodeFact\\ r\_2\\ (applyNodeFact\\ r\_1\\ s) \$\$
+
+This is the precise theorem. References to LVars, CRDTs, and related
+work should be read as analogies in design style, not as direct reuse of
+their stronger shared-key commutativity results.
+
+=== 2.2 Failure Closure
+<22-failure-closure>
+`propagateFailure` is treated as a closure operator on the preorder
+\"has at least as many failed consequences as\":
+
+- extensive
+- monotone
+- idempotent
+
+These laws are what make partial persistence structurally safe. In this
+draft they are stated as semantic obligations of the implementation and
+deferred to the Lean mechanization plan.
+
+=== 2.3 Classification
+<23-classification>
+`classifyGraphState` is a deterministic decision procedure on
+normalized, closed states:
+
+- `Progressing` if some node is ready
+- `Settled` if all nodes are terminal
+- `Suspended` if some node is waiting and no node is ready
+- `Stuck` otherwise
+
+The case split is by construction once readiness, terminality, and
+waiting are fixed.
+
+=== 2.4 Determinism of the Staged Reduction
+<24-determinism-of-the-staged-reduction>
+#strong[Theorem 2 (staged reduction determinism).] For any permutation
+$pi$ of a frontier result set:
+
+$ "reduce" \( G \, pi \( r e s u l t s \) \, s \) = "reduce" \( G \, r e s u l t s \, s \) $
+
+The theorem is conditional on the identity of `NodeResult` values. It is
+a theorem about reduction order, not about worker I/O behavior.
+
+#horizontalrule
+
+== 3. Structural Recovery Safety
+<3-structural-recovery-safety>
+=== 3.1 Theorem Statement
+<31-theorem-statement>
+Let $S = S_1 union S_2$ be a frontier result set, where $S_1$ is the
+subset whose local facts were durably persisted before a crash and $S_2$
+is the subset that must be replayed. Define:
+
+$ s_(p e r s i s t e d) = "accumulate" \( S_1 \, s_0 \) $
+
+$ s_(r e c o v e r e d) = "close" \( G \, "resetRunningToPending" \( s_(p e r s i s t e d) \) \) $
+
+#strong[Theorem 3 (structural recovery safety).] $s_(r e c o v e r e d)$
+satisfies $"wellFormedGraphState" \( G \, s_(r e c o v e r e d) \)$.
+
+Moreover:
+
+- $"readyNodes" \( G \, s_(r e c o v e r e d) \)$ is a correct resume
+  frontier
+- re-closing after replayed facts are accumulated preserves already
+  derived failures
+
+=== 3.2 What the Theorem Does and Does Not Say
+<32-what-the-theorem-does-and-does-not-say>
+The theorem guarantees:
+
+- topology-indexed domain consistency
+- removal of transient `Running`
+- closure completeness
+- frontier correctness
+- schedulable recovery from any persisted accumulation prefix
+
+The theorem does #strong[not] guarantee:
+
+- identical business outputs after replay
+- identical worker exceptions or timing
+- end-to-end correctness of the whole workflow system
+
+Those stronger properties require assumptions or proof obligations
+outside the staged reduction itself.
+
+=== 3.3 Dependency Structure
+<33-dependency-structure>
+The theorem depends on four obligations:
+
++ `applyNodeFact` preserves topology-indexed domains
++ `resetRunningToPending` preserves domains and removes all `Running`
++ `propagateFailure` is a closure operator and preserves domain
+  consistency
++ `readyNodes` is sound and complete for the readiness predicate
+
+Only after these are stated explicitly does the recovery theorem stop
+being circular.
+
+=== 3.4 Proof Status
+<34-proof-status>
+#figure(
+  align(center)[#table(
+    columns: 3,
+    align: (auto,auto,auto,),
+    table.header([Claim], [Status in this draft], [Intended home],),
+    table.hline(),
+    [Frontier antichain], [sketchable from DAG readiness], [Paper 1 +
+    Paper 2],
+    [Disjoint-key commutativity], [direct proof], [Paper 1 + Paper 2],
+    [Closure extensiveness / monotonicity / idempotence], [stated as
+    obligations, not fully proved here], [Lean mechanization plan],
+    [Structural recovery safety], [stated sharply, proof outline
+    only], [Lean mechanization plan + Paper 2],
+    [Outcome reproducibility under replay], [external
+    assumption], [outside the algebra],
+  )]
+  , kind: table
+  )
+
+The point of the table is discipline: this paper should never silently
+upgrade \"tested in implementation\" into \"proved in theory.\"
+
+#horizontalrule
+
+== 4. The Forward Fragment and the Reset Boundary
+<4-the-forward-fragment-and-the-reset-boundary>
+=== 4.1 Forward Fragment
+<41-forward-fragment>
+The forward statuses form the local monotone fragment:
+
+$ upright("Pending") & lt.eq upright("Running") lt.eq upright("Completed")\
+upright("Pending") & lt.eq upright("Running") lt.eq upright("Failed")\
+upright("Pending") & lt.eq upright("Running") lt.eq upright("Skipped")\
+upright("Pending") & lt.eq upright("Running") lt.eq upright("Waiting") \( s i g n a l \) $
+
+Forward outcomes move upward in this partial order. This fragment
+supports the cleanest algebraic reading.
+
+=== 4.2 Reset Boundary
+<42-reset-boundary>
+Cancellation, shutdown, and crash normalization are explicitly
+non-monotone. They do not invalidate the staged reduction, but they do
+invalidate any claim that the runtime is globally monotone.
+
+This separation should remain explicit:
+
+- the forward fragment supports the order-theoretic story
+- reset behavior is handled constitutionally by keeping resets
+  node-local and coordinator-controlled
+
+#horizontalrule
+
+== 5. Extension Boundary
+<5-extension-boundary>
+The staged reduction has three load-bearing invariants:
+
+- #strong[I.] accumulation commutativity for frontier facts
+- #strong[II.] closure idempotence
+- #strong[III.] frontier antichain / readiness soundness
+
+=== 5.1 Extensions That Preserve the Core
+<51-extensions-that-preserve-the-core>
+#figure(
+  align(center)[#table(
+    columns: 5,
+    align: (auto,auto,auto,auto,auto,),
+    table.header([Extension], [I], [II], [III], [Reason],),
+    table.hline(),
+    [new node-local forward outcome], [yes], [yes], [yes], [still a
+    point update],
+    [richer classification output], [yes], [yes], [yes], [classification
+    is observational],
+    [additional closure commuting with failure
+    closure], [yes], [conditionally], [yes], [composition of commuting
+    closures],
+    [edge annotations preserving DAG readiness
+    semantics], [yes], [yes], [conditionally], [if readiness stays
+    predecessor-based],
+  )]
+  , kind: table
+  )
+
+=== 5.2 Extensions That Cross the Boundary
+<52-extensions-that-cross-the-boundary>
+#figure(
+  align(center)[#table(
+    columns: 3,
+    align: (auto,auto,auto,),
+    table.header([Extension], [Broken invariant], [Why],),
+    table.hline(),
+    [inter-node mutation in accumulation], [I], [facts no longer commute
+    by disjoint key],
+    [compensating or oscillating propagation], [II], [closure may stop
+    being idempotent],
+    [topology mutation during accumulation], [III], [frontier and
+    closure are computed over moving topology],
+    [shared-key accumulation without a merge algebra], [I], [update
+    order becomes observable],
+  )]
+  , kind: table
+  )
+
+Topology-changing execution is therefore not \"just another extension.\"
+It requires a different machine and a different safety theorem.
+
+#horizontalrule
+
+== 6. Relation to Other Models
+<6-relation-to-other-models>
+=== 6.1 CALM
+<61-calm>
+The CALM theorem remains a useful interpretation:
+
+- accumulation is coordination-free
+- classification is a threshold observation
+- frontier barriers are the coordination boundary
+
+This is an architectural reading, not a formal reduction of the runtime
+to CALM.
+
+=== 6.2 CKA and BSP
+<62-cka-and-bsp>
+The runtime resembles a BSP-style fragment of concurrent Kleene algebra:
+
+$ \( upright("wave")_1 med upright("workers") \) ; upright("close") ; upright("classify") ; \( upright("wave")_2 med upright("workers") \) ; upright("close") ; upright("classify") ; dots.h.c $
+
+This is useful for intuition about barriered parallel composition, but
+we do not claim a full CKA embedding here.
+
+=== 6.3 Actor Confluence Work
+<63-actor-confluence-work>
+Henrio et al.\'s layered confluence results for actors are relevant
+because our system is also a worker-coordinator architecture. The key
+difference is that our workers are constitutionally restricted to
+node-local facts, which gives a narrower and stronger commutativity
+condition than arbitrary actor messaging.
+
+#horizontalrule
+
+== 7. Open Problems
+<7-open-problems>
++ #strong[Mechanize the closure laws.] This is the main proof debt and
+  the central purpose of the Lean mechanization plan.
++ #strong[Characterize the closed-state subspace.] The closure operator
+  suggests a useful sub-poset of normalized states, but its exact
+  algebraic structure is still only partly understood.
++ #strong[Weaken replay assumptions.] Structural safety needs less than
+  outcome identity. The weakest useful replay-compatibility condition is
+  still open.
++ #strong[Separate theory for topology-changing execution.]
+  Rewrite-capable execution requires a materialization boundary, durable
+  identity scheme, and different recovery theorem. That is the subject
+  of the rewrite materialization and recovery plan.
+
+#horizontalrule
+
+== 8. Takeaway
+<8-takeaway>
+The point of the algebraic foundations paper is not to inflate an
+implementation sketch into a fake theorem. It is to isolate the exact
+mathematical kernel of the fixed-topology runtime:
+
+- node-local facts commute by disjoint key
+- failure closure is the load-bearing closure operator
+- classification is a deterministic read on normalized, closed states
+- structural recovery safety follows only after validity is defined
+  explicitly
+
+Everything stronger must either be proved elsewhere, or named honestly
+as an assumption.
+
+== References
+<references>
++ Kuper, L., Newton, R. (2013). #emph[LVars: Lattice-based Data
+  Structures for Deterministic Parallelism];. FHPC 2013.
++ Shapiro, M. et al. (2011). #emph[Conflict-free Replicated Data Types];.
+  SSS 2011.
++ Conway, N. et al. (2012). #emph[Logic and Lattices for Distributed
+  Programming];. SoCC 2012.
++ Hoare, C. A. R., Möller, B., Struth, G., Wehrman, I. (2009).
+  #emph[Foundations of Concurrent Kleene Algebra];. RelMiCS 2009.
++ Valiant, L. G. (1990). #emph[A Bridging Model for Parallel
+  Computation];. Communications of the ACM 33(8):103--111.
++ Henrio, L. et al. (2026). #emph[Layers of Confluence for Actors];. CPP
+  2026.

--- a/docs/Publications/Paper-2-algebraic-foundations/typst/repo-docs-typst.json
+++ b/docs/Publications/Paper-2-algebraic-foundations/typst/repo-docs-typst.json
@@ -1,0 +1,11 @@
+{
+  "entry": "manuscript.typ",
+  "output": "manuscript.pdf",
+  "route": "Publications/Paper-2-algebraic-foundations/typeset-manuscript",
+  "title": "Paper 2 - Algebraic Foundations",
+  "description": "First-pass Typst PDF rendering of the algebraic foundations manuscript.",
+  "sidebar": {
+    "label": "Typeset PDF",
+    "order": 2
+  }
+}

--- a/docs/Publications/Paper-3-graph-substitution-semantics/typst/manuscript.typ
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/typst/manuscript.typ
@@ -1,0 +1,1043 @@
+#import "../../_typst/cortex-paper.typ": cortex-paper
+
+#let horizontalrule = line(length: 100%)
+
+#show: cortex-paper
+
+= Graph Substitution Semantics for Dynamic Durable Workflows
+<graph-substitution-semantics-for-dynamic-durable-workflows>
+== Abstract
+<abstract>
+We present a semantics for dynamic durable workflows in which workflow
+meaning, durable execution, and topology evolution are separated into
+explicit layers. A workflow program is first interpreted into a typed
+workflow IR, then compiled into an executable graph artifact carrying
+topology, node definitions, typed interfaces, and a compatibility
+witness. The compiled artifact denotes the space of obligations that may
+arise during a run; the materialized run state records what has actually
+been reached after applying an admitted lineage of substitutions.
+Execution proceeds in phases over that materialized state. Dynamic
+change is modeled by #strong[graph substitution];: an admitted operation
+replaces or refines a durable step by splicing in a fragment through an
+explicit interface while preserving causal structure and durable
+provenance.
+
+The paper makes four claims. First, workflow semantics should not be
+identified with runtime scheduling; lowering is a compilation boundary.
+Second, dynamic topology change is best modeled by vertex-anchored
+substitution rather than ad hoc mutation. Third, durable execution
+requires a lineage-plus-materialization semantics, not merely a replay
+story. Fourth, concurrency of node execution and concurrency of
+substitutions are distinct questions and should be treated by different
+laws.
+
+The running examples use Cortex and downstream host applications as
+motivating contexts, but the theory is stated independently of any
+particular implementation.
+
+#horizontalrule
+
+== 1. Introduction
+<1-introduction>
+Durable workflows must survive crashes, suspension, operator
+intervention, and long-running external work. Fixed-topology models
+explain a large class of workflow engines, but they are insufficient
+when execution may reveal that the remaining graph itself should change.
+
+Typical examples include:
+
+- a planning step that elaborates itself into a larger analysis subgraph
+- a validation step that inserts remediation work before release
+- a review step that appends a new branch for additional evidence
+- an operator signal that unblocks or redirects part of the remaining
+  workflow
+
+The central semantic problem is therefore:
+
+#quote(block: true)[
+How can a workflow evolve after partial execution while preserving
+durable replay, causal correctness, and a stable explanation of what was
+executed?
+]
+
+This paper presents the implementation-independent theory of that
+problem. A companion research plan, #strong[Rewrite Materialization and
+Recovery for Dynamic Durable Graphs];, grounds the same ideas in the
+concrete Pulse runtime and uses implementation-specific invariants to
+sharpen the recovery story.
+
+This paper answers that question by separating three levels of meaning:
+
++ #strong[workflow meaning];, expressed in a typed workflow language
++ #strong[compiled executable structure];, expressed as a graph artifact
++ #strong[durable operational semantics];, expressed as phase-based
+  execution with graph substitution
+
+The key terminological choice is deliberate:
+
+- #strong[graph substitution] is the primary term of this paper
+- #strong[graph rewriting] is used only as the umbrella term from the
+  literature on algebraic graph transformation
+
+The reason is precision. The runtime operation is not arbitrary graph
+surgery. It substitutes a fragment into a durable graph through a
+bounded, typed, interface-preserving rule.
+
+#horizontalrule
+
+== 2. Glossary
+<2-glossary>
+- #strong[workflow];: a semantic program describing obligations,
+  dependencies, branching, waiting, and artifact boundaries
+- #strong[workflow IR];: a canonical typed intermediate form of workflow
+  meaning
+- #strong[compiled workflow artifact];: the executable result of
+  lowering a workflow IR into a graph package
+- #strong[materialized run state];: the currently executable graph and
+  node/output state obtained by applying a lineage prefix to an original
+  compiled artifact
+- #strong[node];: a durable execution locus with identity, status, and
+  outputs
+- #strong[fragment];: a graph package intended to be substituted into
+  another graph
+- #strong[substitution];: the operation of splicing a fragment into a
+  graph through an explicit boundary contract
+- #strong[graph rewriting];: the broader literature umbrella; this paper
+  studies a substitution calculus within that space
+- #strong[materialization];: durable installation of admitted
+  substitutions into the graph state
+- #strong[lineage];: append-only history of admitted substitutions
+- #strong[compatibility witness];: a fingerprint or derivation witness
+  tying a compiled artifact to the semantics that produced it
+
+#horizontalrule
+
+== 3. Layered Semantic Architecture
+<3-layered-semantic-architecture>
+The theory is organized around a strict stack:
+
+```mermaid
+flowchart TD
+    A["Workflow semantics"] --> B["Compiled artifact"]
+    B --> C["Phase-based execution"]
+    C --> D["Lineage"]
+    D --> E["Recovery"]
+```
+
+The stack matters because different correctness questions live at
+different layers:
+
+- #strong[workflow meaning] asks whether a program denotes the intended
+  dependency structure
+- #strong[lowering] asks whether the compiled graph preserves workflow
+  meaning
+- #strong[execution] asks whether the runtime reduces graph states
+  soundly
+- #strong[substitution] asks whether topology evolution preserves
+  admissibility
+- #strong[durability] asks whether crash, resume, and explanation remain
+  coherent
+
+Blurring these layers weakens the theory. A runtime graph is not the
+meaning of the source workflow; it is the executable artifact produced
+by a lowering.
+
+#horizontalrule
+
+== 4. Workflow Language and Compilation Boundary
+<4-workflow-language-and-compilation-boundary>
+=== 4.1 Workflow IR
+<41-workflow-ir>
+We assume a typed workflow language with the following representative
+core constructors:
+
+```text
+W ::= step a
+    | W ; W
+    | parallel { W1, ..., Wn }
+    | choose c { Wt, Wf }
+    | await s
+    | artifact k from W
+```
+
+Intuitively:
+
+- `step a` introduces a durable step
+- `;` introduces sequencing
+- `parallel` introduces concurrent obligations
+- `choose` introduces semantically controlled branching
+- `await` introduces suspension on an external signal or fact
+- `artifact` marks a durable product boundary
+
+This IR is semantic, not directly executable. It does not say how node
+identities are serialized, how retries are represented, or how
+persistence occurs.
+
+The purpose of introducing the IR in this paper is narrow: it marks the
+compilation boundary between workflow meaning and graph execution. The
+core formal development begins only after lowering.
+
+=== 4.2 Compiled Workflow Artifact
+<42-compiled-workflow-artifact>
+Lowering produces an original compiled artifact:
+
+$ cal(C)_0 = \( T \, D \, Gamma \, kappa \) $
+
+where:
+
+- $T = \( V \, E \)$ is a finite directed acyclic graph
+- $D : V arrow.r upright("NodeDef")$ assigns executable node definitions
+- $Gamma$ is the interface environment describing input/output
+  contracts, signal contracts, and artifact contracts
+- $kappa$ is a compatibility witness
+
+For the purposes of this paper, the compatibility witness has the form:
+
+$ kappa = \( nu \, lambda \, h \) $
+
+where:
+
+- $nu$ identifies the lowering family
+- $lambda$ identifies the contract and interface regime used to
+  interpret the lowered artifact
+- $h$ is a digest of the normalized source artifact under
+  $\( nu \, lambda \)$
+
+Two compiled artifacts need not have the same digest in order to
+interact, but they must agree on the lowering family and contract
+interpretation regime. We write:
+
+$ sans(C o m p a t)_kappa \( kappa \, kappa_F \) $
+
+for the predicate that the ambient compiled artifact and a fragment were
+produced under compatible lowering and contract interpretation regimes.
+In the minimal version used by this paper:
+
+$ sans(C o m p a t)_kappa \( \( nu \, lambda \, h \) \, \( nu_F \, lambda_F \, h_F \) \) arrow.l.r.double nu = nu_F and lambda = lambda_F $
+
+The digests may differ because the ambient workflow and the fragment may
+denote different source programs. Compatibility requires only that they
+inhabit the same lowering family and contract regime.
+
+This minimal definition is intentionally stricter than lowering-family
+equality alone. Two fragments may be lowered by the same compiler family
+while still disagreeing about the contract language attached to boundary
+nodes. Equality on $\( nu \, lambda \)$ is therefore the smallest useful
+semantic approximation.
+
+The point of $kappa$ is semantic rather than operational: a materialized
+graph should always be interpreted relative to the compilation law that
+produced it.
+
+=== 4.3 Example
+<43-example>
+The following surface syntax is only illustrative:
+
+```text
+workflow QuarterlyPortfolioRebalance {
+  parallel {
+    fetchPositions,
+    fetchMarketData,
+    fetchRiskLimits
+  };
+  computeTargetAllocations;
+  parallel {
+    sequence {
+      proposeEquityTrades;
+      choose complianceOk {
+        signOffEquities,
+        sequence {
+          remediateEquities;
+          signOffEquities
+        }
+      }
+    },
+    sequence {
+      proposeFixedIncomeTrades;
+      signOffFixedIncome
+    },
+    sequence {
+      proposeDerivativesOverlay;
+      await riskDeskApproval;
+      signOffDerivatives
+    }
+  };
+  aggregateExecutionPlan;
+  artifact rebalanceReport
+}
+```
+
+Its lowering may produce a graph whose nodes are durable execution loci
+while preserving the workflow meaning that three acquisition steps are
+initially independent, then join at `computeTargetAllocations`, then fan
+out again into three asymmetric branches before joining at
+`aggregateExecutionPlan`. That shape matters because the ready frontier
+widens and narrows over the same DAG, and later substitutions may widen
+it again.
+
+#horizontalrule
+
+== 5. Executable Graphs and Interface Contracts
+<5-executable-graphs-and-interface-contracts>
+The compiled topology alone is not enough. Dynamic substitution requires
+typed fragment contracts.
+
+=== 5.1 Graph Package
+<51-graph-package>
+A fragment is a graph package:
+
+$ cal(F) = \( T_F \, D_F \, Gamma_F \, upright(I n)_F \, upright(O u t)_F \, kappa_F \) $
+
+where:
+
+- $T_F = \( V_F \, E_F \)$ is a finite DAG
+- $D_F$ assigns node definitions
+- $Gamma_F$ assigns contracts to fragment boundaries and internal nodes
+- $diameter eq.not upright(I n)_F subset.eq V_F$ are entry nodes
+- $diameter eq.not upright(O u t)_F subset.eq V_F$ are exit nodes
+- $kappa_F$ is a compatibility witness for the fragment
+
+The interface contract should be read semantically, not merely
+topologically. A fragment boundary may constrain:
+
+- value types or schemas
+- artifact shapes
+- signal names or capabilities
+- side-effect classes
+- retry or idempotence requirements
+
+=== 5.2 Minimal Contract Discipline
+<52-minimal-contract-discipline>
+To keep the paper\'s formal core honest, we assume only a minimal
+contract discipline.
+
+Let $\( cal(K) \, subset.eq.sq \)$ be a preorder of contracts, where:
+
+$ c_1 subset.eq.sq c_2 $
+
+means \"a value or effect satisfying $c_1$ is acceptable wherever $c_2$
+is required.\"
+
+For each relevant boundary node $v$, the interface environment provides:
+
+- $Gamma^(+) \( v \) in cal(K)$, the contract offered by $v$
+- $Gamma^(-) \( v \) in cal(K)$, the contract required by $v$
+
+Composition across a graph edge $\( u \, v \)$ is then defined by:
+
+$ Gamma^(+) \( u \) subset.eq.sq Gamma^(-) \( v \) $
+
+One concrete toy instantiation takes $cal(K)$ to be finite record
+schemas ordered by width subtyping:
+
+$ { f_1 : tau_1 \, dots.h \, f_n : tau_n \, dots.h } subset.eq.sq { f_1 : tau_1 \, dots.h \, f_n : tau_n } $
+
+meaning that a provider may offer additional fields beyond what the
+consumer requires.
+
+Under that instantiation, semantic admissibility does real work. In the
+running rebalance example, a predecessor might offer
+`{positions, marketData, riskLimits}` while a candidate fragment entry
+requires `{positions, custodianBalances}`. Structural rewiring could
+still succeed, but semantic admissibility fails because
+`custodianBalances` is absent even though the topology alone would
+permit the splice.
+
+This is intentionally minimal. A richer type-and-effect discipline could
+refine it, but this preorder is enough to state semantic admissibility
+in a falsifiable way without pretending to solve the entire typing
+problem.
+
+The abstraction is deliberately weak. It does not yet model named ports,
+channel multiplicity, linear or affine resources, or retention
+obligations for state that may no longer be present in the current
+materialized graph. Those belong to richer interface calculi. The claim
+here is narrower: even a simple contract preorder is enough to
+distinguish structurally valid substitutions from semantically
+admissible ones.
+
+=== 5.3 Why Structural Interfaces Are Insufficient
+<53-why-structural-interfaces-are-insufficient>
+Entry and exit node sets alone only say where reconnection occurs. They
+do not say whether the substituted fragment can actually inhabit the
+obligation being refined. A durable dynamic workflow semantics therefore
+needs both:
+
+- #strong[structural fit];, meaning the splice preserves graph
+  well-formedness
+- #strong[semantic fit];, meaning contracts compose across the
+  substitution boundary
+
+This distinction is one of the central obligations of the theory.
+
+#horizontalrule
+
+== 6. Phase-Based Durable Execution
+<6-phase-based-durable-execution>
+Execution proceeds relative to an original compiled artifact and a
+materialized run state:
+
+$ Sigma_w = \( cal(C)_0 \, cal(C)_w \, sigma \, o \, ell \, w \, chi \) $
+
+where:
+
+- $cal(C)_0$ is the original compiled workflow artifact
+- $cal(C)_w = sans(M a t e r i a l i z e) \( cal(C)_0 \, ell_(lt.eq w) \)$
+  is the current materialized graph artifact for the admitted lineage
+  prefix
+- $sigma : V_w arrow.r upright("NodeStatus")$ is the total status map
+  over $cal(C)_w$
+- $o : V_w harpoon.rt upright("Value")$ is the partial output map over
+  $cal(C)_w$
+- $ell$ is the append-only substitution lineage
+- $w$ is the materialization watermark
+- $chi$ is a materialized-state integrity witness
+
+The abstract status space is:
+
+$ N o d e S t a t u s = upright("Pending") divides upright("Running") divides upright("Completed") divides upright("Failed") divides upright("Skipped") divides upright("Waiting") \( s \) divides upright("Rewritten") $
+
+`Rewritten` is terminal and dependency-satisfying. It represents a
+durable step boundary that has been refined by substitution while
+remaining part of the explanatory structure.
+
+The execution discipline is phase-based:
+
+```mermaid
+flowchart TD
+    A["Ready frontier"] --> B["Node execution"]
+    B --> C["Accumulate facts"]
+    C --> D["Close + classify"]
+    D --> E{"Substitution<br/>pending?"}
+    E -- Yes --> F["Admit + materialize"]
+    F --> A
+    E -- No --> G{"Frontier<br/>empty?"}
+    G -- No --> A
+    G -- Yes --> H["Terminal"]
+```
+
+This picture clarifies a subtle but important point:
+
+- #strong[concurrent node execution] is a question about reducing facts
+  over a fixed materialized graph
+- #strong[concurrent substitution] is a question about changing the
+  graph itself
+
+They are not the same theorem.
+
+The loop above is a runtime control loop, not a cycle in the workflow
+topology. Each materialized artifact $cal(C)_w$ remains a DAG. The
+back-edge means only that the next ready frontier is computed again,
+possibly over a different materialized graph if a substitution was
+admitted at the previous phase boundary.
+
+=== 6.1 Frontier Semantics
+<61-frontier-semantics>
+Let $p r e d_w \( v \)$ denote the immediate predecessors of node $v$ in
+the current materialized graph $cal(C)_w$.
+
+The ready frontier is:
+
+$ "Ready" \( Sigma_w \) = { v in V_w divides sigma \( v \) = upright(P e n d i n g) and forall u in p r e d_w \( v \) . med sigma \( u \) in { upright(C o m p l e t e d) \, upright(S k i p p e d) \, upright(R e w r i t t e n) } } $
+
+The frontier is an antichain in the dependency order. Nodes in the
+frontier may be executed concurrently because readiness is defined
+relative to the same materialized topology.
+
+=== 6.2 Base Phase Discipline
+<62-base-phase-discipline>
+The base calculus adopts a simple rule:
+
+- many nodes may execute concurrently within one frontier phase
+- substitution is admitted only at a phase boundary
+
+This is not merely an implementation convenience. It is the semantic
+barrier that separates reduction over facts from mutation of topology.
+
+#horizontalrule
+
+== 7. Graph Substitution
+<7-graph-substitution>
+=== 7.1 Core Primitive
+<71-core-primitive>
+The core primitive is:
+
+$ sans(s u b s t i t u t e) \( a \, rho \, cal(F) \) $
+
+where:
+
+- $a in V$ is an anchor node
+- $rho$ is a boundary policy
+- $cal(F)$ is a fragment
+
+The boundary policy determines whether the anchor is replaced or
+retained as an envelope.
+
+The literature uses #strong[graph rewriting] broadly for systems that
+transform graphs by local rules. This paper uses #strong[graph
+substitution] for the concrete runtime calculus because the admissible
+operation is more specific: it chooses a durable anchor node, a fragment
+with explicit boundary interface, and a splice discipline that preserves
+the already discharged past.
+
+=== 7.2 Replace and Envelope
+<72-replace-and-envelope>
+Let:
+
+- $"Pred" \( a \) = { u divides \( u \, a \) in E }$
+- $"Succ" \( a \) = { v divides \( a \, v \) in E }$
+
+For a #strong[replace] substitution, the anchor is removed and the
+fragment is spliced into its place:
+
+$ V' = \( V \\ { a } \) union V_F $
+
+$ E' = \( E \\ I \( a \) \) union \( "Pred" \( a \) times upright(I n)_F \) union E_F union \( upright(O u t)_F times "Succ" \( a \) \) $
+
+where $I \( a \)$ is the set of edges incident to $a$.
+
+The base calculus intentionally uses full bipartite reconnection from
+every predecessor to every fragment entry and from every fragment exit
+to every successor. Richer port-matching or channel-discipline rules are
+refinements of the interface system, not part of this minimal core.
+Accordingly, the base calculus proves compatibility for the induced
+reconnections it defines; it does not claim that practical runtimes may
+ignore routing, arity, or multiplicity constraints. Systems that require
+single-input consumers, named ports, or linear channels must refine
+$Gamma$ with that additional structure.
+
+For an #strong[envelope] substitution, the anchor remains as the stable
+step boundary and the fragment is inserted after the anchor\'s own
+completion:
+
+$ sigma \( a \) in { upright(C o m p l e t e d) \, upright(R e w r i t t e n) } $
+
+and, whenever downstream obligations depend on the anchor\'s output,
+$o \( a \)$ is defined.
+
+$ V' = V union V_F $
+
+$ E' = \( E \\ \( { a } times "Succ" \( a \) \) \) union \( { a } times upright(I n)_F \) union E_F union \( upright(O u t)_F times "Succ" \( a \) \) $
+
+The envelope form is useful when the anchor\'s output, audit trail, or
+semantic identity should remain explicit.
+
+Replace substitution does not require $o \( a \)$ to remain defined
+because the anchor leaves the future topology. Envelope substitution may
+require it because the anchor remains part of the explanatory and
+dataflow structure.
+
+=== 7.3 Example
+<73-example>
+Suppose the rebalancing workflow\'s `computeTargetAllocations` step
+completes and discovers unexpected crypto exposure requiring an
+additional execution branch before aggregation.
+
+Materialized shape before substitution:
+
+```mermaid
+flowchart TD
+    C["computeTargetAllocations"] --> EQ["Equity branch"]
+    C --> FI[Fixed income branch]
+    C --> DER[Derivatives branch]
+    EQ --> A["aggregateExecutionPlan"]
+    FI --> A
+    DER --> A
+```
+
+Envelope substitution at `computeTargetAllocations`:
+
+```mermaid
+flowchart TD
+    C["computeTargetAllocations"] --> EQ["Equity branch"]
+    C --> FI[Fixed income branch]
+    C --> DER[Derivatives branch]
+    C --> CR1["proposeCryptoLiquidation"]
+    CR1 --> CR2["awaitCustodianConfirmation"]
+    EQ --> A["aggregateExecutionPlan"]
+    FI --> A
+    DER --> A
+    CR2 --> A
+```
+
+This is not arbitrary mutation. The substitution widens the fan-out by
+one new branch, changes the predecessor set of `aggregateExecutionPlan`,
+and still remains a local refinement of a durable step boundary.
+
+#horizontalrule
+
+== 8. Admissibility
+<8-admissibility>
+A substitution is admissible only if all of the following hold.
+
+=== 8.1 Structural Admissibility
+<81-structural-admissibility>
++ the anchor exists
++ the fragment topology is finite and acyclic
++ the fragment\'s node definitions are total
++ entry and exit interfaces are well-defined and non-empty
++ the resulting topology is acyclic
+
+=== 8.2 Semantic Admissibility
+<82-semantic-admissibility>
++ for every predecessor $u$ rewired to an entry node
+  $x in upright(I n)_F$,
+  $Gamma^(+) \( u \) subset.eq.sq Gamma_F^(-) \( x \)$
++ for every exit node $y in upright(O u t)_F$ rewired to a successor
+  $v$, $Gamma_F^(+) \( y \) subset.eq.sq Gamma^(-) \( v \)$
++ retained-anchor substitutions preserve any contract that downstream
+  nodes rely on from the anchor
++ $sans(C o m p a t)_kappa \( kappa \, kappa_F \)$ holds
+
+These clauses define only a minimal semantic admissibility notion.
+Richer contract systems remain compatible with the paper\'s structure
+but are not required by the core results below. In particular, they do
+not yet express port-level routing, arity bounds, linear consumption, or
+snapshot-retention obligations. Those are extensions of the interface
+discipline, not hidden assumptions of the present calculus.
+
+=== 8.3 Causal Admissibility
+<83-causal-admissibility>
+Substitution must preserve the already discharged past. The past may
+justify a substitution, but substitution does not reinterpret already
+completed causal history. It refines the remaining obligation.
+
+This distinguishes substitution from process migration. Substitution is
+local future refinement, not global re-interpretation of executed
+history.
+
+=== 8.4 Resource Admissibility
+<84-resource-admissibility>
+The runtime may also impose explicit budgets:
+
+$ B = \( b_V \, b_E \, b_D \, b_F \, b_S \) $
+
+bounding:
+
+- added vertices
+- added edges
+- added depth
+- frontier expansion
+- substitution count
+
+Let:
+
+$ sans(C o s t) \( a \, cal(F) \, T \) = \( c_V \, c_E \, c_D \, c_F \, c_S \) $
+
+be the structural cost of substituting fragment $cal(F)$ at anchor $a$
+in topology $T$. Resource admissibility requires:
+
+$ sans(C o s t) \( a \, cal(F) \, T \) lt.eq B $
+
+componentwise. Materialization consumes budget monotonically:
+
+$ B' = B - sans(C o s t) \( a \, cal(F) \, T \) $
+
+Budgets are not the whole safety story, but they make the calculus
+operational by bounding expansion.
+
+No core result below depends on this budget discipline. It is an
+operational guard layered on top of the substitution calculus rather
+than a constitutive part of the paper\'s minimal proof core.
+
+=== 8.5 Concrete Rejection Example
+<85-concrete-rejection-example>
+The admissibility clauses are meant to reject substitutions that are
+topologically plausible but semantically wrong.
+
+Return to the rebalance example and let `computeTargetAllocations` be
+the anchor. Suppose a predecessor $u$ offers
+
+$ Gamma^(+) \( u \) = { p o s i t i o n s \, m a r k e t D a t a \, r i s k L i m i t s } $
+
+and a candidate fragment entry $x$ requires
+
+$ Gamma_F^(-) \( x \) = { p o s i t i o n s \, c u s t o d i a n B a l a n c e s } . $
+
+Suppose also that an exit node $y$ of the fragment offers
+
+$ Gamma_F^(+) \( y \) = { c r y p t o L i q u i d a t i o n P l a n } $
+
+while a downstream successor $v$ requires
+
+$ Gamma^(-) \( v \) = { e x e c u t i o n P l a n } . $
+
+The splice may still satisfy structural admissibility: the anchor
+exists, the fragment is finite and acyclic, and the resulting graph
+remains a DAG. But semantic admissibility fails twice:
+
++ $Gamma^(+) \( u \) subset.eq.sq.not Gamma_F^(-) \( x \)$ because the
+  predecessor does not provide `custodianBalances`
++ $Gamma_F^(+) \( y \) subset.eq.sq.not Gamma^(-) \( v \)$ because a
+  `cryptoLiquidationPlan` is not an `executionPlan`
+
+The candidate substitution is therefore rejected before materialization,
+even though bare graph surgery would permit the splice.
+
+Envelope substitution adds one more check. If the anchor $a$ is retained
+as a durable boundary but the substitution would stop exposing an anchor
+contract that downstream obligations still rely on, clause 8.2(3)
+rejects it. The point is that retained history remains semantically
+live, not merely visually present.
+
+#horizontalrule
+
+== 9. Durability, Lineage, and Materialization
+<9-durability-lineage-and-materialization>
+Substitution is durable only if admission and materialization are
+modeled explicitly.
+
+=== 9.1 Lineage and Watermark
+<91-lineage-and-watermark>
+Let:
+
+- $ell = \[ s_1 \, dots.h \, s_n \]$ be the totally ordered, append-only
+  lineage of admitted substitutions
+- $w lt.eq n$ be the watermark such that the materialized graph state
+  reflects exactly the prefix $ell_(lt.eq w)$
+
+This yields a precise semantics:
+
+$ cal(C)_w = sans(M a t e r i a l i z e) \( cal(C)_0 \, ell_(lt.eq w) \) $
+
+The original compiled artifact $cal(C)_0$ defines the space of durable
+obligations. The materialized artifact $cal(C)_w$ defines the current
+execution surface after the admitted lineage prefix has been installed.
+
+=== 9.2 Integrity Witness
+<92-integrity-witness>
+The watermark alone states prefix application. It does not by itself
+certify that the materialized graph package, node state, and provenance
+all agree.
+
+For that reason the durable state should also carry an integrity witness
+$chi$, such as:
+
+- a topology hash
+- a normalized graph-package hash
+- a stronger derivation witness tying materialized state to the expected
+  compiled artifact
+
+The paper treats this as part of the semantics rather than optional
+operator metadata.
+
+Each successful materialization step computes a fresh integrity witness:
+
+$ chi' = sans(W i t n e s s) \( cal(C)' \, sigma' \, o' \, w' \) $
+
+and subsequent execution or recovery is defined only from states
+satisfying:
+
+$ sans(V e r i f y) \( chi \, cal(C) \, sigma \, o \, w \) $
+
+The paper assumes only the following minimal axioms:
+
+- #strong[soundness:]
+  $sans(V e r i f y) \( sans(W i t n e s s) \( cal(C) \, sigma \, o \, w \) \, cal(C) \, sigma \, o \, w \)$
+- #strong[determinism:] if
+  $\( cal(C) \, sigma \, o \, w \) = \( cal(C)' \, sigma' \, o' \, w' \)$
+  then
+  $sans(W i t n e s s) \( cal(C) \, sigma \, o \, w \) = sans(W i t n e s s) \( cal(C)' \, sigma' \, o' \, w' \)$
+
+Stronger collision-resistance or proof-carrying interpretations are
+valuable, but they are not required by the paper\'s minimal recovery
+claim.
+
+=== 9.3 Recovery Law
+<93-recovery-law>
+Recovery should reconstruct execution from:
+
+$ \( cal(C)_0 \, ell_(lt.eq w) \, sigma \, o \, chi \) $
+
+subject to:
+
+- compatibility checks for every admitted fragment in $ell_(lt.eq w)$
+  derived from the compiled artifact witness $kappa$
+- integrity verification of $chi$
+
+The aim is not merely to restart execution, but to resume from a state
+whose interpretation is stable.
+
+A #strong[canonical schedulable state] is the unique normalized state
+obtained by:
+
++ deterministically materializing
+  $cal(C)_w = sans(M a t e r i a l i z e) \( cal(C)_0 \, ell_(lt.eq w) \)$
++ verifying $chi$ against $\( cal(C)_w \, sigma \, o \, w \)$
++ normalizing transient runtime state and recomputing the ready frontier
+  over $cal(C)_w$
+
+Recovery is correct only if it produces that same $cal(C)_w$ and the
+same normalized ready frontier from the same persisted inputs.
+
+#horizontalrule
+
+== 10. Concurrency and Independence
+<10-concurrency-and-independence>
+The base calculus allows concurrent node execution but treats
+substitution as a phase-boundary act. This should be understood as a
+semantic discipline. The base machine therefore separates two semantic
+phases:
+
+- a #strong[reduction phase] that accumulates node-local facts over a
+  fixed materialized topology
+- a #strong[substitution phase] that may change that topology before the
+  next ready frontier is computed
+
+This separation is not cosmetic. It isolates the order-insensitive fact
+fragment from the topology-changing fragment whose admissibility depends
+on the ambient graph, the candidate fragment, and the remaining budget.
+
+=== 10.1 Reduction Phase
+<101-reduction-phase>
+Within a fixed materialized topology, the execution kernel from the
+previous paper applies unchanged. Frontier nodes run concurrently from
+the same materialized graph, emit node-local facts, and those facts are
+accumulated, closed, and classified without changing the topology to
+which readiness is defined.
+
+That is the coordination-friendly fragment of the machine. The important
+point is not that every operational detail is monotone, but that within
+one fixed topology the reduction kernel only accumulates information
+needed to move from pending work toward a more settled state. Later
+execution in the same phase does not reinterpret the meaning of an
+earlier frontier fact by changing the graph beneath it.
+
+=== 10.2 Coordinated Substitution Phase
+<102-coordinated-substitution-phase>
+Substitution is different because admissibility is
+proposal-set-sensitive. Whether a candidate fragment may be installed
+can depend on:
+
+- compatibility at the anchor boundary
+- the resulting topology
+- the remaining structural budget
+- other proposals that may consume that same budget or overlap in effect
+
+For that reason substitution is isolated at a phase boundary. The
+barrier is the natural coordination boundary induced by the current
+semantics: the runtime finishes reduction on the current materialized
+graph, then admits and materializes any accepted substitutions before
+defining the next ready frontier.
+
+=== 10.3 Why This Restriction Is Natural
+<103-why-this-restriction-is-natural>
+Ordinary node execution accumulates facts about an already materialized
+graph. Substitution changes the graph to which readiness and downstream
+obligations are defined. Mixing these two levels without a barrier
+complicates:
+
+- replay
+- provenance
+- admissibility
+- termination reasoning
+
+This restriction is conservative and not free. In a wide frontier, a
+single admitted substitution may delay further reduction until the next
+materialization boundary, sacrificing some throughput and liveness for a
+simpler replay story, a single lineage order, and a cleaner proof
+boundary. The claim is not that the barrier is always optimal, only that
+it is an explicit baseline whose relaxation requires additional laws
+rather than informal scheduling intuition.
+
+=== 10.4 Independent Substitutions
+<104-independent-substitutions>
+A richer calculus may admit more than one substitution in a logical
+phase, but that requires an explicit independence relation. At minimum,
+one would want conditions such as:
+
+- disjoint anchor regions
+- no interface overlap
+- a formal commutation relation over interface effects
+- a stable explanation of lineage order
+
+Those conditions define a stronger machine. They should not be smuggled
+into the base semantics by informal analogy.
+
+#horizontalrule
+
+== 11. Edge-Oriented Forms as Derived Notation
+<11-edge-oriented-forms-as-derived-notation>
+Edge-oriented refinement is still useful to describe insertion between
+two durable steps. For example:
+
+```text
+insertBetween(gather, review, validateEvidence)
+```
+
+is often easier to read than a node-centered substitution formula. But
+the semantic core should remain node-centered.
+
+The reason is not only implicit joining. It is that a durable node
+carries the execution meaning:
+
+- it owns status transitions
+- it may carry outputs
+- it may wait or fail
+- it anchors provenance
+
+An edge denotes a dependency relation. A node denotes a durable step
+boundary. Since dynamic durable workflows evolve by refining obligations
+embodied by durable steps, vertex-anchored substitution is the better
+core object.
+
+Accordingly, edge-oriented forms are best treated as derived notation or
+a surface language convenience that lowers into the node-centered
+calculus.
+
+#horizontalrule
+
+== 12. Core Results and Extension Program
+<12-core-results-and-extension-program>
+=== 12.1 Core Results
+<121-core-results>
+The paper\'s core formal obligations are the following.
+
+==== Substitution Safety
+<substitution-safety>
+Admissible substitution preserves graph well-formedness, causal
+structure, and interface compatibility.
+
+==== Phase Determinism
+<phase-determinism>
+Within a fixed materialized topology, reducing a frontier phase is
+order-insensitive with respect to the accumulation order of independent
+node facts, provided that frontier execution emits node-local facts
+keyed by the executing node or else emits into a deterministic reducer.
+The intended proof strategy is:
+
++ each node $v$ in the current frontier contributes facts affecting only
+  the loci owned by $v$, such as $sigma \( v \)$ and $o \( v \)$
++ for distinct frontier nodes $u eq.not v$, those node-local updates
+  commute
++ closure and classification are deterministic functions of the
+  resulting normalized materialized state
+
+This excludes the obvious counterexample in which concurrent frontier
+nodes perform uncontrolled writes to the same shared artifact key. Such
+effects must either be represented as node-local outputs or mediated by
+a deterministic reduction step before the theorem applies.
+
+==== Recovery Correctness
+<recovery-correctness>
+Resume from materialized lineage prefix, compatibility witness, and
+integrity witness reconstructs the canonical schedulable state defined
+in §9.3.
+
+=== 12.2 Extension Program
+<122-extension-program>
+The following are intentionally outside the paper\'s core formal
+development but define its natural continuation.
+
+==== Lowering Soundness
+<lowering-soundness>
+One would like a theorem of the form:
+
+$ bracket.l.double W bracket.r.double_(upright(w f)) equiv bracket.l.double upright(c o m p i l e) \( W \) bracket.r.double_(upright(g r a p h)) $
+
+for an appropriate denotational semantics of workflows, graphs, and
+their equivalence. This is a research program for the workflow/lowering
+boundary, not part of the minimal substitution calculus proved here.
+
+==== Routed Interfaces and Resource-Aware Contracts
+<routed-interfaces-and-resource-aware-contracts>
+The minimal preorder on $cal(K)$ intentionally leaves out named ports,
+arity constraints, linear or affine resources, and retention obligations
+for values that later substitutions may still depend on. A stronger
+interface calculus would enrich $Gamma$ with those structures so that
+executable routing policies and resource-sensitive admissibility can be
+stated directly.
+
+==== Concurrent Substitution Commutation
+<concurrent-substitution-commutation>
+For a richer extension, independent substitutions may admit a
+commutation law. That requires an explicit independence relation and
+belongs to a stronger calculus than the base one defined here.
+
+==== Budget-Bounded Growth
+<budget-bounded-growth>
+If substitution cost is tracked and budget decreases monotonically, one
+would like a bounded-growth result limiting the number or size of
+admitted substitutions in a run. That is an operational extension, not
+part of the minimal semantic core established here.
+
+#horizontalrule
+
+== 13. Related Work
+<13-related-work>
+Algebraic graph transformation studies local graph change through
+rule-based systems such as DPO and SPO rewriting. This paper does not
+claim novelty over graph transformation as such. Its contribution is to
+specialize that space to a durable workflow setting with named step
+boundaries, lineage, materialization, and recovery.
+
+Process calculi and workflow encodings provide rich accounts of
+concurrency, communication, and mobility. Their center of gravity is
+usually process interaction rather than durable materialized execution
+over named workflow steps. The contribution here is the layering between
+workflow meaning, compiled graph artifact, substitution, and recovery.
+
+Durable execution systems such as Temporal and Restate provide strong
+replay and suspension semantics. The present contribution is orthogonal:
+it asks how durable execution should behave when the future topology
+itself changes through admitted local substitution.
+
+Accordingly, the claim is not that vertex-anchored substitution is the
+only possible graph evolution formalism, but that it is the right
+semantic center for durable step refinement in this layered setting.
+
+#horizontalrule
+
+== 14. Boundary of the Theory
+<14-boundary-of-the-theory>
+This paper gives a theory of #strong[dynamic durable execution by local
+substitution];. It does not claim to solve all process evolution
+problems.
+
+In particular, the theory should be distinguished from:
+
+- global workflow migration
+- reinterpretation of already executed history
+- arbitrary graph surgery without boundary contracts
+- semantic equivalence of unrelated lowered artifacts
+
+Those are valid research directions, but they are not the same object as
+local durable graph substitution.
+
+#horizontalrule
+
+== 15. Conclusion
+<15-conclusion>
+The conceptual payoff of graph substitution is that it gives dynamic
+durable workflows a stable semantic center.
+
+- workflow meaning lives in a typed language and IR
+- executable structure lives in a compiled graph artifact
+- durable execution lives in a phase-based runtime
+- topology evolution lives in a substitution calculus
+- recovery and explanation live in lineage, materialization, and
+  integrity
+
+This layering makes the design space easier to reason about. It explains
+why vertex-anchored substitution is the right core abstraction, why
+concurrency of execution and concurrency of substitution are different
+problems, and why durability requires more than replay alone.
+
+For motivating contexts such as Cortex and its downstream host
+applications, this theory offers a principled route to dynamic workflow
+execution without collapsing workflow semantics, runtime execution, and
+graph evolution into a single informal notion.
+
+== References
+<references>
++ Ehrig, H., Ehrig, K., Prange, U., Taentzer, G. (2006).
+  #emph[Fundamentals of Algebraic Graph Transformation];. Springer.
+  #link("https://link.springer.com/book/10.1007/3-540-31188-2")
++ Milner, R. (1999). #emph[Communicating and Mobile Systems: The
+  Pi-Calculus];. Cambridge University Press.
++ van der Aalst, W. M. P. (1998). #emph[The Application of Petri Nets to
+  Workflow Management];. Journal of Circuits, Systems and Computers
+  8(1):21--66.
++ Temporal Technologies. #emph[Temporal];. #link("https://temporal.io")
++ Restate. #emph[Workflows];.
+  #link("https://docs.restate.dev/tour/workflows")

--- a/docs/Publications/Paper-3-graph-substitution-semantics/typst/repo-docs-typst.json
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/typst/repo-docs-typst.json
@@ -1,0 +1,11 @@
+{
+  "entry": "manuscript.typ",
+  "output": "manuscript.pdf",
+  "route": "Publications/Paper-3-graph-substitution-semantics/typeset-manuscript",
+  "title": "Paper 3 - Graph Substitution Semantics",
+  "description": "First-pass Typst PDF rendering of the graph substitution semantics manuscript.",
+  "sidebar": {
+    "label": "Typeset PDF",
+    "order": 2
+  }
+}

--- a/docs/Publications/Paper-4-wire-language/typst/manuscript.typ
+++ b/docs/Publications/Paper-4-wire-language/typst/manuscript.typ
@@ -1,0 +1,398 @@
+#import "../../_typst/cortex-paper.typ": cortex-paper
+
+#let horizontalrule = line(length: 100%)
+
+#show: cortex-paper
+
+= Wire: Closed Alphabets, Open Composition for Typed Workflow Graphs
+<wire-closed-alphabets-open-composition-for-typed-workflow-graphs>
+== Abstract
+<abstract>
+We present #strong[Wire];, a source language for authoring typed
+workflow and reasoning graphs above a durable graph-execution substrate.
+The language is designed around one architectural rule:
+#strong[authority stays closed; composition stays open];. Executors,
+contracts, tools, prompts, and policy are registered externally. Wire
+does not invent new runtime authority; it composes the authority that
+the host environment has already made available. This separation yields
+a compact graph language with four distinctive properties. First,
+topology remains honest: the core composition layer is a small graph
+algebra rather than a hidden API in a host language. Second, edges
+remain homogeneous and purely topological; compatibility lives on node
+endpoints through offered and accepted contracts. Third, reuse is
+expressed compositionally through partial nodes and configuration
+layering rather than through a second template language. Fourth, the
+same source language can describe both initial executable graphs and
+candidate structural proposals, while runtime admission, budgeting, and
+materialization remain outside the language.
+
+The paper develops the design rationale for this split, gives a minimal
+semantic account of endpoint-typed composition, and reports the current
+implementation surface in Cortex: parsing, compilation to executable
+circuits, compatibility witnesses, vocabulary catalog generation,
+topological memory annotations, latent condition compilation, and
+append-style proposal fitting. We do not claim a full metatheory for
+Wire in this paper. The contribution is the language boundary itself: a
+safe authoring surface for graph programs that need typed structure,
+bounded extensibility, and downstream-owned semantics.
+
+== 1. Introduction
+<1-introduction>
+Workflow systems and agent runtimes increasingly need an author-facing
+surface for graph structure. Two common approaches dominate. The first
+embeds graph authoring in a host language API. The second allows a
+planner or model to synthesize ad hoc structure through untyped text or
+imperative tool calls. Both approaches lose something important.
+Host-language embeddings blur graph meaning with general programming
+machinery. Open-ended text generation makes structure, authority, and
+runtime policy hard to separate.
+
+Wire starts from a narrower goal: give authors and agents a small
+language for expressing graph structure over a vocabulary that has
+already been registered elsewhere. The language should be strong enough
+to define executable topology, endpoint contracts, reuse by partial
+instantiation, and candidate graph fragments for bounded structural
+change. It should not be strong enough to mint new runtime authority,
+redefine scheduler policy, or smuggle arbitrary host-language
+computation into the graph layer.
+
+The resulting design can be summarized in one sentence:
+
+#quote(block: true)[
+Wire composes registered authority; the implementation owns what that
+authority means.
+]
+
+This paper makes four claims.
+
++ Authoring should separate #strong[authority registration] from
+  #strong[graph composition];.
++ Endpoint-typed composition over a small graph algebra is sufficient
+  for a wide class of practical workflow and reasoning graphs.
++ Initial topology and candidate structural proposals should share one
+  authoring surface, while admission and materialization remain runtime
+  concerns.
++ The right extensibility rule for this language is #strong[closed
+  alphabets, open composition];: grow the registered vocabulary or add
+  bounded composition forms, but do not casually enlarge the core
+  operator set.
+
+== 2. Position in the Cortex Stack
+<2-position-in-the-cortex-stack>
+Wire is not the whole Cortex semantics stack. It sits above the topology
+and execution substrate.
+
+```mermaid
+flowchart LR
+    R[Registered authority<br/>executors, contracts, tools, constructors] --> W[Wire<br/>authoring and composition]
+    W --> C[Circuit<br/>validated executable topology]
+    C --> P[Pulse<br/>durable execution and materialization]
+    D[Downstream bindings<br/>domain policy and artifacts] --> R
+```
+
+#emph[Figure 1.] Wire is an authoring layer above registered authority
+and below the compiled executable artifact.
+
+This placement matters because it keeps three responsibilities distinct:
+
+- Graph and Circuit own structural meaning.
+- Pulse owns execution, admission, budgeting, persistence, and resume
+  behavior.
+- Wire owns author-facing composition.
+
+That separation also prevents a recurring category error. A `.wire` file
+is not a scheduler script and not a general-purpose program. It is a
+graph program authored over a closed vocabulary.
+
+== 3. Closed Alphabets, Open Composition
+<3-closed-alphabets-open-composition>
+The central design rule of Wire is that the language is closed over
+#strong[authority] and open over #strong[composition];.
+
+Closed authority means that executors, contracts, tools, prompts, memory
+presets, and configuration constructors are registered by the host
+environment or a library. A Wire program may reference them by name; it
+does not define their runtime behavior.
+
+Open composition means that those authorities may be arranged into
+arbitrarily large graphs, partial-node families, and bounded proposal
+fragments using a small composition layer.
+
+This split has three benefits.
+
+- It keeps the language small and inspectable.
+- It gives downstream systems control over what a Wire author is allowed
+  to use.
+- It makes LLM-facing authoring safer: a model may propose topology over
+  a known vocabulary instead of inventing opaque capabilities.
+
+The language therefore grows best by extending one of two surfaces:
+
+- the registered vocabulary
+- bounded composition forms over the existing graph algebra
+
+What it should not do casually is grow a large new operator alphabet.
+That is why the current design keeps the core operator set deliberately
+small.
+
+== 4. Endpoint-Typed Composition
+<4-endpoint-typed-composition>
+Wire keeps edges homogeneous and purely topological. Compatibility does
+not live on the edge itself. It lives on the endpoints.
+
+Let each node expose:
+
+- offered output contracts $Gamma^(+) \( v \)$
+- accepted input contracts $Gamma^(-) \( v \)$
+
+Then composition across an edge $\( u \, v \)$ is admissible when the
+offered contract is acceptable at the sink boundary:
+
+$ Gamma^(+) \( u \) subset.eq.sq Gamma^(-) \( v \) $
+
+In the current regime, $subset.eq.sq$ is nominal contract-name equality
+extended with optional per-port labels: the match unit is the port key
+$\( upright("direction") \, upright("contract") \, upright("label") \)$,
+and an absent label is a distinct key, not a wildcard. There is no
+structural refinement relation over contract fields, and no implicit
+subtyping graph; the check is resolved at compile time against the
+registered contract catalog. Richer regimes --- parameterized contracts,
+refinement judgements, or field-level structural compatibility --- are
+future work (see §8); the current language deliberately keeps the
+compile-time check simple and nominal.
+
+This choice is deliberate. If edges themselves carried semantic
+selectors, routing operators, or transformation code, then every graph
+edit would become a small program synthesis problem. Endpoint-owned
+compatibility keeps the graph layer structurally honest.
+
+This is also why default connection syntax can remain simple while
+explicit endpoint syntax exists as a disambiguation tool rather than as
+the primary model.
+
+For example, a simple typed path can remain visually close to the graph
+it denotes:
+
+```wire
+node planner :
+  -> ReportPlan
+= @review.planner {};
+
+node analyst :
+  <- ReportPlan
+  -> AnalysisFragment
+= @review.analyst {};
+
+node report :
+  <- AnalysisFragment
+  -> ReportArtifact
+= @review.report_writer {};
+
+let deep_report = planner => analyst => report;
+```
+
+The graph is explicit. The contracts sit on the boundaries. The
+executors are named but not defined in the language.
+
+When two ports on the same node would otherwise share
+$\( upright("direction") \, upright("contract") \)$, port labels are
+required to disambiguate; the label becomes part of the port key and
+participates in matching.
+
+```wire
+node splitter :
+  <- Report
+  -> primary: Claim
+  -> fallback: Claim
+= @review.splitter {};
+
+node consumer :
+  <- primary: Claim
+  -> Decision
+= @review.consumer {};
+
+let decide = splitter => consumer;
+```
+
+Here `primary:` labels on both sides match and produce the single
+admissible edge; the `fallback:` output remains on the composed boundary
+because no labeled sink accepts it. Labeled routing is available but is
+not the default: unlabeled composition suffices for the common case.
+
+== 5. Reuse Without a Second Language
+<5-reuse-without-a-second-language>
+Wire reuses graph structure through the same value layer it uses for
+ordinary nodes. The key mechanism is the #strong[partial node];: a
+configured executor value whose remaining structural choices are pinned
+later.
+
+```wire
+let analyst_base = @review.analyst {
+  memory = topological { preset = "analyst"; };
+};
+
+node critic :
+  <- AnalysisFragment
+  -> ReviewFragment
+= analyst_base // {
+  instructions = "Critique the draft and call out weak claims.";
+};
+```
+
+This matters because it avoids a common DSL failure mode: one language
+for graphs, another for templates, and a third for runtime
+configuration. In Wire, reuse stays inside the same algebra. The same
+mechanism also gives rewrite proposals a disciplined instantiation path:
+proposals can introduce new nodes by applying bounded configuration
+deltas to already-registered authority.
+
+The current design intentionally stops short of full composition-level
+lambdas. That is a real future direction, but only if variable-arity or
+abstraction-emitting rewrites become load-bearing. For the current
+paper, the important point is simpler: Wire already gets meaningful
+reuse without abandoning graph transparency.
+
+== 6. One Surface for Initial Graphs and Candidate Proposals
+<6-one-surface-for-initial-graphs-and-candidate-proposals>
+Wire does not admit topology changes by itself. That remains a runtime
+responsibility. But it does use the same authoring surface for two
+related tasks:
+
+- authoring the initial executable graph
+- describing a candidate fragment to be proposed later
+
+This is a stronger result than it first appears. It means the authoring
+story for bounded structural change does not require a second graph
+language. The same vocabulary, endpoint compatibility discipline, and
+composition forms can be used to express a proposal fragment, while the
+runtime still owns:
+
+- whether the fragment fits the anchor
+- whether its exits fit the surrounding graph
+- whether it fits the remaining structural budget
+- whether and how it is materialized durably
+
+This is the language-level counterpart to the substitution semantics
+developed in the previous paper. Paper 3 explains why admitted dynamic
+change should be modeled as substitution over compiled artifacts. This
+paper explains why the authoring layer can remain small even when
+programs are allowed to propose such change.
+
+A minimal append-style proposal can therefore look like:
+
+```wire
+let c = @review.foo_to_fizz { instructions = "Bridge foo to fizz."; };
+let d = @review.fizz_to_bar { instructions = "Bridge fizz to bar."; };
+
+c => d
+```
+
+The authoring surface is ordinary Wire. What makes this fragment a
+proposal rather than an initial graph is not the syntax alone, but the
+surrounding runtime context: anchor hole, contract fit, remaining
+budget, and admission policy.
+
+== 7. Implementation Surface
+<7-implementation-surface>
+Wire is no longer a purely architectural sketch. The current
+implementation already supports:
+
+- parsing and compilation of graph programs into executable circuits
+- compatibility witnesses for compiled artifacts
+- endpoint disambiguation when contract-only matching is ambiguous
+- registry-backed vocabulary catalog generation for model-facing
+  authoring
+- typed runtime envelopes for stage outputs
+- topological memory annotations on nodes
+- closed-world conditional forms lowered into latent branch machinery
+- append-style proposal compilation and hole-fit validation
+
+The important point is not that every future semantic claim has been
+proved. It is that the language boundary is real enough to test. That
+matters for publication scope. Wire is not just a desired syntax. It is
+a working authoring surface with identifiable semantics and pressure
+points.
+
+== 8. Boundaries and Open Questions
+<8-boundaries-and-open-questions>
+Three boundaries should remain explicit.
+
+First, Wire is not a runtime policy language. Admission, budgeting,
+replay, persistence, and materialization remain outside it.
+
+Second, closed-world branch selection should not be conflated with open
+structural proposals. A declared conditional with latent alternatives is
+a different semantic object from a planner-generated graph fragment,
+even if early implementations lower both through similar machinery. The
+structural distinction is timing: latent branches are compiled and
+statically validated with the initial circuit, and the runtime only
+selects an alternative whose full typing and budget footprint were known
+at compile time; open proposals are compiled, endpoint-checked,
+budget-checked, and materialized at runtime, against graph state the
+compile-time environment did not see.
+
+Third, the current endpoint model is still compatibility-first rather
+than full multi-channel projection. Contracts label admissible flow
+between nodes. They do not yet imply arbitrary field-level routing
+across edges. That limitation is a feature for now: it keeps the
+language honest with respect to the runtime.
+
+Open questions remain. Known-arity composition repetition may justify
+templates. Variable-arity composition or abstraction-emitting rewrites
+may eventually justify lambdas. Richer compatibility regimes may need to
+appear in compiled artifact witnesses. None of those are required to
+justify the current language boundary.
+
+== 9. Related Work
+<9-related-work>
+Wire belongs at the intersection of several traditions.
+
+From #strong[algebraic graphs];, it takes the idea that overlay and
+connect can form a small honest graph algebra rather than a hidden
+implementation detail. From #strong[selective and build-system
+semantics];, it inherits the idea that static structure and dynamic
+choice should be separated carefully. From #strong[workflow DSLs and
+durable execution systems];, it inherits the need for authoring surfaces
+that survive compilation and runtime interaction without collapsing into
+a host-language embedding.
+
+What distinguishes Wire in this context is the particular boundary it
+draws. The language is not trying to be a full workflow programming
+language, a host-language EDSL, or a scheduler policy surface. It is an
+authoring layer for typed topology over registered authority, with
+bounded structural proposals as a first-class downstream use case.
+
+== 10. Conclusion
+<10-conclusion>
+Wire is valuable not because it is a large language, but because it is a
+narrow one with the right boundary. By keeping authority closed and
+composition open, it gives Cortex an authoring surface that is compact,
+typed, graph-honest, and compatible with bounded structural evolution.
+That makes it suitable both for human authors and for model-assisted
+graph construction without turning the language into an unbounded
+authority generator.
+
+The next steps are clear: sharpen the contract regime carried by
+compiled artifacts, keep closed-world selection distinct from open
+proposals, and evaluate when composition-level abstraction becomes
+necessary. None of those weaken the main claim of this paper. They
+follow from it.
+
+== References
+<references>
++ Andrey Mokhov. #emph[Algebraic Graphs with Class];. 2017.
++ Andrey Mokhov, Neil Mitchell, Simon Peyton Jones. #emph[Build Systems
+  a la Carte: Theory and Practice];. 2020.
++ Andrey Mokhov, Georgy Lukyanov, Simon Marlow, Conor McBride.
+  #emph[Selective Applicative Functors];. 2019.
++ Alexandra Matache, Nicolas Wu, and Sam Staton. #emph[Scoped Effects as
+  Parameterized Algebraic Theories];. 2024.
++ Temporal Technologies. #emph[Temporal];. #link("https://temporal.io")
++ Microsoft. #emph[Azure Durable Functions];.
+  #link("https://learn.microsoft.com/en-us/azure/azure-functions/durable/")
++ Restate. #emph[Workflows];.
+  #link("https://docs.restate.dev/tour/workflows")
+
+== Figures
+<figures>
+- Figure 1 source lives in #link("Figures/wire-layering-overview.mmd");.

--- a/docs/Publications/Paper-4-wire-language/typst/repo-docs-typst.json
+++ b/docs/Publications/Paper-4-wire-language/typst/repo-docs-typst.json
@@ -1,0 +1,11 @@
+{
+  "entry": "manuscript.typ",
+  "output": "manuscript.pdf",
+  "route": "Publications/Paper-4-wire-language/typeset-manuscript",
+  "title": "Paper 4 - Wire Language",
+  "description": "First-pass Typst PDF rendering of the Wire language manuscript.",
+  "sidebar": {
+    "label": "Typeset PDF",
+    "order": 2
+  }
+}

--- a/docs/Publications/_typst/cortex-paper.typ
+++ b/docs/Publications/_typst/cortex-paper.typ
@@ -1,0 +1,27 @@
+#let cortex-paper(body) = [
+  #set document(author: "Julius Koskela")
+  #set page(
+    paper: "us-letter",
+    margin: (x: 0.9in, y: 0.82in),
+    numbering: "1",
+  )
+  #set text(font: "Libertinus Serif", size: 10.5pt, lang: "en")
+  #set par(justify: true, leading: 0.64em)
+  #set heading(numbering: "1.1")
+  #show raw.where(block: true): it => block(
+    fill: luma(245),
+    stroke: luma(220),
+    inset: 8pt,
+    radius: 3pt,
+    width: 100%,
+    it,
+  )
+  #show quote.where(block: true): it => block(
+    fill: luma(248),
+    stroke: (left: 2pt + luma(160)),
+    inset: (left: 10pt, right: 8pt, y: 6pt),
+    width: 100%,
+    it,
+  )
+  #body
+]

--- a/flake.lock
+++ b/flake.lock
@@ -734,11 +734,11 @@
         "tree-sitter-json": "tree-sitter-json"
       },
       "locked": {
-        "lastModified": 1777490081,
-        "narHash": "sha256-KHdc/4jy/3wTVZNNG9zDC+//zYruHi6xrLWTAKhdmzs=",
+        "lastModified": 1777501942,
+        "narHash": "sha256-4s4NaNKMGlZ0qLvmZfp95CDgd3Z2RYzCVd3NyfHrByU=",
         "owner": "Digimuoto",
         "repo": "repo-docs",
-        "rev": "1272747de8ca62fa74c6214b6a2898a05ac76b32",
+        "rev": "76bb104696f3db4b05d40cb8f5c88e0c97b3fb17",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -734,11 +734,11 @@
         "tree-sitter-json": "tree-sitter-json"
       },
       "locked": {
-        "lastModified": 1777403985,
-        "narHash": "sha256-M450gFvia2JJKZpSfeYyrAyUsOfdV4FhZdLqHQ/StBs=",
+        "lastModified": 1777490081,
+        "narHash": "sha256-KHdc/4jy/3wTVZNNG9zDC+//zYruHi6xrLWTAKhdmzs=",
         "owner": "Digimuoto",
         "repo": "repo-docs",
-        "rev": "4de866e71ad64c201896a564a91072861642b00d",
+        "rev": "1272747de8ca62fa74c6214b6a2898a05ac76b32",
         "type": "github"
       },
       "original": {

--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -58,6 +58,21 @@
         };
 
         lean4.theoryDir = "theory";
+
+        haskell.packages.cortex = {
+          packageDir = ".";
+          packageName = "cortex";
+          modulePrefixes = ["Cortex"];
+          title = "Cortex Haskell API";
+          description = "Generated Haddock documentation for the Cortex Haskell package.";
+        };
+
+        typst.manuscripts = {
+          paper1.dir = "Publications/Paper-1-staged-reduction/typst";
+          paper2.dir = "Publications/Paper-2-algebraic-foundations/typst";
+          paper3.dir = "Publications/Paper-3-graph-substitution-semantics/typst";
+          paper4.dir = "Publications/Paper-4-wire-language/typst";
+        };
       };
     };
 

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -5,6 +5,24 @@
       inherit system;
       overlays = [
         (final: prev: {
+          haskellPackages = prev.haskellPackages.override {
+            overrides = hfinal: hprev: {
+              # repo-docs' generated Haddock integration uses nixpkgs
+              # callCabal2nix, while the main Cortex build uses
+              # haskell.nix with allow-newer policy. Apply the same
+              # upper-bound posture to docs-only Haddock generation.
+              callCabal2nix = name: src: args:
+                final.haskell.lib.doJailbreak (hprev.callCabal2nix name src args);
+
+              rel8 =
+                final.haskell.lib.overrideCabal hprev.rel8
+                (_old: {
+                  doCheck = false;
+                  testHaskellDepends = [];
+                });
+            };
+          };
+
           # `tree-sitter build --wasm` downloads wasi-sdk unless this env var
           # points at a local SDK-shaped compiler. repo-docs calls tree-sitter
           # inside a Nix sandbox, so provide the SDK and linker via the wrapper.

--- a/src-platform/Platform/DurableTask/Error.hs
+++ b/src-platform/Platform/DurableTask/Error.hs
@@ -41,7 +41,7 @@ mVal <- logDbFailure
  (\\err -> emitEvent ObsWarn "op.name" ("Failed: " <> T.pack err) [])
  (DB.withConnection pool $ Q.loadConfig ...)
 case mVal of
- Nothing -> ... -- logged, but continue
+ Nothing -> ...
  Just val -> ...
 @
 -}

--- a/src-platform/Platform/Observability/Fields.hs
+++ b/src-platform/Platform/Observability/Fields.hs
@@ -64,7 +64,7 @@ instance Monoid ObsFields where
 {- | Construct a single observation field.
 
 @
-field "run_id" runId    -- instead of ("run_id", Aeson.toJSON runId)
+field "run_id" runId
 @
 -}
 field :: ToJSON a => Text -> a -> ObsFields

--- a/src-platform/Platform/Require.hs
+++ b/src-platform/Platform/Require.hs
@@ -35,8 +35,8 @@ import Platform.Error
 {- | Require a Maybe value or throw a 404 Not Found error.
 
 @
-requireMaybe "Asset" (Just asset)  -- returns asset
-requireMaybe "Asset" Nothing       -- throws notFoundError "Asset" (HTTP 404)
+requireMaybe "Asset" (Just asset)
+requireMaybe "Asset" Nothing
 @
 -}
 requireMaybe :: Text -> Maybe a -> Handler a
@@ -48,10 +48,8 @@ The Left value is converted to a string using the provided function,
 logged internally via AppError, and a safe message is sent to the client.
 
 @
-requireEither id (Right asset)       -- returns asset
+requireEither id (Right asset)
 requireEither show (Left "Parse error")
--- logs: "Internal error: Parse error"
--- throws: internalError (HTTP 500), client sees generic message
 @
 -}
 requireEither :: (e -> String) -> Either e a -> Handler a
@@ -68,9 +66,8 @@ Similar to 'requireEither', but includes the error message as context.
 The message is logged internally; the client sees a safe generic error.
 
 @
-requireEitherWith id (Right asset)  -- returns asset
+requireEitherWith id (Right asset)
 requireEitherWith id (Left "Invalid asset type")
--- logs with context, throws internalError (HTTP 500)
 @
 -}
 requireEitherWith :: (e -> String) -> Either e a -> Handler a

--- a/src/Cortex/Algebra/Graph/Decompose.hs
+++ b/src/Cortex/Algebra/Graph/Decompose.hs
@@ -90,7 +90,6 @@ To fold in reverse (sinks first, seeing successor values), pass
 are successors in the original.
 
 @
--- Longest path from sources (sinks first, seeing successor values):
 foldTopSort (\\_ succVals -> 1 + maximum (0 : Map.elems succVals))
            (transposeRelation rel)
 @
@@ -142,7 +141,6 @@ At each vertex, the step function receives the vertex and a map from
 its predecessors to their already-computed values.
 
 @
--- Compute depth of each vertex (distance from sources):
 foldTopSort (\\_ predVals -> 1 + maximum (0 : Map.elems predVals)) rel
 @
 -}


### PR DESCRIPTION
## Summary
Wire repo-docs generated Haskell API pages for Cortex and first-pass Typst manuscript reader pages into the published docs site.

## Changes
- Pin `repo-docs` to the Haddock-capable feature branch.
- Configure the generated `Haskell` section for the Cortex package Haddock output.
- Configure four generated `typeset-manuscript` PDF reader routes under Publications.
- Add first-pass Typst sources generated from the current Markdown manuscripts with a shared Cortex paper layout.
- Scope nixpkgs Haskell overrides needed by repo-docs' nixpkgs-based Haddock build path.

## Validation
- [x] `just fmt-check`
- [x] `just docs-lint`
- [x] `just docs-build`
- [x] `just check-commit-provenance origin/main..HEAD`
- [x] Built sidebar includes `Haskell`, `Cortex Haskell API`, and all four `Typeset PDF` routes.

## Checklist
- [x] Implementation complete
- [x] Docs build passes locally
- [x] Commit provenance passes
- [ ] Ready for review