### PR TITLE
feat: mechanize CorePure proof subset

### DIFF
--- a/agents/skills/research/SKILL.md
+++ b/agents/skills/research/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: research
+description: >
+  Cross-source research synthesis through the seven archetype lenses. Use after a stretch of work —
+  a slice landed, a PR shipped, a sweep completed — to find loose ends, new ideas, design tensions,
+  missed abstractions, and research directions across implementation, theory, docs, ADRs, issues,
+  and external prior art.
+
+date: 2026-04-30
+status: active
+---
+
+# Research
+
+Synthesize Cortex context across implementation, the Lean theory track, canonical docs, ADRs,
+issues, PRs, and external literature to find high-value discrepancies and connections that only
+become visible when multiple layers are read together.
+
+The default mode is read-only. Do not modify code, theorems, or docs unless the user asks for
+follow-up changes after the memo lands.
+
+This skill complements `architecture` and `lean-theorem-attack`. Architecture decides the right
+shape of a single design question. Theorem-attack stress-tests one formal claim. Research is the
+zoomed-out pass that asks "given everything that has shifted, what is now visible that wasn't
+before?"
+
+## When to use
+
+Use research when:
+
+- A non-trivial slice has landed and the surrounding picture has changed.
+- The user asks for "loose ends", "what's next", "what did we miss", "are there ideas hiding here",
+  or "synthesize where we are".
+- A paper, draft, or external article needs to be read against the current implementation.
+- Multiple ADRs have moved together and downstream coherence needs to be checked.
+- A speculative idea needs evaluation against current state.
+
+Do not use research for:
+
+- Single-file code review (use `haskell-code-style` or `lean-code-style`).
+- One specific architectural decision (use `architecture`).
+- One specific theorem's adequacy (use `lean-theorem-attack`).
+- CI repair, doc fixes, or shipping work.
+
+## Invocation modes
+
+Dispatch on whether the user supplied a scope.
+
+### Sweep mode (no args)
+
+Infer the scope from the current state:
+
+1. Branch diff against `main` (commits, changed files, touched modules).
+2. Recently changed ADRs and architecture chapters.
+3. Recently merged PRs that touch the same area.
+4. The conversational topic if obvious.
+
+Sweep mode is the most common use case after a slice lands. Surface findings; do not edit.
+
+### Targeted mode (args supplied)
+
+| Form                             | Meaning                                                                                                               |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `area <path>`                    | Focus on a subsystem or directory (e.g. `area src/Cortex/Wire`, `area theory/Cortex/Pulse`).                          |
+| `issue <id>` or `pr <id>`        | Read the issue/PR plus its surrounding technical context (linked docs, code paths, prior decisions).                  |
+| `paper <name>` or `draft <path>` | Cross-reference a paper, draft, or research note against current implementation and theory.                           |
+| `idea <free text>`               | Evaluate a speculative direction against current Cortex state.                                                        |
+| `broad`                          | Full corpus sweep across implementation, theory, docs, ADRs, issues, and external literature. Heavier; use sparingly. |
+| free text                        | Steer emphasis on top of any of the above (e.g. `area src/Cortex/Wire "focus on admission/runtime drift"`).           |
+
+Examples:
+
+```text
+/research
+/research area theory/Cortex/Wire "look for Haskell↔Lean correspondence gaps"
+/research pr 111 "what does this PR open up for the next slice"
+/research paper mokhov-graphs "compare to our Track 1 algebra"
+/research idea "treat where-records as a typed extension of input ports"
+/research broad "prioritize cross-layer drift over elegance"
+```
+
+## Operating posture
+
+- **Cortex-first.** Frame Cortex as the substrate. Treat Logos and downstream consumers as examples
+  or migration pressure, not as the centre of gravity.
+- **Implementation reality before abstraction.** Read code, theory, and tests before theorizing.
+  Memory is not evidence.
+- **Cross-reference is the source of insight.** The strongest findings live at boundaries between
+  layers (impl ↔ theory, theory ↔ ADR, ADR ↔ ADR, impl ↔ issue, claim ↔ literature).
+- **Separate fact, inference, and hypothesis.** Imagination is welcome; mislabelling it is not.
+- **Respect the extension boundary.** A clean abstraction that blocks the next ADR or roadmap phase
+  is not clean enough.
+- **Evidence current, not remembered.** Re-read the code, the ADR, the lakefile. Do not trust prior
+  conversation summaries as authoritative.
+- **Do not silently edit.** Surface findings, prioritize, and let the user pick which to act on.
+
+## Required sources
+
+Read only what the scope demands, but always check the layer map before forming a finding.
+
+### Layer 1 — Implementation reality
+
+- `src/Cortex/` — Cortex Haskell library
+- `src-platform/Platform/` — runtime substrate sub-library
+- `src-logos/Logos/` — downstream reasoning library
+- `app/cortex-pulse/` — substrate shell executable
+- `editors/tree-sitter-wire/` — Wire grammar
+- `test/`, `test-logos/` — hspec suites
+- module export lists, type signatures, partial functions, and `error` calls
+- `TODO`, `FIXME`, `HACK`, `XXX`, `-- TODO`, deprecation comments
+
+### Layer 2 — Formal narratives
+
+- `theory/Cortex/Graph/`, `theory/Cortex/Pulse/`, `theory/Cortex/Wire/` — Lean mechanization
+- `theory/README.md` — proof surface and Status table
+- `theory/Main.lean`, `theory/lakefile.lean`
+- module-level Lean docstrings; named theorems; `axiom` and `sorry` (should be none)
+
+### Layer 3 — Canonical docs and roadmap
+
+- `docs/Architecture/01-overview.md` … `08-artifacts-and-provenance.md`
+- `docs/Reference/Wire/*.md`
+- `docs/Consumers/Logos/*.md` (downstream surface)
+- `docs/Logos/reasoning-library.md`
+- `agents/context.md`, `agents/archetypes/*`
+
+### Layer 4 — Decision history
+
+- `docs/ADRs/index.md` plus every ADR file (status field: `proposed`, `accepted`, `superseded`)
+- ADR `related:` graph, supersession chains
+- `git log` on the affected paths — what shipped, what reverted
+
+### Layer 5 — Live tracking
+
+- GitHub Issues (`gh issue list`, `gh issue view`)
+- GitHub PRs (`gh pr view`, `gh pr list`)
+- linked discussions, design notes, draft PRs, RFCs
+
+### Layer 6 — External literature and prior art
+
+- Mokhov graph algebra papers
+- Temporal / Cadence / durable-execution writeups
+- Effect systems, capability-secure design, JSON Schema and contract validation
+- Nix language semantics (CorePure)
+- Bidirectional type-checking, structural typing, capability-bounded interpretation
+
+Use the layers that exist. Note the layers you did not check and why.
+
+## Archetype baseline
+
+Every research pass runs all seven archetype lenses, but the value is the change of viewpoint, not
+seven mini-essays. Keep each lens compact.
+
+| Lens                            | Reads for                                                                                                       | Outputs                                                                                             |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `agents/archetypes/episteme.md` | What is established by current code, theory, docs, tests, ADRs, issues, literature.                             | Evidence brief: sources read, facts established, inferences, unverified assumptions, evidence gaps. |
+| `agents/archetypes/logos.md`    | Precise statement of the claims, invariants, and theorem boundaries currently in play.                          | Claim map: what is asserted, what is proved, what is assumed, what is out of scope.                 |
+| `agents/archetypes/kritikos.md` | Counterexamples, edge cases, off-domain inputs, layer leaks, broken assumptions, drifted invariants.            | Adversarial findings: where the current system can fail, be misused, or contradict itself.          |
+| `agents/archetypes/themis.md`   | Contracts, ownership boundaries, authority surfaces, layer placement, ADR conformance.                          | Contract audit: what is owed by which layer, what is currently enforced, what is only prose.        |
+| `agents/archetypes/techne.md`   | Convertibility of findings into concrete artifacts: issues, ADRs, theorems, tests, prototypes, migration notes. | Repair sketches: smallest concrete next step per finding.                                           |
+| `agents/archetypes/poiesis.md`  | Alternative framings, encodings, names, decompositions; missing vocabulary; cross-domain analogies.             | Alternative encodings and naming: how else could this be modelled.                                  |
+| `agents/archetypes/sophia.md`   | Prioritization, readiness, blocker vs accepted-debt, the next coherent slice.                                   | Decision summary: top priorities, residual risks, next owner or pass.                               |
+
+Skills remain orchestrators. Archetypes do not have authority to expand scope or edit files.
+
+## Finding categories
+
+Read `references/finding-quality.md` before writing the memo. Use these categories on every major
+finding:
+
+| Category             | Use when                                                                           |
+| -------------------- | ---------------------------------------------------------------------------------- |
+| `Correctness Gap`    | A claimed or expected property is not enforced, tested, proved, or true.           |
+| `Missed Abstraction` | Several ad hoc mechanisms want one principled interface, algebra, or capability.   |
+| `Layer Leak`         | A concept lives at the wrong layer (Platform vs Cortex vs Logos vs downstream).    |
+| `ADR Drift`          | An ADR's accepted decision and current code/docs/theory have diverged.             |
+| `Novel Idea`         | A new conceptual connection or research angle the synthesis surfaces.              |
+| `Design Tension`     | Two legitimate goals pull the design in conflicting directions.                    |
+| `Evidence Gap`       | A claim may be true, but the current evidence is weak, partial, or stale.          |
+| `Extension Risk`     | A plausible next ADR or roadmap step will break a current invariant or assumption. |
+| `Dead End`           | A promising direction looks attractive but does not survive closer analysis.       |
+| `Terminology Gap`    | The system lacks the right names for concepts it already relies on.                |
+
+## Workflow
+
+### 1. Determine scope
+
+Use the user's scope if given. Otherwise infer from branch diff, recent commits, and active topic.
+Note the scope explicitly in the memo so future readers know what was in frame.
+
+### 2. Assemble context in layers
+
+Walk the layer map above in order. For each layer:
+
+- Read what the scope demands.
+- Capture concrete artifacts: file paths, line numbers, ADR ids, theorem names, issue ids, commit
+  hashes.
+- Note layers that exist but were not read; the memo declares this.
+
+Do not theorize before the implementation reality layer is read.
+
+### 3. Cross-reference between pairs
+
+For every pair of layers that the scope touches, ask:
+
+- **Implementation ↔ Theory.** Does the Lean track witness what the Haskell evaluator does? Where
+  does the proof model lag, lead, or diverge from the implementation?
+- **Implementation ↔ Canonical docs.** Are docs ahead of code, code ahead of docs, or both telling
+  different stories?
+- **Theory ↔ ADRs.** Do theorems mechanize what the ADR commits to, or is the ADR ahead of the
+  theory?
+- **ADR ↔ ADR.** Are accepted decisions consistent? Is a `proposed` ADR conflicting with an
+  `accepted` one without supersession?
+- **Implementation ↔ Issues.** Are several open issues symptoms of the same structural gap?
+- **Architecture ↔ Literature.** Is Cortex rediscovering a known abstraction or moving away from a
+  known good pattern?
+- **Layer placement.** Does each concept live at the right semantic level: `Platform` vs generic
+  Cortex vs Logos vs downstream?
+
+The strongest findings are usually pair findings, not layer findings.
+
+### 4. Run the seven archetypes
+
+Pass the assembled context through each archetype lens, in this order. Keep each output short (one
+paragraph or a few bullets). The lens result is a viewpoint, not a report.
+
+1. `episteme` — what is established, what is assumed, what is unverified
+2. `logos` — claim map, theorem boundaries, what is in/out of scope
+3. `kritikos` — countermodels, drift, broken assumptions
+4. `themis` — contract coverage, layer ownership, ADR conformance
+5. `techne` — convert each finding into a concrete next step
+6. `poiesis` — alternative framings worth recording even if not adopted
+7. `sophia` — prioritize and decide
+
+### 5. Build findings with evidence discipline
+
+Every major finding must include:
+
+- title (one precise sentence)
+- category (from the table above)
+- status: `Observed`, `Inferred`, or `Speculative`
+- confidence: `High`, `Medium`, or `Low`
+- primary evidence (files, line numbers, ADRs, theorems, issues, literature)
+- cross-reference (the pair or layers from which the finding emerges)
+- why it matters (impact on correctness, extensibility, performance, clarity, or scientific
+  contribution)
+- recommended next step (issue, ADR draft, theorem, test, prototype, literature check, parked note)
+
+### 6. Prioritize and write the memo
+
+Rank findings by impact, novelty, actionability, and confidence. Group results into:
+
+- **Act now** — must move before the next slice or before something else lands.
+- **Design next** — a coherent next ADR, theorem, or implementation slice.
+- **Write up** — papers, blog posts, ADRs that capture insight already implicit in the work.
+- **Parked** — not now; recorded so the synthesis is not lost.
+
+Use `templates/research-memo.md` as the output shape. Compress when the scope is small; preserve
+evidence discipline either way.
+
+## Output shape
+
+Default to the memo template at `templates/research-memo.md`. The minimum surface is:
+
+- executive summary (2-6 sentences)
+- per-finding cards with evidence, archetype lens that surfaced it, and next step
+- archetype synthesis box (one line per lens)
+- recommended actions in the four buckets
+- known unknowns / evidence gaps
+
+Compressed memos are fine for narrow scopes — keep the evidence discipline.
+
+## Quality bar
+
+- Cite paths, theorem names, ADR ids, issue numbers — not vague memory.
+- Default to 5-8 major findings; fewer is fine, more usually means the memo is doing two jobs.
+- No more than 20-30% of findings should be Speculative or Low confidence.
+- Every Speculative finding has a validation path attached.
+- Every novel idea has at least one cross-reference and one experiment that would settle it.
+- Prefer one strong finding over three weak observations.
+- Negative results count: a recorded dead end prevents the team from re-treading it.
+
+## Anti-patterns
+
+- Theorizing before reading code or theory.
+- Treating one surprise as one bug.
+- Presenting speculation as established fact.
+- Listing observations without prioritizing.
+- Proposing abstractions for single instances.
+- Praising the current cleanliness while ignoring the next roadmap phase.
+- Failing to record what was not checked.
+- Writing seven archetype reports instead of seven viewpoints.
+
+## Validation
+
+Research is read-only by default. If the user asks for follow-up edits after the memo:
+
+- treat each follow-up as a separate skill (architecture, lean-theorem-attack, doc-review-and-fix,
+  impl, etc.) rather than blurring research into editing
+- run the relevant validators per the target skill (`just fmt`, `just docs-check`,
+  `just lean-build`, `just check`, etc.)
+- never silently edit ADRs, theorems, or canonical docs while a research pass is in progress
+
+## References
+
+- `references/finding-quality.md` — evidence discipline, finding bar, traceability rules
+- `references/archetype-lenses.md` — how each archetype reads in research mode, with worked prompts
+- `references/cortex-source-map.md` — Cortex-specific layer map with file paths and pitfalls
+- `templates/research-memo.md` — memo output shape with archetype synthesis section

