### PR TITLE
docs: scope Wire boundary resources and proof ledger

### DIFF
--- a/docs/ADRs/0032-wire-boundary-contract-resources.md
+++ b/docs/ADRs/0032-wire-boundary-contract-resources.md
@@ -1,0 +1,145 @@
+---
+title: "ADR 0032 - Wire Boundary Contracts as Planning Resources"
+description:
+  "Treats Wire boundary contracts, not nodes themselves, as the local resources that rewrites,
+  conditionals, and planning certificates must account for."
+sidebar:
+  label: "0032. Boundary resources"
+  order: 32
+status: proposed
+date: 2026-04-29
+superseded_by: null
+related:
+  - docs/Architecture/03-formalism-stack.md
+  - docs/Architecture/05-wire-language.md
+  - docs/Architecture/07-rewrites-and-materialization.md
+  - docs/Reference/Wire/contracts-ports-and-matching.md
+  - docs/Reference/Wire/conditionality.md
+  - docs/Reference/rewrites.md
+  - docs/ADRs/0005-budgeted-rewrite-admission-and-materialization.md
+  - docs/ADRs/0007-latent-branch-conditional-lowering.md
+  - docs/ADRs/0009-rewrite-provenance-and-topology-integrity.md
+  - docs/ADRs/0028-wire-topology-composition-and-boundary-labels.md
+  - docs/ADRs/0033-wire-select-guarded-affine-collapse.md
+  - docs/ADRs/0034-wire-pure-select-actualization-authority.md
+  - docs/ADRs/0035-wire-rewrite-algebra-forms.md
+  - docs/ADRs/0036-wire-latent-branch-budget-recovery.md
+  - docs/ADRs/0037-wire-latent-structural-control.md
+  - docs/ADRs/0038-wire-proof-track-theorem-ledger.md
+  - "GitHub #99"
+---
+
+# ADR 0032 - Wire Boundary Contracts as Planning Resources
+
+## Status
+
+Proposed - establishes the resource vocabulary used by the follow-up Wire rewrite and conditionality
+ADRs.
+
+## Context
+
+Wire already has strong global admission checks: rewrite proposals must fit the remaining budget,
+stay inside the registered executor and contract vocabulary, preserve topology validity, and
+materialize through the durable rewrite log. Lean also models proof-carrying rewrite chains whose
+per-step certificates lift to chain-level preservation.
+
+Those mechanisms still leave an important semantic distinction implicit. A node is both an
+addressable runtime/provenance object and a boundary of port contracts. Rewrites and conditionals do
+not always consume the node as an object. A retained conditional owner stays visible for lineage,
+and an append continuation keeps the anchor computation in place. What must be accounted for locally
+is the boundary contract that the operation consumes, forwards, or transforms.
+
+Treating the node itself as the linear resource is therefore too coarse. Treating only global
+predicates as the accounting surface is too diffuse. Wire needs a local vocabulary for the resources
+that graph operations spend and return.
+
+## Decision
+
+Wire should treat boundary contracts as first-class planning resources. A rewrite, conditional
+selection, or planner certificate consumes or transforms a boundary obligation and must provide a
+witness for how the resulting graph satisfies the exposed contract.
+
+The resource vocabulary is:
+
+| Resource                  | Meaning                                                                         | Mode                                                     |
+| ------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Boundary obligation       | The input/output contract boundary exposed by a node or graph expression.       | Linear unless explicitly guarded or optional.            |
+| Rewrite slot              | Exclusive authority to transform a boundary at an anchor in one planning epoch. | Linear.                                                  |
+| Port obligation           | A concrete labeled input or output obligation within a boundary.                | Linear, affine, or graded according to port cardinality. |
+| Branch-local obligation   | A boundary obligation inside a not-yet-selected conditional branch.             | Guarded affine.                                          |
+| Rewrite budget            | The natural-vector budget consumed by admitted structural change.               | Graded.                                                  |
+| Namespace freshness       | Authority to allocate deterministic names under an anchor or namespace.         | Ghost planning resource.                                 |
+| Registry/contract witness | Evidence that introduced nodes stay within the registered boundary.             | Ghost proof resource.                                    |
+
+This is a semantic layer over the existing graph algebra. Mokhov overlay and connect still describe
+the denotation of graph expressions. Boundary resources describe whether a graph operation is
+locally well-accounted before it is admitted or proved safe.
+
+## Consequences
+
+### Positive
+
+- Separates node identity from the contract obligation carried by the node boundary.
+- Gives later ADRs precise language for replacement, append, retained envelopes, and conditionals.
+- Makes it possible to state local no-double-spend and port-coverage obligations without relying
+  only on global topology checks.
+- Matches the existing rewrite-budget model by treating budget as a graded resource rather than a
+  boolean permission.
+
+### Negative
+
+- Adds another semantic layer that authors and implementers must keep distinct from graph equality.
+- Requires care around cardinality: not every port-like thing is exactly-once linear.
+- Does not by itself prove Haskell runtime correspondence or Lean-side construction witnesses.
+
+### Obligations
+
+#### Semantic and Proof Obligations
+
+- Future rewrite and conditional specs should say which boundary obligation they consume and which
+  boundary they produce.
+- Lean models should prefer resource-context predicates over ad hoc per-node token language.
+- Lean theorem target: resource-consumption faithfulness, stating that a valid operation consumes
+  exactly the declared boundary resources.
+- Lean theorem target: per-epoch rewrite-slot uniqueness, stating that a rewrite slot is spent at
+  most once in a planning epoch.
+- Lean theorem target: boundary preservation, stating that a valid operation preserves the exposed
+  boundary promised by the operation.
+- ADR 0038 tracks the concrete theorem names and implementation issues for these proof targets.
+- Runtime prose should avoid claiming that nodes are linear resources. The stricter claim is that
+  boundary obligations are locally accounted resources.
+
+#### Documentation Obligations After Acceptance
+
+- After acceptance, architecture chapters 03, 05, and 07 should introduce the boundary-resource
+  vocabulary and cite this ADR stack.
+
+## Alternatives considered
+
+- **Nodes as linear tokens** - rejected as the canonical model because retained owners, append
+  continuations, and provenance envelopes can keep node identity while transforming boundary
+  obligations.
+- **Global predicates only** - rejected because global admission checks are necessary but do not
+  express local resource consumption, guarded branch discard, or no-double-rewrite discipline.
+- **Runtime leases only** - rejected because leases can protect implementation state but do not
+  state the source-language or proof-side contract semantics.
+
+## Related
+
+- [../Architecture/03-formalism-stack.md](../Architecture/03-formalism-stack.md)
+- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md)
+- [../Architecture/07-rewrites-and-materialization.md](../Architecture/07-rewrites-and-materialization.md)
+- [../Reference/Wire/contracts-ports-and-matching.md](../Reference/Wire/contracts-ports-and-matching.md)
+- [../Reference/Wire/conditionality.md](../Reference/Wire/conditionality.md)
+- [../Reference/rewrites.md](../Reference/rewrites.md)
+- [0005-budgeted-rewrite-admission-and-materialization.md](0005-budgeted-rewrite-admission-and-materialization.md)
+- [0007-latent-branch-conditional-lowering.md](0007-latent-branch-conditional-lowering.md)
+- [0009-rewrite-provenance-and-topology-integrity.md](0009-rewrite-provenance-and-topology-integrity.md)
+- [0028-wire-topology-composition-and-boundary-labels.md](0028-wire-topology-composition-and-boundary-labels.md)
+- [0033-wire-select-guarded-affine-collapse.md](0033-wire-select-guarded-affine-collapse.md)
+- [0034-wire-pure-select-actualization-authority.md](0034-wire-pure-select-actualization-authority.md)
+- [0035-wire-rewrite-algebra-forms.md](0035-wire-rewrite-algebra-forms.md)
+- [0036-wire-latent-branch-budget-recovery.md](0036-wire-latent-branch-budget-recovery.md)
+- [0037-wire-latent-structural-control.md](0037-wire-latent-structural-control.md)
+- [0038-wire-proof-track-theorem-ledger.md](0038-wire-proof-track-theorem-ledger.md)
+- GitHub #99

