### PR TITLE
feat: add Pulse graph-state CAS

### DIFF
--- a/cortex.cabal
+++ b/cortex.cabal
@@ -187,6 +187,7 @@ library
         Cortex.Pulse.Executor.Resume
         Cortex.Pulse.Executor.Types
         Cortex.Pulse.Frontier
+        Cortex.Pulse.GraphStateRevision
         Cortex.Pulse.Hydrate
         Cortex.Pulse.Materialize
         Cortex.Pulse.Outcome

--- a/docs/Architecture/03-formalism-stack.md
+++ b/docs/Architecture/03-formalism-stack.md
@@ -40,6 +40,12 @@ another wire value under `<>` or `=>` is itself a wire value. The class is close
 operators. This is what makes source authoring, configured executor reuse, and rewriting tractable:
 authors and rewrites manipulate the same kind of object the compiler consumes.
 
+Composition closure is graph-theoretic, not the whole resource story. Wire also tracks **boundary
+obligations**: the input/output contract boundary that an operation consumes, preserves, or
+transforms. Boundary resources sit above Mokhov graph equality. They say whether a rewrite,
+conditional, or planner certificate has accounted for the exposed contract boundary it promises,
+while the graph algebra still says what topology denotes.
+
 ## Detailed structure
 
 ### Mokhov's algebraic graph model
@@ -112,6 +118,25 @@ side — gas, admission, materialization, replay contracts — is the subject of
 [`chapter 07`](./07-rewrites-and-materialization.md). The formalism only records that rewrites are
 algebraic operations over the same object class, not a separate mutation layer.
 
+Boundary resources refine that statement without changing the algebra. A contract-preserving
+substitution consumes the anchor's boundary obligation and must expose the same boundary again. An
+append continuation keeps the anchor node and consumes the anchor output as the continuation input.
+A conditional branch actualization consumes an owner-bound actualization capability and promotes one
+guarded branch into the live linear resource context. Those are resource laws over the graph
+operation; they are not new Mokhov constructors.
+
+### Latent structural control
+
+`select(...)` is the first accepted **latent structural control** operator. Before selection, its
+branches are a sealed family of graph possibilities, not live topology and not a fifth constructor
+in the graph algebra. Every branch can be checked against its variant boundary, but each
+branch-local obligation is guarded and affine until the selected arm is actualized.
+
+After selection, the chosen branch lowers to ordinary Wire graph composition and the usual overlay
+and connect laws apply to the materialized result. Unselected branches do not become graph fragments
+for the run. This is how Wire can represent structured runtime choice without treating conditionals
+as ordinary fan-out or hiding the choice inside executor code.
+
 ## Boundaries and invariants
 
 What this stack enforces:
@@ -122,6 +147,11 @@ What this stack enforces:
   laws on the port-key-matched projection.
 - **Layered invariants.** Acyclicity and port-contract compatibility attach at the Circuit boundary,
   not at Graph. Fragments remain algebraically first-class below that line.
+- **Boundary-resource accounting.** Structural operations consume, preserve, or transform declared
+  boundary obligations. Node identity, provenance envelopes, and boundary obligations are related
+  but not the same resource.
+- **Latent control lowers after resolution.** A latent branch family is checked before runtime, but
+  only the selected branch enters the live graph and inherits the graph laws.
 - **Rewrites as algebraic operations.** Structural edits are expressible in the same algebra that
   authored the topology; admission preserves the laws.
 
@@ -133,10 +163,10 @@ provenance — all delegated to Circuit, Pulse, or the contract registry.
 The Mokhov alphabet is fixed at four constructors. Cortex does not extend it. New authoring
 convenience enters Wire as derived value operators (`//`, `++`, `let`, configured executor values)
 that reduce to explicit graph vertices before the expression reaches the Graph layer. New semantic
-categories — payload kinds, structural-authority classes, parameterized latent branches explored in
-the foundation synthesis note — attach as registry metadata on the Circuit layer, not as new graph
-primitives. The algebra stays small on purpose; the ecosystem grows by registering authority into a
-closed alphabet, not by mutating the alphabet.
+categories — payload kinds, boundary-resource modes, structural-authority classes, and latent
+structural control operators — attach as registry metadata, proof obligations, or runtime admission
+rules above the Circuit layer, not as new graph primitives. The algebra stays small on purpose; the
+ecosystem grows by registering authority into a closed alphabet, not by mutating the alphabet.
 
 ## Related
 
@@ -147,6 +177,10 @@ closed alphabet, not by mutating the alphabet.
   [`../Reference/Wire/grammar.md`](../Reference/Wire/grammar.md).
 - [`./07-rewrites-and-materialization.md`](./07-rewrites-and-materialization.md) — rewrite admission
   mechanics.
+- [`../ADRs/0032-wire-boundary-contract-resources.md`](../ADRs/0032-wire-boundary-contract-resources.md)
+  — boundary obligations as planning resources.
+- [`../ADRs/0037-wire-latent-structural-control.md`](../ADRs/0037-wire-latent-structural-control.md)
+  — latent structural control operators and their graph-algebra boundary.
 - [`../Publications/Paper-2-algebraic-foundations/manuscript.md`](../Publications/Paper-2-algebraic-foundations/manuscript.md)
   — algebraic foundations of staged durable execution.
 - [`../Publications/Paper-3-graph-substitution-semantics/manuscript.md`](../Publications/Paper-3-graph-substitution-semantics/manuscript.md)

--- a/docs/Architecture/05-wire-language.md
+++ b/docs/Architecture/05-wire-language.md
@@ -30,6 +30,8 @@ The normative rules live in the reference:
   namespace, port declarations, `=>` matching
 - [Configured executors and execution boundary](../Reference/Wire/configured-executors-and-execution-boundary.md)
   — configured executor values, typed node boundaries, runnable-wire boundary
+- [Conditionality](../Reference/Wire/conditionality.md) — `select(...)`, guarded-affine collapse,
+  latent continuations, and selected-branch actualization
 - [Rewrites](../Reference/rewrites.md) — bounded dynamic rewrite algebra, budget, admission,
   materialization, provenance
 - [Modules, imports, and file returns](../Reference/Wire/modules-imports-and-file-returns.md) — file
@@ -111,6 +113,30 @@ One practical design rule follows from this split: edges carry typed values, not
 When a node aggregates several upstream values, author that shape explicitly as typed input ports
 and pass a record or list to the executor body. Wire does not infer list aggregation from many
 incoming arrows.
+
+This typed port boundary is also the resource accounting surface for structural control. A node is
+an addressable runtime and provenance object, but the locally consumed resource is the boundary
+obligation it exposes. Rewrites, append continuations, and conditional actualization all have to
+state which boundary they consume and which boundary they return. Retaining a node for provenance is
+therefore not the same as keeping its original boundary obligation unspent.
+
+## Conditionality and latent control
+
+Wire conditionality is topology-level structural control, not value-level `if` hidden inside a
+stage. The canonical surface is postfix `select(...)`: the graph on the left exposes an exclusive
+output boundary, each arm provides a continuation for one variant, and exactly one continuation is
+actualized.
+
+The formal model is **guarded-affine collapse**. Before selection, every arm is checked as a sealed
+latent continuation, and each branch-local boundary obligation is guarded by its arm key and affine:
+it may be chosen at most once, but it is not live topology. Selection promotes the chosen arm into
+the live linear context and discards the unselected arms for that run.
+
+Pure computation may compute the selected arm key, but it does not gain graph rewrite authority. The
+structural effect belongs to the compiled `select(...)` operator and to a restricted actualization
+capability for that owner and arm. In the current runtime, that capability is realized through
+retained-owner `AppendAfter` admission rather than a separate persisted `SelectActualize` token.
+Branch actualization is not an arbitrary planner-authored rewrite.
 
 ## Configured executor values and reuse
 
@@ -200,6 +226,17 @@ Wire is also the authoring surface for runtime topology evolution. A rewrite is 
 of object from the initial graph; it is another composition over the same registered vocabulary and
 compatibility rules.
 