--- a/agents/skills/research/references/archetype-lenses.md
+++ b/agents/skills/research/references/archetype-lenses.md
@@ -1,0 +1,201 @@
+# Archetype Lenses in Research Mode
+
+How each of the seven archetypes reads in a research synthesis pass. Keep each lens compact: the
+value is the change of viewpoint, not seven mini-essays.
+
+Load the canonical archetype profile from `agents/archetypes/<name>.md` for stance and failure
+modes. This file describes how the archetype is _used_ inside a research memo specifically.
+
+## episteme — what is established
+
+The first lens. Walks the layered source map and records primary evidence before any interpretation.
+
+Reads:
+
+- current state of the implementation (not memory, not summaries)
+- current state of the theory track
+- current state of canonical docs and ADRs
+- current state of issues and PRs
+- relevant external literature
+
+Asks:
+
+- What does the code/theorem/doc actually say today?
+- Which artifacts are stale, which are current, which are draft?
+- What did I choose not to read, and why is that acceptable?
+
+Outputs:
+
+- evidence brief: layer-by-layer list of artifacts read, with paths and line numbers
+- list of unverified assumptions surfaced during reading
+- list of evidence gaps the memo will surface
+
+Failure mode: treating a prior conversation summary as evidence. Re-read the file.
+
+## logos — claim map
+
+After episteme establishes what is true, logos states what is claimed. The scope of every theorem,
+ADR, prose invariant, and runtime guarantee is mapped explicitly.
+
+Reads:
+
+- module docstrings, theorem statements, ADR Decision sections, Architecture chapter "what this
+  layer owns" sentences
+- export lists, type signatures, public API surface
+
+Asks:
+
+- What is being asserted, by which artifact, with which quantifiers?
+- What is genuinely proved vs assumed vs prose-only?
+- Where is the boundary between "this layer owns it" and "this layer borrows it"?
+
+Outputs:
+
+- claim map: a small table or list pairing each load-bearing claim with the artifact that carries it
+  and what is in/out of scope
+
+Failure mode: paraphrasing claims into vagueness. Quote precisely or cite path:line.
+
+## kritikos — adversarial pass
+
+Find counterexamples, broken assumptions, drift between layers, off-domain inputs, and silent
+failure modes.
+
+Reads:
+
+- the boundaries logos identified
+- error paths, partial functions, `error` calls, `unsafeCoerce`, `IO` lifts in pure contexts
+- admission predicates vs theorem hypotheses
+- ADR exclusion lists vs ADT shapes
+
+Asks:
+
+- Can an arbitrary value satisfy the formal assumptions while violating the intended runtime
+  behavior?
+- Where does the implementation accept inputs that the theory rejects, or vice versa?
+- What is the smallest model that satisfies the current contract but breaks the intended claim?
+- Where is one layer silently more permissive than another?
+
+Outputs:
+
+- countermodels and concrete drift cases, each tied to a layer pair
+
+Failure mode: confusing surprise with error. A surprising design is not necessarily a wrong design;
+check the ADR and module owners first.
+
+## themis — contract audit
+
+Audit contracts, invariants, ownership, layer placement, and ADR conformance.
+
+Reads:
+
+- ADR-by-ADR conformance against current code/docs/theory
+- the layer map: Platform / Cortex / Logos / downstream
+- implicit invariants in module docstrings and module exports
+- the closed-authority and registered-authority surfaces
+
+Asks:
+
+- For each contract a layer claims to own, is it enforced by a typed boundary, a compiler check, a
+  runtime guard, a process gate, or only prose?
+- Does each concept live at the right semantic level, or has it leaked up/down?
+- Are there ADRs that commit to obligations the implementation has not yet taken on?
+- Are there obligations the implementation has taken on that no ADR records?
+
+Outputs:
+
+- contract coverage matrix: what is owed, what carries it, what is missing
+- layer-leak list: concepts that are not at the layer their owners think they are
+
+Failure mode: treating ADRs as authoritative when code has moved on, or vice versa.
+
+## techne — repair sketches
+
+Convert findings into concrete next steps. Each finding earns its place by being actionable.
+
+Reads:
+
+- the findings produced so far
+- existing skills (`architecture`, `lean-theorem-attack`, `impl`, `doc-review-and-fix`, `ship`)
+- ADR templates, issue templates, theorem patterns
+
+Asks:
+
+- What is the smallest concrete artifact that would resolve this finding — issue, ADR draft, theorem
+  statement, test, prototype, migration note, doc patch?
+- Which skill is the right home for the follow-up?
+- What is the rough cost?
+
+Outputs:
+
+- per-finding "next step" line: artifact + skill + cost estimate
+
+Failure mode: proposing big abstractions when one concrete next step is available.
+
+## poiesis — alternative framings
+
+Generate alternative encodings, names, decompositions, and analogies — even ones the user will not
+adopt — so the memo records the design space, not just the chosen branch.
+
+Reads:
+
+- the current encoding and its alternatives in nearby ADRs and prior art
+- adjacent literature for richer vocabulary
+- analogous systems and their boundary choices
+
+Asks:
+
+- Could this be encoded type-level instead of predicate-level, or vice versa?
+- Is there better vocabulary the system is reaching for?
+- Is the current decomposition cutting at the right joint?
+- What would a different layering choice cost?
+
+Outputs:
+
+- alternative-encodings list: short notes describing each alternative, with one line on cost vs
+  benefit
+
+Failure mode: aestheticism. An "elegant" alternative that blocks the next ADR is not better.
+
+## sophia — synthesis and priority
+
+The final lens. Decide what matters most now, and what should be deferred.
+
+Reads:
+
+- every finding from the previous lenses
+- the project's near-term roadmap and active priorities
+
+Asks:
+
+- What is the highest-risk unresolved issue?
+- Which findings block the next slice, the next PR, or the next ADR?
+- Which can be accepted as explicit debt with a tracked owner?
+- What is the one thing the user should pick up first if they read no further?
+- What single trade-off best characterizes the current state?
+
+Outputs:
+
+- decision summary: top priorities, residual risks, and the single next move
+- bucket assignment for each finding: Act now / Design next / Write up / Parked
+
+Failure mode: averaging incompatible findings into a bland recommendation.
+
+## How the lenses compose
+
+The seven lenses are not independent reports. They run in order:
+
+1. `episteme` produces the evidence base.
+2. `logos` extracts the claim structure from that base.
+3. `kritikos` attacks the claim structure.
+4. `themis` checks the contracts the claim structure is supposed to carry.
+5. `techne` turns the survivors into concrete next steps.
+6. `poiesis` records the design space around them.
+7. `sophia` ranks and decides.
+
+A finding becomes load-bearing when it survives at least one cross-lens check. A finding that only
+appears under one lens is usually still genuine, but earns more confidence when a second lens
+agrees.
+
+Compress the archetype synthesis in the memo into one line per lens. Long archetype reports are an
+anti-pattern in research mode.

--- a/agents/skills/research/references/cortex-source-map.md
+++ b/agents/skills/research/references/cortex-source-map.md
@@ -1,0 +1,133 @@
+# Cortex Source Map for Research
+
+Cortex-specific layer map. Use this to walk evidence in order and to catch layer-leaks.
+
+## Layer 1 — Implementation reality
+
+| Path                        | What lives here                                                                                          | Watch for                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `src/Cortex/Algebra/`       | Pure graph algebra surface (Mokhov-style)                                                                | Algebraic laws stated in haddock vs proven in `theory/Cortex/Graph`                    |
+| `src/Cortex/Wire/`          | Wire authoring surface, parser, compiler, executor registry, pure evaluator                              | Wire-language ADRs (0010, 0017, 0020-0031); admission rules                            |
+| `src/Cortex/Pulse/`         | Pulse runtime kernel, frontier, durable execution, recovery                                              | ADR 0003-0009; theory under `theory/Cortex/Pulse/`                                     |
+| `src/Cortex/Capability/`    | Capability tokens and authority surface                                                                  | ADR 0010 closed-authority discipline                                                   |
+| `src/Cortex/Artifact/`      | Artifact and provenance contracts                                                                        | ADRs 0006, 0009, 0013                                                                  |
+| `src-platform/Platform/`    | Runtime substrate sub-library: `Platform.Observability`, `DurableTask`, `Database`, `HTTP.Retry`, `Text` | Layer-leak smell when generic Cortex semantics import Platform internals or vice versa |
+| `src-logos/Logos/`          | Downstream reasoning library: LLM workflows, archetypes, cognitive memory                                | Cortex must not depend on Logos; Logos may depend on Cortex                            |
+| `app/cortex-pulse/`         | Substrate shell executable                                                                               | Empty task registry by design; consumers link their own                                |
+| `editors/tree-sitter-wire/` | Wire grammar                                                                                             | Must keep parity with `docs/Reference/Wire/grammar.md`                                 |
+| `test/`, `test-logos/`      | hspec-discover test suites                                                                               | What is actually covered vs what the prose claims                                      |
+
+Pitfalls:
+
+- A function in `src/Cortex/...` that takes `IO` should be checked against ADR 0010 (closed
+  authority).
+- A type in `Cortex.*` referenced from `Logos.*` is fine; the reverse is a layer leak.
+- Any `error`, `undefined`, `unsafeCoerce`, or partial pattern match in `src/Cortex/` is a finding
+  candidate.
+
+## Layer 2 — Formal narratives (Lean theory)
+
+| Path                                     | Purpose                                                         |
+| ---------------------------------------- | --------------------------------------------------------------- |
+| `theory/Cortex/Graph/`                   | Track 1: Mokhov graph algebra, denotational laws, quotient laws |
+| `theory/Cortex/Pulse/`                   | Track 2: fixed-topology Pulse kernel safety                     |
+| `theory/Cortex/Wire/`                    | Track 3: rewrite soundness, registry boundary, CorePure subset  |
+| `theory/Main.lean`, `theory/Cortex.lean` | Top-level imports; treat as the canonical proof surface         |
+| `theory/README.md`                       | Status table; what is statement vs proved vs axiomatized        |
+| `theory/lakefile.lean`                   | Build wiring; missing imports here are real findings            |
+
+Pitfalls:
+
+- `axiom`, `sorry`, `admit`, `partial`, `unsafe`, `set_option autoImplicit true` should not exist in
+  committed theory. Their presence is a hard finding.
+- A theorem whose name overstates what its body proves (e.g. `pureExpr_authorityFree` defined as
+  `False`) is a tautology trap.
+- A theorem whose hypotheses are richer than admission predicates discharge cannot be applied at the
+  use site — flag the gap.
+
+## Layer 3 — Canonical docs and roadmap
+
+| Path                                                   | Purpose                                                      |
+| ------------------------------------------------------ | ------------------------------------------------------------ |
+| `docs/Architecture/01-overview.md`                     | Public substrate framing                                     |
+| `docs/Architecture/02-ownership-and-boundaries.md`     | Cortex vs consumer ownership                                 |
+| `docs/Architecture/03-formalism-stack.md`              | Algebraic and proof-layer vocabulary                         |
+| `docs/Architecture/04-graph-and-circuit.md`            | Graph and Circuit boundary                                   |
+| `docs/Architecture/05-wire-language.md`                | Wire language architecture                                   |
+| `docs/Architecture/06-pulse-runtime.md`                | Runtime, frontier, durable execution                         |
+| `docs/Architecture/07-rewrites-and-materialization.md` | Rewrite admission and materialization                        |
+| `docs/Architecture/08-artifacts-and-provenance.md`     | Artifact and provenance contracts                            |
+| `docs/Reference/Wire/grammar.md`                       | Wire grammar reference                                       |
+| `docs/Reference/Wire/pure-execution.md`                | CorePure runtime reference                                   |
+| `docs/Reference/Wire/contracts-ports-and-matching.md`  | Contract and port reference                                  |
+| `docs/Consumers/Logos/`                                | Downstream consumer surface; not the frame for Cortex itself |
+
+Pitfalls:
+
+- Docs that paraphrase an accepted ADR but disagree with it are silently authoritative — readers
+  treat docs as canonical even when ADRs are.
+- Architecture chapters that mention concepts with no typed carrier in `src/Cortex/` are prose
+  conventions, not invariants.
+
+## Layer 4 — Decision history
+
+| Path                  | Purpose                                                                          |
+| --------------------- | -------------------------------------------------------------------------------- |
+| `docs/ADRs/index.md`  | ADR catalog with status                                                          |
+| `docs/ADRs/NNNN-*.md` | One decision per ADR. Status: `proposed`, `accepted`, `superseded`, `deprecated` |
+
+Read `index.md` first. Then read every ADR whose status is `proposed` and that touches the scope —
+`proposed` ADRs are where the active edge is.
+
+Pitfalls:
+
+- An ADR is `accepted` but the implementation has moved past it without supersession.
+- Two `proposed` ADRs commit to incompatible decisions in interlocking parts of the same subsystem.
+- An ADR's `related:` list is missing forward links from a newer ADR that depends on it.
+
+## Layer 5 — Live tracking
+
+| Source         | Command                                | Watch for                                              |
+| -------------- | -------------------------------------- | ------------------------------------------------------ |
+| GitHub Issues  | `gh issue list --search "<scope>"`     | Multiple issues that point at the same structural gap  |
+| Recent PRs     | `gh pr list --state merged --limit 20` | What shipped in adjacent areas; what reverted          |
+| Open PRs       | `gh pr list --state open`              | Conflict surfaces with ongoing work                    |
+| Specific issue | `gh issue view <id>`                   | The owner's framing, the discussion thread, linked PRs |
+
+Cortex tracks active work in GitHub Issues and PRs. Linear, downstream issue IDs, and downstream
+trackers are not authoritative for Cortex planning — historical research notes may retain those
+references, but new work is tracked in this repo.
+
+## Layer 6 — External literature and prior art
+
+Areas where Cortex sits close enough to published prior art that a memo benefits from cross-check:
+
+- **Graph algebra.** Mokhov's polymorphic graph algebra (Track 1). Kleene-style closure semantics.
+  Algebraic effects.
+- **Durable execution.** Temporal/Cadence replay semantics; Restate; AWS Step Functions.
+  Frontier/closure recovery is the same problem under different names.
+- **Workflow languages.** Airflow, Prefect, Argo — for what _not_ to inherit (Wire is closed
+  authority).
+- **Pure expression languages.** Nix (CorePure surface). Dhall. Starlark.
+- **Capability-secure design.** E, Caja, capability machines.
+- **Bidirectional type-checking.** Dunfield-Krishnaswami, Pierce-Turner — relevant to typed contract
+  checking.
+- **Effect systems.** Koka, Eff, OCaml 5 effects.
+
+Use literature to:
+
+- name what Cortex already does so docs become more precise
+- catch when Cortex is reinventing a poorly-documented version of an existing pattern
+- propose stronger versions of internal claims when external results support them
+
+Do not use literature to mandate vocabulary that has not earned its place in the codebase.
+
+## Skipped layers
+
+Always note in the memo which layers were not read. Common acceptable reasons:
+
+- "Theory layer not reviewed because the scope is purely Wire-side parser work."
+- "External literature not consulted because the scope is internal CI repair."
+- "Issue tracker not consulted because the user supplied a specific paper as scope."
+
+Silent skips are a finding-quality smell, not a research outcome.

