### PR TITLE
feat: validate persisted Pulse recovery state

### DIFF
--- a/src/Cortex/Pulse/Executor/Resume.hs
+++ b/src/Cortex/Pulse/Executor/Resume.hs
@@ -32,6 +32,11 @@ import Rel8 (Result)
 import Cortex.Algebra.Graph (Relation (..))
 import Cortex.Pulse.Executor.Events (ExecutorEvent (..))
 import Cortex.Pulse.Executor.Frontier (resolveDeliveredSignals)
+import Cortex.Pulse.Executor.Outcome
+  ( handleSettled
+  , handleStuck
+  , handleSuspended
+  )
 import Cortex.Pulse.Executor.Persistence
   ( failRun
   , requireGraphStatePersist
@@ -40,8 +45,10 @@ import Cortex.Pulse.Executor.ReplayPolicy (enforceGraphReplayPolicy)
 import Cortex.Pulse.Executor.Types (RunTVars (..), mkStageEnv)
 import Cortex.Pulse.GraphRuntime
   ( GraphState (..)
-  , normalizeForResume
-  , readyNodes
+  , StepResult (..)
+  , recoverPersistedGraphState
+  , renderRecoveryPreconditionErrors
+  , stepResultState
   )
 import Cortex.Pulse.Materialization
   ( NodeProvenance
@@ -220,19 +227,24 @@ resumeFromPersistedState pool pulseConfig shutdownFlag runId task initialStagePl
                                   emitObsEvent $ EvtResumeIntegrityMismatch runId expectedHash dbHash
                             _ -> pure ()
                           gs1 <- resolveDeliveredSignals pool runId materializedState.pgsGraphState
-                          let persistedState =
-                                materializedState
-                                  { pgsGraphState = normalizeForResume gs1
-                                  }
-                              frontier = readyNodes (spTopology stagePlan) persistedState.pgsGraphState
-                          if persistedState /= persistedState0
-                            then do
-                              persistFailed <- requireGraphStatePersist env persistedState
-                              case persistFailed of
-                                Just outcome -> pure outcome
-                                Nothing -> continueAfterReplay stagePlan persistedState frontier
-                            else
-                              continueAfterReplay stagePlan persistedState frontier
+                          case recoverPersistedGraphState (spTopology stagePlan) gs1 of
+                            Left validationErrors ->
+                              failResume
+                                "graph_state_recovery_preconditions_failed"
+                                (renderRecoveryPreconditionErrors validationErrors)
+                            Right recoveryStep -> do
+                              let persistedState =
+                                    materializedState
+                                      { pgsGraphState = stepResultState recoveryStep
+                                      }
+                              if persistedState /= persistedState0
+                                then do
+                                  persistFailed <- requireGraphStatePersist env persistedState
+                                  case persistFailed of
+                                    Just outcome -> pure outcome
+                                    Nothing -> continueAfterRecovery env stagePlan persistedState recoveryStep
+                                else
+                                  continueAfterRecovery env stagePlan persistedState recoveryStep
     _ ->
       failResume
         "graph_state_parse_failed"
@@ -245,8 +257,15 @@ resumeFromPersistedState pool pulseConfig shutdownFlag runId task initialStagePl
       pure OutcomeFailed
 
     continueAfterReplay stagePlan persistedState frontier = do
-      emitObsEvent $ EvtResumeGraph runId
       blocked <- enforceGraphReplayPolicy pool runId stagePlan frontier
       case blocked of
         Just outcome -> pure outcome
         Nothing -> continueWithResumedState stagePlan persistedState frontier
+
+    continueAfterRecovery env stagePlan persistedState recoveryStep = do
+      emitObsEvent $ EvtResumeGraph runId
+      case recoveryStep of
+        Progressing _ frontier -> continueAfterReplay stagePlan persistedState frontier
+        Settled gs outcome -> handleSettled env gs outcome
+        Suspended gs -> handleSuspended env gs
+        Stuck gs diag -> handleStuck env runId gs diag

--- a/src/Cortex/Pulse/GraphRuntime.hs
+++ b/src/Cortex/Pulse/GraphRuntime.hs
@@ -34,6 +34,12 @@ module Cortex.Pulse.GraphRuntime
   , markSkipped
   , markWaiting
   , normalizeForResume
+  , RecoveryCausalHistoryViolation (..)
+  , RecoveryPreconditionError (..)
+  , validatePersistedRecoveryPreconditions
+  , recoverPersistedGraphState
+  , renderRecoveryPreconditionError
+  , renderRecoveryPreconditionErrors
   , StepResult (..)
   , StuckDiagnostic (..)
   , classifyGraphState
@@ -65,16 +71,21 @@ where
 
 import Data.Aeson (FromJSON, ToJSON, Value)
 import Data.Either (lefts)
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text (Text)
+import Data.Text qualified as T
 import GHC.Generics (Generic)
 
 import Cortex.Algebra.Graph
   ( Relation (..)
   , predecessors
+  , reachable
   , successors
+  , transposeRelation
   )
 import Cortex.Pulse.Node (NodeId (..))
 
@@ -216,6 +227,14 @@ markWaiting :: NodeId -> Text -> GraphState o -> GraphState o
 markWaiting nid signalName gs =
   gs {gsNodeStatuses = Map.insert nid (NodeWaiting signalName) (gsNodeStatuses gs)}
 
+{- | Reset volatile in-flight statuses before resuming persisted graph state.
+
+This is the Haskell counterpart of Lean's @GraphState.resetRunningToPending@,
+not the full @recoveredState G state@ in @theory/Cortex/Pulse/Recovery.lean@
+(which also applies @propagateFailure@).  Runtime recovery validates the
+persisted preconditions before this reset; @classifyGraphState@ applies
+@propagateFailure@ before choosing the next frontier or terminal outcome.
+-}
 normalizeForResume :: GraphState o -> GraphState o
 normalizeForResume gs =
   gs {gsNodeStatuses = Map.map resetOne (gsNodeStatuses gs)}
@@ -228,6 +247,205 @@ normalizeForResume gs =
     resetOne NodeSkipped = NodeSkipped
     resetOne NodeRewritten = NodeRewritten
     resetOne (NodeWaiting s) = NodeWaiting s
+
+-- | Evidence for a persisted successor-unblocking node whose causal history is still open.
+data RecoveryCausalHistoryViolation = RecoveryCausalHistoryViolation
+  { rchvNode :: !NodeId
+  , rchvAncestor :: !NodeId
+  , rchvAncestorStatus :: !NodeStatus
+  }
+  deriving stock (Eq, Show)
+
+-- | Persisted graph-state validation error detected before recovery classification.
+data RecoveryPreconditionError
+  = RecoveryStatusOutsideTopology !NodeId
+  | RecoveryStatusMissing !NodeId
+  | RecoveryOutputOutsideTopology !NodeId
+  | RecoveryOutputNotAllowed !NodeId !NodeStatus
+  | RecoveryRequiredOutputMissing !NodeId !NodeStatus
+  | RecoveryCausalHistoryOpen !RecoveryCausalHistoryViolation
+  deriving stock (Eq, Show)
+
+{- | Validate persisted recovery input against the executable counterpart of
+Lean's persisted recovery preconditions.
+
+The Haskell map representation is intentionally stricter than Lean's total
+status/output functions: off-topology keys are rejected even when they would
+read as pending/no-output in Lean, and every topology node must have an
+explicit persisted status entry.  Runtime reconciliation and rewrite
+materialization restore those map invariants before calling this validator.
+-}
+validatePersistedRecoveryPreconditions
+  :: Relation NodeId
+  -> GraphState o
+  -> Either (NonEmpty RecoveryPreconditionError) ()
+validatePersistedRecoveryPreconditions topology state =
+  case recoveryPreconditionErrors topology state of
+    [] -> Right ()
+    err : errs -> Left (err :| errs)
+
+{- | Validate and classify a persisted graph state for resume.
+
+This is the runtime counterpart of Lean's @recoveredState G state@: validation
+checks the persisted preconditions, 'normalizeForResume' performs
+@resetRunningToPending@, and 'classifyGraphState' applies @propagateFailure@
+before returning a frontier or terminal outcome.
+-}
+recoverPersistedGraphState
+  :: Relation NodeId
+  -> GraphState Value
+  -> Either (NonEmpty RecoveryPreconditionError) StepResult
+recoverPersistedGraphState topology state =
+  case validatePersistedRecoveryPreconditions topology state of
+    Left errs -> Left errs
+    Right () -> Right (classifyGraphState topology (normalizeForResume state))
+
+-- | Render one persisted recovery validation error for operator-facing logs.
+renderRecoveryPreconditionError :: RecoveryPreconditionError -> Text
+renderRecoveryPreconditionError = \case
+  RecoveryStatusOutsideTopology node ->
+    "Persisted status for node "
+      <> unNodeId node
+      <> " is outside the materialized topology"
+  RecoveryStatusMissing node ->
+    "Persisted status for topology node "
+      <> unNodeId node
+      <> " is missing"
+  RecoveryOutputOutsideTopology node ->
+    "Persisted output for node "
+      <> unNodeId node
+      <> " is outside the materialized topology"
+  RecoveryOutputNotAllowed node status ->
+    "Persisted output for node "
+      <> unNodeId node
+      <> " is not allowed while status is "
+      <> renderNodeStatus status
+  RecoveryRequiredOutputMissing node status ->
+    "Persisted node "
+      <> unNodeId node
+      <> " is "
+      <> renderNodeStatus status
+      <> " but has no persisted output"
+  RecoveryCausalHistoryOpen violation ->
+    "Persisted successor-unblocking node "
+      <> unNodeId violation.rchvNode
+      <> " has non-terminal strict ancestor "
+      <> unNodeId violation.rchvAncestor
+      <> " with status "
+      <> renderNodeStatus violation.rchvAncestorStatus
+
+-- | Render all persisted recovery validation errors as a single operator-facing message.
+renderRecoveryPreconditionErrors :: NonEmpty RecoveryPreconditionError -> Text
+renderRecoveryPreconditionErrors =
+  T.intercalate "; " . fmap renderRecoveryPreconditionError . NE.toList
+
+recoveryPreconditionErrors :: Relation NodeId -> GraphState o -> [RecoveryPreconditionError]
+recoveryPreconditionErrors topology state =
+  statusDomainErrors
+    <> missingStatusErrors
+    <> outputDomainErrors
+    <> outputStatusErrors
+    <> missingOutputErrors
+    <> causalHistoryErrors
+  where
+    topologyNodes = relVertices topology
+    transposedTopology = transposeRelation topology
+    statusNodes = Map.keysSet state.gsNodeStatuses
+    outputNodes = Map.keysSet state.gsNodeOutputs
+
+    statusOf node = Map.findWithDefault NodePending node state.gsNodeStatuses
+    strictAncestorsOf node = Set.delete node (reachable transposedTopology node)
+
+    statusDomainErrors =
+      RecoveryStatusOutsideTopology
+        <$> Set.toList (Set.difference statusNodes topologyNodes)
+
+    missingStatusErrors =
+      RecoveryStatusMissing
+        <$> Set.toList (Set.difference topologyNodes statusNodes)
+
+    outputDomainErrors =
+      RecoveryOutputOutsideTopology
+        <$> Set.toList (Set.difference outputNodes topologyNodes)
+
+    outputStatusErrors =
+      [ RecoveryOutputNotAllowed node status
+      | node <- Set.toList (Set.intersection outputNodes topologyNodes)
+      , let status = statusOf node
+      , not (mayHaveOutputStatus status)
+      ]
+
+    missingOutputErrors =
+      [ RecoveryRequiredOutputMissing node status
+      | node <- Set.toList topologyNodes
+      , let status = statusOf node
+      , requiresOutputStatus status
+      , Map.notMember node state.gsNodeOutputs
+      ]
+
+    causalHistoryErrors =
+      [ RecoveryCausalHistoryOpen
+          RecoveryCausalHistoryViolation
+            { rchvNode = node
+            , rchvAncestor = ancestor
+            , rchvAncestorStatus = ancestorStatus
+            }
+      | node <- Set.toList topologyNodes
+      , unblocksSuccessorsStatus (statusOf node)
+      , ancestor <- Set.toList (strictAncestorsOf node)
+      , let ancestorStatus = statusOf ancestor
+      , not (isTerminalStatus ancestorStatus)
+      ]
+
+mayHaveOutputStatus :: NodeStatus -> Bool
+mayHaveOutputStatus = \case
+  NodeCompleted -> True
+  NodeRewritten -> True
+  NodePending -> False
+  NodeRunning -> False
+  NodeFailed -> False
+  NodeSkipped -> False
+  NodeInterrupted _ -> False
+  NodeWaiting _ -> False
+
+requiresOutputStatus :: NodeStatus -> Bool
+requiresOutputStatus = \case
+  NodeCompleted -> True
+  NodeRewritten -> True
+  NodePending -> False
+  NodeRunning -> False
+  NodeFailed -> False
+  NodeSkipped -> False
+  NodeInterrupted _ -> False
+  NodeWaiting _ -> False
+
+unblocksSuccessorsStatus :: NodeStatus -> Bool
+unblocksSuccessorsStatus = \case
+  NodeCompleted -> True
+  NodeSkipped -> True
+  NodeRewritten -> True
+  NodePending -> False
+  NodeRunning -> False
+  NodeFailed -> False
+  NodeInterrupted _ -> False
+  NodeWaiting _ -> False
+
+renderNodeStatus :: NodeStatus -> Text
+renderNodeStatus = \case
+  NodePending -> "pending"
+  NodeRunning -> "running"
+  NodeCompleted -> "completed"
+  NodeFailed -> "failed"
+  NodeSkipped -> "skipped"
+  NodeInterrupted reason -> "interrupted: " <> renderInterruptReason reason
+  NodeRewritten -> "rewritten"
+  NodeWaiting signalName -> "waiting on \"" <> signalName <> "\""
+
+renderInterruptReason :: InterruptReason -> Text
+renderInterruptReason = \case
+  InterruptedSiblingCancelled -> "sibling cancelled"
+  InterruptedShutdown -> "shutdown"
+  InterruptedRunCancelled -> "run cancelled"
 
 data NodeInputError
   = MissingOutput NodeId

--- a/test/Cortex/Algebra/GraphSpec.hs
+++ b/test/Cortex/Algebra/GraphSpec.hs
@@ -12,8 +12,10 @@ Tests may import the surface they exercise, but they do not define downstream pr
 -}
 module Cortex.Algebra.GraphSpec (spec) where
 
+import Control.Monad (forM_)
 import Data.Aeson qualified as Aeson
 import Data.List (sort, sortOn)
+import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as Map
 import Data.Maybe (listToMaybe)
 import Data.Ord (Down (..))
@@ -38,6 +40,12 @@ normalizeSCCs = sortOn safeMin . fmap sort
   where
     safeMin [] = Nothing
     safeMin (x : _) = Just x
+
+recoveryErrors :: Relation NodeId -> GraphState Aeson.Value -> [RecoveryPreconditionError]
+recoveryErrors rel gs =
+  case validatePersistedRecoveryPreconditions rel gs of
+    Right () -> []
+    Left errs -> NE.toList errs
 
 spec :: Spec
 spec = do
@@ -452,6 +460,127 @@ spec = do
               , gsNodeOutputs = Map.empty :: Map.Map NodeId Int
               }
       normalizeForResume gs `shouldBe` gs