+The source-language view distinguishes three structural effects:
+
+- **substitution**, where an anchor boundary is consumed and replaced by a graph exposing the same
+  promised boundary;
+- **append continuation**, where the anchor stays live and its output feeds a new downstream graph;
+- **selected-branch actualization**, where a guarded continuation from a compiled branch family is
+  promoted into live topology.
+
+The current runtime may realize more than one conceptual effect with the same v1 constructor, but
+the Wire language should keep their resource laws distinct.
+
 The generic pattern is:
 
 ```text
@@ -214,6 +251,10 @@ Wire does not admit rewrites by itself. The handoff is:
 - Wire expresses the candidate structure
 - Circuit validates that the structure is still executable
 - Pulse decides admission, budgeting, materialization, and resume behavior
+
+For latent branches, Pulse uses the current **selected-cost** policy: unselected arms do not consume
+runtime rewrite budget, and the selected arm consumes ordinary rewrite budget when actualized. This
+is not a reserved-capacity guarantee for every compiled arm.
 
 That boundary keeps the language small. Wire describes candidate topology. Pulse owns runtime
 policy.
@@ -244,6 +285,8 @@ Cortex still owns the source language, composition rules, and substrate runtime.
   — contract, port, executor, and binding separation
 - [ADR 0020 — Wire Pure Output Equations](../ADRs/0020-wire-pure-output-equations.md) —
   deterministic CorePure output equations
+- [ADR 0034 — Pure Selectors and Restricted Actualization Authority](../ADRs/0034-wire-pure-select-actualization-authority.md)
+  — pure branch choice without general rewrite authority
 - [Wire Grammar](../Reference/Wire/grammar.md) — normative grammar
 - [Cortex Terminology](../Reference/terminology.md) — accepted vocabulary
 - [Consumer examples](../Consumers/) — downstream binding examples

--- a/docs/Architecture/07-rewrites-and-materialization.md
+++ b/docs/Architecture/07-rewrites-and-materialization.md
@@ -57,6 +57,19 @@ evidence-gathering branch. `AppendAfter` inserts a subgraph downstream of a node
 validation once the anchor finishes. `InsertBefore`, `PruneSubgraph`, `AddJoin`, and `ReplaceNode`
 are recognized future forms but not part of the admitted alphabet.
 
+Those constructors are the current runtime alphabet, not the full conceptual vocabulary. Cortex
+keeps the boundary laws explicit:
+
+| Boundary law                     | Current realization           | Resource effect                                                                                              |
+| -------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Contract-preserving substitution | `ExpandNode anchor mode spec` | Consumes the anchor rewrite slot and boundary obligation; the replacement must expose the promised boundary. |
+| Append continuation              | `AppendAfter anchor spec`     | Consumes the anchor rewrite slot while retaining the anchor and using its output as continuation input.      |
+| Conditional branch actualization | `AppendAfter anchor spec`     | When the anchor is a conditional owner, retained-owner lowering makes the selected guarded branch live.      |
+
+The conditional row names the resource law, not a separate v1 `GraphRewrite` constructor. The
+compiler-side vocabulary may call the restricted capability `SelectActualize owner selectedArm`, but
+the current runtime persists ordinary admitted rewrite rows for the selected branch.
+
 A `SubgraphSpec` is a self-contained fragment: local topology, stage definitions for every local
 node, explicit entry nodes where inbound edges attach, explicit exit nodes where outbound edges
 continue. Entry and exit declarations are serialized lists but semantically sets, so duplicates are
@@ -101,6 +114,12 @@ Each admitted rewrite consumes a natural-valued `RewriteCost` computed staticall
 invalid before admission. Runaway rewrite elaboration becomes a runtime impossibility rather than an
 executor-discipline problem. Gas is visible in run history: operators can inspect remaining budget,
 each rewrite's cost, and the rewrite that exhausted a dimension.
+
+Latent branches use **selected-cost** accounting in the current runtime. A compiled branch family is
+validated as a closed set of possibilities, but unselected arms do not prepay or consume runtime
+rewrite budget. The selected arm consumes ordinary rewrite budget when it is actualized. This is
+deliberately weaker than a reserved-capacity policy: Cortex does not yet guarantee that every
+compiled latent arm can still materialize after unrelated rewrites have spent the remaining budget.
 
 ## Admission policy
 
@@ -172,6 +191,11 @@ See the
 [rewrite materialization and recovery plan](../Roadmap/Plans/rewrite-materialization-and-recovery.md)
 for the formal treatment of the materialization boundary and recovery invariants.
 
+For selected branches, recovery replays the same admitted selected rewrite from durable state. It
+does not materialize unselected alternatives and does not invent a separate "discard branch" event.
+If branch selection occurred but materialization did not finish, resume must finish the admitted
+selected branch before scheduling against the new topology.
+
 ## Provenance of rewrite events
 
 This chapter covers provenance of **structural events**; provenance of **values** flowing through
@@ -191,8 +215,13 @@ This layer enforces:
 - stages and planners propose; only the runtime admits.
 - rewrites stay inside the closed executor alphabet, contract registry, endpoint compatibility, DAG
   validity, and the five-dimensional gas budget.
+- conceptual boundary laws stay distinct even when v1 realizes them through the same runtime
+  constructor. Substitution, append continuation, and branch actualization consume different
+  boundary resources.
 - same-wave rewrite proposals are admitted in deterministic order against shared remaining budget;
   ordinary node execution across the frontier is still concurrent.
+- latent branch actualization follows selected-cost semantics: only the selected branch spends
+  rewrite budget and becomes live; unselected branches remain sealed alternatives for the artifact.
 - the rewrite log is append-only, and watermark and remaining budget update atomically with the
   node-state changes they imply.
 - static DAGs and linear stage paths remain valid programs — a run with no rewrites is a degenerate
@@ -207,12 +236,14 @@ to [Chapter 06](./06-pulse-runtime.md), value-envelope provenance to
 
 New rewrite forms enter by adding constructors to `GraphRewrite` and extending the validator — not
 by letting stages emit arbitrary edits. `InsertBefore`, `PruneSubgraph`, `AddJoin`, and
-`ReplaceNode` lie along this path. Richer gas dimensions (semantic weighting, effect classes,
-irreversibility boundaries) enter by extending `RewriteBudget` and the static cost estimator with a
-matching durability migration. Hierarchical subgraphs — composite nodes owning nested budgets — are
-the planned composition extension once the flat algebra has been proven on a real task. Planner
-integration proceeds by registering planner-capable nodes with a policy-gated, budget-aware
-contract, not by loosening admission checks.
+`ReplaceNode` lie along this path. New latent structural control operators are separate: each needs
+its own boundary law, actualization authority, budget policy, recovery story, and theorem target
+before it can lower into ordinary rewrite materialization. Richer gas dimensions (semantic
+weighting, effect classes, irreversibility boundaries) enter by extending `RewriteBudget` and the
+static cost estimator with a matching durability migration. Hierarchical subgraphs — composite nodes
+owning nested budgets — are the planned composition extension once the flat algebra has been proven
+on a real task. Planner integration proceeds by registering planner-capable nodes with a
+policy-gated, budget-aware contract, not by loosening admission checks.
 
 ## Related
 
@@ -221,6 +252,12 @@ contract, not by loosening admission checks.
   [./05-wire-language.md](./05-wire-language.md), [./06-pulse-runtime.md](./06-pulse-runtime.md),
   [./08-artifacts-and-provenance.md](./08-artifacts-and-provenance.md)
 - [../Reference/terminology.md](../Reference/terminology.md) — normative vocabulary.
+- [../Reference/rewrites.md](../Reference/rewrites.md) — normative rewrite algebra and boundary
+  laws.
+- [../Reference/Wire/conditionality.md](../Reference/Wire/conditionality.md) — `select(...)`,
+  guarded-affine collapse, and selected-cost branch actualization.
+- [../ADRs/0034-wire-pure-select-actualization-authority.md](../ADRs/0034-wire-pure-select-actualization-authority.md)
+  — pure selectors and restricted actualization authority.
 - [../Roadmap/Plans/rewrite-materialization-and-recovery.md](../Roadmap/Plans/rewrite-materialization-and-recovery.md),
   [../Publications/Paper-3-graph-substitution-semantics/manuscript.md](../Publications/Paper-3-graph-substitution-semantics/manuscript.md)
   — formal treatment.

--- a/docs/Reference/Pulse/events.md
+++ b/docs/Reference/Pulse/events.md
@@ -72,6 +72,7 @@ Common `details` fields observed across events (present when applicable):
 | `run.shutdown`                   | info     | Shutdown requested; executor stopping at a stage boundary.           |
 | `run.stuck`                      | error    | Frontier empty but not all nodes settled (blocked-graph diagnostic). |
 | `run.graph_state_persist_failed` | error    | Graph-state persistence write failed mid-run.                        |
+| `run.graph_state_stale_write`    | warn     | Executor lost a graph-state CAS race and stopped without overwrite.  |
 
 ### Stage
 

--- a/docs/Reference/Pulse/schema.md
+++ b/docs/Reference/Pulse/schema.md
@@ -150,7 +150,30 @@ pulse.run_events
 Append-only per-run event log. The normative event catalog, severity, and field contract live in
 [`events.md`](./events.md); persistence is best-effort — event writes never block or fail a run.
 
-## 8. Signals
+## 8. Graph state
+
+```text
+pulse.graph_state
+  run_id                    uuid primary key references pulse.runs(run_id) on delete cascade
+  node_statuses             jsonb not null
+  node_outputs              jsonb not null
+  remaining_rewrite_budget  jsonb
+  runtime_version           integer
+  applied_rewrite_id        bigint references pulse.graph_rewrites(rewrite_id)
+  node_provenance           jsonb
+  topology_hash             text
+  updated_at                timestamptz not null
+```
+
+Mutable latest graph snapshot for durable resume. `node_statuses` and `node_outputs` carry the
+runtime graph-state maps; rewrite fields bind the snapshot to the materialized rewrite lineage.
+
+`updated_at` is also the optimistic compare-and-swap revision token. The first graph-state write is
+insert-only. Later writes update the row only when the caller's expected revision matches the
+current `updated_at`; stale owners stop without overwriting newer graph state and emit
+[`run.graph_state_stale_write`](./events.md#run-lifecycle).
+
+## 9. Signals
 
 ```text
 pulse.signals

--- a/docs/Reference/Pulse/signals.md
+++ b/docs/Reference/Pulse/signals.md
@@ -121,7 +121,7 @@ a successful delivery. Both are surfaced through the run-detail API.
 ## 6. Storage and ordering
 
 Signal storage is the durable backing for the protocol; the normative contract is above.