--- a/agents/skills/research/references/finding-quality.md
+++ b/agents/skills/research/references/finding-quality.md
@@ -1,0 +1,101 @@
+# Finding Quality Bar
+
+Use this file when deciding whether a research finding belongs in the memo and how it should be
+labeled.
+
+## Evidence discipline
+
+Classify every nontrivial claim as one of:
+
+- `Observed` — directly supported by code, theorems, docs, ADRs, tests, commits, issues, or
+  literature. The reader can re-derive the claim from the cited artifact.
+- `Inferred` — not explicit in any single artifact, but strongly supported by multiple observations
+  across layers.
+- `Speculative` — plausible and useful, but not yet validated. Every Speculative finding must attach
+  a concrete validation path.
+
+Do not present speculation as fact. Do not suppress useful speculation either — label it and give it
+a path.
+
+## Confidence levels
+
+- `High` — direct evidence or multiple independent artifacts agree.
+- `Medium` — evidence is strong but partial; one good counterexample would shift the conclusion.
+- `Low` — plausible but under-validated; the finding is in the memo because the idea is worth
+  recording, not because it is settled.
+
+## Finding quality requirements
+
+A finding belongs in the memo only if every line is true:
+
+1. It is grounded in at least one concrete artifact (file path, theorem, ADR id, issue, commit,
+   literature reference).
+2. It matters for correctness, extensibility, performance, clarity, or scientific contribution.
+3. It can be stated precisely. If the title needs to hedge, the finding is not ready.
+4. It is stronger than a single observation; it is a pattern, a gap, or a claim.
+5. It has a plausible next step that someone could pick up.
+
+If a candidate point fails any of these, move it to Known Unknowns, Evidence Gaps, or leave it out.
+
+## Finding categories
+
+| Category             | Use when                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------- |
+| `Correctness Gap`    | A claimed or expected property is not enforced, tested, proved, or true.              |
+| `Missed Abstraction` | Several ad hoc mechanisms want one principled interface, algebra, or capability.      |
+| `Layer Leak`         | A concept lives at the wrong semantic level (Platform / Cortex / Logos / downstream). |
+| `ADR Drift`          | An ADR's accepted decision and current code/docs/theory have diverged.                |
+| `Novel Idea`         | A new conceptual connection or research angle the synthesis surfaces.                 |
+| `Design Tension`     | Two legitimate goals pull the design in conflicting directions.                       |
+| `Evidence Gap`       | A claim may be true, but the current evidence is weak, partial, or stale.             |
+| `Extension Risk`     | A plausible next ADR or roadmap step will break a current invariant or assumption.    |
+| `Dead End`           | A promising direction looks attractive but does not survive closer analysis.          |
+| `Terminology Gap`    | The system lacks the right names for concepts it already relies on.                   |
+
+## Traceability
+
+Every major finding traces to concrete artifacts when possible:
+
+- code path with line number (`src/Cortex/Wire/Pure.hs:1391-1422`)
+- theorem name and file (`whereStaticFields_sound` at `theory/Cortex/Wire/Pure.lean:672`)
+- ADR id and section
+  (`ADR 0031 §"Invariant: where-records have a statically determinable field set"`)
+- issue or PR (`#107`, `gh pr view 111`)
+- architecture chapter (`docs/Architecture/05-wire-language.md:#binding-surfaces`)
+- commit hash (`48663c5`)
+- external source (paper title, section, year; or URL if a public writeup)
+
+The memo should let the reader verify the claim without repeating the whole investigation.
+
+## Speculation budget
+
+- Default to 5-8 major findings.
+- No more than 20-30% of findings should be Speculative or Low confidence.
+- A Novel Idea is fine as Speculative if it has a validation path attached.
+- If half the memo is Speculative, the synthesis is not ready; widen the evidence layer first.
+
+## Helpful checks
+
+Before finalizing a finding, answer:
+
+- What did I observe directly?
+- What do I infer from that?
+- How sure am I, and why?
+- Why does it matter — for correctness, for the next slice, for scientific contribution?
+- How would I validate it cheaply — a test, a small theorem, a literature check, a prototype?
+
+If you cannot answer those five questions, the finding is not ready for the main list.
+
+## Cortex-specific signals
+
+Beyond the general bar, treat these as elevated signals when ranking:
+
+- A Lean theorem and a Haskell function disagree on shape, semantics, or ordering.
+- An accepted ADR and the implementation disagree about an admission rule.
+- Two `proposed` ADRs commit to incompatible decisions in interlocking parts of the same subsystem.
+- A concept named in `docs/Architecture/` has no typed carrier in code.
+- A typed carrier in code has no description in `docs/Architecture/` or in any ADR.
+- A theorem's hypotheses are richer than what admission discharges (the use site cannot apply the
+  theorem).
+- A `runtimeOnly` policy is enforced by prose convention rather than by a compiler check, runtime
+  guard, or process gate.

--- a/agents/skills/research/templates/research-memo.md
+++ b/agents/skills/research/templates/research-memo.md
@@ -1,0 +1,143 @@
+# Research Memo: {scope}
+
+**Date:** {date} **Scope:** {what was analyzed} **Branch / PR:** {branch or PR if applicable}
+**Layers examined:** {implementation, theory, docs, ADRs, issues, literature — list which} **Layers
+skipped:** {layers not read, with reason} **Method:** Cross-source synthesis through the seven
+archetype lenses **Confidence profile:** {brief note on evidence quality and uncertainty}
+
+---
+
+## Executive Summary
+
+{2-6 sentences. The single thing the user should pick up if they read no further. Name the biggest
+finding, the biggest opportunity, and the residual uncertainty.}
+
+---
+
+## Archetype Synthesis
+
+| Lens     | One-line read                             |
+| -------- | ----------------------------------------- |
+| Episteme | {what the layered evidence established}   |
+| Logos    | {the load-bearing claim structure}        |
+| Kritikos | {the sharpest counterexample or drift}    |
+| Themis   | {the contract or layer ownership finding} |
+| Techne   | {the smallest concrete next step}         |
+| Poiesis  | {the most useful alternative framing}     |
+| Sophia   | {the priority decision}                   |
+
+---
+
+## Key Findings
+
+### [P1] {Finding title}
+
+**Category:** {Correctness Gap | Missed Abstraction | Layer Leak | ADR Drift | Novel Idea | Design
+Tension | Evidence Gap | Extension Risk | Dead End | Terminology Gap} **Status:** {Observed |
+Inferred | Speculative} **Confidence:** {High | Medium | Low} **Surfaced by:** {episteme | logos |
+kritikos | themis | techne | poiesis | sophia, plus any cross-lens agreement} **Primary evidence:**
+{file:line, theorem name, ADR id, issue id, commit, paper §} **Cross-reference:** {the layer pair
+the finding emerged from — e.g. "implementation ↔ theory", "ADR 0023 ↔ ADR 0031"}
+
+{Precise description of the finding. Quote or cite. Avoid paraphrase.}
+
+**Why it matters:** {Impact on correctness, extensibility, performance, clarity, scientific
+contribution.}
+
+**Next step:** {Concrete artifact: issue draft, ADR amendment, theorem statement, test, prototype,
+literature check, parked note. Name the skill that owns the follow-up if any.}
+
+### [P2] {Finding title}
+
+**Category:** {...} **Status:** {...} **Confidence:** {...} **Surfaced by:** {...} **Primary
+evidence:** {...} **Cross-reference:** {...}
+
+{Description}
+
+**Why it matters:** {Impact}
+
+**Next step:** {Action}
+
+{Continue P3, P4, … as needed. Default to 5-8 major findings.}
+
+---
+
+## Missed Abstractions
+
+{Compact narrative or table. Each entry names the multiple ad hoc mechanisms and what shared
+interface they want.}
+
+| Multiple sites           | Shared shape | Proposed name | Cost of unifying |
+| ------------------------ | ------------ | ------------- | ---------------- |
+| {site A, site B, site C} | {shape}      | {name}        | {cost}           |
+
+## Evidence Gaps
+
+| Claim   | Source   | Current evidence | Missing evidence | Recommended validation |
+| ------- | -------- | ---------------- | ---------------- | ---------------------- |
+| {claim} | {source} | {evidence}       | {gap}            | {validation}           |
+
+## Design Tensions
+
+{Two legitimate goals pulling against each other. Analyze the real trade-off rather than picking a
+winner.}
+
+## Novel Ideas & Hypotheses
+
+{Speculative ideas that earn a place because the synthesis surfaced them. Each one has a validation
+path.}
+
+- **{Idea}** — {one-paragraph description}. **Validation path:** {test, theorem, prototype,
+  literature check}.
+
+## Dead Ends / Rejected Directions
+
+{Useful things that look elegant but do not survive. Recording them prevents re-treading.}
+
+- **{Direction}** — {why it fails}.
+
+---
+
+## Recommended Actions
+
+### Act now
+
+- [ ] {Action} — owner: {skill or person}; cost: {S/M/L}.
+
+### Design next
+
+- [ ] {Action} — typically an ADR draft, theorem slice, or implementation sketch.
+
+### Write up
+
+- [ ] {Action} — paper section, blog post, ADR that captures insight already implicit in the work.
+
+### Parked
+
+- {Idea} — {why deferred}; revisit when {condition}.
+
+---
+
+## Optional Sections
+
+### Known Unknowns
+
+{What could not be checked, why, and what it would take to settle.}
+
+### Claim-to-Evidence Matrix
+
+| Claim   | Artifact that supports it | Artifact that weakens it | Verdict   |
+| ------- | ------------------------- | ------------------------ | --------- |
+| {claim} | {support}                 | {weakener}               | {verdict} |
+
+### Cortex layer placement check
+
+| Concept   | Currently lives in                       | Should live in | Reason                          |
+| --------- | ---------------------------------------- | -------------- | ------------------------------- |
+| {concept} | {Platform / Cortex / Logos / downstream} | {target layer} | {ADR, layer rule, or invariant} |
+
+### ADR conformance check
+
+| ADR    | Status                             | Implementation | Theory    | Docs      | Drift?              |
+| ------ | ---------------------------------- | -------------- | --------- | --------- | ------------------- |
+| {NNNN} | {accepted / proposed / superseded} | {summary}      | {summary} | {summary} | {yes/no, with note} |

--- a/docs/ADRs/0023-corepure-expression-surface.md
+++ b/docs/ADRs/0023-corepure-expression-surface.md
@@ -72,6 +72,52 @@ CorePure explicitly disallows:
 
 `fold` can be reconsidered only after budget accounting is solid enough to state its cost model.
 
+### Duplicate Names
+
+CorePure rejects duplicate names at parse/elaboration time across every authoring surface that
+introduces names. No such surface uses silent right-biased or left-biased override. The only place
+in CorePure where one record's keys may override another's is the explicit record merge operator
+`//`, which is unaffected by this rule.
+
+The duplicate-name rule applies to:
+
+- record literals;
+- `let` bindings within one scope;
+- lambda parameters within one lambda;
+- output equations within one node.
+
+Within a record literal, two field declarations conflict when their paths are equal or when one path
+is a strict prefix of the other. The following are parse errors:
+
+```wire
+{ a = 1 ; a = 2 ; }                        -- equal paths
+{ a.b = 1 ; a.b = 2 ; }                    -- equal paths
+{ a = 1 ; a.b = 2 ; }                      -- `a` is a strict prefix of `a.b`
+{ a.b = 1 ; a = { b = 2 ; } ; }            -- `a` is a strict prefix of `a.b`
+```
+
+The following is permitted because neither path is a prefix of the other; the distinct leaves
+combine into one nested record:
+
+```wire
+{ a.b = 1 ; a.c = 2 ; }                    -- equivalent to { a = { b = 1 ; c = 2 ; } ; }
+```
+
+The runtime evaluator never observes duplicate names within one scope, because the parser and
+elaborator reject them upstream. Shadowing across distinct nested scopes is unaffected: an inner
+`let` binding with the same name as an outer one shadows the outer per ADR 0023's non-recursive
+scoping rules.
+
+The decision follows Nix's attrset semantics. Nix rejects `{ a = 1; a = 2; }` and
+`let x = 1; x = 2; in x` at parse time regardless of recursive scope, and Nix's `//` operator
+performs explicit right-biased override on already-constructed attrsets. CorePure adopts the same
+split for the same reason: a silent in-literal override would let one of two visibly distinct
+authoring intents win without telling the reader, while explicit `//` makes the override visible at
+the call site.
+
+Authors who want override behavior write `defaults // { field = newValue ; }` rather than declaring
+`field` twice in one record literal.
+
 ### Pipe Sugar
 
 `|>` is the canonical function-composition operator inside CorePure expressions. It is