+
+  describe "validatePersistedRecoveryPreconditions" $ do
+    it "accepts a completed prefix with required outputs" $ do
+      let rel = toRelation (path [NodeId "a", NodeId "b"])
+          gs0 = initialGraphState rel
+          gs =
+            gs0
+              { gsNodeStatuses = Map.insert (NodeId "a") NodeCompleted gs0.gsNodeStatuses
+              , gsNodeOutputs = Map.singleton (NodeId "a") Aeson.Null
+              }
+      validatePersistedRecoveryPreconditions rel gs `shouldBe` Right ()
+
+    it "rejects status entries outside the topology without requiring resume reconciliation" $ do
+      let rel = toRelation (path [NodeId "a", NodeId "b"])
+          ghost = NodeId "ghost"
+          gs0 = initialGraphState rel
+          gs =
+            gs0
+              { gsNodeStatuses = Map.insert ghost NodePending gs0.gsNodeStatuses
+              }
+      recoveryErrors rel gs `shouldContain` [RecoveryStatusOutsideTopology ghost]
+
+    it "rejects missing explicit status entries for topology nodes" $ do
+      let rel = toRelation (path [NodeId "a", NodeId "b"])
+          missing = NodeId "b"
+          gs0 = initialGraphState rel
+          gs =
+            gs0
+              { gsNodeStatuses = Map.delete missing gs0.gsNodeStatuses
+              }
+      recoveryErrors rel gs `shouldContain` [RecoveryStatusMissing missing]
+
+    it "rejects status and output domains outside the topology" $ do
+      let rel = toRelation (path [NodeId "a", NodeId "b"])
+          ghost = NodeId "ghost"
+          gs0 = initialGraphState rel
+          gs =
+            gs0
+              { gsNodeStatuses = Map.insert ghost NodeCompleted gs0.gsNodeStatuses
+              , gsNodeOutputs = Map.singleton ghost Aeson.Null
+              }
+      recoveryErrors rel gs
+        `shouldContain` [ RecoveryStatusOutsideTopology ghost
+                        , RecoveryOutputOutsideTopology ghost
+                        ]
+
+    it "rejects completed and rewritten nodes missing required outputs" $ do
+      let rel = toRelation (vertices [NodeId "a"])
+          node = NodeId "a"
+          invalidStatuses =
+            [ NodeCompleted
+            , NodeRewritten
+            ]
+      forM_ invalidStatuses $ \status -> do
+        let gs =
+              GraphState
+                { gsNodeStatuses = Map.singleton node status
+                , gsNodeOutputs = Map.empty
+                }
+        recoveryErrors rel gs `shouldContain` [RecoveryRequiredOutputMissing node status]
+
+    it "rejects outputs on statuses that cannot own payloads" $ do
+      let rel = toRelation (vertices [NodeId "a"])
+          node = NodeId "a"
+          invalidStatuses =
+            [ NodePending
+            , NodeRunning
+            , NodeFailed
+            , NodeSkipped
+            , NodeInterrupted InterruptedShutdown
+            , NodeWaiting "approval"
+            ]
+      forM_ invalidStatuses $ \status -> do
+        let gs =
+              GraphState
+                { gsNodeStatuses = Map.singleton node status
+                , gsNodeOutputs = Map.singleton node Aeson.Null
+                }
+        recoveryErrors rel gs `shouldContain` [RecoveryOutputNotAllowed node status]
+
+    it "rejects successor-unblocking nodes with non-terminal strict ancestors" $ do
+      let rel = toRelation (path [NodeId "a", NodeId "b"])
+          ancestor = NodeId "a"
+          node = NodeId "b"
+          gs =
+            GraphState
+              { gsNodeStatuses =
+                  Map.fromList
+                    [ (ancestor, NodePending)
+                    , (node, NodeCompleted)
+                    ]
+              , gsNodeOutputs = Map.singleton node Aeson.Null
+              }
+      recoveryErrors rel gs
+        `shouldContain` [ RecoveryCausalHistoryOpen
+                            RecoveryCausalHistoryViolation
+                              { rchvNode = node
+                              , rchvAncestor = ancestor
+                              , rchvAncestorStatus = NodePending
+                              }
+                        ]
+
+    it "recovers persisted state with failure propagation before exposing a frontier" $ do
+      let rel = toRelation (path [NodeId "a", NodeId "b", NodeId "c"])
+          a = NodeId "a"
+          b = NodeId "b"
+          c = NodeId "c"
+          gs =
+            GraphState
+              { gsNodeStatuses =
+                  Map.fromList
+                    [ (a, NodeFailed)
+                    , (b, NodeCompleted)
+                    , (c, NodePending)
+                    ]
+              , gsNodeOutputs = Map.singleton b Aeson.Null
+              }
+      case recoverPersistedGraphState rel gs of
+        Right (Settled recovered OutcomeFailed) ->
+          Map.lookup c recovered.gsNodeStatuses `shouldBe` Just NodeFailed
+        other -> expectationFailure $ "Expected recovered failed settlement, got: " <> show other
 
   describe "applyFrontierResults terminal outcomes" $ do
     it "OutcomeNodeShutdown leaves node interrupted and returns Stuck" $ do