-Schema-level detail is in [`schema.md §8`](./schema.md#8-signals).
+Schema-level detail is in [`schema.md §9`](./schema.md#9-signals).
 
 - Pending-uniqueness is scoped to `(run_id, signal_name)` via a partial unique index; `node_id` is
   informational.

--- a/docs/Reference/Wire/conditionality.md
+++ b/docs/Reference/Wire/conditionality.md
@@ -24,6 +24,7 @@ The short version is:
 
 - conditionality is not ordinary fan-out
 - conditionality is **exclusive-output reduction**
+- the formal resource model is **guarded-affine collapse**
 - the canonical surface is postfix `select(...)`
 - branches are **latent continuations** until one is selected
 - output labels are the canonical arm keys, with unique contract names accepted as fallback keys
@@ -53,7 +54,7 @@ This page therefore does five things:
 - specifies the target semantic model for conditionality
 - specifies the target `select(...)` surface
 - defines latent branches in the target model
-- states the main typing, composition, and budgeting rules
+- states the main typing, composition, resource, and budgeting rules
 - records how the current Cortex implementation realizes a narrower subset today
 
 This page does not repeat the full EBNF for `select(...)`; that lives in [grammar.md](grammar.md).
@@ -81,6 +82,12 @@ It is better understood as:
 - with an exclusive output boundary
 - reduced by `select(...)` into a graph `x'`
 - where `x'` has one actualized continuation path
+
+The resource term for this reduction is **guarded-affine collapse**. Before selection, each arm is a
+guarded continuation: it is validated as a possible future, but it is not live topology. It is
+affine because at most one guarded arm can be promoted for the run. Selection collapses the
+exclusive boundary by promoting the chosen arm into the live linear context and discarding the
+unchosen arms.
 
 This is also why parentheses are natural in branch bodies:
 
@@ -346,6 +353,8 @@ The reduced graph simply continues through the already-correct boundary.
 - **Owner remains** — The anchor stays visible for provenance and lineage.
 - **Latent until selected** — Unselected branches are not eligible under ordinary readiness rules;
   conditionality never lowers to ordinary fan-out.
+- **Guarded-affine resources** — Branch-local boundary obligations are checked under their arm key
+  before selection and become ordinary live obligations only for the selected arm.
 
 ## 8. Typing and Composition
 
@@ -555,19 +564,23 @@ So the current implementation status is:
 This page treats that narrower implementation as a subset of the intended model, not as the final
 shape of the language.
 
-## 11. Gas, Budget, and Provenance
+## 11. Resources, Budget, and Provenance
 
 Three truths should be kept explicit.
 
-### 11.1 The whole branch set should not count by sum
+### 11.1 The whole branch set is guarded-affine, not sum-prepaid
 
-For closed-world latent alternatives, the right intuition is:
+For closed-world latent alternatives, the right resource intuition is:
 
-- branch reserve is `max`, not `sum`
+- branch validation is universal: every arm must be valid if chosen
+- branch execution is exclusive: only one arm can become live
+- branch-local obligations are guarded and affine before selection
 
-because only one branch can actualize.
+That means Cortex should not charge `sum(allBranchCosts)` up front. The current runtime goes one
+step narrower: it does not reserve `max(branchCosts)` either. It charges the selected branch when
+the branch is actualized.
 
-### 11.2 Current runtime does not yet reserve latent capacity
+### 11.2 Current runtime uses selected-cost accounting
 
 Today, selected latent branches still consume ordinary rewrite budget because they are operationally
 realized through `AppendAfter`.
@@ -576,13 +589,16 @@ So current Cortex already gives:
 
 - no “sum of all branches” cost up front
 - truthful latent-branch semantics
+- selected-cost admission through the ordinary durable rewrite path
 
 but does **not yet** give:
 
 - guaranteed reserved capacity for any later-selected branch regardless of prior open rewrites
 
 If Cortex later decides that compiled latent alternatives must be guaranteed, that is an
-architectural choice beyond this chapter and likely ADR-worthy.
+architectural choice beyond this chapter and likely ADR-worthy. That future policy would need to say
+whether it reserves `max(branchCosts)`, reserves per branch family, or changes the rewrite-budget
+algebra.
 
 ### 11.3 Provenance remains attached to the owner
 
@@ -649,6 +665,7 @@ This chapter makes the following commitments unless later superseded:
 7. Shared continuation should usually live outside `select(...)`.
 8. Productive arms converge to a common downstream boundary.
 9. The current Cortex implementation is a narrower subset of this target model.
+10. The current runtime uses selected-cost branch actualization, not reserved latent capacity.
 
 ## 14. Deferred
 
@@ -673,6 +690,12 @@ alongside the accepted grammar.
 - [../rewrites.md](../rewrites.md) — runtime rewrite algebra and current `AppendAfter` realization.
 - [../../ADRs/0007-latent-branch-conditional-lowering.md](../../ADRs/0007-latent-branch-conditional-lowering.md)
   — accepted latent-branch architecture decision.
+- [../../ADRs/0033-wire-select-guarded-affine-collapse.md](../../ADRs/0033-wire-select-guarded-affine-collapse.md)
+  — guarded-affine collapse vocabulary.
+- [../../ADRs/0034-wire-pure-select-actualization-authority.md](../../ADRs/0034-wire-pure-select-actualization-authority.md)
+  — pure selectors and restricted actualization authority.
+- [../../ADRs/0036-wire-latent-branch-budget-recovery.md](../../ADRs/0036-wire-latent-branch-budget-recovery.md)
+  — selected-cost latent branch policy.
 - [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) — Wire substrate
   architecture.
 - [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md)

--- a/docs/Reference/rewrites.md
+++ b/docs/Reference/rewrites.md
@@ -12,6 +12,10 @@ related:
   - docs/Architecture/07-rewrites-and-materialization.md
   - docs/ADRs/0005-budgeted-rewrite-admission-and-materialization.md
   - docs/ADRs/0009-rewrite-provenance-and-topology-integrity.md
+  - docs/ADRs/0032-wire-boundary-contract-resources.md
+  - docs/ADRs/0034-wire-pure-select-actualization-authority.md
+  - docs/ADRs/0035-wire-rewrite-algebra-forms.md
+  - docs/ADRs/0036-wire-latent-branch-budget-recovery.md
 ---
 
 # Rewrites Reference
@@ -80,6 +84,26 @@ The following constructors are recognized future forms but **not part of the adm
 v1**: `InsertBefore`, `PruneSubgraph`, `AddJoin`, `ReplaceNode`. Introducing any of them requires a
 new ADR and a runtime-version bump.
 
+### 1.4 Boundary laws and runtime constructors
+
+The v1 constructors are operational forms. The conceptual boundary laws are the stable semantic
+vocabulary:
+
+| Boundary law                     | v1 realization                | Contract/resource effect                                                                           |
+| -------------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------- |
+| Contract-preserving substitution | `ExpandNode anchor mode spec` | Consumes one rewrite slot and the anchor boundary; the replacement exposes the consumed boundary.  |
+| Append continuation              | `AppendAfter anchor spec`     | Consumes one rewrite slot while retaining the anchor; the continuation consumes the anchor output. |
+| Conditional branch actualization | `AppendAfter anchor spec`     | When the anchor is a conditional owner, the selected guarded branch becomes live topology.         |
+
+`SelectActualize owner selectedArm` is the compiler/proof vocabulary for the restricted
+actualization capability of a compiled `select(...)`. It is not a v1 `GraphRewrite` constructor and
+is not a separately persisted runtime token. Current runtime materialization records the admitted
+selected branch as an ordinary rewrite row.
+
+Observation/instrumentation is future boundary-law vocabulary only. There is no admitted v1
+constructor for it, and observers must not consume or alter the anchor boundary unless a later ADR
+adds a resource path.
+
 ## 2. Stage-result extension
 
 Stages signal rewrite proposals through a richer `StageResult`:
@@ -134,7 +158,20 @@ The proof contract is the leader here: runtime `RewriteBudget` and `RewriteCost`
 natural-vector shape as the mechanized rewrite-admission model, and runtime validation rejects list
 or JSON shapes that cannot denote the proof-side sets and natural numbers.
 
-### 3.3 Budget visibility
+### 3.3 Selected-cost latent branches
+
+Latent branch families use selected-cost accounting in the current runtime:
+
+- unselected arms do not consume runtime rewrite budget;
+- the selected arm consumes ordinary rewrite budget when actualized;
+- branch actualization is admitted or rejected through the same durable rewrite admission path as
+  other topology changes;
+- the runtime does not yet reserve capacity for every compiled latent arm.
+
+This differs from max-reserved capacity. A future reservation policy would need to say whether it
+reserves `max(branchCosts)`, reserves per branch family, or changes the rewrite-budget algebra.
+
+### 3.4 Budget visibility
 
 Remaining budget is persisted in graph state and surfaced on operator surfaces (run detail, rewrite
 history). Each admitted rewrite records budget-before and budget-after snapshots so operators can
@@ -239,6 +276,10 @@ Pre-watermark rewrite-capable runs are **legacy** and not guaranteed resumable. 
 schema change requires a runtime-version bump (see
 [ADR 0011](./../ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md)).
 
+For selected branches, the admitted selected rewrite is the durable fact replayed by recovery.
+Unselected latent arms remain sealed alternatives in the compiled artifact and are not materialized
+for that run. The current model has no durable "discard branch" event.
+
 ## 6. Hydration
 
 ### 6.1 Keying
@@ -293,6 +334,14 @@ admin-visibility decisions track ([ADR 0008](../ADRs/0008-pulse-operator-visibil
   — provenance and integrity decision.
 - [../ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md](../ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md)
   — watermark version discipline.
+- [../ADRs/0032-wire-boundary-contract-resources.md](../ADRs/0032-wire-boundary-contract-resources.md)
+  — boundary obligations as planning resources.
+- [../ADRs/0034-wire-pure-select-actualization-authority.md](../ADRs/0034-wire-pure-select-actualization-authority.md)
+  — pure selectors and restricted actualization authority.
+- [../ADRs/0035-wire-rewrite-algebra-forms.md](../ADRs/0035-wire-rewrite-algebra-forms.md) —
+  conceptual boundary laws and v1 runtime constructors.
+- [../ADRs/0036-wire-latent-branch-budget-recovery.md](../ADRs/0036-wire-latent-branch-budget-recovery.md)
+  — selected-cost branch actualization and recovery policy.
 
 ---
 

--- a/docs/Roadmap/Plans/rewrite-materialization-and-recovery.md
+++ b/docs/Roadmap/Plans/rewrite-materialization-and-recovery.md
@@ -101,6 +101,11 @@ Recovery should:
 
 This is closer to projection-checkpoint recovery than to raw log replay.
 
+For selected latent branches, the admitted selected rewrite is the recovery fact. Recovery must
+replay that same selected branch and must not materialize unselected branch alternatives. The
+current model has no durable "discard branch" event; unselected arms remain sealed possibilities in
+the compiled artifact rather than becoming runtime state for the run.
+
 ## Rewrite Admission Contract
 
 Admitted rewrites must satisfy explicit structural conditions:
@@ -119,6 +124,12 @@ The current shipped rejection policy is intentionally narrow:
 Configurable fallback or planner-visible rejection handling is future work, not part of the current
 contract.
 
+Conditional branch actualization is a restricted case of the same admission path in the current
+runtime. Conceptually it consumes an owner-bound actualization capability for one sealed branch, but
+v1 materialization persists an ordinary admitted rewrite row for the selected branch. The selected
+branch consumes ordinary rewrite budget at actualization time; unselected branches do not prepay or
+consume budget.
+
 ## Proof Obligations
 
 The plan centers on the new proof burdens:
@@ -128,6 +139,10 @@ The plan centers on the new proof burdens:
 3. hydration safety from persisted template identity back to executable semantics
 4. dataflow preservation for output-preserving rewrite modes
 5. admitted-rewrite-before-termination correctness
+6. selected-branch replay determinism: recovery materializes the same admitted selected branch
+   without making unselected alternatives live
+7. selected-cost budget preservation: only the admitted selected branch consumes runtime rewrite
+   budget, and no sum-prepayment for the latent family is implied
 
 The fixed-topology theorem can be reused only inside a single materialized topology epoch.
 
@@ -161,6 +176,8 @@ The following are explicitly outside the current shipped and theory contract:
 - configurable rewrite rejection fallback instead of fail-fast only
 - richer operator-facing graph visualization and rewrite provenance
 - hierarchical child workflows with explicit sub-budget assignment
+- reserved latent-branch capacity, including max-branch reservation or escrow rules for every
+  compiled branch family
 - integrity witnesses stronger than the current watermark model, such as materialized-graph
   checksums
 
@@ -172,3 +189,7 @@ The following are explicitly outside the current shipped and theory contract:
   — implementation-independent substitution theory.
 - [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md)
   — canonical runtime architecture chapter.
+- [../../Reference/Wire/conditionality.md](../../Reference/Wire/conditionality.md) — guarded-affine
+  `select(...)` and selected-cost branch semantics.
+- [../../ADRs/0036-wire-latent-branch-budget-recovery.md](../../ADRs/0036-wire-latent-branch-budget-recovery.md)
+  — current latent-branch budget and recovery policy.

--- a/nix/materialized/cortex/.plan.nix/cortex.nix
+++ b/nix/materialized/cortex/.plan.nix/cortex.nix
@@ -148,6 +148,7 @@
           "Cortex/Pulse/Executor/Resume"
           "Cortex/Pulse/Executor/Types"
           "Cortex/Pulse/Frontier"
+          "Cortex/Pulse/GraphStateRevision"
           "Cortex/Pulse/Hydrate"
           "Cortex/Pulse/Materialize"
           "Cortex/Pulse/Outcome"

--- a/src/Cortex/Pulse/Executor.hs
+++ b/src/Cortex/Pulse/Executor.hs
@@ -53,7 +53,7 @@ import Cortex.Pulse.Executor.Loop (runGraphPlan)
 import Cortex.Pulse.Executor.Persistence
   ( failRun
   , failUnsupportedTaskType
-  , requireGraphStatePersist
+  , requireGraphStatePersistVar
   , retryDelayMicros
   )
 import Cortex.Pulse.Executor.ReplayPolicy (enforceGraphReplayPolicy)
@@ -145,6 +145,7 @@ executeStagePlan taskContext runId task stagePlan = do
               , pgsAppliedRewriteId = Nothing
               , pgsNodeProvenance = initialProvenance stagePlan.spTopology
               , pgsTopologyHash = Just (computeTopologyHash stagePlan.spTopology)
+              , pgsRevision = Nothing
               }
       gsVar <- newTVarIO initialPersistedState
       nodeCompletedAtVar <- newTVarIO Map.empty
@@ -164,10 +165,10 @@ executeStagePlan taskContext runId task stagePlan = do
               task
               stagePlan
               tvars
-      persistFailed <- requireGraphStatePersist env initialPersistedState
+      persistFailed <- requireGraphStatePersistVar env gsVar initialPersistedState
       case persistFailed of
-        Just outcome -> pure outcome
-        Nothing ->
+        Left outcome -> pure outcome
+        Right _ ->
           runGraphPlan
             taskContext.tcPool
             (tcConfig taskContext)

--- a/src/Cortex/Pulse/Executor/Frontier.hs
+++ b/src/Cortex/Pulse/Executor/Frontier.hs
@@ -49,10 +49,12 @@ import Cortex.Pulse.Executor.Attempt
   )
 import Cortex.Pulse.Executor.Events (ExecutorEvent (..))
 import Cortex.Pulse.Executor.Persistence
-  ( failRun
+  ( GraphStatePersistError
+  , failRun
+  , handleGraphStatePersistError
   , persistGraphState
   , recordRunEvent
-  , requireGraphStatePersist
+  , requireGraphStatePersistVar
   )
 import Cortex.Pulse.Executor.Types
   ( RewriteAdmissionState (..)
@@ -297,14 +299,13 @@ runFrontierSequential env task stagePlan gsVar (nid : rest) = do
       let inputs = computeNodeInputs stagePlan gs nid
       let runningState =
             persistedState {pgsGraphState = markRunning nid persistedState.pgsGraphState}
-      atomically $ writeTVar gsVar runningState
       -- Persist running state so the API can report it during execution.
       -- Abort on failure, matching the concurrent frontier pattern.
-      markRunningFailed <- requireGraphStatePersist env runningState
+      markRunningFailed <- requireGraphStatePersistVar env gsVar runningState
       case markRunningFailed of
-        Just outcome -> pure (Just (Left outcome))
-        Nothing -> do
-          budgetRef <- newTVarIO persistedState.pgsRemainingRewriteBudget
+        Left outcome -> pure (Just (Left outcome))
+        Right runningState' -> do
+          budgetRef <- newTVarIO runningState'.pgsRemainingRewriteBudget
           admissionLock <- newMVar ()
           let rewriteAdmission =
                 RewriteAdmissionState
@@ -317,7 +318,7 @@ runFrontierSequential env task stagePlan gsVar (nid : rest) = do
               task
               stagePlan
               rewriteAdmission
-              persistedState.pgsRemainingRewriteBudget
+              runningState'.pgsRemainingRewriteBudget
               nid
               inputs
           recordUnexpectedNodeFailure env nodeResult
@@ -329,17 +330,18 @@ runFrontierSequential env task stagePlan gsVar (nid : rest) = do
             Just termOutcome -> do
               let stepResult = applyFrontierResults stagePlan.spTopology [nodeResult] gsCurrent
                   persistedState' = current {pgsGraphState = stepResultState stepResult}
-              atomically $ writeTVar gsVar persistedState'
-              persistFailed <- requireGraphStatePersist env persistedState'
-              pure (Just (Left (fromMaybe termOutcome persistFailed)))
+              persistFailed <- requireGraphStatePersistVar env gsVar persistedState'
+              case persistFailed of
+                Left outcome -> pure (Just (Left outcome))
+                Right _ ->
+                  pure (Just (Left termOutcome))
             Nothing -> do
               let stepResult = applyFrontierResults stagePlan.spTopology [nodeResult] gsCurrent
                   persistedState' = current {pgsGraphState = stepResultState stepResult}
-              atomically $ writeTVar gsVar persistedState'
-              persistFailed <- requireGraphStatePersist env persistedState'
+              persistFailed <- requireGraphStatePersistVar env gsVar persistedState'
               case persistFailed of
-                Just outcome -> pure (Just (Left outcome))
-                Nothing ->
+                Left outcome -> pure (Just (Left outcome))
+                Right _ ->
                   case mRewrite of
                     Just rewrite ->
                       pure (Just (Right [rewrite]))
@@ -414,7 +416,7 @@ collectWorkerResults
   :: StageEnv
   -> TVar PersistedGraphState
   -> TVar Bool
-  -> TVar (Maybe T.Text)
+  -> TVar (Maybe GraphStatePersistError)
   -> [WorkerHandle stageId]
   -> [(NodeResult, Maybe (PersistedRewrite stageId))]
   -> IO [(NodeResult, Maybe (PersistedRewrite stageId))]
@@ -433,7 +435,7 @@ collectWorkerResults env gsVar terminalFlag persistFailRef remaining acc = do
         Left err -> do
           atomically $ writeTVar persistFailRef (Just err)
           atomically $ writeTVar terminalFlag True
-        Right () -> pure ()
+        Right persistedState -> atomically $ writeTVar gsVar persistedState
       collectWorkerResults env gsVar terminalFlag persistFailRef remaining' ((nr, mRewrite) : acc)
     Left ex ->
       case mCompletedWorker of
@@ -458,7 +460,7 @@ collectWorkerResults env gsVar terminalFlag persistFailRef remaining acc = do
             Left err -> do
               atomically $ writeTVar persistFailRef (Just err)
               atomically $ writeTVar terminalFlag True
-            Right () -> pure ()
+            Right persistedState -> atomically $ writeTVar gsVar persistedState
           collectWorkerResults env gsVar terminalFlag persistFailRef remaining' ((nr, mRewrite) : acc)
         Nothing -> do
           recordRunEvent
@@ -495,7 +497,6 @@ classifyFrontierOutcome env topology gsVar results = do
         [ Aeson.object ["node" Aeson..= unNodeId nid, "blocked_by" Aeson..= fmap unNodeId failedPreds]
         | (nid, BlockedByFailed failedPreds) <- blockedReasons topology gs'
         ]
-  atomically $ writeTVar gsVar (currentState {pgsGraphState = gs'})
   unless (null failedNodeIds) $
     recordRunEvent
       env
@@ -509,9 +510,9 @@ classifyFrontierOutcome env topology gsVar results = do
               ]
           )
       )
-  classifyPersistFailed <-
+  classifyPersistResult <-
     if gs' /= gs1
-      then requireGraphStatePersist env (currentState {pgsGraphState = gs'})
+      then Just <$> requireGraphStatePersistVar env gsVar (currentState {pgsGraphState = gs'})
       else pure Nothing
   let nodeResults = fmap fst results
       rewriteResults = sortOn prRewriteId [rewrite | (_, Just rewrite) <- results]
@@ -520,10 +521,7 @@ classifyFrontierOutcome env topology gsVar results = do
         case stepResult of
           Settled _ OutcomeFailed -> Just OutcomeFailed
           _ -> Nothing
-  pure $
-    case classifyPersistFailed of
-      Just outcome -> Just (Left outcome)
-      Nothing ->
+      classifyTerminal =
         case terminalOutcomes of
           outcome : _ -> Just (Left outcome)
           [] ->
@@ -538,6 +536,11 @@ classifyFrontierOutcome env topology gsVar results = do
                       Suspended _ -> Just (Left OutcomeSuspended)
                       Stuck {} -> Nothing
                   _ -> Just (Right rewriteResults)
+  pure $
+    case classifyPersistResult of
+      Just (Left outcome) -> Just (Left outcome)
+      Just (Right _) -> classifyTerminal
+      Nothing -> classifyTerminal
 
 runFrontierConcurrent
   :: StableStageId stageId
@@ -565,25 +568,26 @@ runFrontierConcurrent env task stagePlan gsVar readyNodeIds = do
           { pgsGraphState =
               foldl' (flip markRunning) gs pendingNodeIds
           }
-  atomically $ writeTVar gsVar markRunningState
-  markRunningFailed <- requireGraphStatePersist env markRunningState
+  markRunningFailed <- requireGraphStatePersistVar env gsVar markRunningState
   case markRunningFailed of
-    Just outcome -> pure (Just (Left outcome))
-    Nothing -> do
+    Left outcome -> pure (Just (Left outcome))
+    Right markRunningState' -> do
       preCheckResult <- withPreAttemptGuards env "frontier" (pure (StageAdvance Aeson.Null))
       case preCheckResult of
         StageTerminal termOutcome -> do
           let cancelResults = [NodeResult nid OutcomeNodeCancelled | nid <- pendingNodeIds]
               persistedState' =
-                persistedState
+                markRunningState'
                   { pgsGraphState = stepResultState (applyFrontierResults topology cancelResults gs)
                   }
-          atomically $ writeTVar gsVar persistedState'
-          persistFailed <- requireGraphStatePersist env persistedState'
-          pure (Just (Left (fromMaybe termOutcome persistFailed)))
+          persistFailed <- requireGraphStatePersistVar env gsVar persistedState'
+          case persistFailed of
+            Left outcome -> pure (Just (Left outcome))
+            Right _ ->
+              pure (Just (Left termOutcome))
         _ -> do
           sem <- newQSem cap
-          budgetRef <- newTVarIO persistedState.pgsRemainingRewriteBudget
+          budgetRef <- newTVarIO markRunningState'.pgsRemainingRewriteBudget
           admissionLock <- newMVar ()
           let rewriteAdmission =
                 RewriteAdmissionState
@@ -598,7 +602,7 @@ runFrontierConcurrent env task stagePlan gsVar readyNodeIds = do
                 task
                 stagePlan
                 rewriteAdmission
-                persistedState.pgsRemainingRewriteBudget
+                markRunningState'.pgsRemainingRewriteBudget
                 terminalFlag
                 sem
                 inputsMap
@@ -611,21 +615,8 @@ runFrontierConcurrent env task stagePlan gsVar readyNodeIds = do
           mPersistFail <- readTVarIO persistFailRef
           case mPersistFail of
             Just err -> do
-              now <- getCurrentTime
-              recordRunEvent
-                env
-                "run.graph_state_persist_failed"
-                Q.RunEventError
-                ("Graph state persistence failed during frontier: " <> err)
-                Nothing
-              failRun
-                env.sePool
-                env.seRunId
-                now
-                "graph_state_persist_failed"
-                ("Graph state persistence failed: " <> err)
-                True
-              pure (Just (Left OutcomeFailed))
+              outcome <- handleGraphStatePersistError env err
+              pure (Just (Left outcome))
             Nothing -> do
               frontierResult <- classifyFrontierOutcome env topology gsVar results
               frontierEnd <- getCurrentTime

--- a/src/Cortex/Pulse/Executor/Loop.hs
+++ b/src/Cortex/Pulse/Executor/Loop.hs
@@ -105,10 +105,10 @@ runGraphPlan pool config shutdownFlag runId task stagePlan tvars = do
             Right (stagePlan', gsWithRewrite) -> do
               persistFailed <- requireGraphStatePersist env gsWithRewrite
               case persistFailed of
-                Just outcome -> pure outcome
-                Nothing -> do
+                Left outcome -> pure outcome
+                Right gsWithRewrite' -> do
                   atomically $ do
-                    writeTVar tvars.rvGsVar gsWithRewrite
+                    writeTVar tvars.rvGsVar gsWithRewrite'
                     writeTVar tvars.rvTopologyVar stagePlan'.spTopology
                   runGraphPlan pool config shutdownFlag runId task stagePlan' tvars
         Nothing -> runGraphPlan pool config shutdownFlag runId task stagePlan tvars

--- a/src/Cortex/Pulse/Executor/Persistence.hs
+++ b/src/Cortex/Pulse/Executor/Persistence.hs
@@ -51,7 +51,7 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Time (UTCTime, addUTCTime, getCurrentTime)
+import Data.Time (NominalDiffTime, UTCTime, addUTCTime, getCurrentTime)
 import Data.UUID (UUID)
 
 import Cortex.Pulse.Executor.Events
@@ -185,12 +185,19 @@ The DB-level CAS compares @expected_revision@ to the current @updated_at@
 value.  Keep the replacement timestamp strictly greater than the previous
 revision so a clock with coarse precision or brief backwards drift cannot
 write the same token back and accidentally leave a stale owner eligible.
+PostgreSQL stores @timestamptz@ at microsecond precision, so the wall-clock
+value must be at least one microsecond ahead before we accept it.
 -}
 nextGraphStateRevision :: Maybe GraphStateRevision -> UTCTime -> UTCTime
 nextGraphStateRevision Nothing now = now
 nextGraphStateRevision (Just (GraphStateRevision previous)) now
-  | now > previous = now
-  | otherwise = addUTCTime 0.000001 previous
+  | now >= minimumNext = now
+  | otherwise = minimumNext
+  where
+    minimumNext = addUTCTime graphStateRevisionStep previous
+
+graphStateRevisionStep :: NominalDiffTime
+graphStateRevisionStep = 0.000001
 
 -- | Record the operator-visible consequence of a graph-state persist failure.
 handleGraphStatePersistError :: StageEnv -> GraphStatePersistError -> IO RunOutcome

--- a/src/Cortex/Pulse/Executor/Persistence.hs
+++ b/src/Cortex/Pulse/Executor/Persistence.hs
@@ -11,8 +11,11 @@ The module belongs to Cortex's upstream runtime and library surface.
 Pulse modules implement durable runtime mechanics without binding consumer task registries.
 -}
 module Cortex.Pulse.Executor.Persistence
-  ( persistGraphState
+  ( GraphStatePersistError (..)
+  , persistGraphState
   , requireGraphStatePersist
+  , requireGraphStatePersistVar
+  , handleGraphStatePersistError
   , persistStageSuccess
   , persistStageRewrite
   , flushDeferredRejections
@@ -40,6 +43,7 @@ where
 
 import Control.Concurrent.MVar (withMVar)
 import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO, writeTVar)
+import Control.Concurrent.STM.TVar (TVar)
 import Control.Monad (when)
 import Data.Aeson qualified as Aeson
 import Data.Bifunctor (first)
@@ -47,7 +51,7 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Time (UTCTime, getCurrentTime)
+import Data.Time (UTCTime, addUTCTime, getCurrentTime)
 import Data.UUID (UUID)
 
 import Cortex.Pulse.Executor.Events
@@ -67,6 +71,7 @@ import Cortex.Pulse.Executor.Types
   , StageEnv (..)
   )
 import Cortex.Pulse.GraphRuntime (GraphState (..))
+import Cortex.Pulse.GraphStateRevision (GraphStateRevision (..))
 import Cortex.Pulse.Materialization
   ( PersistedGraphState (..)
   , PersistedRewrite (..)
@@ -107,9 +112,19 @@ import Platform.DurableTask.Checkpoint (buildCheckpointEnvelope)
 import Platform.DurableTask.Types (RunOutcome (..), StageStatus (..))
 import Platform.Observability (emitObsEvent)
 
-persistGraphState :: StageEnv -> PersistedGraphState -> IO (Either Text ())
+-- | Failure mode from a durable graph-state write.
+data GraphStatePersistError
+  = -- | The database rejected or failed the write.
+    GraphStatePersistDbError !Text
+  | -- | The row revision no longer matches; another owner wrote newer state.
+    GraphStatePersistStaleWrite
+  deriving stock (Eq, Show)
+
+-- | Persist graph state and return the same state annotated with its new revision.
+persistGraphState
+  :: StageEnv -> PersistedGraphState -> IO (Either GraphStatePersistError PersistedGraphState)
 persistGraphState env persistedState = do
-  now <- getCurrentTime
+  now <- nextGraphStateRevision persistedState.pgsRevision <$> getCurrentTime
   let input =
         Q.GraphStateWrite
           { gswRunId = env.seRunId
@@ -121,27 +136,83 @@ persistGraphState env persistedState = do
           , gswNodeProvenance = Just (Aeson.toJSON persistedState.pgsNodeProvenance)
           , gswTopologyHash = persistedState.pgsTopologyHash
           , gswUpdatedAt = now
+          , gswExpectedRevision = persistedState.pgsRevision
           }
   result <-
     DB.runTransaction env.sePool $
       Q.writeGraphState input
-  pure (first T.pack result)
+  pure $
+    case first (GraphStatePersistDbError . T.pack) result of
+      Left err -> Left err
+      Right (Q.GraphStateWriteApplied revision) ->
+        Right persistedState {pgsRevision = Just revision}
+      Right Q.GraphStateWriteStale ->
+        Left GraphStatePersistStaleWrite
 
-requireGraphStatePersist :: StageEnv -> PersistedGraphState -> IO (Maybe RunOutcome)
+-- | Persist graph state, interpreting write failure as a runtime outcome.
+requireGraphStatePersist
+  :: StageEnv -> PersistedGraphState -> IO (Either RunOutcome PersistedGraphState)
 requireGraphStatePersist env persistedState = do
   result <- persistGraphState env persistedState
   case result of
-    Right () -> pure Nothing
-    Left err -> do
-      now <- getCurrentTime
-      recordRunEvent
-        env
-        "run.graph_state_persist_failed"
-        Q.RunEventError
-        ("Graph state persistence failed: " <> err)
-        Nothing
-      failRun env.sePool env.seRunId now "graph_state_persist_failed" err True
-      pure (Just OutcomeFailed)
+    Right persistedState' -> pure (Right persistedState')
+    Left err ->
+      Left <$> handleGraphStatePersistError env err
+
+{- | Persist graph state, interpret failures, and publish the accepted revision
+back into the live graph-state TVar.
+
+Callers that already own the run-scoped 'PersistedGraphState' TVar should use
+this helper instead of open-coding the @Right state' -> writeTVar@ branch.
+-}
+requireGraphStatePersistVar
+  :: StageEnv
+  -> TVar PersistedGraphState
+  -> PersistedGraphState
+  -> IO (Either RunOutcome PersistedGraphState)
+requireGraphStatePersistVar env gsVar persistedState = do
+  result <- requireGraphStatePersist env persistedState
+  case result of
+    Right persistedState' ->
+      atomically $ writeTVar gsVar persistedState'
+    Left _ ->
+      pure ()
+  pure result
+
+{- | Choose the next graph-state revision for production writes.
+
+The DB-level CAS compares @expected_revision@ to the current @updated_at@
+value.  Keep the replacement timestamp strictly greater than the previous
+revision so a clock with coarse precision or brief backwards drift cannot
+write the same token back and accidentally leave a stale owner eligible.
+-}
+nextGraphStateRevision :: Maybe GraphStateRevision -> UTCTime -> UTCTime
+nextGraphStateRevision Nothing now = now
+nextGraphStateRevision (Just (GraphStateRevision previous)) now
+  | now > previous = now
+  | otherwise = addUTCTime 0.000001 previous
+
+-- | Record the operator-visible consequence of a graph-state persist failure.
+handleGraphStatePersistError :: StageEnv -> GraphStatePersistError -> IO RunOutcome
+handleGraphStatePersistError env = \case
+  GraphStatePersistDbError err -> do
+    now <- getCurrentTime
+    recordRunEvent
+      env
+      "run.graph_state_persist_failed"
+      Q.RunEventError
+      ("Graph state persistence failed: " <> err)
+      Nothing
+    failRun env.sePool env.seRunId now "graph_state_persist_failed" err True
+    pure OutcomeFailed
+  GraphStatePersistStaleWrite -> do
+    recordRunEvent
+      env
+      "run.graph_state_stale_write"
+      Q.RunEventWarn
+      "Graph state persistence lost the ownership race; stopping this executor without overwriting newer state"
+      Nothing
+    pure OutcomeShutdown
 
 persistStageSuccess
   :: StageEnv

--- a/src/Cortex/Pulse/Executor/Resume.hs
+++ b/src/Cortex/Pulse/Executor/Resume.hs
@@ -188,6 +188,7 @@ resumeFromPersistedState pool pulseConfig shutdownFlag runId task initialStagePl
                           , pgsAppliedRewriteId = persistedSnapshot.pgssAppliedRewriteId
                           , pgsNodeProvenance = restoredProvenance
                           , pgsTopologyHash = persistedSnapshot.pgssTopologyHash
+                          , pgsRevision = Just persistedSnapshot.pgssRevision
                           }
                       topology0 = spTopology materializedStagePlan
                   case reconcileGraphState topology0 gs0 of
@@ -241,8 +242,8 @@ resumeFromPersistedState pool pulseConfig shutdownFlag runId task initialStagePl
                                 then do
                                   persistFailed <- requireGraphStatePersist env persistedState
                                   case persistFailed of
-                                    Just outcome -> pure outcome
-                                    Nothing -> continueAfterRecovery env stagePlan persistedState recoveryStep
+                                    Left outcome -> pure outcome
+                                    Right persistedState' -> continueAfterRecovery env stagePlan persistedState' recoveryStep
                                 else
                                   continueAfterRecovery env stagePlan persistedState recoveryStep
     _ ->

--- a/src/Cortex/Pulse/GraphStateRevision.hs
+++ b/src/Cortex/Pulse/GraphStateRevision.hs
@@ -1,0 +1,22 @@
+{- |
+Module      : Cortex.Pulse.GraphStateRevision
+Description : Durable graph-state revision token.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Pulse uses the graph-state row's @updated_at@ value as an optimistic
+compare-and-swap revision token.  The newtype keeps revision comparisons
+distinct from ordinary timestamps at Haskell call sites.
+-}
+module Cortex.Pulse.GraphStateRevision
+  ( GraphStateRevision (..)
+  )
+where
+
+import Data.Time (UTCTime)
+
+-- | Opaque graph-state compare-and-swap revision.
+newtype GraphStateRevision = GraphStateRevision {unGraphStateRevision :: UTCTime}
+  deriving stock (Eq, Ord, Show)

--- a/src/Cortex/Pulse/Materialization.hs
+++ b/src/Cortex/Pulse/Materialization.hs
@@ -46,6 +46,7 @@ import Cortex.Algebra.Graph
   , relEdges
   , relVertices
   )
+import Cortex.Pulse.GraphStateRevision (GraphStateRevision)
 import Cortex.Pulse.Hydrate
   ( RewriteError (..)
   , SerializableStageDefinition (..)
@@ -103,6 +104,7 @@ data PersistedGraphState = PersistedGraphState
   , pgsAppliedRewriteId :: Maybe Int64
   , pgsNodeProvenance :: NodeProvenance
   , pgsTopologyHash :: Maybe Text
+  , pgsRevision :: Maybe GraphStateRevision
   }
   deriving stock (Eq, Show)
 

--- a/src/Cortex/Pulse/Query.hs
+++ b/src/Cortex/Pulse/Query.hs
@@ -76,6 +76,7 @@ module Cortex.Pulse.Query
   , RunEventSeverity (..)
   , RunEventInsert (..)
   , GraphStateWrite (..)
+  , GraphStateWriteResult (..)
   , GraphRewriteInsert (..)
   , PulsePendingRunClaim (..)
   , createTaskDefinition
@@ -146,6 +147,7 @@ import Hasql.Transaction qualified as Tx
 import Rel8 hiding (Statement)
 import System.IO qualified
 
+import Cortex.Pulse.GraphStateRevision (GraphStateRevision (..))
 import Cortex.Pulse.Node (NodeId (..))
 import Cortex.Pulse.Schema
 import Cortex.Pulse.Signal (SignalName (..))
@@ -249,6 +251,7 @@ data PulseGraphStateSnapshot = PulseGraphStateSnapshot
   , pgssAppliedRewriteId :: Maybe Int64
   , pgssNodeProvenance :: Maybe Value
   , pgssTopologyHash :: Maybe Text
+  , pgssRevision :: GraphStateRevision
   }
   deriving stock (Eq, Show)
 
@@ -331,7 +334,13 @@ data GraphStateWrite = GraphStateWrite
   , gswNodeProvenance :: Maybe Value
   , gswTopologyHash :: Maybe Text
   , gswUpdatedAt :: UTCTime
+  , gswExpectedRevision :: Maybe GraphStateRevision
   }
+  deriving stock (Eq, Show)
+
+data GraphStateWriteResult
+  = GraphStateWriteApplied !GraphStateRevision
+  | GraphStateWriteStale
   deriving stock (Eq, Show)
 
 data PulsePendingRunClaim = PulsePendingRunClaim
@@ -1474,7 +1483,7 @@ readGraphState runId =
   Session.statement runId $
     Statement
       "SELECT node_statuses, node_outputs, remaining_rewrite_budget, runtime_version, \
-      \applied_rewrite_id, node_provenance, topology_hash \
+      \applied_rewrite_id, node_provenance, topology_hash, updated_at \
       \FROM pulse.graph_state WHERE run_id = $1"
       (Enc.encode1 (Prelude.id, Enc.nonNullable Enc.uuid))
       (D.rowMaybe graphStateDecoder)
@@ -1489,6 +1498,7 @@ readGraphState runId =
         <*> D.column (D.nullable D.int8) -- applied_rewrite_id
         <*> D.column (D.nullable D.jsonb) -- node_provenance
         <*> D.column (D.nullable D.text) -- topology_hash
+        <*> (GraphStateRevision <$> D.column (D.nonNullable D.timestamptz)) -- updated_at
 
 -- | Read persisted graph state for admin display.
 readGraphStateForAdmin :: UUID -> Session (Maybe PulseGraphStateAdminView)
@@ -1513,24 +1523,62 @@ readGraphStateForAdmin runId =
         <*> D.column (D.nullable D.text) -- topology_hash
         <*> D.column (D.nonNullable D.timestamptz) -- updated_at
 
--- | Persist graph state (upsert).
-writeGraphState :: GraphStateWrite -> Transaction ()
+{- | Persist graph state using optimistic compare-and-swap semantics.
+
+A write with no expected revision is an insert-only first write. A write
+with an expected revision updates only the row whose @updated_at@ still
+matches that revision.  Production callers choose the replacement
+@updated_at@ through
+'Cortex.Pulse.Executor.Persistence.persistGraphState', which keeps revisions
+strictly increasing even if the system clock returns an equal or older
+timestamp.
+-}
+writeGraphState :: GraphStateWrite -> Transaction GraphStateWriteResult
 writeGraphState input =
-  Tx.statement input $
+  fmap toWriteResult . Tx.statement input $
     Statement
-      "INSERT INTO pulse.graph_state \
-      \(run_id, node_statuses, node_outputs, remaining_rewrite_budget, \
-      \ runtime_version, applied_rewrite_id, node_provenance, topology_hash, updated_at) \
-      \VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) \
-      \ON CONFLICT (run_id) DO UPDATE SET \
-      \  node_statuses = EXCLUDED.node_statuses, \
-      \  node_outputs = EXCLUDED.node_outputs, \
-      \  remaining_rewrite_budget = EXCLUDED.remaining_rewrite_budget, \
-      \  runtime_version = EXCLUDED.runtime_version, \
-      \  applied_rewrite_id = EXCLUDED.applied_rewrite_id, \
-      \  node_provenance = EXCLUDED.node_provenance, \
-      \  topology_hash = EXCLUDED.topology_hash, \
-      \  updated_at = EXCLUDED.updated_at"
+      "WITH input AS ( \
+      \  SELECT \
+      \    $1::uuid AS run_id, \
+      \    $2::jsonb AS node_statuses, \
+      \    $3::jsonb AS node_outputs, \
+      \    $4::jsonb AS remaining_rewrite_budget, \
+      \    $5::int4 AS runtime_version, \
+      \    $6::int8 AS applied_rewrite_id, \
+      \    $7::jsonb AS node_provenance, \
+      \    $8::text AS topology_hash, \
+      \    $9::timestamptz AS updated_at, \
+      \    $10::timestamptz AS expected_revision \
+      \), inserted AS ( \
+      \  INSERT INTO pulse.graph_state \
+      \    (run_id, node_statuses, node_outputs, remaining_rewrite_budget, \
+      \     runtime_version, applied_rewrite_id, node_provenance, topology_hash, updated_at) \
+      \  SELECT run_id, node_statuses, node_outputs, remaining_rewrite_budget, \
+      \         runtime_version, applied_rewrite_id, node_provenance, topology_hash, updated_at \
+      \  FROM input \
+      \  WHERE expected_revision IS NULL \
+      \  ON CONFLICT (run_id) DO NOTHING \
+      \  RETURNING updated_at \
+      \), updated AS ( \
+      \  UPDATE pulse.graph_state gs SET \
+      \    node_statuses = input.node_statuses, \
+      \    node_outputs = input.node_outputs, \
+      \    remaining_rewrite_budget = input.remaining_rewrite_budget, \
+      \    runtime_version = input.runtime_version, \
+      \    applied_rewrite_id = input.applied_rewrite_id, \
+      \    node_provenance = input.node_provenance, \
+      \    topology_hash = input.topology_hash, \
+      \    updated_at = input.updated_at \
+      \  FROM input \
+      \  WHERE input.expected_revision IS NOT NULL \
+      \    AND gs.run_id = input.run_id \
+      \    AND gs.updated_at = input.expected_revision \
+      \  RETURNING gs.updated_at \
+      \) \
+      \SELECT updated_at FROM inserted \
+      \UNION ALL \
+      \SELECT updated_at FROM updated \
+      \LIMIT 1"
       ( Enc.encodeParams
           ( Enc.col (.gswRunId) (Enc.nonNullable Enc.uuid)
               :| [ Enc.col (.gswNodeStatuses) (Enc.nonNullable Enc.jsonb)
@@ -1541,11 +1589,18 @@ writeGraphState input =
                  , Enc.col (.gswNodeProvenance) (Enc.nullable Enc.jsonb)
                  , Enc.col (.gswTopologyHash) (Enc.nullable Enc.text)
                  , Enc.col (.gswUpdatedAt) (Enc.nonNullable Enc.timestamptz)
+                 , Enc.col
+                     (fmap unGraphStateRevision . (.gswExpectedRevision))
+                     (Enc.nullable Enc.timestamptz)
                  ]
           )
       )
-      D.noResult
+      (D.rowMaybe (GraphStateRevision <$> D.column (D.nonNullable D.timestamptz)))
       False
+  where
+    toWriteResult = \case
+      Just revision -> GraphStateWriteApplied revision
+      Nothing -> GraphStateWriteStale
 
 -- | Persist a graph rewrite event (append-only) and return its durable rewrite id.
 writeGraphRewrite :: GraphRewriteInsert -> Transaction Int64

--- a/test/Cortex/Pulse/ExecutorSpec.hs
+++ b/test/Cortex/Pulse/ExecutorSpec.hs
@@ -34,7 +34,7 @@ import Data.Maybe (isJust)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Time (diffUTCTime, getCurrentTime)
+import Data.Time (addUTCTime, diffUTCTime, getCurrentTime)
 import Data.UUID (UUID)
 import GHC.Generics (Generic)
 import Hasql.Decoders qualified as D
@@ -87,7 +87,15 @@ import Cortex.Pulse.Executor
   , stageTemplateId
   )
 import Cortex.Pulse.Executor qualified as Executor
-import Cortex.Pulse.Materialize (NodeProvenanceEntry (..))
+import Cortex.Pulse.Executor.Persistence (requireGraphStatePersist)
+import Cortex.Pulse.Executor.Types (RunTVars (..), mkStageEnv)
+import Cortex.Pulse.GraphStateRevision (GraphStateRevision (..))
+import Cortex.Pulse.Materialize
+  ( NodeProvenanceEntry (..)
+  , PersistedGraphState (..)
+  , computeTopologyHash
+  , initialProvenance
+  )
 import Cortex.Pulse.Memory (defaultMemoryStrategy)
 import Cortex.Pulse.Node (NodeId (..))
 import Cortex.Pulse.Query
@@ -244,6 +252,13 @@ readGraphNodeOutputs pool runId = do
               <> show runId
               <> ": "
               <> err
+
+expectGraphStateSnapshot :: Pool -> UUID -> IO Q.PulseGraphStateSnapshot
+expectGraphStateSnapshot pool runId = do
+  result <- runSession pool $ Q.readGraphState runId
+  case result of
+    Nothing -> expectationFailure "Expected persisted graph state snapshot" >> fail "missing graph state"
+    Just snapshot -> pure snapshot
 
 -- | Count stage log entries for a run.
 countStageLogs :: Pool -> UUID -> IO Int32
@@ -605,20 +620,26 @@ writeGraphStateCompat
   -> Maybe Int64
   -> IO ()
 writeGraphStateCompat pool runId statuses outputs runtimeVersion appliedRewriteId = do
+  snapshot <- runSession pool $ Q.readGraphState runId
   now <- getCurrentTime
-  runTx pool $
-    Q.writeGraphState
-      Q.GraphStateWrite
-        { gswRunId = runId
-        , gswNodeStatuses = statuses
-        , gswNodeOutputs = outputs
-        , gswRemainingRewriteBudget = Nothing
-        , gswRuntimeVersion = runtimeVersion
-        , gswAppliedRewriteId = appliedRewriteId
-        , gswNodeProvenance = Nothing
-        , gswTopologyHash = Nothing
-        , gswUpdatedAt = now
-        }
+  result <-
+    runTx pool $
+      Q.writeGraphState
+        Q.GraphStateWrite
+          { gswRunId = runId
+          , gswNodeStatuses = statuses
+          , gswNodeOutputs = outputs
+          , gswRemainingRewriteBudget = Nothing
+          , gswRuntimeVersion = runtimeVersion
+          , gswAppliedRewriteId = appliedRewriteId
+          , gswNodeProvenance = Nothing
+          , gswTopologyHash = Nothing
+          , gswUpdatedAt = now
+          , gswExpectedRevision = fmap Q.pgssRevision snapshot
+          }
+  case result of
+    Q.GraphStateWriteApplied {} -> pure ()
+    Q.GraphStateWriteStale -> expectationFailure "expected graph_state compatibility write to apply"
 
 expectRecoveryPreconditionFailure :: Pool -> UUID -> Text -> IO ()
 expectRecoveryPreconditionFailure pool runId expectedMessageSnippet = do
@@ -2807,6 +2828,116 @@ spec = beforeAll setupTestDb $ do
           Just (Right outcome) -> outcome `shouldBe` OutcomeCompleted
 
   describe "graph-state persistence hardening" $ do
+    it "rejects graph_state writes whose expected revision is stale" $ \mPool -> withDb mPool $ \pool -> do
+      taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-graph-state-cas-stale"
+      runId <- createTestRun pool taskId
+      let node = NodeId "test_alpha"
+          stagePlan =
+            mkLinearStagePlan
+              [simpleStage TestStageAlpha (\_runId state -> pure state)]
+              Aeson.Null
+              1
+              ReplayPolicyWarn
+          gs0 = initialGraphState stagePlan.spTopology
+      writeRawGraphStateForPlan pool runId stagePlan gs0
+      snapshot0 <- expectGraphStateSnapshot pool runId
+      let revision1 =
+            GraphStateRevision (addUTCTime 1 (unGraphStateRevision snapshot0.pgssRevision))
+          revision2 =
+            GraphStateRevision (addUTCTime 2 (unGraphStateRevision snapshot0.pgssRevision))
+          winningState = markCompleted node (Aeson.String "winner") gs0
+          staleState = markFailed node gs0
+          mkWrite revision state =
+            Q.GraphStateWrite
+              { gswRunId = runId
+              , gswNodeStatuses = Aeson.toJSON state.gsNodeStatuses
+              , gswNodeOutputs = Aeson.toJSON state.gsNodeOutputs
+              , gswRemainingRewriteBudget = Just (Aeson.toJSON defaultRewriteBudget)
+              , gswRuntimeVersion = Just (fromIntegral stagePlan.spCheckpointRuntimeVersion :: Int32)
+              , gswAppliedRewriteId = Nothing
+              , gswNodeProvenance = Just (Aeson.toJSON (initialProvenance stagePlan.spTopology))
+              , gswTopologyHash = Just (computeTopologyHash stagePlan.spTopology)
+              , gswUpdatedAt = unGraphStateRevision revision
+              , gswExpectedRevision = Just snapshot0.pgssRevision
+              }
+
+      firstResult <- runTx pool $ Q.writeGraphState (mkWrite revision1 winningState)
+      firstResult `shouldBe` Q.GraphStateWriteApplied revision1
+      staleResult <- runTx pool $ Q.writeGraphState (mkWrite revision2 staleState)
+      staleResult `shouldBe` Q.GraphStateWriteStale
+
+      statuses <- readGraphNodeStatuses pool runId
+      (Map.lookup node =<< statuses) `shouldBe` Just NodeCompleted
+      outputs <- readGraphNodeOutputs pool runId
+      fmap (Map.lookup node . fst) outputs `shouldBe` Just (Just (Aeson.String "winner"))
+
+    it "stops a stale graph_state owner without overwriting newer state" $ \mPool -> withDb mPool $ \pool -> do
+      (shutdownFlag, _taskContext) <- mkTaskContext pool
+      taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-graph-state-stale-owner"
+      runId <- createTestRun pool taskId
+      task <- loadTaskDef pool taskId
+      let node = NodeId "test_alpha"
+          stagePlan =
+            mkLinearStagePlan
+              [simpleStage TestStageAlpha (\_runId state -> pure state)]
+              Aeson.Null
+              1
+              ReplayPolicyWarn
+          gs0 = initialGraphState stagePlan.spTopology
+      writeRawGraphStateForPlan pool runId stagePlan gs0
+      snapshot0 <- expectGraphStateSnapshot pool runId
+      let winningState = markCompleted node (Aeson.String "winner") gs0
+          winnerRevision =
+            GraphStateRevision (addUTCTime 1 (unGraphStateRevision snapshot0.pgssRevision))
+          winnerWrite =
+            Q.GraphStateWrite
+              { gswRunId = runId
+              , gswNodeStatuses = Aeson.toJSON winningState.gsNodeStatuses
+              , gswNodeOutputs = Aeson.toJSON winningState.gsNodeOutputs
+              , gswRemainingRewriteBudget = Just (Aeson.toJSON defaultRewriteBudget)
+              , gswRuntimeVersion = Just (fromIntegral stagePlan.spCheckpointRuntimeVersion :: Int32)
+              , gswAppliedRewriteId = Nothing
+              , gswNodeProvenance = Just (Aeson.toJSON (initialProvenance stagePlan.spTopology))
+              , gswTopologyHash = Just (computeTopologyHash stagePlan.spTopology)
+              , gswUpdatedAt = unGraphStateRevision winnerRevision
+              , gswExpectedRevision = Just snapshot0.pgssRevision
+              }
+          stalePersistedState =
+            PersistedGraphState
+              { pgsGraphState = markFailed node gs0
+              , pgsRemainingRewriteBudget = defaultRewriteBudget
+              , pgsAppliedRewriteId = Nothing
+              , pgsNodeProvenance = initialProvenance stagePlan.spTopology
+              , pgsTopologyHash = Just (computeTopologyHash stagePlan.spTopology)
+              , pgsRevision = Just snapshot0.pgssRevision
+              }
+      winnerResult <- runTx pool $ Q.writeGraphState winnerWrite
+      winnerResult `shouldBe` Q.GraphStateWriteApplied winnerRevision
+
+      gsVar <- newTVarIO stalePersistedState
+      nodeCompletedAtVar <- newTVarIO Map.empty
+      topologyVar <- newTVarIO stagePlan.spTopology
+      let tvars =
+            RunTVars
+              { rvGsVar = gsVar
+              , rvNodeCompletedAtVar = nodeCompletedAtVar
+              , rvTopologyVar = topologyVar
+              }
+          env = mkStageEnv pool testPulseConfig shutdownFlag runId task stagePlan tvars
+
+      persistResult <- requireGraphStatePersist env stalePersistedState
+
+      persistResult `shouldBe` Left OutcomeShutdown
+      statuses <- readGraphNodeStatuses pool runId
+      (Map.lookup node =<< statuses) `shouldBe` Just NodeCompleted
+      events <- readRunEvents pool runId
+      case filter ((== "run.graph_state_stale_write") . preEventType) events of
+        [event] -> preSeverity event `shouldBe` "warn"
+        matching ->
+          expectationFailure $
+            "Expected one stale graph-state event, found "
+              <> show (length matching)
+
     it "fails a sequential frontier when graph_state persistence fails" $ \mPool -> withDb mPool $ \pool -> do
       (_, taskContext) <- mkTaskContext pool
       taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-sequential-persist-failure"

--- a/test/Cortex/Pulse/ExecutorSpec.hs
+++ b/test/Cortex/Pulse/ExecutorSpec.hs
@@ -3019,14 +3019,12 @@ spec = beforeAll setupTestDb $ do
               , spDefinitions = defs
               , spTemplateRegistry = mkTemplateRegistry defs
               }