--- a/docs/ADRs/0033-wire-select-guarded-affine-collapse.md
+++ b/docs/ADRs/0033-wire-select-guarded-affine-collapse.md
@@ -1,0 +1,124 @@
+---
+title: "ADR 0033 - Wire Select as Guarded Affine Collapse"
+description:
+  "Defines `select(...)` as guarded affine alternatives under one linear boundary contract, with
+  superposition collapse retained only as a colloquial explanation."
+sidebar:
+  label: "0033. Guarded collapse"
+  order: 33
+status: proposed
+date: 2026-04-29
+superseded_by: null
+related:
+  - docs/Reference/Wire/conditionality.md
+  - docs/Reference/Wire/grammar.md
+  - docs/Architecture/05-wire-language.md
+  - docs/Architecture/07-rewrites-and-materialization.md
+  - docs/ADRs/0007-latent-branch-conditional-lowering.md
+  - docs/ADRs/0028-wire-topology-composition-and-boundary-labels.md
+  - docs/ADRs/0032-wire-boundary-contract-resources.md
+  - docs/ADRs/0034-wire-pure-select-actualization-authority.md
+  - docs/ADRs/0035-wire-rewrite-algebra-forms.md
+  - docs/ADRs/0036-wire-latent-branch-budget-recovery.md
+  - docs/ADRs/0037-wire-latent-structural-control.md
+  - docs/ADRs/0038-wire-proof-track-theorem-ledger.md
+  - "GitHub #99"
+---
+
+# ADR 0033 - Wire Select as Guarded Affine Collapse
+
+## Status
+
+Proposed - extends ADR 0007 with resource semantics for latent conditional branches. ADR 0037 places
+`select(...)` in the broader category of latent structural control operators.
+
+## Context
+
+ADR 0007 establishes that Wire conditionals lower to condition anchors with latent branch fragments.
+The conditionality reference states the target model as exclusive-output reduction: compiled
+possibility is wider than current actuality, and exactly one continuation becomes live.
+
+The resource question is what kind of obligation lives inside those alternatives before selection.
+If every branch edge were ordinary linear topology, all branches would need to run or be discharged
+as live work. That is the fan-out mistake ADR 0007 rejects. If branches were hidden inside
+imperative code, the workflow artifact would stop telling the truth about possible obligations.
+
+Wire needs a model that preserves both intuitions: several futures are represented, but only one
+becomes actual runtime topology. Colloquial explanations may call that state a superposition, but
+the formal term should be guarded affine collapse.
+
+## Decision
+
+Wire should define `select(...)` formally as guarded affine choice under a linear boundary contract.
+Colloquial explanations may describe the intuition as superposition collapse: the wavefront reaches
+a conditional, possibilities fan out as latent alternatives, and selection collapses the frontier to
+one live continuation. Formal specs, theorem statements, and implementation names should use guarded
+affine collapse.
+
+The rules are:
+
+- The selecting graph exposes one exclusive output boundary.
+- Each arm provides a latent continuation for one variant of that boundary.
+- Each branch-local resource is guarded by its arm key and is affine before selection.
+- Branch validation is universal: every arm must be locally valid if chosen.
+- Branch execution is exclusive: runtime selects exactly one arm.
+- The selected arm is promoted into the live linear resource context.
+- Unselected arms are discarded and never become runnable topology.
+- The reduced `select(...)` expression exposes the common downstream boundary produced by the
+  productive arms.
+
+## Consequences
+
+### Positive
+
+- Explains why branch internals are not globally linear before selection.
+- Preserves the existing latent-branch model without lowering conditionals to ordinary fan-out.
+- Gives a controlled author-facing metaphor for branch choice while retaining a precise formal
+  model.
+- Aligns with boundary resources: the outer boundary is linear, branch interiors are guarded affine,
+  and the chosen branch becomes linear after collapse.
+
+### Negative
+
+- The word "superposition" can mislead if used without the formal guarded-affine explanation.
+- Tooling and docs must keep latent branch visibility distinct from materialized topology.
+- Native n-way selection still needs runtime work; current lowering remains a narrower binary
+  subset.
+
+### Obligations
+
+- Reference docs should use "superposition" only as the intuition and "guarded affine choice" as the
+  formal model.
+- Type and proof work should validate every branch while executing at most one branch.
+- Lean theorem target: guarded-affine collapse soundness, stating that if every arm is valid from
+  its variant boundary to the common downstream boundary, then selecting one arm promotes only that
+  arm to the live linear context and preserves the reduced graph boundary.
+- ADR 0038 tracks the concrete theorem names and implementation issues for this proof target.
+- After acceptance, architecture chapter 05 and the conditionality reference should adopt the
+  guarded-affine-collapse vocabulary.
+- Runtime and operator surfaces should continue to distinguish compiled latent alternatives from
+  materialized graph state.
+
+## Alternatives considered
+
+- **Ordinary fan-out** - rejected because all branches would become live under readiness rules.
+- **Hidden imperative branching** - rejected because the compiled artifact would omit real possible
+  obligations.
+- **Literal probabilistic or quantum semantics** - rejected because Wire branch selection is
+  deterministic or replayable runtime choice, not amplitude evolution.
+
+## Related
+
+- [../Reference/Wire/conditionality.md](../Reference/Wire/conditionality.md)
+- [../Reference/Wire/grammar.md](../Reference/Wire/grammar.md)
+- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md)
+- [../Architecture/07-rewrites-and-materialization.md](../Architecture/07-rewrites-and-materialization.md)
+- [0007-latent-branch-conditional-lowering.md](0007-latent-branch-conditional-lowering.md)
+- [0028-wire-topology-composition-and-boundary-labels.md](0028-wire-topology-composition-and-boundary-labels.md)
+- [0032-wire-boundary-contract-resources.md](0032-wire-boundary-contract-resources.md)
+- [0034-wire-pure-select-actualization-authority.md](0034-wire-pure-select-actualization-authority.md)
+- [0035-wire-rewrite-algebra-forms.md](0035-wire-rewrite-algebra-forms.md)
+- [0036-wire-latent-branch-budget-recovery.md](0036-wire-latent-branch-budget-recovery.md)
+- [0037-wire-latent-structural-control.md](0037-wire-latent-structural-control.md)
+- [0038-wire-proof-track-theorem-ledger.md](0038-wire-proof-track-theorem-ledger.md)
+- GitHub #99