--- a/test/Cortex/Pulse/ExecutorSpec.hs
+++ b/test/Cortex/Pulse/ExecutorSpec.hs
@@ -25,7 +25,7 @@ import Control.Exception
   , throwIO
   , try
   )
-import Control.Monad (void, when)
+import Control.Monad (forM_, void, when)
 import Data.Aeson qualified as Aeson
 import Data.IORef (atomicModifyIORef', newIORef, readIORef)
 import Data.Int (Int32, Int64)
@@ -581,6 +581,21 @@ writeGraphStateForPlan pool runId stagePlan completedCount outputValue = do
     (Just (fromIntegral stagePlan.spCheckpointRuntimeVersion :: Int32))
     Nothing
 
+writeRawGraphStateForPlan
+  :: Pool
+  -> UUID
+  -> StagePlan stageId
+  -> GraphState Aeson.Value
+  -> IO ()
+writeRawGraphStateForPlan pool runId stagePlan gs =
+  writeGraphStateCompat
+    pool
+    runId
+    (Aeson.toJSON gs.gsNodeStatuses)
+    (Aeson.toJSON gs.gsNodeOutputs)
+    (Just (fromIntegral stagePlan.spCheckpointRuntimeVersion :: Int32))
+    Nothing
+
 writeGraphStateCompat
   :: Pool
   -> UUID
@@ -604,6 +619,17 @@ writeGraphStateCompat pool runId statuses outputs runtimeVersion appliedRewriteI
         , gswTopologyHash = Nothing
         , gswUpdatedAt = now
         }