-      -- The trigger fires on both INSERT and UPDATE.  writeGraphState uses
-      -- INSERT ... ON CONFLICT DO UPDATE, so the first call (INSERT) fires
-      -- once, and every subsequent call (INSERT-conflict then UPDATE) fires
-      -- twice.  Writes: (1) initial state INSERT, (2+3) markRunning
-      -- INSERT-conflict + UPDATE, (4+5) collectWorkerResults after first
-      -- worker.  We want to fail on (5) so workers actually run.
+      -- The trigger fires once per accepted graph_state write.  The first
+      -- call is an insert, and subsequent CAS writes are update-only:
+      -- (1) initial state, (2) markRunning, (3) collectWorkerResults after
+      -- the first worker.  We want to fail on (3) so workers actually run.
       outcome <-
-        withInjectedGraphStateWriteFailure pool runId 5
+        withInjectedGraphStateWriteFailure pool runId 3
           . withAsync (executeStagePlan taskContext runId task stagePlan)
           $ \planAsync -> do
             _ <- readMVar fastDone

--- a/test/Cortex/Pulse/MemoryIntegrationSpec.hs
+++ b/test/Cortex/Pulse/MemoryIntegrationSpec.hs
@@ -126,6 +126,7 @@ initialPersistedState =
     , pgsAppliedRewriteId = Nothing
     , pgsNodeProvenance = Map.empty
     , pgsTopologyHash = Nothing