@@ -251,6 +297,11 @@ can build text outputs without unreadable manual `concat` and `toString` calls.
   core use case. Without interpolation, real examples become noisy immediately.
 - **Stringify every value.** Rejected because records and lists need explicit serialization rules.
   Accidental structural stringification would become observable semantics.
+- **Silently right-merge or left-merge duplicate field declarations in record literals.** Rejected
+  because it lets one of two visibly distinct authoring intents win without informing the reader,
+  diverges from Nix's attrset semantics, and diverges from CorePure's existing duplicate-name
+  discipline for `let` bindings, lambda parameters, and output equations. Override remains available
+  through the explicit `//` operator.
 
 ## Consequences
 
@@ -274,6 +325,10 @@ can build text outputs without unreadable manual `concat` and `toString` calls.
 - Add budget tests for list operations and string concatenation.
 - Add parser tests for double-quoted strings, indented strings, interpolation, and escapes.
 - Keep `toString` constrained to scalar values until explicit structured serialization is designed.
+- Reject duplicate field declarations in record literals at parse time, where two declarations
+  conflict when their paths are equal or when one path is a strict prefix of the other. This matches
+  the duplicate-name discipline already enforced for `let` bindings, lambda parameters, and output
+  equations.
 
 ## Related
 

--- a/theory/Cortex.lean
+++ b/theory/Cortex.lean
@@ -15,6 +15,7 @@ import Cortex.Pulse.Recovery
 import Cortex.Pulse.Classify
 
 -- Track 3 — Wire rewrite soundness
+import Cortex.Wire.Pure
 import Cortex.Wire.Registry
 import Cortex.Wire.Rewrite
 import Cortex.Wire.Admission
@@ -39,5 +40,5 @@ check that every proof track remains importable together.
 
 The imported tracks are the theorem split: `Cortex.Graph.*` for algebra,
 `Cortex.Pulse.*` for fixed-topology runtime safety, and
-`Cortex.Wire.*` for registry-boundary and rewrite admission.
+`Cortex.Wire.*` for pure-node, registry-boundary, and rewrite admission.
 -/