+
+expectRecoveryPreconditionFailure :: Pool -> UUID -> Text -> IO ()
+expectRecoveryPreconditionFailure pool runId expectedMessageSnippet = do
+  runView <- runSession pool $ Q.getRunAdminView runId
+  case runView of
+    Nothing -> expectationFailure "Expected run admin view"
+    Just view -> do
+      Q.pravErrorType view `shouldBe` Just "graph_state_recovery_preconditions_failed"
+      case Q.pravErrorMessage view of
+        Nothing -> expectationFailure "Expected recovery precondition error message"
+        Just errMsg -> errMsg `shouldSatisfy` T.isInfixOf expectedMessageSnippet
 
 installGraphStateWriteFailureInjector :: Pool -> IO ()
 installGraphStateWriteFailureInjector pool =
@@ -3036,6 +3062,162 @@ spec = beforeAll setupTestDb $ do
         Nothing
       outcome <- resumeStagePlan taskContext runId task stagePlan
       outcome `shouldBe` OutcomeCompleted
+
+  describe "graph-state recovery precondition validation" $ do
+    it "resume rejects off-topology output entries" $ \mPool -> withDb mPool $ \pool -> do
+      (_, taskContext) <- mkTaskContext pool
+      taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-recovery-output-domain"
+      runId <- createTestRun pool taskId
+      task <- loadTaskDef pool taskId
+      let stagePlan =
+            mkLinearStagePlan
+              [simpleStage TestStageAlpha (\_runId state -> pure state)]
+              Aeson.Null
+              5
+              ReplayPolicyWarn
+          gs0 = initialGraphState stagePlan.spTopology
+          gs =
+            gs0
+              { gsNodeOutputs = Map.insert (NodeId "ghost") Aeson.Null gs0.gsNodeOutputs
+              }
+      writeRawGraphStateForPlan pool runId stagePlan gs
+
+      outcome <- resumeStagePlan taskContext runId task stagePlan
+
+      outcome `shouldBe` OutcomeFailed
+      expectRecoveryPreconditionFailure pool runId "output for node ghost is outside"
+
+    it "resume rejects completed or rewritten nodes missing output" $ \mPool -> withDb mPool $ \pool -> do
+      let missingOutputCases =
+            [ ("completed", NodeCompleted)
+            , ("rewritten", NodeRewritten)
+            ]
+      forM_ missingOutputCases $ \(caseName, status) -> do
+        (_, taskContext) <- mkTaskContext pool
+        taskId <- insertTestTaskDef pool "paper_portfolio_cycle" ("test-recovery-missing-" <> caseName)
+        runId <- createTestRun pool taskId
+        task <- loadTaskDef pool taskId
+        let alpha = NodeId "test_alpha"
+            stagePlan =
+              mkLinearStagePlan
+                [simpleStage TestStageAlpha (\_runId state -> pure state)]
+                Aeson.Null
+                5
+                ReplayPolicyWarn
+            gs0 = initialGraphState stagePlan.spTopology
+            gs =
+              gs0
+                { gsNodeStatuses = Map.insert alpha status gs0.gsNodeStatuses
+                , gsNodeOutputs = Map.empty
+                }
+        writeRawGraphStateForPlan pool runId stagePlan gs
+
+        outcome <- resumeStagePlan taskContext runId task stagePlan
+
+        outcome `shouldBe` OutcomeFailed
+        expectRecoveryPreconditionFailure pool runId "has no persisted output"
+
+    it "resume rejects outputs on non-output-owning statuses" $ \mPool -> withDb mPool $ \pool -> do
+      let invalidOutputCases =
+            [ ("pending", NodePending)
+            , ("failed", NodeFailed)
+            , ("skipped", NodeSkipped)
+            , ("waiting", NodeWaiting "approval")
+            ]
+      forM_ invalidOutputCases $ \(caseName, status) -> do
+        (_, taskContext) <- mkTaskContext pool
+        taskId <- insertTestTaskDef pool "paper_portfolio_cycle" ("test-recovery-output-" <> caseName)
+        runId <- createTestRun pool taskId
+        task <- loadTaskDef pool taskId
+        let alpha = NodeId "test_alpha"
+            stagePlan =
+              mkLinearStagePlan
+                [simpleStage TestStageAlpha (\_runId state -> pure state)]
+                Aeson.Null
+                5
+                ReplayPolicyWarn
+            gs0 = initialGraphState stagePlan.spTopology
+            gs =
+              gs0
+                { gsNodeStatuses = Map.insert alpha status gs0.gsNodeStatuses
+                , gsNodeOutputs = Map.singleton alpha Aeson.Null
+                }
+        writeRawGraphStateForPlan pool runId stagePlan gs
+
+        outcome <- resumeStagePlan taskContext runId task stagePlan
+
+        outcome `shouldBe` OutcomeFailed
+        expectRecoveryPreconditionFailure pool runId "is not allowed while status"
+
+    it "resume rejects successor-unblocking state with open causal history" $ \mPool -> withDb mPool $ \pool -> do
+      (_, taskContext) <- mkTaskContext pool
+      taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-recovery-causal-open"
+      runId <- createTestRun pool taskId
+      task <- loadTaskDef pool taskId
+      let alpha = NodeId "test_alpha"
+          beta = NodeId "test_beta"
+          stagePlan =
+            mkLinearStagePlan
+              [ simpleStage TestStageAlpha (\_runId state -> pure state)
+              , simpleStage TestStageBeta (\_runId state -> pure state)
+              ]
+              Aeson.Null
+              5
+              ReplayPolicyWarn
+          gs0 = initialGraphState stagePlan.spTopology
+          gs =
+            gs0
+              { gsNodeStatuses =
+                  Map.insert alpha NodePending $
+                    Map.insert beta NodeCompleted gs0.gsNodeStatuses
+              , gsNodeOutputs = Map.singleton beta Aeson.Null
+              }
+      writeRawGraphStateForPlan pool runId stagePlan gs
+
+      outcome <- resumeStagePlan taskContext runId task stagePlan
+
+      outcome `shouldBe` OutcomeFailed
+      expectRecoveryPreconditionFailure pool runId "successor-unblocking node test_beta"
+
+    it "resume propagates persisted ancestor failure before selecting a frontier" $ \mPool -> withDb mPool $ \pool -> do
+      gammaRanRef <- newIORef False
+      (_, taskContext) <- mkTaskContext pool
+      taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-recovery-propagates-failure"
+      runId <- createTestRun pool taskId
+      task <- loadTaskDef pool taskId
+      let alpha = NodeId "test_alpha"
+          beta = NodeId "test_beta"
+          gamma = NodeId "test_gamma"
+          stagePlan =
+            mkLinearStagePlan
+              [ simpleStage TestStageAlpha (\_runId state -> pure state)
+              , simpleStage TestStageBeta (\_runId state -> pure state)
+              , simpleStage TestStageGamma $ \_runId state -> do
+                  atomicModifyIORef' gammaRanRef (const (True, ()))
+                  pure state
+              ]
+              Aeson.Null
+              5
+              ReplayPolicyWarn
+          gs =
+            GraphState
+              { gsNodeStatuses =
+                  Map.fromList
+                    [ (alpha, NodeFailed)
+                    , (beta, NodeCompleted)
+                    , (gamma, NodePending)
+                    ]
+              , gsNodeOutputs = Map.singleton beta Aeson.Null
+              }
+      writeRawGraphStateForPlan pool runId stagePlan gs
+
+      outcome <- resumeStagePlan taskContext runId task stagePlan
+
+      outcome `shouldBe` OutcomeFailed
+      gammaRan <- readIORef gammaRanRef
+      gammaRan `shouldBe` False
+      statuses <- readGraphNodeStatuses pool runId
+      (Map.lookup gamma =<< statuses) `shouldBe` Just NodeFailed
 
   describe "first-writer-wins failRun" $ do
     it "second failRun does not overwrite the first error_type" $ \mPool -> withDb mPool $ \pool -> do