--- a/docs/ADRs/0034-wire-pure-select-actualization-authority.md
+++ b/docs/ADRs/0034-wire-pure-select-actualization-authority.md
@@ -1,0 +1,139 @@
+---
+title: "ADR 0034 - Pure Selectors and Restricted Actualization Authority"
+description:
+  "Allows deterministic pure selectors to drive `select(...)` collapse without giving pure nodes
+  general graph rewrite authority."
+sidebar:
+  label: "0034. Pure select authority"
+  order: 34
+status: proposed
+date: 2026-04-29
+superseded_by: null
+related:
+  - docs/Reference/Wire/pure-execution.md
+  - docs/Reference/Wire/conditionality.md
+  - docs/Reference/rewrites.md
+  - docs/ADRs/0005-budgeted-rewrite-admission-and-materialization.md
+  - docs/ADRs/0007-latent-branch-conditional-lowering.md
+  - docs/ADRs/0010-wire-closed-authority-and-three-layer-stack.md
+  - docs/ADRs/0020-wire-pure-output-equations.md
+  - docs/ADRs/0023-corepure-expression-surface.md
+  - docs/ADRs/0032-wire-boundary-contract-resources.md
+  - docs/ADRs/0033-wire-select-guarded-affine-collapse.md
+  - docs/ADRs/0035-wire-rewrite-algebra-forms.md
+  - docs/ADRs/0036-wire-latent-branch-budget-recovery.md
+  - docs/ADRs/0037-wire-latent-structural-control.md
+  - docs/ADRs/0038-wire-proof-track-theorem-ledger.md
+  - "GitHub #99"
+---
+
+# ADR 0034 - Pure Selectors and Restricted Actualization Authority
+
+## Status
+
+Proposed - separates deterministic branch-choice computation from structural rewrite authority.
+
+## Context
+
+Wire pure execution is deterministic and authority-free. A pure node can transform JSON-shaped
+values from its inputs into declared outputs, but it cannot call tools, access durable state,
+perform host callbacks, or author arbitrary runtime graph changes.
+
+Executor-variant selection is the existing baseline. An executor node may declare a sum-grouped
+output boundary, the runtime observes which variant the executor produced, and `select(...)`
+resolves arm keys against that declared variant identity. In that case the selector source is the
+executor's typed output boundary, not CorePure.
+
+Conditionals need deterministic branch selection. That makes CorePure attractive as the selector
+language: it can compute an arm key from upstream values, and replay can recompute or validate the
+same choice without executor authority. But if "pure selector" becomes "pure node with rewrite
+authority", pure execution would lose its clean authority boundary.
+
+The language-level distinction is that CorePure `if ... then ... else ...` selects a value, while
+Wire `select(...)` selects a continuation graph. Those operations must stay separate even when the
+first drives the second.
+
+## Decision
+
+Pure execution may compute the branch choice for a compiled `select(...)`, but pure nodes do not
+receive general rewrite authority. Whether the selected arm comes from an executor-emitted variant
+or from a pure expression, the structural effect belongs to the compiled `select(...)` operator and
+runtime admission.
+
+A compiled `select(...)` may carry a compiler-minted, single-use actualization capability:
+
+```text
+SelectActualize owner selectedArm
+```
+
+That capability is narrower than `GraphRewrite` authority:
+
+- it is bound to one conditional owner;
+- it can actualize only one sealed branch from the compiled branch family;
+- it cannot invent new nodes outside that branch;
+- it cannot target unrelated anchors;
+- it still passes through runtime admission, budget accounting, and durability;
+- it is consumed once when the branch is actualized.
+
+CorePure may produce the selected arm key or selection value. Executor outputs may produce the same
+selection through sum-grouped variants. In both cases the selection value chooses an arm; it does
+not itself carry arbitrary graph authority.
+
+## Consequences
+
+### Positive
+
+- Preserves pure execution as deterministic and authority-free.
+- Gives conditionals replayable branch choice without hiding topology in imperative stage code.
+- Narrows the structural authority surface to a compiler-generated capability with one owner and one
+  branch family.
+- Fits the boundary-resource model: the pure selector computes collapse, while `SelectActualize`
+  consumes the linear outer boundary and promotes one guarded branch.
+
+### Negative
+
+- Requires compiler/runtime vocabulary for restricted actualization instead of reusing arbitrary
+  rewrite authority in docs and proofs.
+- The current implementation realizes conditionals through retained-anchor `AppendAfter`, so the
+  conceptual capability is ahead of the runtime naming.
+
+### Obligations
+
+- Pure execution docs must keep value-level `if` separate from topology-level `select(...)`.
+- Pure-selector failures need a clear failure surface distinct from rejected branch materialization.
+- Runtime admission should be able to distinguish compiler-minted branch actualization from
+  planner-authored open rewrites.
+- Lean theorem target: selected-branch admissibility, stating that a `SelectActualize` capability
+  minted for one owner and arm can only admit the sealed branch for that owner and cannot produce an
+  arbitrary planner rewrite.
+- Future Lean statements should model the actualization capability separately from arbitrary planner
+  rewrite certificates.
+- ADR 0038 tracks the concrete theorem names and implementation issues for pure selector authority
+  and selected-branch actualization.
+
+## Alternatives considered
+
+- **Give pure nodes general rewrite authority** - rejected because it collapses the authority
+  boundary established by pure execution.
+- **Require selectors to be effectful executor nodes** - rejected because deterministic branch
+  choice should not require model/tool authority.
+- **Materialize every branch and let pure values route around them** - rejected because it revives
+  ordinary fan-out and makes unchosen branches runnable topology.
+
+## Related
+
+- [../Reference/Wire/pure-execution.md](../Reference/Wire/pure-execution.md)
+- [../Reference/Wire/conditionality.md](../Reference/Wire/conditionality.md)
+- [../Reference/rewrites.md](../Reference/rewrites.md)
+- [0005-budgeted-rewrite-admission-and-materialization.md](0005-budgeted-rewrite-admission-and-materialization.md)
+- [0007-latent-branch-conditional-lowering.md](0007-latent-branch-conditional-lowering.md)
+- [0010-wire-closed-authority-and-three-layer-stack.md](0010-wire-closed-authority-and-three-layer-stack.md)
+- [0020-wire-pure-output-equations.md](0020-wire-pure-output-equations.md)
+- [0023-corepure-expression-surface.md](0023-corepure-expression-surface.md)
+- [0032-wire-boundary-contract-resources.md](0032-wire-boundary-contract-resources.md)
+- [0033-wire-select-guarded-affine-collapse.md](0033-wire-select-guarded-affine-collapse.md)
+- [0035-wire-rewrite-algebra-forms.md](0035-wire-rewrite-algebra-forms.md)
+- [0036-wire-latent-branch-budget-recovery.md](0036-wire-latent-branch-budget-recovery.md)
+- [0037-wire-latent-structural-control.md](0037-wire-latent-structural-control.md)
+- [0038-wire-proof-track-theorem-ledger.md](0038-wire-proof-track-theorem-ledger.md)
+- GitHub #99