--- a/theory/Cortex/Wire/Pure.lean
+++ b/theory/Cortex/Wire/Pure.lean
@@ -1,0 +1,1272 @@
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Int.Basic
+
+/-!
+## Overview
+
+Proof-facing model of Wire's CorePure subset and native pure-task lowering.
+
+## Context
+
+Wire pure output equations use a deterministic expression layer. The Haskell
+implementation evaluates JSON-shaped values and lowers one
+source pure node to one internal native pure task with top-level bindings, an
+optional `where` expression, and output expressions.
+
+This module does not prove the Haskell evaluator correct. It gives the Lean
+track a small executable model for the first proof slice: integers, booleans,
+records, field access, non-recursive sequential `let`, `if`, record merge, and
+simple operators. ADR 0010 keeps authority behind registered executor
+boundaries, and ADR 0023 keeps CorePure in the deterministic expression layer;
+accordingly, `Expr` has no constructors for executor calls, rewrites,
+durable-state reads, tools, model calls, or host callbacks.
+
+ADR 0023 makes duplicate record fields an upstream parse/elaboration error.
+The evaluator remains deterministic outside the admitted surface, but duplicate
+field overwrite is not an intended record-literal semantics.
+
+For static `where` fields, ADR 0031 settles the source surface in favor of the
+Haskell behavior: local CorePure `let` bindings are evaluated at runtime but are
+not expanded by static field discovery. Module-level let-declared records are
+represented by the initial `StaticContext`.
+
+## Theorem Split
+
+The page defines values, expressions, deterministic evaluation, static
+`where`-field discovery, pure-node admission, native pure-task lowering, and
+the local soundness side condition needed when a `where` expression contains
+CorePure `let`. The facts are local to this proof model; no theorem here claims
+that the Haskell evaluator or compiler already produces these Lean witnesses.
+The `where` soundness chain is exported for downstream output-value and contract
+proofs; the output-key theorems in this file are structural and do not need it.
+-/
+
+namespace Cortex.Wire
+
+/-! ## CorePure Subset -/
+
+namespace CorePure
+
+/-- CorePure names for variables, fields, ports, and output labels. -/
+abbrev Name : Type := String
+
+/-- `EvalError` is the deterministic typed failure surface for this proof subset. -/
+inductive EvalError : Type where
+  | missingVariable : Name → EvalError
+  | missingField : Name → EvalError
+  | expectedBool : EvalError
+  | expectedInt : EvalError
+  | expectedRecord : EvalError
+  | duplicateBinding : Name → EvalError
+  deriving Repr
+
+/-- `Value` is the JSON-shaped value subset modeled by the first proof pass. -/
+inductive Value : Type where
+  | null : Value
+  | bool : Bool → Value
+  | int : Int → Value
+  | string : String → Value
+  | record : (Name → Option Value) → Value
+
+/-- Runtime CorePure environment. -/
+abbrev Env : Type := Name → Option Value
+
+namespace Env
+
+/-- Empty runtime environment. -/
+def empty : Env :=
+  fun _name => none
+
+/-- Insert or shadow a runtime binding. -/
+def insert (name : Name) (value : Value) (env : Env) : Env :=
+  fun candidate => if candidate = name then some value else env candidate
+
+end Env
+
+/-- Static context for expressions known to expose record fields. -/
+abbrev StaticContext : Type := Name → Option (Finset Name)
+
+namespace StaticContext
+
+/-- Empty static field context. -/
+def empty : StaticContext :=
+  fun _name => none
+
+/-- Insert or shadow a static field binding. `none` deliberately shadows an outer record. -/
+def insert (name : Name) (fields : Option (Finset Name)) (ctx : StaticContext) :
+    StaticContext :=
+  fun candidate => if candidate = name then fields else ctx candidate
+
+/-- Hide static record facts for names opened by a node-local `where` record. -/
+def hideFields (fields : Finset Name) (ctx : StaticContext) : StaticContext :=
+  fun candidate => if candidate ∈ fields then none else ctx candidate
+
+end StaticContext
+
+/-- Unary operators in the modeled CorePure subset. -/
+inductive UnaryOp : Type where
+  | not
+  | negate
+
+/-- Binary operators in the modeled CorePure subset. -/
+inductive BinaryOp : Type where
+  | add
+  | subtract
+  | multiply
+  | and
+  | or
+  | merge
+
+/-- CorePure expression subset for the first proof slice. -/
+inductive Expr : Type where
+  | lit : Value → Expr
+  | var : Name → Expr
+  | record : List (Name × Expr) → Expr
+  | field : Expr → Name → Expr
+  | letE : List (Name × Expr) → Expr → Expr
+  | ifE : Expr → Expr → Expr → Expr
+  | unary : UnaryOp → Expr → Expr
+  | binary : BinaryOp → Expr → Expr → Expr
+
+namespace Value
+
+/-- Interpret a value as a boolean or fail deterministically. -/
+def asBool : Value → Except EvalError Bool
+  | null => Except.error EvalError.expectedBool
+  | bool value => Except.ok value
+  | int _value => Except.error EvalError.expectedBool
+  | string _value => Except.error EvalError.expectedBool
+  | record _fields => Except.error EvalError.expectedBool
+
+/-- Interpret a value as an integer or fail deterministically. -/
+def asInt : Value → Except EvalError Int
+  | null => Except.error EvalError.expectedInt
+  | bool _value => Except.error EvalError.expectedInt
+  | int value => Except.ok value
+  | string _value => Except.error EvalError.expectedInt
+  | record _fields => Except.error EvalError.expectedInt
+
+/-- Interpret a value as a record or fail deterministically. -/
+def asRecord : Value → Except EvalError (Name → Option Value)
+  | null => Except.error EvalError.expectedRecord
+  | bool _value => Except.error EvalError.expectedRecord
+  | int _value => Except.error EvalError.expectedRecord
+  | string _value => Except.error EvalError.expectedRecord
+  | record fields => Except.ok fields
+
+/-- `hasOnlyFields value fields` says a record value exposes no keys outside `fields`. -/
+def hasOnlyFields (value : Value) (fields : Finset Name) : Prop :=
+  match value with
+  | record recordFields =>
+      ∀ name fieldValue, recordFields name = some fieldValue → name ∈ fields
+  | null => False
+  | bool _value => False
+  | int _value => False
+  | string _value => False
+
+end Value
+
+/-! ## Record Helpers -/
+
+/-- Convert evaluated field pairs to a record lookup function.
+
+Admitted CorePure record literals must reject duplicate fields before evaluation. The right-biased
+fallback here only makes the proof-side evaluator total on raw lists. -/
+def recordFromValues : List (Name × Value) → Name → Option Value
+  | [], _name => none
+  | (fieldName, fieldValue) :: rest, name =>
+      match recordFromValues rest name with
+      | some value => some value
+      | none => if name = fieldName then some fieldValue else none
+
+/-- Names present in a field-expression list. -/
+def fieldNameSet (fields : List (Name × Expr)) : Finset Name :=
+  fields.foldr (fun field acc => insert field.1 acc) ∅
+
+/-- Names present in an evaluated field-value list. -/
+def valueFieldNameSet (fields : List (Name × Value)) : Finset Name :=
+  fields.foldr (fun field acc => insert field.1 acc) ∅
+
+/-- Right-biased record merge for the modeled CorePure `merge` operator. -/
+def mergeRecordFields
+    (leftFields rightFields : Name → Option Value) :
+    Name → Option Value :=
+  fun name =>
+    match rightFields name with
+    | some value => some value
+    | none => leftFields name
+
+/-- `recordFromValues` exposes only names present in its input field list. -/
+theorem recordFromValues_hasOnlyFields
+    (fields : List (Name × Value)) :
+    ∀ name fieldValue,
+      recordFromValues fields name = some fieldValue →
+        name ∈ valueFieldNameSet fields := by
+  induction fields with
+  | nil =>
+      intro name fieldValue hLookup
+      simp [recordFromValues] at hLookup
+  | cons field rest ih =>
+      intro name fieldValue hLookup
+      rcases field with ⟨fieldName, currentValue⟩
+      by_cases hName : name = fieldName
+      · simp [valueFieldNameSet, hName]
+      · cases hRest : recordFromValues rest name with
+        | some restValue =>
+            have hMember := ih name restValue hRest
+            change name ∈ insert fieldName (valueFieldNameSet rest)
+            exact Finset.mem_insert.mpr (Or.inr hMember)
+        | none =>
+            simp [recordFromValues, hRest, hName] at hLookup
+
+/-- Every name present in an evaluated field-value list has a concrete record lookup. -/
+theorem recordFromValues_field_present
+    {fields : List (Name × Value)}
+    {name : Name}
+    (hName : name ∈ valueFieldNameSet fields) :
+    ∃ fieldValue, recordFromValues fields name = some fieldValue := by
+  induction fields with
+  | nil =>
+      simp [valueFieldNameSet] at hName
+  | cons field rest ih =>
+      rcases field with ⟨fieldName, currentValue⟩
+      by_cases hCurrent : name = fieldName
+      · subst fieldName
+        cases hRest : recordFromValues rest name with
+        | some restValue =>
+            exact ⟨restValue, by simp [recordFromValues, hRest]⟩
+        | none =>
+            exact ⟨currentValue, by simp [recordFromValues, hRest]⟩
+      · have hRestName : name ∈ valueFieldNameSet rest := by
+          have hInserted : name ∈ insert fieldName (valueFieldNameSet rest) := by
+            simpa [valueFieldNameSet] using hName
+          exact (Finset.mem_insert.mp hInserted).resolve_left hCurrent
+        obtain ⟨restValue, hRestLookup⟩ := ih hRestName
+        exact ⟨restValue, by simp [recordFromValues, hRestLookup]⟩
+
+/-! ## Evaluation -/
+
+/-- Find the first duplicate name in a list, if one exists. -/
+def duplicateName : List Name → Option Name
+  | [] => none
+  | name :: rest =>
+      if name ∈ rest then some name else duplicateName rest
+
+mutual
+
+/-- Evaluate a CorePure expression in a runtime environment. -/
+def eval (env : Env) : Expr → Except EvalError Value
+  | Expr.lit value => Except.ok value
+  | Expr.var name =>
+      match env name with
+      | some value => Except.ok value
+      | none => Except.error (EvalError.missingVariable name)
+  | Expr.record fields =>
+      match evalFields env fields with
+      | Except.ok values => Except.ok (Value.record (recordFromValues values))
+      | Except.error err => Except.error err
+  | Expr.field base fieldName => do
+      let baseRecord ← (← eval env base).asRecord
+      match baseRecord fieldName with
+      | some value => Except.ok value
+      | none => Except.error (EvalError.missingField fieldName)
+  | Expr.letE bindings body =>
+      match evalBindings env bindings with
+      | Except.ok localEnv => eval localEnv body
+      | Except.error err => Except.error err
+  | Expr.ifE condition thenExpr elseExpr => do
+      let conditionValue ← (← eval env condition).asBool
+      if conditionValue then eval env thenExpr else eval env elseExpr
+  | Expr.unary op operand => do
+      match op with
+      | UnaryOp.not =>
+          Except.ok (Value.bool (!(← (← eval env operand).asBool)))
+      | UnaryOp.negate =>
+          Except.ok (Value.int (-(← (← eval env operand).asInt)))
+  | Expr.binary op left right => do
+      match op with
+      | BinaryOp.add =>
+          Except.ok (Value.int ((← (← eval env left).asInt) + (← (← eval env right).asInt)))
+      | BinaryOp.subtract =>
+          Except.ok (Value.int ((← (← eval env left).asInt) - (← (← eval env right).asInt)))
+      | BinaryOp.multiply =>
+          Except.ok (Value.int ((← (← eval env left).asInt) * (← (← eval env right).asInt)))
+      | BinaryOp.and =>
+          let leftValue ← (← eval env left).asBool
+          if leftValue then
+            Except.ok (Value.bool (← (← eval env right).asBool))
+          else
+            Except.ok (Value.bool false)
+      | BinaryOp.or =>
+          let leftValue ← (← eval env left).asBool
+          if leftValue then
+            Except.ok (Value.bool true)
+          else
+            Except.ok (Value.bool (← (← eval env right).asBool))
+      | BinaryOp.merge =>
+          match eval env left with
+          | Except.error err => Except.error err
+          | Except.ok Value.null => Except.error EvalError.expectedRecord
+          | Except.ok (Value.bool _value) => Except.error EvalError.expectedRecord
+          | Except.ok (Value.int _value) => Except.error EvalError.expectedRecord
+          | Except.ok (Value.string _value) => Except.error EvalError.expectedRecord
+          | Except.ok (Value.record leftRecord) =>
+              match eval env right with
+              | Except.error err => Except.error err
+              | Except.ok Value.null => Except.error EvalError.expectedRecord
+              | Except.ok (Value.bool _value) => Except.error EvalError.expectedRecord
+              | Except.ok (Value.int _value) => Except.error EvalError.expectedRecord
+              | Except.ok (Value.string _value) => Except.error EvalError.expectedRecord
+              | Except.ok (Value.record rightRecord) =>
+                  Except.ok (Value.record (mergeRecordFields leftRecord rightRecord))
+
+/-- Evaluate record fields independently in the same environment. -/
+def evalFields (env : Env) :
+    List (Name × Expr) → Except EvalError (List (Name × Value))
+  | [] => Except.ok []
+  | (fieldName, fieldExpr) :: rest =>
+      match eval env fieldExpr with
+      | Except.ok fieldValue =>
+          match evalFields env rest with
+          | Except.ok restValues => Except.ok ((fieldName, fieldValue) :: restValues)
+          | Except.error err => Except.error err
+      | Except.error err => Except.error err
+
+/-- Evaluate non-recursive sequential `let` bindings. -/
+def evalBindings (env : Env) :
+    List (Name × Expr) → Except EvalError Env
+  | bindings =>
+      match duplicateName (bindings.map Prod.fst) with
+      | some name => Except.error (EvalError.duplicateBinding name)
+      | none => evalBindingsNoDuplicate env bindings
+
+/-- Evaluate bindings after duplicate names have been rejected. -/
+def evalBindingsNoDuplicate (env : Env) :
+    List (Name × Expr) → Except EvalError Env
+  | [] => Except.ok env
+  | (bindingName, bindingExpr) :: rest =>
+      match eval env bindingExpr with
+      | Except.ok bindingValue =>
+          evalBindingsNoDuplicate (Env.insert bindingName bindingValue env) rest
+      | Except.error err => Except.error err
+
+end
+
+/-- Evaluating fields preserves their field-name set. -/
+theorem evalFields_preserves_names
+    {env : Env}
+    {fields : List (Name × Expr)}
+    {values : List (Name × Value)}
+    (hEval : evalFields env fields = Except.ok values) :
+    valueFieldNameSet values = fieldNameSet fields := by
+  induction fields generalizing values with
+  | nil =>
+      simp [evalFields] at hEval
+      cases hEval
+      rfl
+  | cons field rest ih =>
+      rcases field with ⟨fieldName, fieldExpr⟩
+      simp [evalFields] at hEval
+      cases hField : eval env fieldExpr with
+      | error err =>
+          simp [hField] at hEval
+      | ok fieldValue =>
+          simp [hField] at hEval
+          cases hRest : evalFields env rest with
+          | error err =>
+              simp [hRest] at hEval
+          | ok restValues =>
+              simp [hRest] at hEval
+              cases hEval
+              change insert fieldName (valueFieldNameSet restValues) =
+                insert fieldName (fieldNameSet rest)
+              rw [ih hRest]
+
+/-- Record expressions evaluate to records containing only their statically named fields. -/
+theorem eval_record_hasOnlyFields
+    {env : Env}
+    {fields : List (Name × Expr)}
+    {recordFields : Name → Option Value}
+    (hEval : eval env (Expr.record fields) = Except.ok (Value.record recordFields)) :
+    ∀ name fieldValue,
+      recordFields name = some fieldValue →
+        name ∈ fieldNameSet fields := by
+  simp [eval] at hEval
+  cases hFields : evalFields env fields with
+  | error err =>
+      simp [hFields] at hEval
+  | ok values =>
+      simp [hFields] at hEval
+      cases hEval
+      intro name fieldValue hLookup
+      have hMember := recordFromValues_hasOnlyFields values name fieldValue hLookup
+      have hNames := evalFields_preserves_names hFields
+      simpa [hNames] using hMember
+
+/-- Record expressions evaluate to values containing only their statically named fields. -/
+theorem eval_record_value_hasOnlyFields
+    {env : Env}
+    {fields : List (Name × Expr)}
+    {value : Value}
+    (hEval : eval env (Expr.record fields) = Except.ok value) :
+    Value.hasOnlyFields value (fieldNameSet fields) := by
+  cases hFields : evalFields env fields with
+  | error err =>
+      simp [eval, hFields] at hEval
+  | ok values =>
+      simp [eval, hFields] at hEval
+      cases hEval
+      have hNames := evalFields_preserves_names hFields
+      simpa [Value.hasOnlyFields, hNames] using recordFromValues_hasOnlyFields values
+
+/-- Right-biased record merge exposes only fields from either input record. -/
+theorem mergeRecordFields_hasOnlyFields
+    {leftFields rightFields : Name → Option Value}
+    {leftStatic rightStatic : Finset Name}
+    (hLeft : Value.hasOnlyFields (Value.record leftFields) leftStatic)
+    (hRight : Value.hasOnlyFields (Value.record rightFields) rightStatic) :
+    Value.hasOnlyFields
+      (Value.record (mergeRecordFields leftFields rightFields))
+      (leftStatic ∪ rightStatic) := by
+  intro name fieldValue hLookup
+  cases hRightLookup : rightFields name with
+  | some rightValue =>
+      have hRightMember := hRight name rightValue hRightLookup
+      exact Finset.mem_union.mpr (Or.inr hRightMember)
+  | none =>
+      have hLeftLookup : leftFields name = some fieldValue := by
+        simpa [mergeRecordFields, hRightLookup] using hLookup
+      have hLeftMember := hLeft name fieldValue hLeftLookup
+      exact Finset.mem_union.mpr (Or.inl hLeftMember)
+
+/-! ## Static `where` Field Discovery -/
+
+/-- Static field discovery for expressions used as node-local `where` clauses. -/
+def whereStaticFields (ctx : StaticContext) : Expr → Option (Finset Name)
+  | Expr.lit _value => none
+  | Expr.record fields => some (fieldNameSet fields)
+  | Expr.var name => ctx name
+  | Expr.field _base _fieldName => none
+  | Expr.letE _bindings body => whereStaticFields ctx body
+  | Expr.ifE _condition _thenExpr _elseExpr => none
+  | Expr.unary _op _operand => none
+  | Expr.binary BinaryOp.merge left right =>
+      match whereStaticFields ctx left, whereStaticFields ctx right with
+      | some leftFields, some rightFields => some (leftFields ∪ rightFields)
+      | some _leftFields, none => none
+      | none, some _rightFields => none
+      | none, none => none
+  | Expr.binary BinaryOp.add _left _right => none
+  | Expr.binary BinaryOp.subtract _left _right => none
+  | Expr.binary BinaryOp.multiply _left _right => none
+  | Expr.binary BinaryOp.and _left _right => none
+  | Expr.binary BinaryOp.or _left _right => none
+
+/-- Runtime environments match the static context for known record bindings. -/
+def EnvMatchesStatic (env : Env) (ctx : StaticContext) : Prop :=
+  ∀ name fields value,
+    ctx name = some fields →
+      env name = some value →
+        Value.hasOnlyFields value fields
+
+/-- Local CorePure `let` bindings do not shadow statically known module-level records. -/
+def letBindingsDoNotShadowStatic
+    (ctx : StaticContext) :
+    List (Name × Expr) → Prop
+  | [] => True
+  | (bindingName, _bindingExpr) :: rest =>
+      ctx bindingName = none ∧ letBindingsDoNotShadowStatic ctx rest
+
+/-- Side condition for expressions whose local `let` binders preserve static discovery soundness. -/
+def Expr.staticLetSafe (ctx : StaticContext) : Expr → Prop
+  | Expr.lit _value => True
+  | Expr.record _fields => True
+  | Expr.var _name => True
+  | Expr.field _base _fieldName => True
+  | Expr.letE bindings body =>
+      letBindingsDoNotShadowStatic ctx bindings ∧ Expr.staticLetSafe ctx body
+  | Expr.ifE _condition _thenExpr _elseExpr => True
+  | Expr.unary _op _operand => True
+  | Expr.binary BinaryOp.merge left right =>
+      Expr.staticLetSafe ctx left ∧ Expr.staticLetSafe ctx right
+  | Expr.binary BinaryOp.add _left _right => True
+  | Expr.binary BinaryOp.subtract _left _right => True
+  | Expr.binary BinaryOp.multiply _left _right => True
+  | Expr.binary BinaryOp.and _left _right => True
+  | Expr.binary BinaryOp.or _left _right => True
+
+/-- Static field discovery succeeds for record literals with exactly their field-name set. -/
+theorem where_staticFields_record
+    (ctx : StaticContext)
+    (fields : List (Name × Expr)) :
+    whereStaticFields ctx (Expr.record fields) = some (fieldNameSet fields) :=
+  rfl
+
+/-- Static field discovery for merge is the union of both record field sets. -/
+theorem where_staticFields_merge
+    {ctx : StaticContext}
+    {left right : Expr}
+    {leftFields rightFields : Finset Name}
+    (hLeft : whereStaticFields ctx left = some leftFields)
+    (hRight : whereStaticFields ctx right = some rightFields) :
+    whereStaticFields ctx (Expr.binary BinaryOp.merge left right) =
+      some (leftFields ∪ rightFields) := by
+  simp [whereStaticFields, hLeft, hRight]
+
+/-- Static field discovery for `let` checks only the final body expression. -/
+theorem where_staticFields_let
+    (ctx : StaticContext)
+    (bindings : List (Name × Expr))
+    (body : Expr) :
+    whereStaticFields ctx (Expr.letE bindings body) =
+      whereStaticFields ctx body :=
+  rfl
+
+/-- Evaluated non-duplicate bindings preserve the static context when they do not shadow it. -/
+theorem evalBindingsNoDuplicate_preserves_static_context
+    {ctx : StaticContext}
+    {env localEnv : Env}
+    {bindings : List (Name × Expr)}
+    (hMatch : EnvMatchesStatic env ctx)
+    (hNoShadow : letBindingsDoNotShadowStatic ctx bindings)
+    (hEval : evalBindingsNoDuplicate env bindings = Except.ok localEnv) :
+    EnvMatchesStatic localEnv ctx := by
+  induction bindings generalizing ctx env localEnv with
+  | nil =>
+      simp [evalBindingsNoDuplicate] at hEval
+      cases hEval
+      exact hMatch
+  | cons head tail ih =>
+      rcases head with ⟨bindingName, bindingExpr⟩
+      have hHeadNoShadow : ctx bindingName = none := hNoShadow.1
+      have hTailNoShadow : letBindingsDoNotShadowStatic ctx tail := hNoShadow.2
+      simp [evalBindingsNoDuplicate] at hEval
+      cases hBindingEval : eval env bindingExpr with
+      | error err =>
+          simp [hBindingEval] at hEval
+      | ok bindingValue =>
+          simp [hBindingEval] at hEval
+          have hNextMatch :
+              EnvMatchesStatic (Env.insert bindingName bindingValue env) ctx := by
+            intro candidate fields value hStaticLookup hEnvLookup
+            simp [Env.insert] at hEnvLookup
+            by_cases hCandidate : candidate = bindingName
+            · rw [hCandidate] at hStaticLookup
+              simp [hHeadNoShadow] at hStaticLookup
+            · simp [hCandidate] at hEnvLookup
+              exact hMatch candidate fields value hStaticLookup hEnvLookup
+          exact ih hNextMatch hTailNoShadow hEval
+
+/-- Runtime binding evaluation preserves the static context when it succeeds without shadowing. -/
+theorem evalBindings_preserves_static_context
+    {ctx : StaticContext}
+    {env localEnv : Env}
+    {bindings : List (Name × Expr)}
+    (hMatch : EnvMatchesStatic env ctx)
+    (hNoShadow : letBindingsDoNotShadowStatic ctx bindings)
+    (hEval : evalBindings env bindings = Except.ok localEnv) :
+    EnvMatchesStatic localEnv ctx := by
+  cases hDuplicate : duplicateName (bindings.map Prod.fst) with
+  | some duplicate =>
+      simp [evalBindings, hDuplicate] at hEval
+  | none =>
+      have hNoDuplicateEval :
+          evalBindingsNoDuplicate env bindings = Except.ok localEnv := by
+        simpa [evalBindings, hDuplicate] using hEval
+      exact evalBindingsNoDuplicate_preserves_static_context hMatch hNoShadow hNoDuplicateEval
+
+/-- Runtime merge evaluation preserves the union of the statically admitted fields. -/
+private theorem eval_merge_hasOnlyFields
+    {ctx : StaticContext}
+    {env : Env}
+    {left right : Expr}
+    {leftFields rightFields : Finset Name}
+    {value : Value}
+    (hLeftSafe : Expr.staticLetSafe ctx left)
+    (hRightSafe : Expr.staticLetSafe ctx right)
+    (hMatch : EnvMatchesStatic env ctx)
+    (hLeftStatic : whereStaticFields ctx left = some leftFields)
+    (hRightStatic : whereStaticFields ctx right = some rightFields)
+    (hEval : eval env (Expr.binary BinaryOp.merge left right) = Except.ok value)
+    (leftIH :
+      ∀ {ctx : StaticContext}
+        {env : Env}
+        {fields : Finset Name}
+        {value : Value},
+        Expr.staticLetSafe ctx left →
+          EnvMatchesStatic env ctx →
+            whereStaticFields ctx left = some fields →
+              eval env left = Except.ok value →
+                Value.hasOnlyFields value fields)
+    (rightIH :
+      ∀ {ctx : StaticContext}
+        {env : Env}
+        {fields : Finset Name}
+        {value : Value},
+        Expr.staticLetSafe ctx right →
+          EnvMatchesStatic env ctx →
+            whereStaticFields ctx right = some fields →
+              eval env right = Except.ok value →
+                Value.hasOnlyFields value fields) :
+    Value.hasOnlyFields value (leftFields ∪ rightFields) := by
+  cases hLeftEval : eval env left with
+  | error err =>
+      simp [eval, hLeftEval] at hEval
+  | ok leftValue =>
+      cases leftValue with
+      | null =>
+          simp [eval, hLeftEval] at hEval
+      | bool leftBool =>
+          simp [eval, hLeftEval] at hEval
+      | int leftInt =>
+          simp [eval, hLeftEval] at hEval
+      | string leftString =>
+          simp [eval, hLeftEval] at hEval
+      | record leftRecord =>
+          cases hRightEval : eval env right with
+          | error err =>
+              simp [eval, hLeftEval, hRightEval] at hEval
+          | ok rightValue =>
+              cases rightValue with
+              | null =>
+                  simp [eval, hLeftEval, hRightEval] at hEval
+              | bool rightBool =>
+                  simp [eval, hLeftEval, hRightEval] at hEval
+              | int rightInt =>
+                  simp [eval, hLeftEval, hRightEval] at hEval
+              | string rightString =>
+                  simp [eval, hLeftEval, hRightEval] at hEval
+              | record rightRecord =>
+                  simp [eval, hLeftEval, hRightEval] at hEval
+                  cases hEval
+                  have hLeftHas :=
+                    leftIH hLeftSafe hMatch hLeftStatic hLeftEval
+                  have hRightHas :=
+                    rightIH hRightSafe hMatch hRightStatic hRightEval
+                  exact mergeRecordFields_hasOnlyFields hLeftHas hRightHas
+
+/-- Core recursive proof for static `where` field soundness. -/
+private theorem whereStaticFields_sound_expr
+    (expr : Expr) :
+    ∀ {ctx : StaticContext}
+      {env : Env}
+      {fields : Finset Name}
+      {value : Value},
+      Expr.staticLetSafe ctx expr →
+        EnvMatchesStatic env ctx →
+          whereStaticFields ctx expr = some fields →
+            eval env expr = Except.ok value →
+              Value.hasOnlyFields value fields :=
+  Expr.rec
+    (motive_1 := fun expr =>
+      ∀ {ctx : StaticContext}
+        {env : Env}
+        {fields : Finset Name}
+        {value : Value},
+        Expr.staticLetSafe ctx expr →
+          EnvMatchesStatic env ctx →
+            whereStaticFields ctx expr = some fields →
+              eval env expr = Except.ok value →
+                Value.hasOnlyFields value fields)
+    (motive_2 := fun _bindings => True)
+    (motive_3 := fun _binding => True)
+    (fun literalValue {ctx env fields value} hSafe hMatch hStatic hEval => by
+      simp [whereStaticFields] at hStatic)
+    (fun name {ctx env fields value} hSafe hMatch hStatic hEval => by
+      exact hMatch name fields value hStatic (by
+        cases hLookup : env name with
+        | none =>
+            simp [eval, hLookup] at hEval
+        | some envValue =>
+            simp [eval, hLookup] at hEval
+            cases hEval
+            rfl))
+    (fun fields _fieldsIH {ctx env staticFields value} hSafe hMatch hStatic hEval => by
+      cases hStatic
+      exact eval_record_value_hasOnlyFields hEval)
+    (fun base fieldName _baseIH {ctx env fields value} hSafe hMatch hStatic hEval => by
+      simp [whereStaticFields] at hStatic)
+    (fun bindings body _bindingsIH bodyIH {ctx env fields value} hSafe hMatch hStatic hEval => by
+      have hNoShadow : letBindingsDoNotShadowStatic ctx bindings := hSafe.1
+      have hBodySafe : Expr.staticLetSafe ctx body := hSafe.2
+      simp [whereStaticFields] at hStatic
+      cases hBindings : evalBindings env bindings with
+      | error err =>
+          simp [eval, hBindings] at hEval
+      | ok localEnv =>
+          have hLocalMatch : EnvMatchesStatic localEnv ctx :=
+            evalBindings_preserves_static_context hMatch hNoShadow hBindings
+          have hBodyEval : eval localEnv body = Except.ok value := by
+            simpa [eval, hBindings] using hEval
+          exact bodyIH hBodySafe hLocalMatch hStatic hBodyEval)
+    (fun condition thenExpr elseExpr _conditionIH _thenIH _elseIH {ctx env fields value}
+        hSafe hMatch hStatic hEval => by
+      simp [whereStaticFields] at hStatic)
+    (fun op operand _operandIH {ctx env fields value} hSafe hMatch hStatic hEval => by
+      simp [whereStaticFields] at hStatic)
+    (fun op left right leftIH rightIH {ctx env fields value} hSafe hMatch hStatic hEval => by
+      cases op with
+      | add =>
+          simp [whereStaticFields] at hStatic
+      | subtract =>
+          simp [whereStaticFields] at hStatic
+      | multiply =>
+          simp [whereStaticFields] at hStatic
+      | and =>
+          simp [whereStaticFields] at hStatic
+      | or =>
+          simp [whereStaticFields] at hStatic
+      | merge =>
+          have hLeftSafe : Expr.staticLetSafe ctx left := hSafe.1
+          have hRightSafe : Expr.staticLetSafe ctx right := hSafe.2
+          cases hLeftStatic : whereStaticFields ctx left with
+          | none =>
+              cases hRightStatic : whereStaticFields ctx right with
+              | none =>
+                  simp [whereStaticFields, hLeftStatic, hRightStatic] at hStatic
+              | some rightFields =>
+                  simp [whereStaticFields, hLeftStatic, hRightStatic] at hStatic
+          | some leftFields =>
+              cases hRightStatic : whereStaticFields ctx right with
+              | none =>
+                  simp [whereStaticFields, hLeftStatic, hRightStatic] at hStatic
+              | some rightFields =>
+                  simp [whereStaticFields, hLeftStatic, hRightStatic] at hStatic
+                  cases hStatic
+                  exact
+                    eval_merge_hasOnlyFields
+                      hLeftSafe hRightSafe hMatch hLeftStatic hRightStatic hEval leftIH rightIH)
+    True.intro
+    (fun head tail _headIH _tailIH => True.intro)
+    (fun bindingName bindingExpr _exprIH => True.intro)
+    expr
+
+/-- Static field discovery is sound for safe expressions in matching runtime environments. -/
+theorem whereStaticFields_sound
+    {ctx : StaticContext}
+    {env : Env}
+    {expr : Expr}
+    {fields : Finset Name}
+    {value : Value}
+    (hSafe : Expr.staticLetSafe ctx expr)
+    (hMatch : EnvMatchesStatic env ctx)
+    (hStatic : whereStaticFields ctx expr = some fields)
+    (hEval : eval env expr = Except.ok value) :
+    Value.hasOnlyFields value fields :=
+  whereStaticFields_sound_expr expr hSafe hMatch hStatic hEval
+
+/-! ## Pure Node Lowering -/
+
+/-- Pure output equation in the proof-side lowering model. -/
+structure PureOutputEquation where
+  /-- Declared output label. -/
+  output : Name
+  /-- CorePure expression that computes the output value. -/
+  expr : Expr
+
+/-- Output labels present in an output-equation list. -/
+def outputEquationKeySet (outputs : List PureOutputEquation) : Finset Name :=
+  outputs.foldr (fun output acc => insert output.output acc) ∅
+
+/-- Source pure node model needed for lowering proofs. -/
+structure PureNode where
+  /-- Declared input port names. -/
+  inputPorts : Finset Name
+  /-- Declared output port names. -/
+  outputPorts : Finset Name
+  /-- Top-level delayed bindings visible to this node. -/
+  bindings : List (Name × Expr)
+  /-- Optional node-local `where` expression. -/
+  whereExpr : Option Expr
+  /-- Output equations. -/
+  outputs : List PureOutputEquation
+
+namespace PureNode
+
+/-- Output labels declared by the output-equation map. -/
+def outputKeys (node : PureNode) : Finset Name :=
+  outputEquationKeySet node.outputs
+
+/-- Static `where` field set, with no fields when the node has no `where` expression. -/
+def whereFields (ctx : StaticContext) (node : PureNode) : Option (Finset Name) :=
+  match node.whereExpr with
+  | none => some ∅
+  | some whereExpr => whereStaticFields ctx whereExpr
+
+end PureNode
+
+/-- Admission checks needed before lowering a source pure node. -/
+structure PureNodeAdmitted (ctx : StaticContext) (node : PureNode) : Prop where
+  /-- Top-level node bindings do not shadow statically known module-level records. -/
+  bindings_noShadow : letBindingsDoNotShadowStatic ctx node.bindings
+  /-- Output equations match declared output ports exactly. -/
+  outputs_match : node.outputKeys = node.outputPorts
+  /-- The node-local `where` expression has a statically known field set. -/
+  where_static : ∃ fields, node.whereFields ctx = some fields
+  /-- Local `let` binders inside the `where` expression preserve static field soundness. -/
+  where_letSafe :
+    ∀ whereExpr,
+      node.whereExpr = some whereExpr →
+        Expr.staticLetSafe ctx whereExpr
+  /-- Node-local `where` fields do not collide with input port names. -/
+  where_noInputCollision :
+    ∀ fields,
+      node.whereFields ctx = some fields →
+        Disjoint fields node.inputPorts
+
+/-- Native pure task configuration produced by lowering. -/
+structure NativePureTaskConfig where
+  /-- Top-level delayed bindings or captured constants. -/
+  bindings : List (Name × Expr)
+  /-- Optional node-local `where` expression. -/
+  whereExpr : Option Expr
+  /-- Output expression map. -/
+  outputs : List PureOutputEquation
+
+/-- Lowered node kind used to state that pure nodes lower to one native pure task. -/
+inductive LoweredNodeKind : Type where
+  | nativePure
+
+/-- Lowered pure node artifact. -/
+structure LoweredPureNode where
+  /-- Lowered node kind. -/
+  kind : LoweredNodeKind
+  /-- Native pure task configuration. -/
+  config : NativePureTaskConfig
+
+/-- Lower a source pure node to one native pure task. -/
+def lowerPureNode (_ctx : StaticContext) (node : PureNode) :
+    LoweredPureNode :=
+  { kind := LoweredNodeKind.nativePure
+    config :=
+      { bindings := node.bindings
+        whereExpr := node.whereExpr
+        outputs := node.outputs } }
+
+/-- Open a record value into an environment, shadowing outer variables by field name. -/
+def openRecordIntoEnv (recordFields : Name → Option Value) (env : Env) : Env :=
+  fun name =>
+    match recordFields name with
+    | some value => some value
+    | none => env name
+
+/-- Opening a `where` record preserves static facts outside names opened by the record. -/
+theorem openRecordIntoEnv_preserves_hidden_static_context
+    {ctx : StaticContext}
+    {env : Env}
+    {recordFields : Name → Option Value}
+    {staticFields : Finset Name}
+    (hMatch : EnvMatchesStatic env ctx)
+    (hRecord : Value.hasOnlyFields (Value.record recordFields) staticFields) :
+    EnvMatchesStatic
+      (openRecordIntoEnv recordFields env)
+      (StaticContext.hideFields staticFields ctx) := by
+  intro name fields value hStatic hLocal
+  cases hRecordLookup : recordFields name with
+  | none =>
+      have hOuterLookup : env name = some value := by
+        simpa [openRecordIntoEnv, hRecordLookup] using hLocal
+      by_cases hMember : name ∈ staticFields
+      · have hHidden : StaticContext.hideFields staticFields ctx name = none := by
+          simp [StaticContext.hideFields, hMember]
+        rw [hHidden] at hStatic
+        simp at hStatic
+      · have hOuterStatic : ctx name = some fields := by
+          simpa [StaticContext.hideFields, hMember] using hStatic
+        exact hMatch name fields value hOuterStatic hOuterLookup
+  | some openedValue =>
+      have hMember : name ∈ staticFields := hRecord name openedValue hRecordLookup
+      have hHidden : StaticContext.hideFields staticFields ctx name = none := by
+        simp [StaticContext.hideFields, hMember]
+      rw [hHidden] at hStatic
+      simp at hStatic
+
+/-- Evaluate an optional `where` expression into the local pure-task environment. -/
+def evalWhereEnv (env : Env) : Option Expr → Except EvalError Env
+  | none => Except.ok env
+  | some whereExpr =>
+      match eval env whereExpr with
+      | Except.error err => Except.error err
+      | Except.ok Value.null => Except.error EvalError.expectedRecord
+      | Except.ok (Value.bool _value) => Except.error EvalError.expectedRecord
+      | Except.ok (Value.int _value) => Except.error EvalError.expectedRecord
+      | Except.ok (Value.string _value) => Except.error EvalError.expectedRecord
+      | Except.ok (Value.record recordFields) =>
+          Except.ok (openRecordIntoEnv recordFields env)
+
+/-- Evaluate output equations in an already prepared pure-task environment. -/
+def evalOutputEquationValues (env : Env) :
+    List PureOutputEquation → Except EvalError (List (Name × Value))
+  | [] => Except.ok []
+  | output :: rest =>
+      match eval env output.expr with
+      | Except.error err => Except.error err
+      | Except.ok outputValue =>
+          match evalOutputEquationValues env rest with
+          | Except.error err => Except.error err
+          | Except.ok restValues => Except.ok ((output.output, outputValue) :: restValues)
+
+/-- Convert evaluated output values into the proof-side output lookup surface. -/
+def outputLookupFromValues (values : List (Name × Value)) : Name → Option Value :=
+  recordFromValues values
+
+/-- Evaluate output equations to a lookup function in an already prepared environment. -/
+def evalOutputEquations (env : Env)
+    (outputs : List PureOutputEquation) :
+    Except EvalError (Name → Option Value) :=
+  match evalOutputEquationValues env outputs with
+  | Except.error err => Except.error err
+  | Except.ok values => Except.ok (outputLookupFromValues values)
+
+/-- Evaluating output equations preserves their declared output-label set. -/
+theorem evalOutputEquationValues_preserves_names
+    {env : Env}
+    {outputs : List PureOutputEquation}
+    {values : List (Name × Value)}
+    (hEval : evalOutputEquationValues env outputs = Except.ok values) :
+    valueFieldNameSet values = outputEquationKeySet outputs := by
+  induction outputs generalizing values with
+  | nil =>
+      simp [evalOutputEquationValues] at hEval
+      cases hEval
+      rfl
+  | cons output rest ih =>
+      simp [evalOutputEquationValues] at hEval
+      cases hOutputEval : eval env output.expr with
+      | error err =>
+          simp [hOutputEval] at hEval
+      | ok outputValue =>
+          simp [hOutputEval] at hEval
+          cases hRest : evalOutputEquationValues env rest with
+          | error err =>
+              simp [hRest] at hEval
+          | ok restValues =>
+              simp [hRest] at hEval
+              cases hEval
+              change insert output.output (valueFieldNameSet restValues) =
+                insert output.output (outputEquationKeySet rest)
+              rw [ih hRest]
+
+/-- Output lookup exposes only names present in the evaluated output-value list. -/
+theorem outputLookupFromValues_keys_subset
+    {values : List (Name × Value)}
+    {name : Name}
+    {value : Value}
+    (hLookup : outputLookupFromValues values name = some value) :
+    name ∈ valueFieldNameSet values :=
+  recordFromValues_hasOnlyFields values name value hLookup
+
+/-- Every evaluated output-value name is present in the output lookup. -/
+theorem outputLookupFromValues_key_present
+    {values : List (Name × Value)}
+    {name : Name}
+    (hName : name ∈ valueFieldNameSet values) :
+    ∃ value, outputLookupFromValues values name = some value :=
+  recordFromValues_field_present hName
+
+/-- Successful output-equation evaluation exposes only declared output labels. -/
+theorem evalOutputEquations_keys_subset
+    {env : Env}
+    {outputs : List PureOutputEquation}
+    {lookup : Name → Option Value}
+    {name : Name}
+    {value : Value}
+    (hEval : evalOutputEquations env outputs = Except.ok lookup)
+    (hLookup : lookup name = some value) :
+    name ∈ outputEquationKeySet outputs := by
+  cases hValues : evalOutputEquationValues env outputs with
+  | error err =>
+      simp [evalOutputEquations, hValues] at hEval
+  | ok values =>
+      simp [evalOutputEquations, hValues] at hEval
+      cases hEval
+      have hMember := outputLookupFromValues_keys_subset (values := values) hLookup
+      have hNames := evalOutputEquationValues_preserves_names hValues
+      simpa [hNames] using hMember
+
+/-- Every declared output label is present after successful output-equation evaluation. -/
+theorem evalOutputEquations_keys_present
+    {env : Env}
+    {outputs : List PureOutputEquation}
+    {lookup : Name → Option Value}
+    {name : Name}
+    (hEval : evalOutputEquations env outputs = Except.ok lookup)
+    (hName : name ∈ outputEquationKeySet outputs) :
+    ∃ value, lookup name = some value := by
+  cases hValues : evalOutputEquationValues env outputs with
+  | error err =>
+      simp [evalOutputEquations, hValues] at hEval
+  | ok values =>
+      simp [evalOutputEquations, hValues] at hEval
+      cases hEval
+      have hNames := evalOutputEquationValues_preserves_names hValues
+      have hValueName : name ∈ valueFieldNameSet values := by
+        simpa [hNames] using hName
+      exact outputLookupFromValues_key_present hValueName
+
+namespace PureNode
+
+/-- Evaluate a source pure node to its proof-side output lookup function. -/
+def evalOutputs (env : Env) (node : PureNode) :
+    Except EvalError (Name → Option Value) :=
+  match evalBindings env node.bindings with
+  | Except.error err => Except.error err
+  | Except.ok outerEnv =>
+      match evalWhereEnv outerEnv node.whereExpr with
+      | Except.error err => Except.error err
+      | Except.ok localEnv => evalOutputEquations localEnv node.outputs
+
+end PureNode
+
+namespace NativePureTaskConfig
+
+/-- Evaluate a native pure-task config to its proof-side output lookup function. -/
+def evalOutputs (env : Env) (config : NativePureTaskConfig) :
+    Except EvalError (Name → Option Value) :=
+  match evalBindings env config.bindings with
+  | Except.error err => Except.error err
+  | Except.ok outerEnv =>
+      match evalWhereEnv outerEnv config.whereExpr with
+      | Except.error err => Except.error err
+      | Except.ok localEnv => evalOutputEquations localEnv config.outputs
+
+end NativePureTaskConfig
+
+/-- Pure output equation keys match declared ports for admitted pure nodes. -/
+theorem pureOutput_keys_match_declaredPorts
+    {ctx : StaticContext}
+    {node : PureNode}
+    (hNode : PureNodeAdmitted ctx node) :
+    node.outputKeys = node.outputPorts :=
+  hNode.outputs_match
+
+/-- Admitted `where` fields are disjoint from input ports. -/
+theorem where_noInputCollision
+    {ctx : StaticContext}
+    {node : PureNode}
+    {fields : Finset Name}
+    (hNode : PureNodeAdmitted ctx node)
+    (hFields : node.whereFields ctx = some fields) :
+    Disjoint fields node.inputPorts :=
+  hNode.where_noInputCollision fields hFields
+
+/-- Admitted pure nodes expose a statically known `where` field set. -/
+theorem pureNode_whereFields_known
+    {ctx : StaticContext}
+    {node : PureNode}
+    (hNode : PureNodeAdmitted ctx node) :
+    ∃ fields, node.whereFields ctx = some fields :=
+  hNode.where_static
+
+/-- Admitted node bindings preserve the static context when evaluated. -/
+theorem pureNode_bindings_noShadow
+    {ctx : StaticContext}
+    {node : PureNode}
+    (hNode : PureNodeAdmitted ctx node) :
+    letBindingsDoNotShadowStatic ctx node.bindings :=
+  hNode.bindings_noShadow
+
+/-- Admitted `where` expressions satisfy the local-let safety side condition. -/
+theorem pureNode_where_letSafe
+    {ctx : StaticContext}
+    {node : PureNode}
+    {whereExpr : Expr}
+    (hNode : PureNodeAdmitted ctx node)
+    (hWhere : node.whereExpr = some whereExpr) :
+    Expr.staticLetSafe ctx whereExpr :=
+  hNode.where_letSafe whereExpr hWhere
+
+/-- Admitted `where` evaluation exposes only the statically admitted fields. -/
+theorem pureNode_where_hasOnlyFields
+    {ctx : StaticContext}
+    {env outerEnv : Env}
+    {node : PureNode}
+    {whereExpr : Expr}
+    {whereFields : Finset Name}
+    {whereValue : Value}
+    (hNode : PureNodeAdmitted ctx node)
+    (hMatch : EnvMatchesStatic env ctx)
+    (hBindings : evalBindings env node.bindings = Except.ok outerEnv)
+    (hWhere : node.whereExpr = some whereExpr)
+    (hStatic : whereStaticFields ctx whereExpr = some whereFields)
+    (hEval : eval outerEnv whereExpr = Except.ok whereValue) :
+    Value.hasOnlyFields whereValue whereFields := by
+  have hOuterMatch : EnvMatchesStatic outerEnv ctx :=
+    evalBindings_preserves_static_context hMatch hNode.bindings_noShadow hBindings
+  have hSafe : Expr.staticLetSafe ctx whereExpr :=
+    hNode.where_letSafe whereExpr hWhere
+  exact whereStaticFields_sound hSafe hOuterMatch hStatic hEval
+
+/-- Successful `where` environment evaluation opens a record with statically admitted fields. -/
+theorem pureNode_evalWhereEnv_record_hasOnlyFields
+    {ctx : StaticContext}
+    {env outerEnv localEnv : Env}
+    {node : PureNode}
+    {whereExpr : Expr}
+    {whereFields : Finset Name}
+    (hNode : PureNodeAdmitted ctx node)
+    (hMatch : EnvMatchesStatic env ctx)
+    (hBindings : evalBindings env node.bindings = Except.ok outerEnv)
+    (hWhere : node.whereExpr = some whereExpr)
+    (hStatic : whereStaticFields ctx whereExpr = some whereFields)
+    (hEvalWhere : evalWhereEnv outerEnv node.whereExpr = Except.ok localEnv) :
+    ∃ recordFields,
+      eval outerEnv whereExpr = Except.ok (Value.record recordFields) ∧
+        localEnv = openRecordIntoEnv recordFields outerEnv ∧
+          Value.hasOnlyFields (Value.record recordFields) whereFields := by
+  simp [evalWhereEnv, hWhere] at hEvalWhere
+  cases hEval : eval outerEnv whereExpr with
+  | error err =>
+      simp [hEval] at hEvalWhere
+  | ok whereValue =>
+      cases whereValue with
+      | null =>
+          simp [hEval] at hEvalWhere
+      | bool whereBool =>
+          simp [hEval] at hEvalWhere
+      | int whereInt =>
+          simp [hEval] at hEvalWhere
+      | string whereString =>
+          simp [hEval] at hEvalWhere
+      | record recordFields =>
+          simp [hEval] at hEvalWhere
+          cases hEvalWhere
+          have hWhereFields :
+              Value.hasOnlyFields (Value.record recordFields) whereFields :=
+            pureNode_where_hasOnlyFields hNode hMatch hBindings hWhere hStatic hEval
+          exact ⟨recordFields, rfl, rfl, hWhereFields⟩
+
+/-- The environment produced by the `where` step matches static facts outside opened fields. -/
+theorem pureNode_evalWhereEnv_localEnv_match_for_fields
+    {ctx : StaticContext}
+    {env outerEnv localEnv : Env}
+    {node : PureNode}
+    {whereFields : Finset Name}
+    (hNode : PureNodeAdmitted ctx node)
+    (hMatch : EnvMatchesStatic env ctx)
+    (hBindings : evalBindings env node.bindings = Except.ok outerEnv)
+    (hFields : node.whereFields ctx = some whereFields)
+    (hEvalWhere : evalWhereEnv outerEnv node.whereExpr = Except.ok localEnv) :
+    EnvMatchesStatic localEnv (StaticContext.hideFields whereFields ctx) := by
+  have hOuterMatch : EnvMatchesStatic outerEnv ctx :=
+    evalBindings_preserves_static_context hMatch hNode.bindings_noShadow hBindings
+  cases hWhere : node.whereExpr with
+  | none =>
+      simp [PureNode.whereFields, hWhere] at hFields
+      cases hFields
+      simp [evalWhereEnv, hWhere] at hEvalWhere
+      cases hEvalWhere
+      simpa [StaticContext.hideFields] using hOuterMatch
+  | some whereExpr =>
+      have hStatic : whereStaticFields ctx whereExpr = some whereFields := by
+        simpa [PureNode.whereFields, hWhere] using hFields
+      obtain ⟨recordFields, _hEval, hLocalEnv, hRecordFields⟩ :=
+        pureNode_evalWhereEnv_record_hasOnlyFields
+          hNode hMatch hBindings hWhere hStatic hEvalWhere
+      cases hLocalEnv
+      exact
+        openRecordIntoEnv_preserves_hidden_static_context hOuterMatch hRecordFields
+
+/-- The environment produced by the `where` step matches a hidden admitted static context. -/
+theorem pureNode_evalWhereEnv_localEnv_match
+    {ctx : StaticContext}
+    {env outerEnv localEnv : Env}
+    {node : PureNode}
+    (hNode : PureNodeAdmitted ctx node)
+    (hMatch : EnvMatchesStatic env ctx)
+    (hBindings : evalBindings env node.bindings = Except.ok outerEnv)
+    (hEvalWhere : evalWhereEnv outerEnv node.whereExpr = Except.ok localEnv) :
+    ∃ whereFields,
+      node.whereFields ctx = some whereFields ∧
+        EnvMatchesStatic localEnv (StaticContext.hideFields whereFields ctx) := by
+  obtain ⟨whereFields, hFields⟩ := hNode.where_static
+  exact
+    ⟨ whereFields,
+      hFields,
+      pureNode_evalWhereEnv_localEnv_match_for_fields
+        hNode hMatch hBindings hFields hEvalWhere ⟩
+
+/-- Successful source pure-node evaluation exposes only declared output ports. -/
+theorem pureNode_evalOutputs_keys_in_outputPorts
+    {ctx : StaticContext}
+    {env : Env}
+    {node : PureNode}
+    {lookup : Name → Option Value}
+    (hNode : PureNodeAdmitted ctx node)
+    (hEval : node.evalOutputs env = Except.ok lookup) :
+    ∀ name value, lookup name = some value → name ∈ node.outputPorts := by
+  cases hBindings : evalBindings env node.bindings with
+  | error err =>
+      simp [PureNode.evalOutputs, hBindings] at hEval
+  | ok outerEnv =>
+      cases hWhere : evalWhereEnv outerEnv node.whereExpr with
+      | error err =>
+          simp [PureNode.evalOutputs, hBindings, hWhere] at hEval
+      | ok localEnv =>
+          have hOutputEval :
+              evalOutputEquations localEnv node.outputs = Except.ok lookup := by
+            simpa [PureNode.evalOutputs, hBindings, hWhere] using hEval
+          intro name value hLookup
+          have hMember := evalOutputEquations_keys_subset hOutputEval hLookup
+          have hOutputKey : name ∈ node.outputKeys := by
+            simpa [PureNode.outputKeys] using hMember
+          simpa [hNode.outputs_match] using hOutputKey
+
+/-- Successful source pure-node evaluation produces every declared output port. -/
+theorem pureNode_evalOutputs_outputPorts_present
+    {ctx : StaticContext}
+    {env : Env}
+    {node : PureNode}
+    {lookup : Name → Option Value}
+    (hNode : PureNodeAdmitted ctx node)
+    (hEval : node.evalOutputs env = Except.ok lookup) :
+    ∀ name, name ∈ node.outputPorts → ∃ value, lookup name = some value := by
+  cases hBindings : evalBindings env node.bindings with
+  | error err =>
+      simp [PureNode.evalOutputs, hBindings] at hEval
+  | ok outerEnv =>
+      cases hWhere : evalWhereEnv outerEnv node.whereExpr with
+      | error err =>
+          simp [PureNode.evalOutputs, hBindings, hWhere] at hEval
+      | ok localEnv =>
+          have hOutputEval :
+              evalOutputEquations localEnv node.outputs = Except.ok lookup := by
+            simpa [PureNode.evalOutputs, hBindings, hWhere] using hEval
+          intro name hPort
+          have hOutputKey : name ∈ node.outputKeys := by
+            simpa [hNode.outputs_match] using hPort
+          have hKeySet : name ∈ outputEquationKeySet node.outputs := by
+            simpa [PureNode.outputKeys] using hOutputKey
+          exact evalOutputEquations_keys_present hOutputEval hKeySet
+
+/-- Source pure nodes lower to one native pure task. -/
+theorem pureNode_lowers_to_one_nativeTask
+    (ctx : StaticContext)
+    (node : PureNode) :
+    (lowerPureNode ctx node).kind = LoweredNodeKind.nativePure :=
+  rfl
+
+/-- Lowering preserves source pure-node output evaluation in the proof-side evaluator. -/
+theorem pureNode_lowering_evalOutputs_eq
+    (ctx : StaticContext)
+    (env : Env)
+    (node : PureNode) :
+    (lowerPureNode ctx node).config.evalOutputs env =
+      node.evalOutputs env :=
+  rfl
+
+/-- CorePure evaluation is deterministic because it is a pure function. -/
+theorem pureEvaluation_deterministic
+    {env : Env}
+    {expr : Expr}
+    {left right : Value}
+    (hLeft : eval env expr = Except.ok left)
+    (hRight : eval env expr = Except.ok right) :
+    left = right := by
+  rw [hLeft] at hRight
+  cases hRight
+  rfl
+
+end CorePure
+
+end Cortex.Wire