+    , pgsRevision = Nothing
     }
 
 completedAtMap :: Map.Map NodeId UTCTime


### PR DESCRIPTION
## Summary
Add durable compare-and-swap protection for Pulse graph-state writes so stale executor owners cannot silently overwrite newer per-run state.

## Plan
- [x] Add graph-state revision token to query/runtime state.
- [x] Make graph-state persistence conditional on the expected revision.
- [x] Thread successful revisions through runtime TVars.
- [x] Surface stale-write conflicts as a specific run event/outcome.
- [x] Add DB/runtime regressions and Pulse docs updates.

## Validation
- [x] `just build`
- [x] `just build-pulse`
- [x] `just test` — 485 examples, 0 failures, 96 pending because `PGHOST` is not set locally.
- [x] `just fmt-check`
- [x] `just lint`
- [x] `just docs-check`
- [x] `just check-commit-provenance origin/main..HEAD`
- [x] pre-commit hooks during signed amend (`docs-lint`, `fourmolu`, `hlint`, `module-haddock`, `treefmt`, etc.)

## Notes
The two new graph-state CAS integration tests are PostgreSQL-backed and are currently pending in the local run for the same `PGHOST` reason as the existing Pulse DB suite. CI should exercise them where the test database is available.

## Issue
Closes #22