--- a/docs/ADRs/0035-wire-rewrite-algebra-forms.md
+++ b/docs/ADRs/0035-wire-rewrite-algebra-forms.md
@@ -1,0 +1,136 @@
+---
+title: "ADR 0035 - Wire Rewrite Algebra Forms"
+description:
+  "Separates conceptual boundary laws from their current Wire rewrite runtime realizations."
+sidebar:
+  label: "0035. Rewrite forms"
+  order: 35
+status: proposed
+date: 2026-04-29
+superseded_by: null
+related:
+  - docs/Architecture/07-rewrites-and-materialization.md
+  - docs/Reference/rewrites.md
+  - docs/Reference/Wire/conditionality.md
+  - docs/ADRs/0005-budgeted-rewrite-admission-and-materialization.md
+  - docs/ADRs/0007-latent-branch-conditional-lowering.md
+  - docs/ADRs/0009-rewrite-provenance-and-topology-integrity.md
+  - docs/ADRs/0032-wire-boundary-contract-resources.md
+  - docs/ADRs/0033-wire-select-guarded-affine-collapse.md
+  - docs/ADRs/0034-wire-pure-select-actualization-authority.md
+  - docs/ADRs/0036-wire-latent-branch-budget-recovery.md
+  - docs/ADRs/0037-wire-latent-structural-control.md
+  - docs/ADRs/0038-wire-proof-track-theorem-ledger.md
+  - "GitHub #99"
+---
+
+# ADR 0035 - Wire Rewrite Algebra Forms
+
+## Status
+
+Proposed - clarifies the conceptual rewrite taxonomy before further runtime or Lean changes.
+
+## Context
+
+The rewrite reference currently exposes forms such as `ExpandNode` and `AppendAfter`. The current
+conditional runtime realizes selected latent branches through retained-anchor `AppendAfter`, which
+is operationally useful because the condition owner remains visible for lineage and the selected
+fragment materializes behind it.
+
+That operational shape should not become the general mental model for expansion. If a rewrite claims
+to replace a node, the replacement graph must satisfy the original boundary contract of the node.
+Appending work after the node is sequencing, not substitution. The distinction matters for port
+obligations, provenance, and future Lean statements.
+
+## Decision
+
+Wire should distinguish conceptual boundary laws from current runtime constructors.
+
+The conceptual boundary laws are:
+
+| Conceptual boundary law          | Resource use                                                                    | Contract effect                                                                                                                                   |
+| -------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Contract-preserving substitution | Consumes one rewrite slot at the anchor and consumes the anchor boundary.       | The replacement graph must expose the consumed anchor boundary.                                                                                   |
+| Append continuation              | Consumes one rewrite slot at the anchor while retaining the anchor node.        | The anchor satisfies its own output; the continuation consumes that output and produces a new downstream boundary.                                |
+| Conditional branch actualization | Consumes one owner-bound actualization capability and the owner's rewrite slot. | The selected branch consumes its variant boundary and yields the common downstream boundary, realizing the guarded-affine collapse from ADR 0033. |
+| Observation/instrumentation      | No v1 resource path; a future form would need to consume an anchor slot.        | Observers must not consume or alter the anchor's required boundary.                                                                               |
+
+The current runtime realization is:
+
+| Boundary law                     | Current realization                  | Notes                                                                                                                                                                                                                                   |
+| -------------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Contract-preserving substitution | `ExpandNode anchor mode spec`        | v1 `GraphRewrite` constructor.                                                                                                                                                                                                          |
+| Append continuation              | `AppendAfter anchor spec`            | v1 `GraphRewrite` constructor.                                                                                                                                                                                                          |
+| Conditional branch actualization | `AppendAfter owner selectedFragment` | Current retained-owner conditional lowering realizes the selected branch with ordinary rewrite machinery. `SelectActualize owner selectedArm` names the restricted capability from ADR 0034; it is not a v1 `GraphRewrite` constructor. |
+| Observation/instrumentation      | None                                 | Potential future boundary law only. It is not admitted by v1 and is not added by this ADR.                                                                                                                                              |
+
+The conditional row names target resource semantics. In the current v1 realization, there is one
+ordinary `AppendAfter` admission; the owner-bound actualization capability is not a separately
+persisted runtime token.
+
+`AppendAfter` remains a valid operational mechanism for the current retained-owner conditional
+implementation. It should not be described as the canonical semantics of node expansion. Expansion
+is substitution into an anchor boundary; conditional branch actualization is retained-owner branch
+collapse. Both can preserve provenance, but they preserve it through different laws.
+
+ADR 0037 separates this conditional actualization law from the broader graph-denotation layer:
+latent branch families are not plain Mokhov graphs before resolution, even when the selected result
+lowers to ordinary graph composition.
+
+## Consequences
+
+### Positive
+
+- Prevents replacement and sequencing from being conflated.
+- Makes the original port contract of an expanded node explicit.
+- Lets the current conditional implementation keep using retained anchors without claiming that all
+  rewrites are append-style.
+- Gives proof work clearer theorem targets for substitution, continuation, and selection.
+
+### Negative
+
+- May require renaming or documentation around existing constructors whose operational names are
+  broader than their conceptual role.
+- Introduces more cases for admission docs and future mechanization.
+- Names observation/instrumentation only as a deferred boundary law, so any future implementation
+  still needs a separate ADR and runtime-version bump.
+- Does not by itself change the current runtime representation.
+
+### Obligations
+
+- Rewrite docs should state which rewrite concept each runtime constructor realizes.
+- Rewrite docs should state which rewrite slot each admitted constructor spends.
+- Future constructors should be added only when they correspond to a distinct boundary law.
+- Observation/instrumentation must remain non-admitted until a follow-up ADR introduces a concrete
+  constructor and admission rules.
+- Conditional lowering docs should treat retained-anchor `AppendAfter` as the current realization of
+  branch actualization, not as the semantic definition of all conditionals.
+- Lean theorem targets: boundary preservation under substitution, append-continuation boundary
+  preservation, and selection realization of guarded-affine collapse. Observation has no theorem
+  target until a concrete constructor exists.
+- ADR 0038 tracks the concrete theorem names and implementation issues for these proof targets.
+
+## Alternatives considered
+
+- **Use append as the universal rewrite model** - rejected because replacement must discharge the
+  original anchor boundary rather than merely run after the anchor.
+- **Use substitution as the universal rewrite model** - rejected because append continuations,
+  observers, and retained conditional owners are legitimate non-substitutional graph operations.
+- **Keep provenance only in side tables and erase retained owners** - rejected because current
+  operator and recovery surfaces benefit from lineage being visible in the graph evolution story.
+
+## Related
+
+- [../Architecture/07-rewrites-and-materialization.md](../Architecture/07-rewrites-and-materialization.md)
+- [../Reference/rewrites.md](../Reference/rewrites.md)
+- [../Reference/Wire/conditionality.md](../Reference/Wire/conditionality.md)
+- [0005-budgeted-rewrite-admission-and-materialization.md](0005-budgeted-rewrite-admission-and-materialization.md)
+- [0007-latent-branch-conditional-lowering.md](0007-latent-branch-conditional-lowering.md)
+- [0009-rewrite-provenance-and-topology-integrity.md](0009-rewrite-provenance-and-topology-integrity.md)
+- [0032-wire-boundary-contract-resources.md](0032-wire-boundary-contract-resources.md)
+- [0033-wire-select-guarded-affine-collapse.md](0033-wire-select-guarded-affine-collapse.md)
+- [0034-wire-pure-select-actualization-authority.md](0034-wire-pure-select-actualization-authority.md)
+- [0036-wire-latent-branch-budget-recovery.md](0036-wire-latent-branch-budget-recovery.md)
+- [0037-wire-latent-structural-control.md](0037-wire-latent-structural-control.md)
+- [0038-wire-proof-track-theorem-ledger.md](0038-wire-proof-track-theorem-ledger.md)
+- GitHub #99