--- a/theory/Main.lean
+++ b/theory/Main.lean
@@ -23,6 +23,6 @@ def main : IO Unit := do
   IO.println "Cortex theory — Lean 4 mechanization (scaffold)"
   IO.println "  Track 1 (Graph algebra) ......... import Cortex.Graph.Quotient"
   IO.println "  Track 2 (Pulse kernel) .......... import Cortex.Pulse.Classify"
-  IO.println "  Track 3 (Wire rewrite) .......... import Cortex.Wire.Planner.Construction"
+  IO.println "  Track 3 (Wire proof surface) .... import Cortex.Wire.Planner.Chain"
   IO.println ""
   IO.println "Open obligations: see `theory/README.md`."

--- a/theory/README.md
+++ b/theory/README.md
@@ -82,6 +82,9 @@ Haskell-side establishment of the persisted recovery preconditions.
 
 ### Track 3 — Rewrite soundness
 
+`Cortex.Wire.Pure` models the proof-facing CorePure subset for pure output equations: deterministic
+integer/boolean/record evaluation, static `where`-field discovery soundness, an expression ADT with
+no authority-bearing constructors, and one-source-node-to-one-native-pure-task lowering.
 `Cortex.Wire.Registry` models the `@` executor boundary as pure staging of registered authority:
 executor lookup, config validation, registry-wide contract vocabulary, endpoint compatibility,
 effect-class policy, output validation, and host authority. `Cortex.Wire.Rewrite` defines the