--- a/theory/README.md
+++ b/theory/README.md
@@ -77,8 +77,11 @@ Mechanized results now include:
   the runtime closure step.
 
 The Paper 1 Lean-Haskell modeling boundary is documented in
-`docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md`. Remaining obligations include
-Haskell-side establishment of the persisted recovery preconditions.
+`docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md`. The executable resume path
+now validates that the post-decode, post-reconciliation, post-rewrite-materialization, and
+post-signal-resolution resume input state satisfies the Haskell counterpart of the persisted
+recovery preconditions, then classifies the reset-and-failure-propagated recovered state before
+continuing from materialized graph state.
 
 ### Track 3 — Rewrite soundness
 


### PR DESCRIPTION
## Summary
Establish the executable Pulse resume-side validation and recovery classification that persisted graph state satisfies the recovery preconditions mirrored by the Lean `persistence_safety` theorem.

## Changes
- Added a pure `validatePersistedRecoveryPreconditions` surface over `GraphState` and materialized topology.
- Added `recoverPersistedGraphState`, which validates, resets in-flight statuses, applies failure propagation through `classifyGraphState`, and only then exposes a frontier or terminal outcome.
- Fail resume with `graph_state_recovery_preconditions_failed` after rewrite materialization and delivered-signal resolution when persisted recovery input is invalid.
- Tightened Haskell map invariants for recovery input: off-topology keys are rejected and topology nodes require explicit status entries after reconciliation/materialization.
- Added pure validation/recovery regressions plus DB-backed resume rejection and propagated-failure resume cases.
- Updated the Track 2 bridge note in `theory/README.md`.

## Checklist
- [x] Implementation complete
- [x] Tests added/updated
- [x] `just test` passes locally
- [x] `just lean-check` passes locally
- [ ] Ready for review

## Issue
Closes #120