--- a/docs/ADRs/0036-wire-latent-branch-budget-recovery.md
+++ b/docs/ADRs/0036-wire-latent-branch-budget-recovery.md
@@ -1,0 +1,122 @@
+---
+title: "ADR 0036 - Latent Branch Budget and Recovery Policy"
+description:
+  "States the budget and recovery policy for closed-world latent branches under the current
+  selected-branch materialization model."
+sidebar:
+  label: "0036. Latent branch budget"
+  order: 36
+status: proposed
+date: 2026-04-29
+superseded_by: null
+related:
+  - docs/Architecture/07-rewrites-and-materialization.md
+  - docs/Reference/rewrites.md
+  - docs/Reference/Wire/conditionality.md
+  - docs/Roadmap/Plans/rewrite-materialization-and-recovery.md
+  - docs/ADRs/0005-budgeted-rewrite-admission-and-materialization.md
+  - docs/ADRs/0007-latent-branch-conditional-lowering.md
+  - docs/ADRs/0009-rewrite-provenance-and-topology-integrity.md
+  - docs/ADRs/0032-wire-boundary-contract-resources.md
+  - docs/ADRs/0033-wire-select-guarded-affine-collapse.md
+  - docs/ADRs/0034-wire-pure-select-actualization-authority.md
+  - docs/ADRs/0035-wire-rewrite-algebra-forms.md
+  - docs/ADRs/0037-wire-latent-structural-control.md
+  - docs/ADRs/0038-wire-proof-track-theorem-ledger.md
+  - "GitHub #99"
+---
+
+# ADR 0036 - Latent Branch Budget and Recovery Policy
+
+## Status
+
+Proposed - documents the current selected-branch policy and separates it from possible reserved
+capacity policies.
+
+## Context
+
+Latent branches are closed-world alternatives. Only one branch can become live, so summing the cost
+of every branch is a poor semantic fit. The conditionality reference already records the right
+intuition: branch reserve is closer to `max` than `sum`, while the current runtime does not yet
+reserve latent capacity.
+
+The current implementation realizes selected branches through ordinary admitted rewrites. That means
+the selected branch consumes rewrite budget when it is actualized. If unrelated rewrites consume the
+remaining budget first, a later branch actualization can fail admission. That is honest current
+behavior, but it is not the same as promising that every compiled latent branch is already reserved
+and guaranteed.
+
+Recovery also needs a precise story. A crash around branch selection must not turn latent
+alternatives into live fan-out or allow a different branch to materialize silently.
+
+## Decision
+
+Under the current runtime model, latent branches use selected-branch budgeting:
+
+- unselected branches do not consume runtime rewrite budget;
+- the selected branch consumes ordinary rewrite budget at actualization time;
+- branch actualization is admitted or rejected by the same durable rewrite admission path as other
+  runtime graph evolution;
+- the runtime does not yet guarantee capacity for every compiled latent branch;
+- recovery replays the admitted selected branch from durable rewrite state;
+- unselected branches remain sealed latent alternatives in the compiled artifact and are never
+  materialized for that run. The current model has no durable "discard branch" event.
+
+This policy is intentionally narrower than a future reserved-capacity model. If Cortex later wants
+to guarantee that every compiled latent branch can always materialize, that should be a separate
+decision introducing max-branch reservation or another escrow rule.
+
+## Consequences
+
+### Positive
+
+- Matches the current runtime implementation and rewrite-budget accounting.
+- Avoids charging for branches that cannot all become live.
+- Keeps branch materialization auditable through the existing rewrite log and watermark machinery.
+- Leaves room for a future reserved-capacity ADR without overstating current guarantees.
+
+### Negative
+
+- A selected branch may fail if earlier rewrites have exhausted the remaining budget.
+- Authors cannot yet treat compiled latent branches as prepaid guaranteed capacity.
+- Operators need clear rejected-rewrite events when branch actualization fails after selection.
+
+### Obligations
+
+- Docs must distinguish selected-cost semantics from max-reserved latent capacity.
+- Runtime recovery tests should cover crashes before branch selection, after selection but before
+  materialization, and after materialization.
+- Lean theorem targets: selected-cost budget preservation, stating that only the admitted selected
+  branch consumes rewrite budget, and recovery determinism, stating that replay materializes the
+  same selected branch without making unselected alternatives live.
+- ADR 0038 tracks the concrete theorem names and implementation issues for these proof targets.
+- After acceptance, architecture chapter 07, the rewrite reference, and the recovery plan should
+  distinguish selected-cost semantics from any future reserved-capacity policy.
+- Any future capacity guarantee must specify whether it reserves `max(branchCosts)`, reserves per
+  branch family, or changes the rewrite-budget algebra.
+
+## Alternatives considered
+
+- **Sum-prepay all branches** - rejected because it charges for mutually exclusive futures and makes
+  large branch families unnecessarily expensive.
+- **Max-reserve branch families now** - deferred because it requires new runtime accounting and
+  recovery rules beyond the current selected-branch implementation.
+- **Make latent branch actualization free** - rejected because selected branches still add live
+  topology and must remain bounded by runtime authority.
+
+## Related
+
+- [../Architecture/07-rewrites-and-materialization.md](../Architecture/07-rewrites-and-materialization.md)
+- [../Reference/rewrites.md](../Reference/rewrites.md)
+- [../Reference/Wire/conditionality.md](../Reference/Wire/conditionality.md)
+- [../Roadmap/Plans/rewrite-materialization-and-recovery.md](../Roadmap/Plans/rewrite-materialization-and-recovery.md)
+- [0005-budgeted-rewrite-admission-and-materialization.md](0005-budgeted-rewrite-admission-and-materialization.md)
+- [0007-latent-branch-conditional-lowering.md](0007-latent-branch-conditional-lowering.md)
+- [0009-rewrite-provenance-and-topology-integrity.md](0009-rewrite-provenance-and-topology-integrity.md)
+- [0032-wire-boundary-contract-resources.md](0032-wire-boundary-contract-resources.md)
+- [0033-wire-select-guarded-affine-collapse.md](0033-wire-select-guarded-affine-collapse.md)
+- [0034-wire-pure-select-actualization-authority.md](0034-wire-pure-select-actualization-authority.md)
+- [0035-wire-rewrite-algebra-forms.md](0035-wire-rewrite-algebra-forms.md)
+- [0037-wire-latent-structural-control.md](0037-wire-latent-structural-control.md)
+- [0038-wire-proof-track-theorem-ledger.md](0038-wire-proof-track-theorem-ledger.md)
+- GitHub #99