@@ -102,6 +105,29 @@ delta establishes the planner-construction bridge under the remaining runtime va
 
 Mechanized results now include:
 
+- `pureEvaluation_deterministic`: CorePure subset evaluation is deterministic because evaluation is
+  a pure function over an explicit environment.
+- `where_staticFields_record`, `where_staticFields_merge`, and `where_staticFields_let`: static
+  field discovery computes record-literal fields, merge unions, and ADR 0031-style local `let`
+  transparency explicitly.
+- `whereStaticFields_sound`, `evalBindingsNoDuplicate_preserves_static_context`, and
+  `evalBindings_preserves_static_context`: static `where` discovery is sound for runtime
+  environments that match the static context when local `let` binders do not shadow statically known
+  module-level records.
+- `pureOutput_keys_match_declaredPorts`, `where_noInputCollision`, `pureNode_whereFields_known`, and
+  `pureNode_lowers_to_one_nativeTask`: admitted source pure nodes lower to one native pure task
+  while preserving output equations and the statically checked `where` boundary.
+- `pureNode_bindings_noShadow`, `pureNode_where_letSafe`, `pureNode_where_hasOnlyFields`,
+  `pureNode_evalWhereEnv_record_hasOnlyFields`, `openRecordIntoEnv_preserves_hidden_static_context`,
+  and `pureNode_evalWhereEnv_localEnv_match`: admitted nodes carry the no-shadow obligations needed
+  to apply static `where` soundness through the actual `evalWhereEnv` call site, while opened
+  `where` fields hide any same-named static record facts.
+- `evalOutputEquationValues_preserves_names`, `evalOutputEquations_keys_subset`,
+  `evalOutputEquations_keys_present`, `pureNode_evalOutputs_keys_in_outputPorts`, and
+  `pureNode_evalOutputs_outputPorts_present`: successful proof-side pure-node evaluation exposes
+  exactly the declared output ports.
+- `pureNode_lowering_evalOutputs_eq`: lowered native pure-task configs evaluate to the same
+  proof-side output lookup function as their source pure nodes.
 - `plannedRewriteSafety_of_checks`: runtime planning checks supply the acyclicity and positive
   rewrite-operation parts of a proof-carrying rewrite.
 - `planGraphRewriteChecks_topology_matches`: planning checks expose the final-topology construction