--- a/docs/ADRs/0037-wire-latent-structural-control.md
+++ b/docs/ADRs/0037-wire-latent-structural-control.md
@@ -1,0 +1,197 @@
+---
+title: "ADR 0037 - Wire Latent Structural Control Operators"
+description:
+  "Names the category for Wire constructs, including `select(...)`, that carry possible topology at
+  compile time and materialize only a controlled subset at runtime."
+sidebar:
+  label: "0037. Latent control"
+  order: 37
+status: proposed
+date: 2026-04-29
+superseded_by: null
+related:
+  - docs/Architecture/03-formalism-stack.md
+  - docs/Architecture/05-wire-language.md
+  - docs/Architecture/07-rewrites-and-materialization.md
+  - docs/Reference/Wire/conditionality.md
+  - docs/Reference/rewrites.md
+  - docs/ADRs/0007-latent-branch-conditional-lowering.md
+  - docs/ADRs/0028-wire-topology-composition-and-boundary-labels.md
+  - docs/ADRs/0032-wire-boundary-contract-resources.md
+  - docs/ADRs/0033-wire-select-guarded-affine-collapse.md
+  - docs/ADRs/0034-wire-pure-select-actualization-authority.md
+  - docs/ADRs/0035-wire-rewrite-algebra-forms.md
+  - docs/ADRs/0036-wire-latent-branch-budget-recovery.md
+  - docs/ADRs/0038-wire-proof-track-theorem-ledger.md
+  - "GitHub #99"
+---
+
+# ADR 0037 - Wire Latent Structural Control Operators
+
+## Status
+
+Proposed - names the category that `select(...)` belongs to and records seams that should stay
+explicit before Wire adds more operators in the same family.
+
+## Context
+
+Wire's algebraic graph layer is intentionally small. `<>` and `=>` lower to overlay and connect,
+refining Mokhov-style algebraic graphs with port labels and contract matching. A materialized
+conditional result can be described in that algebra after selection:
+
+```text
+selector => selected_branch => continuation
+```
+
+The pre-selection conditional is different:
+
+```wire
+selector select(
+  A: branch_a,
+  B: branch_b
+)
+```
+
+That expression is not one live graph. It is a sealed family of possible graph fragments, plus a
+rule that exactly one member may become live. ADR 0033 defines that rule for `select(...)` as
+guarded affine collapse. ADR 0034 then separates branch-choice computation from structural
+actualization authority.
+
+This creates an architectural seam: some Wire constructs may carry possible topology that is
+compiled, validated, and explained, but not yet materialized as live topology.
+
+## Decision
+
+Wire should name this category **latent structural control operators**.
+
+A latent structural control operator has four layers:
+
+1. **Algebraic result.** After the operator resolves, the live result is an ordinary graph fragment
+   expressible with Wire's overlay/connect composition.
+2. **Latent family.** Before resolution, the operator carries one or more sealed graph fragments
+   that are validated but not live topology.
+3. **Proof or compile-time promise.** Compilation checks closure, arm/key coverage, boundary
+   compatibility, and authority limits for every possible fragment.
+4. **Runtime materialization.** Runtime observes a selector or guard, admits the chosen structural
+   effect, persists enough state for replay, and keeps non-chosen fragments from becoming runnable.
+
+`select(...)` is the first operator in this category and the only one accepted by the current Wire
+surface. The category does not add new runtime authority by itself. Every member needs its own ADR,
+admission rules, budget policy, recovery story, and Lean theorem targets.
+
+## Boundary With Mokhov Algebra
+
+Mokhov overlay/connect remains the graph denotation layer. Latent structural control is not a fifth
+Mokhov constructor.
+
+- Before resolution, a latent family is a controlled set of graph possibilities, not a graph.
+- After resolution, the selected result lowers to ordinary graph composition.
+- Equational laws over overlay/connect apply to the selected materialized graph, not automatically
+  to the sealed family before selection.
+
+This keeps the graph algebra small while allowing Wire to represent structured runtime choice
+without lowering it to ordinary fan-out or hiding it in imperative executor code.
+
+## Candidate Operators
+
+The category is intentionally broader than `select(...)`, but candidates are not admitted by this
+ADR.
+
+| Candidate                           | Shape                                                                   | Main unresolved seam                                            |
+| ----------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `select(...)`                       | Exactly one of `N` latent continuations becomes live.                   | Already scoped by ADRs 0033-0036.                               |
+| `onFailure` / `recover`             | A failure variant actualizes a recovery continuation.                   | Failure taxonomy, retry interaction, and provenance.            |
+| `optional`                          | Zero or one continuation becomes live.                                  | Boundary typing when no continuation is selected.               |
+| `race` / `firstSuccess`             | Several candidates may start, but one winner remains semantically live. | Cancellation, side effects, replay, and budget accounting.      |
+| Bounded `repeat` / `unfold`         | A guarded continuation may actualize repeatedly up to a bound.          | Loop bounds, acyclicity, and accumulated budget.                |
+| Data-indexed `forEach` / `fanoutBy` | One continuation actualizes for each selected data item.                | Cardinality, namespace generation, and branch-cost aggregation. |
+
+Any such operator must be introduced as a separate decision. The default stance is rejection until
+its boundary law, resource consumption, runtime realization, and recovery behavior are explicit.
+
+## Open Seams
+
+- **Denotation.** Decide whether Lean models latent families as finite maps from guards to graph
+  fragments, as an indexed family of resource contexts, or as a separate control layer that lowers
+  into graph algebra after resolution.
+- **Authority.** Decide which capabilities are compile-time witnesses only and which become durable
+  runtime facts. In v1, `SelectActualize` is not a separately persisted token.
+- **Composition.** State when latent operators may appear under `<>`, `=>`, or inside another latent
+  operator, and whether any distributive laws are valid before resolution.
+- **Budget.** Distinguish selected-cost, max-reserved, sum-prepaid, and escrow policies per
+  operator. ADR 0036 chooses selected-cost only for current latent branches.
+- **Recovery.** Decide whether an operator needs a distinct durable selection event or whether an
+  admitted rewrite row is the only durable fact.
+- **Failure and cancellation.** Operators such as `race`, `recover`, and bounded repetition require
+  side-effect and retry semantics beyond the `select(...)` baseline.
+- **Proof targets.** Each operator needs theorem targets for branch validity, boundary preservation,
+  resource consumption, and replay determinism.
+
+## Prior Art
+
+- **Algebraic graphs** - Mokhov's overlay/connect algebra is the graph-denotation layer that Wire
+  keeps small and does not extend for control.
+- **Guarded commands** - Dijkstra's guarded-command discipline is useful prior art for separating
+  guarded alternatives from ordinary sequential composition.
+- **Linear logic and session types** - additive choice is the closest proof-theoretic analogue for
+  guarded alternatives where one branch is selected and the others are discarded.
+- **Selective applicative functors and build-system semantics** - useful prior art for separating
+  static structure from dynamic choice without hiding possible dependencies.
+- **Graph transformation control** - graph transformation literature distinguishes graph rewrite
+  rules from control programs that choose, sequence, or repeat those rules.
+
+## Consequences
+
+### Positive
+
+- Gives `select(...)` a home without pretending it is plain overlay/connect.
+- Prevents future control constructs from entering Wire as ad hoc rewrite forms.
+- Makes the proof, budget, recovery, and authority seams visible before new operators are accepted.
+- Preserves Mokhov algebra as the graph-denotation layer.
+
+### Negative
+
+- Adds another layer of terminology that must stay separate from graph composition and runtime
+  rewrite constructors.
+- Leaves several useful workflow constructs explicitly deferred.
+- Requires future docs to distinguish compile-time latent topology from live materialized topology.
+
+### Obligations
+
+- Architecture chapter 03 should state that latent structural control lowers to graph algebra after
+  resolution rather than extending Mokhov's constructor set.
+- Architecture chapter 05 and the conditionality reference should place `select(...)` in this
+  category.
+- Architecture chapter 07 and the rewrite reference should distinguish latent control from ordinary
+  planner-authored rewrites.
+- Lean theorem targets for future operators must include denotation-after-resolution and
+  no-live-topology-before-resolution statements.
+- ADR 0038 tracks the concrete theorem names and implementation issues for `select(...)` and
+  deferred latent-control proof targets.
+
+## Alternatives considered
+
+- **Make `select(...)` a graph-algebra constructor** - rejected because pre-selection alternatives
+  are not one graph and would enlarge the Graph layer beyond overlay/connect.
+- **Treat `select(...)` as an ordinary rewrite constructor** - rejected because the branch family is
+  compile-time sealed and typed before runtime admission; arbitrary planner rewrites do not have
+  that shape.
+- **Hide the branch choice inside executor code** - rejected because it makes possible topology
+  invisible to compilation, proof, replay, and operator surfaces.
+
+## Related
+
+- [../Architecture/03-formalism-stack.md](../Architecture/03-formalism-stack.md)
+- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md)
+- [../Architecture/07-rewrites-and-materialization.md](../Architecture/07-rewrites-and-materialization.md)
+- [../Reference/Wire/conditionality.md](../Reference/Wire/conditionality.md)
+- [../Reference/rewrites.md](../Reference/rewrites.md)
+- [0007-latent-branch-conditional-lowering.md](0007-latent-branch-conditional-lowering.md)
+- [0028-wire-topology-composition-and-boundary-labels.md](0028-wire-topology-composition-and-boundary-labels.md)
+- [0032-wire-boundary-contract-resources.md](0032-wire-boundary-contract-resources.md)
+- [0033-wire-select-guarded-affine-collapse.md](0033-wire-select-guarded-affine-collapse.md)
+- [0034-wire-pure-select-actualization-authority.md](0034-wire-pure-select-actualization-authority.md)
+- [0035-wire-rewrite-algebra-forms.md](0035-wire-rewrite-algebra-forms.md)
+- [0036-wire-latent-branch-budget-recovery.md](0036-wire-latent-branch-budget-recovery.md)
+- [0038-wire-proof-track-theorem-ledger.md](0038-wire-proof-track-theorem-ledger.md)
+- GitHub #99

--- a/docs/ADRs/0038-wire-proof-track-theorem-ledger.md
+++ b/docs/ADRs/0038-wire-proof-track-theorem-ledger.md
@@ -1,0 +1,168 @@
+---
+title: "ADR 0038 - Wire Proof-Track Theorem Ledger"
+description:
+  "Collects the Wire proof-track theorem targets and separates Lean proof work from Haskell
+  correspondence obligations."
+sidebar:
+  label: "0038. Proof ledger"
+  order: 38
+status: proposed
+date: 2026-04-30
+superseded_by: null
+related:
+  - docs/Architecture/03-formalism-stack.md
+  - docs/Architecture/05-wire-language.md
+  - docs/Architecture/07-rewrites-and-materialization.md
+  - docs/Reference/Wire/pure-execution.md
+  - docs/Reference/Wire/conditionality.md
+  - docs/Reference/rewrites.md
+  - docs/ADRs/0010-wire-closed-authority-and-three-layer-stack.md
+  - docs/ADRs/0023-corepure-expression-surface.md
+  - docs/ADRs/0032-wire-boundary-contract-resources.md
+  - docs/ADRs/0033-wire-select-guarded-affine-collapse.md
+  - docs/ADRs/0034-wire-pure-select-actualization-authority.md
+  - docs/ADRs/0035-wire-rewrite-algebra-forms.md
+  - docs/ADRs/0036-wire-latent-branch-budget-recovery.md
+  - docs/ADRs/0037-wire-latent-structural-control.md
+  - "GitHub #99"
+  - "GitHub #103"
+  - "GitHub #106"
+---
+
+# ADR 0038 - Wire Proof-Track Theorem Ledger
+
+## Status
+
+Proposed - this ADR is the theorem-ledger slice for the Wire boundary-resource ADR stack. It names
+the proof obligations that guide the next Lean and Haskell correspondence work without deciding that
+the Wire compiler must move into Lean.
+
+## Context
+
+ADRs 0032-0037 define the semantic vocabulary for boundary resources, guarded-affine `select(...)`,
+restricted actualization authority, rewrite boundary laws, selected-branch budget policy, and latent
+structural control operators.
+
+The proof obligations from those ADRs are intentionally precise, but they are spread across several
+documents. The current Lean track also already proves a substantial subset of Wire rewrite and
+CorePure obligations, while other claims still depend on Haskell compiler/runtime correspondence or
+future runtime policy.
+
+Cortex therefore needs one proof-track ledger that states which theorem targets exist, which layer
+owns each target, and which open issue advances it. This is the ADR-A slice from GitHub #103: it
+settles what must be proved before deciding whether the compiler remains Haskell-first, becomes a
+Lean-specified Haskell implementation, or eventually moves into Lean.
+
+## Decision
+
+Wire proof work should use a theorem ledger that separates four classes of obligations:
+
+1. **Mechanized Lean surfaces** - theorem statements already present under `theory/`.
+2. **Immediate Lean theorem targets** - proof-side declarations that can be added before proving
+   executable Haskell correspondence.
+3. **Haskell correspondence targets** - executable compiler/runtime paths that must produce the
+   witnesses consumed by the Lean proof model, usually through tests or a future Lean oracle.
+4. **Deferred semantic targets** - obligations that require a later runtime or language decision
+   before they should be mechanized.
+
+The ledger is the canonical place to add or retire Wire proof targets. Individual ADRs should state
+their semantic obligations, while this ADR records the implementation-facing theorem names,
+dependencies, and status.
+
+## Ledger
+
+In the status column, "Mechanized" means the named proof-side declaration has landed for the row's
+claim. "Mechanized on the Lean side" emphasizes that the proof-side theorem exists while executable
+Haskell correspondence remains a separate open target.
+
+| Area                                   | Theorem or witness target                                                                                                           | Runtime or proof counterpart                                                                                                         | Status                                                                   |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| CorePure output keys                   | `pureNode_evalOutputs_keys_in_outputPorts`, `pureNode_evalOutputs_outputPorts_present`                                              | Source pure nodes lower to one native pure task whose successful output map exposes exactly the declared ports.                      | Mechanized.                                                              |
+| CorePure where fields                  | `whereStaticFields_sound`, `pureNode_evalWhereEnv_record_hasOnlyFields`, `pureNode_evalWhereEnv_localEnv_match`                     | Static `where` discovery is sound for matching runtime environments, and opened fields hide same-named static facts.                 | Mechanized.                                                              |
+| CorePure lowering                      | `pureNode_lowering_evalOutputs_eq`                                                                                                  | Lowered native pure-task configs evaluate like their source pure node in the proof model.                                            | Mechanized.                                                              |
+| CorePure value contracts               | `pureNode_evalOutputs_values_satisfy_outputContracts`                                                                               | Successful pure outputs validate and wrap through the declared Wire output contracts.                                                | Open; tracked by GitHub #117.                                            |
+| CorePure builtin authority             | `closedBuiltinEnv_authorityFree`                                                                                                    | The fixed builtin environment cannot name executor, host, durable-state, model, tool, or rewrite authority.                          | Open; tracked by GitHub #116.                                            |
+| CorePure static context correspondence | `topLevelBindings_establish_staticContext`                                                                                          | Haskell lowering builds the Lean static context from module-level pure helpers and captured pure data.                               | Open; tracked by GitHub #114.                                            |
+| CorePure duplicate record fields       | Parser/elaborator witness for duplicate and prefix-conflicting record paths                                                         | ADR 0023's duplicate-name discipline prevents admitted record literals from relying on silent overwrite.                             | Open; tracked by GitHub #115.                                            |
+| Rewrite admission                      | `planGraphRewriteChecks_admissible`, `runtimePlannerConstruction_admissible`, `constructedPlannedRewriteDelta_admissible_of_inputs` | Runtime-shaped planner witnesses instantiate abstract admissible rewrites.                                                           | Mechanized on the Lean side.                                             |
+| Constructed chains                     | `ConstructedPlanningChain.toRewriteChain`, `.preserves_sourceValid`, `.steps_le_rewriteOps`, `.finalBudget_le_initial`              | Finite constructed chains erase to abstract rewrite chains and preserve source validity and budget bounds.                           | Mechanized on the Lean side.                                             |
+| Registry boundary                      | `constructedPlannedRewriteDelta_preserves_registryBoundary`                                                                         | Constructed deltas preserve `registryBoundary registry` without arbitrary caller-supplied witnesses.                                 | Open; tracked by GitHub #109.                                            |
+| Planner/runtime correspondence         | `planGraphRewrite_produces_RuntimeConstructionInputs` and `admitRewriteDelta_produces_AdmittedRewriteDelta`                         | Haskell `planGraphRewrite`, `consumeRewriteBudget`, and `admitRewriteDelta` produce the Lean witness fields.                         | Open; tracked by GitHub #110.                                            |
+| Boundary resources                     | `resourceConsumption_faithful`, `rewriteSlot_spent_at_most_once`, `boundaryPreserved`                                               | Valid operations consume declared boundary resources, spend the anchor rewrite slot at most once, and preserve the exposed boundary. | Target named by ADR 0032; proof decomposition still open.                |
+| Rewrite boundary laws                  | `substitution_preserves_boundary`, `appendContinuation_preserves_boundary`                                                          | Replacement and append are separate boundary laws even when both pass through runtime rewrite admission.                             | Target named by ADR 0035; depends on the resource model.                 |
+| Select actualization                   | `selectActualize_lowers_to_appendAfter`, `selectActualize_admissible_of_constructedStep`                                            | A selected branch lowers to the current retained-owner `AppendAfter` realization and reuses existing admission proofs.               | Open; tracked by GitHub #108.                                            |
+| Unselected branches                    | `selectActualize_unselected_not_materialized`                                                                                       | Unselected sealed arms do not become live topology for the run.                                                                      | Open; tracked by GitHub #108.                                            |
+| Latent branch budget                   | `selectActualize_consumes_selected_cost`                                                                                            | Only the admitted selected branch consumes runtime rewrite budget under ADR 0036's selected-cost policy.                             | Open; tracked by GitHub #108.                                            |
+| Latent recovery                        | `selectedBranch_recovery_deterministic`                                                                                             | Recovery replays the same admitted selected branch and never materializes unselected alternatives.                                   | Deferred until the durable selection/rewrite record boundary is settled. |
+
+## Ordering
+
+The next implementation proof work should proceed in this order:
+
+1. **CorePure value and authority bridge** - close output value/contract soundness, closed builtin
+   authority, duplicate record-path rejection, and static-context correspondence.
+2. **Registry-boundary preservation** - prove constructed deltas can supply the registry-boundary
+   `contractPreserved` witness instead of receiving it from the caller.
+3. **Planner/runtime correspondence** - connect Haskell planner and budget admission paths to the
+   Lean witness structures.
+4. **SelectActualize** - model selected-arm actualization as latent structural control that lowers
+   to existing admitted-delta machinery.
+5. **Recovery determinism** - prove durable replay properties after the runtime record boundary is
+   sharp enough to state them.
+
+This order is intentionally asymmetric: proof-side Lean targets should be named before Haskell
+correspondence attempts to produce their witnesses.
+
+## Consequences
+
+### Positive
+
+- Prevents proof obligations from being lost across ADRs, issues, and `theory/README.md`.
+- Makes the Lean/Haskell boundary explicit without prematurely moving the compiler into Lean.
+- Gives future proof PRs a canonical place to add, rename, discharge, or defer theorem targets.
+- Keeps `select(...)` proof work tied to existing rewrite admission instead of inventing a parallel
+  proof stack.
+
+### Negative
+
+- Adds one more internal ADR that must be kept current as theorem targets land or change names.
+- Some theorem names in this ledger are target names, not current declarations.
+- Haskell correspondence remains a testing/oracle obligation until Cortex chooses a stronger
+  compiler-spec authority model.
+
+### Obligations
+
+- When a listed theorem target lands, update this ADR or the Track 3 proof summary so the status is
+  no longer stale.
+- New Wire proof work should link to the relevant ledger row and issue.
+- If GitHub #103 later chooses Lean as compiler spec or implementation, this ADR should be updated
+  or superseded to reflect the new authority model.
+
+## Alternatives considered
+
+- **Keep the proof roadmap only in `theory/README.md`** - rejected because the README should
+  summarize landed proof surfaces, not be the canonical decision record for future theorem targets.
+- **Track every proof target only in GitHub issues** - rejected because issues are active planning
+  state, while the theorem split is an architectural decision.
+- **Decide the Lean compiler question now** - rejected because the theorem list should come before
+  choosing Haskell-first, Lean-spec, or Lean-implementation authority.
+
+## Related
+
+- [../Architecture/03-formalism-stack.md](../Architecture/03-formalism-stack.md)
+- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md)
+- [../Architecture/07-rewrites-and-materialization.md](../Architecture/07-rewrites-and-materialization.md)
+- [../Reference/Wire/pure-execution.md](../Reference/Wire/pure-execution.md)
+- [../Reference/Wire/conditionality.md](../Reference/Wire/conditionality.md)
+- [../Reference/rewrites.md](../Reference/rewrites.md)
+- [0010-wire-closed-authority-and-three-layer-stack.md](0010-wire-closed-authority-and-three-layer-stack.md)
+- [0023-corepure-expression-surface.md](0023-corepure-expression-surface.md)
+- [0032-wire-boundary-contract-resources.md](0032-wire-boundary-contract-resources.md)
+- [0033-wire-select-guarded-affine-collapse.md](0033-wire-select-guarded-affine-collapse.md)
+- [0034-wire-pure-select-actualization-authority.md](0034-wire-pure-select-actualization-authority.md)
+- [0035-wire-rewrite-algebra-forms.md](0035-wire-rewrite-algebra-forms.md)
+- [0036-wire-latent-branch-budget-recovery.md](0036-wire-latent-branch-budget-recovery.md)
+- [0037-wire-latent-structural-control.md](0037-wire-latent-structural-control.md)
+- GitHub #99
+- GitHub #103
+- GitHub #106

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -48,6 +48,13 @@ values: `proposed`, `accepted`, `superseded`, `deprecated`.
 | [0029](0029-corepure-structured-serialization.md)               | CorePure Structured Serialization                                   | proposed |
 | [0030](0030-wire-node-implementation-forms.md)                  | Wire Node Implementation Forms                                      | proposed |
 | [0031](0031-wire-binding-forms-and-where-clauses.md)            | Wire Binding Forms and Node Where Clauses                           | proposed |