@@ -177,6 +203,16 @@ Mechanized results now include:
 
 Remaining obligations:
 
+- prove that the executable Haskell CorePure evaluator and compiler lowering
+  (`evaluatePureTaskOutputs`, `loweredPureNodeFromBody`, `validateWhereClause`, and
+  `staticWhereFieldNames`) produce the Lean `Cortex.Wire.Pure` witnesses, including duplicate-name
+  rejection, output-port equality, static `where` fields, and ADR 0010/0023's authority exclusion by
+  syntax; the static `where` correspondence must also produce the `bindings_noShadow` and
+  `where_letSafe` admission witnesses when field discovery ignores local CorePure `let` binders, and
+  show that opened `where` fields hide same-named static record facts;
+- connect ADR 0023's duplicate-name discipline to executable parser/elaborator witnesses, especially
+  duplicate record fields and nested-path conflicts, so record evaluation never relies on silent
+  overwrite inside admitted CorePure literals;
 - prove that the executable Haskell planner and budget admission path (`planGraphRewrite`,
   `consumeRewriteBudget`, and `admitRewriteDelta`) produce the `RuntimeConstructionInputs` and
   `AdmittedRewriteDelta` witnesses used by constructed Lean chains, including the source context
@@ -233,15 +269,15 @@ The repo's pre-commit hook checks theory changes through the flake surface
 
 ## Status
 
-| Track                            | Statements                                                                              | Proved                                                                                                                                                                                                                                         | Axiomatized |
-| -------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 1a. Graph relation semantics     | finite relation denotation + Mokhov laws                                                | relation-level laws                                                                                                                                                                                                                            | none        |
-| 1b. Graph denotational AST laws  | AST laws over graph equivalence                                                         | denotational law surface                                                                                                                                                                                                                       | none        |
-| 1c. Graph quotient laws          | lifted quotient equality laws                                                           | `AlgGraph` quotient carrier, lifted operations, quotient equality bridge, Mokhov laws as `=`                                                                                                                                                   | none        |
-| 2. Fixed-topology Pulse kernel   | edge-derived DAG/state/fact/frontier/closure/recovery/classification surface            | frontier antichain, direct/runtime frontier bridge, fact commutativity, admissible fact recovery, closure idempotence, topology-domain/output/volatile-state/causal preservation, structural recovery predicate, classification exhaustiveness | none        |
-| 3. Rewrite soundness             | registry-boundary model + proof-carrying rewrite certificate + runtime admission bridge | node/edge registry predicates, runtime planning predicates, acyclicity/contract/budget projections, admitted planned-delta bridge, chain-level preservation, step bound by rewrite-operation budget                                            | none        |
-| 4. Provider / sparks             | —                                                                                       | —                                                                                                                                                                                                                                              | not started |
-| 5. Substrate / consumer boundary | —                                                                                       | —                                                                                                                                                                                                                                              | not started |
+| Track                            | Statements                                                                                                      | Proved                                                                                                                                                                                                                                                                       | Axiomatized |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| 1a. Graph relation semantics     | finite relation denotation + Mokhov laws                                                                        | relation-level laws                                                                                                                                                                                                                                                          | none        |
+| 1b. Graph denotational AST laws  | AST laws over graph equivalence                                                                                 | denotational law surface                                                                                                                                                                                                                                                     | none        |
+| 1c. Graph quotient laws          | lifted quotient equality laws                                                                                   | `AlgGraph` quotient carrier, lifted operations, quotient equality bridge, Mokhov laws as `=`                                                                                                                                                                                 | none        |
+| 2. Fixed-topology Pulse kernel   | edge-derived DAG/state/fact/frontier/closure/recovery/classification surface                                    | frontier antichain, direct/runtime frontier bridge, fact commutativity, admissible fact recovery, closure idempotence, topology-domain/output/volatile-state/causal preservation, structural recovery predicate, classification exhaustiveness                               | none        |
+| 3. Rewrite soundness             | CorePure proof subset + registry-boundary model + proof-carrying rewrite certificate + runtime admission bridge | pure evaluator determinism/static-field soundness/lowering preservation, node/edge registry predicates, runtime planning predicates, acyclicity/contract/budget projections, admitted planned-delta bridge, chain-level preservation, step bound by rewrite-operation budget | none        |
+| 4. Provider / sparks             | —                                                                                                               | —                                                                                                                                                                                                                                                                            | not started |
+| 5. Substrate / consumer boundary | —                                                                                                               | —                                                                                                                                                                                                                                                                            | not started |
 
 Discharging the remaining obligations is the actual work. The scaffold's job is to make the
 obligation graph compile and run end-to-end so that proof debt is visible and each abstract

--- a/theory/lakefile.lean
+++ b/theory/lakefile.lean
@@ -39,6 +39,7 @@ lean_lib «Cortex» where
     `Cortex.Pulse.Validity,
     `Cortex.Pulse.Recovery,
     `Cortex.Pulse.Classify,
+    `Cortex.Wire.Pure,
     `Cortex.Wire.Registry,
     `Cortex.Wire.Rewrite,
     `Cortex.Wire.Admission,


### PR DESCRIPTION
## Summary
Mechanizes the first CorePure proof slice for issue #107 and hardens it against theorem-attack review:

- adds `Cortex.Wire.Pure` with a proof-facing CorePure value/expression/environment model;
- trims authority modeling back to the ADT boundary: CorePure has no authority-bearing `Expr` constructors, per ADR 0010 and ADR 0023, so no separate authority predicate/theorem surface is claimed;
- aligns static `where` field discovery with ADR 0031 and Haskell: local CorePure `let` bindings are evaluated at runtime but not expanded by static discovery;
- proves static `where`-field discovery soundness under `EnvMatchesStatic` plus the explicit `Expr.staticLetSafe` side condition that local `let` binders do not shadow statically known module-level records;
- extends `PureNodeAdmitted` with `bindings_noShadow` and `where_letSafe`, the witnesses needed to use static `where` soundness through the actual `evalWhereEnv` call site;
- models node-local `where` shadowing by hiding same-named static facts after a `where` record is opened, via `StaticContext.hideFields` and `openRecordIntoEnv_preserves_hidden_static_context`;
- proves `pureNode_where_hasOnlyFields`, `pureNode_evalWhereEnv_record_hasOnlyFields`, and `pureNode_evalWhereEnv_localEnv_match`, closing the admitted-node bridge from matching entry environment through evaluated node bindings and opened `where` records;
- proves `pureNode_evalOutputs_keys_in_outputPorts` and `pureNode_evalOutputs_outputPorts_present`, so successful proof-side pure-node evaluation exposes exactly the declared output ports;
- factors the merge branch of static `where` soundness into `eval_merge_hasOnlyFields`, keeping the recursive theorem body smaller;
- adds separate proof-side `PureNode.evalOutputs` and `NativePureTaskConfig.evalOutputs` surfaces, with `pureNode_lowering_evalOutputs_eq` as the lowering preservation theorem;
- aligns proof docs with ADR 0023's duplicate-name decision: duplicate record fields and nested-path conflicts are upstream parse/elaboration errors, while explicit `//` merge remains right-biased;
- adds the repo-local `research` skill and memo template used to synthesize cross-layer findings after this proof slice.

## Review focus
This PR is still proof-side only for the CorePure claims. It deliberately does not claim Haskell correspondence yet; `theory/README.md` tracks that `evaluatePureTaskOutputs`, `loweredPureNodeFromBody`, `validateWhereClause`, `staticWhereFieldNames`, and the parser/elaborator duplicate-name witnesses must still be connected to these Lean witnesses.

Known pressure points left visible rather than hidden:

- Haskell correspondence must produce the `bindings_noShadow` and `where_letSafe` admission witnesses when executable static field discovery ignores local CorePure `let` binders, and must connect opened `where` records to hidden same-named static facts. Tracked by #114.
- ADR 0023 now makes duplicate record fields and nested-path conflicts illegal before evaluation; the Haskell parser/elaborator still needs the corresponding witness path. Tracked by #115.
- Authority-freeness is carried by the current CorePure ADT excluding authority-bearing constructors; a future closed-builtin authority ledger is tracked by #116.
- Output-value and per-port contract soundness beyond exact output keys is tracked by #117.

## Checklist
- [x] Implementation complete
- [x] Tests/proofs added or updated
- [x] `just lean-lint` passes locally
- [x] `just lean-check` passes locally
- [x] `just lean-build` passes locally
- [x] `just lean-build-exe` passes locally
- [x] `just fmt-check` passes locally
- [x] `just docs-check` passes locally
- [x] Commit provenance verified
- [x] Ready for review

## Issue
Closes #107