+| [0032](0032-wire-boundary-contract-resources.md)                | Wire Boundary Contracts as Planning Resources                       | proposed |
+| [0033](0033-wire-select-guarded-affine-collapse.md)             | Wire Select as Guarded Affine Collapse                              | proposed |
+| [0034](0034-wire-pure-select-actualization-authority.md)        | Pure Selectors and Restricted Actualization Authority               | proposed |
+| [0035](0035-wire-rewrite-algebra-forms.md)                      | Wire Rewrite Algebra Forms                                          | proposed |
+| [0036](0036-wire-latent-branch-budget-recovery.md)              | Latent Branch Budget and Recovery Policy                            | proposed |
+| [0037](0037-wire-latent-structural-control.md)                  | Wire Latent Structural Control Operators                            | proposed |
+| [0038](0038-wire-proof-track-theorem-ledger.md)                 | Wire Proof-Track Theorem Ledger                                     | proposed |
 
 ## Writing a new ADR
 

--- a/flake.lock
+++ b/flake.lock
@@ -766,11 +766,11 @@
         "tree-sitter-json": "tree-sitter-json"
       },
       "locked": {
-        "lastModified": 1777501942,
-        "narHash": "sha256-4s4NaNKMGlZ0qLvmZfp95CDgd3Z2RYzCVd3NyfHrByU=",
+        "lastModified": 1777503097,
+        "narHash": "sha256-fRBBuZwMD9dwJ4wnB6iJ4w1hCVrXjB5UAyVnYmSff6M=",
         "owner": "Digimuoto",
         "repo": "repo-docs",
-        "rev": "76bb104696f3db4b05d40cb8f5c88e0c97b3fb17",
+        "rev": "a4b65a2f6a6690bb967296890dfe29c639a16e37",
         "type": "github"
       },
       "original": {

--- a/theory/README.md
+++ b/theory/README.md
@@ -201,27 +201,16 @@ Mechanized results now include:
   `rewriteChain_preserves_registryBoundary`, `rewriteChain_steps_le_rewriteOps`, and
   `rewriteChain_finalBudget_le_initial`: local rewrite certificates lift across finite chains.
 
-Remaining obligations:
+The remaining Track 3 obligations are now tracked in
+`docs/ADRs/0038-wire-proof-track-theorem-ledger.md`. The next proof slices are:
 
-- prove that the executable Haskell CorePure evaluator and compiler lowering
-  (`evaluatePureTaskOutputs`, `loweredPureNodeFromBody`, `validateWhereClause`, and
-  `staticWhereFieldNames`) produce the Lean `Cortex.Wire.Pure` witnesses, including duplicate-name
-  rejection, output-port equality, static `where` fields, and ADR 0010/0023's authority exclusion by
-  syntax; the static `where` correspondence must also produce the `bindings_noShadow` and
-  `where_letSafe` admission witnesses when field discovery ignores local CorePure `let` binders, and
-  show that opened `where` fields hide same-named static record facts;
-- connect ADR 0023's duplicate-name discipline to executable parser/elaborator witnesses, especially
-  duplicate record fields and nested-path conflicts, so record evaluation never relies on silent
-  overwrite inside admitted CorePure literals;
-- prove that the executable Haskell planner and budget admission path (`planGraphRewrite`,
-  `consumeRewriteBudget`, and `admitRewriteDelta`) produce the `RuntimeConstructionInputs` and
-  `AdmittedRewriteDelta` witnesses used by constructed Lean chains, including the source context
-  validity invariant, namespace discipline, current anchor membership, raw-subgraph validity, final
-  acyclicity, inserted-depth computation, and pointwise remaining-budget equation;
-- prove staged-executor registry-boundary preservation for constructed deltas, so the headline
-  registry-boundary chain theorem can discharge its per-step `contractPreserved` witness from the
-  compiler and registry model rather than from a caller-supplied hypothesis;
-- connect constructed planner chains to durable materialization order and lineage.
+- CorePure value/contract soundness, closed builtin authority, duplicate record-path rejection, and
+  Haskell static-context correspondence;
+- constructed-delta registry-boundary preservation;
+- Haskell planner and budget-admission correspondence for `RuntimeConstructionInputs` and
+  `AdmittedRewriteDelta`;
+- `SelectActualize` proof certificates for selected-arm lowering, unselected-arm
+  non-materialization, selected-cost budgeting, and later recovery determinism.
 
 This is the "sandbox by proof" story for dynamic graph rewriting. Rewrites may transform topology,
 but chain-level preservation requires them to stay inside the registry boundary documented in


### PR DESCRIPTION
## Summary

Adds a proposed ADR stack for the Wire boundary-resource, conditionality, and proof-track discussion:

- ADR 0032: boundary contracts as planning resources
- ADR 0033: `select(...)` as guarded affine collapse, with superposition kept as colloquial intuition
- ADR 0034: executor and pure selectors with restricted actualization authority
- ADR 0035: rewrite boundary laws split from current runtime realization
- ADR 0036: selected-branch budget and recovery policy for latent branches
- ADR 0037: latent structural control operators, including the Mokhov-algebra boundary, candidate operators, prior art, and open seams
- ADR 0038: Wire proof-track theorem ledger, separating mechanized Lean surfaces, immediate Lean targets, Haskell correspondence, and deferred runtime/recovery targets

Also updates `theory/README.md` so Track 3 remaining obligations point to ADR 0038 instead of duplicating the proof roadmap, and bumps the repo-docs `flake.lock` input used by the generated docs site.

## Follow-up

- Post-acceptance architecture/reference rollout is tracked in #118.

## Verification

- `just docs-lint`
- `just docs-check`
- `just fmt-check`
- `git diff --check`
- commit hooks: `docs-lint`, `treefmt`
- `just check-commit-provenance origin/main..HEAD`

## Issues

Closes #99
Closes #106
