### PR TITLE
docs: propagate Wire boundary vocabulary

### DIFF
--- a/docs/Architecture/03-formalism-stack.md
+++ b/docs/Architecture/03-formalism-stack.md
@@ -40,6 +40,12 @@ another wire value under `<>` or `=>` is itself a wire value. The class is close
 operators. This is what makes source authoring, configured executor reuse, and rewriting tractable:
 authors and rewrites manipulate the same kind of object the compiler consumes.
 
+Composition closure is graph-theoretic, not the whole resource story. Wire also tracks **boundary
+obligations**: the input/output contract boundary that an operation consumes, preserves, or
+transforms. Boundary resources sit above Mokhov graph equality. They say whether a rewrite,
+conditional, or planner certificate has accounted for the exposed contract boundary it promises,
+while the graph algebra still says what topology denotes.
+
 ## Detailed structure
 
 ### Mokhov's algebraic graph model
@@ -112,6 +118,25 @@ side — gas, admission, materialization, replay contracts — is the subject of
 [`chapter 07`](./07-rewrites-and-materialization.md). The formalism only records that rewrites are
 algebraic operations over the same object class, not a separate mutation layer.
 
+Boundary resources refine that statement without changing the algebra. A contract-preserving
+substitution consumes the anchor's boundary obligation and must expose the same boundary again. An
+append continuation keeps the anchor node and consumes the anchor output as the continuation input.
+A conditional branch actualization consumes an owner-bound actualization capability and promotes one
+guarded branch into the live linear resource context. Those are resource laws over the graph
+operation; they are not new Mokhov constructors.
+
+### Latent structural control
+
+`select(...)` is the first accepted **latent structural control** operator. Before selection, its
+branches are a sealed family of graph possibilities, not live topology and not a fifth constructor
+in the graph algebra. Every branch can be checked against its variant boundary, but each
+branch-local obligation is guarded and affine until the selected arm is actualized.
+
+After selection, the chosen branch lowers to ordinary Wire graph composition and the usual overlay
+and connect laws apply to the materialized result. Unselected branches do not become graph fragments
+for the run. This is how Wire can represent structured runtime choice without treating conditionals
+as ordinary fan-out or hiding the choice inside executor code.
+
 ## Boundaries and invariants
 
 What this stack enforces:
@@ -122,6 +147,11 @@ What this stack enforces:
   laws on the port-key-matched projection.
 - **Layered invariants.** Acyclicity and port-contract compatibility attach at the Circuit boundary,
   not at Graph. Fragments remain algebraically first-class below that line.
+- **Boundary-resource accounting.** Structural operations consume, preserve, or transform declared
+  boundary obligations. Node identity, provenance envelopes, and boundary obligations are related
+  but not the same resource.
+- **Latent control lowers after resolution.** A latent branch family is checked before runtime, but
+  only the selected branch enters the live graph and inherits the graph laws.
 - **Rewrites as algebraic operations.** Structural edits are expressible in the same algebra that
   authored the topology; admission preserves the laws.
 
@@ -133,10 +163,10 @@ provenance — all delegated to Circuit, Pulse, or the contract registry.
 The Mokhov alphabet is fixed at four constructors. Cortex does not extend it. New authoring
 convenience enters Wire as derived value operators (`//`, `++`, `let`, configured executor values)
 that reduce to explicit graph vertices before the expression reaches the Graph layer. New semantic
-categories — payload kinds, structural-authority classes, parameterized latent branches explored in
-the foundation synthesis note — attach as registry metadata on the Circuit layer, not as new graph
-primitives. The algebra stays small on purpose; the ecosystem grows by registering authority into a
-closed alphabet, not by mutating the alphabet.
+categories — payload kinds, boundary-resource modes, structural-authority classes, and latent
+structural control operators — attach as registry metadata, proof obligations, or runtime admission
+rules above the Circuit layer, not as new graph primitives. The algebra stays small on purpose; the
+ecosystem grows by registering authority into a closed alphabet, not by mutating the alphabet.
 
 ## Related
 
@@ -147,6 +177,10 @@ closed alphabet, not by mutating the alphabet.
   [`../Reference/Wire/grammar.md`](../Reference/Wire/grammar.md).
 - [`./07-rewrites-and-materialization.md`](./07-rewrites-and-materialization.md) — rewrite admission
   mechanics.
+- [`../ADRs/0032-wire-boundary-contract-resources.md`](../ADRs/0032-wire-boundary-contract-resources.md)
+  — boundary obligations as planning resources.
+- [`../ADRs/0037-wire-latent-structural-control.md`](../ADRs/0037-wire-latent-structural-control.md)
+  — latent structural control operators and their graph-algebra boundary.
 - [`../Publications/Paper-2-algebraic-foundations/manuscript.md`](../Publications/Paper-2-algebraic-foundations/manuscript.md)
   — algebraic foundations of staged durable execution.
 - [`../Publications/Paper-3-graph-substitution-semantics/manuscript.md`](../Publications/Paper-3-graph-substitution-semantics/manuscript.md)

--- a/docs/Architecture/05-wire-language.md
+++ b/docs/Architecture/05-wire-language.md
@@ -30,6 +30,8 @@ The normative rules live in the reference:
   namespace, port declarations, `=>` matching
 - [Configured executors and execution boundary](../Reference/Wire/configured-executors-and-execution-boundary.md)
   — configured executor values, typed node boundaries, runnable-wire boundary
+- [Conditionality](../Reference/Wire/conditionality.md) — `select(...)`, guarded-affine collapse,
+  latent continuations, and selected-branch actualization
 - [Rewrites](../Reference/rewrites.md) — bounded dynamic rewrite algebra, budget, admission,
   materialization, provenance
 - [Modules, imports, and file returns](../Reference/Wire/modules-imports-and-file-returns.md) — file
@@ -111,6 +113,30 @@ One practical design rule follows from this split: edges carry typed values, not
 When a node aggregates several upstream values, author that shape explicitly as typed input ports
 and pass a record or list to the executor body. Wire does not infer list aggregation from many
 incoming arrows.
+
+This typed port boundary is also the resource accounting surface for structural control. A node is
+an addressable runtime and provenance object, but the locally consumed resource is the boundary
+obligation it exposes. Rewrites, append continuations, and conditional actualization all have to
+state which boundary they consume and which boundary they return. Retaining a node for provenance is
+therefore not the same as keeping its original boundary obligation unspent.
+
+## Conditionality and latent control
+
+Wire conditionality is topology-level structural control, not value-level `if` hidden inside a
+stage. The canonical surface is postfix `select(...)`: the graph on the left exposes an exclusive
+output boundary, each arm provides a continuation for one variant, and exactly one continuation is
+actualized.
+
+The formal model is **guarded-affine collapse**. Before selection, every arm is checked as a sealed
+latent continuation, and each branch-local boundary obligation is guarded by its arm key and affine:
+it may be chosen at most once, but it is not live topology. Selection promotes the chosen arm into
+the live linear context and discards the unselected arms for that run.
+
+Pure computation may compute the selected arm key, but it does not gain graph rewrite authority. The
+structural effect belongs to the compiled `select(...)` operator and to a restricted actualization
+capability for that owner and arm. In the current runtime, that capability is realized through
+retained-owner `AppendAfter` admission rather than a separate persisted `SelectActualize` token.
+Branch actualization is not an arbitrary planner-authored rewrite.
 
 ## Configured executor values and reuse
 
@@ -200,6 +226,17 @@ Wire is also the authoring surface for runtime topology evolution. A rewrite is 
 of object from the initial graph; it is another composition over the same registered vocabulary and
 compatibility rules.
 
+The source-language view distinguishes three structural effects:
+
+- **substitution**, where an anchor boundary is consumed and replaced by a graph exposing the same
+  promised boundary;
+- **append continuation**, where the anchor stays live and its output feeds a new downstream graph;
+- **selected-branch actualization**, where a guarded continuation from a compiled branch family is
+  promoted into live topology.
+
+The current runtime may realize more than one conceptual effect with the same v1 constructor, but
+the Wire language should keep their resource laws distinct.
+
 The generic pattern is:
 
 ```text
@@ -214,6 +251,10 @@ Wire does not admit rewrites by itself. The handoff is:
 - Wire expresses the candidate structure
 - Circuit validates that the structure is still executable
 - Pulse decides admission, budgeting, materialization, and resume behavior
+
+For latent branches, Pulse uses the current **selected-cost** policy: unselected arms do not consume
+runtime rewrite budget, and the selected arm consumes ordinary rewrite budget when actualized. This
+is not a reserved-capacity guarantee for every compiled arm.
 
 That boundary keeps the language small. Wire describes candidate topology. Pulse owns runtime
 policy.
@@ -244,6 +285,8 @@ Cortex still owns the source language, composition rules, and substrate runtime.
   — contract, port, executor, and binding separation
 - [ADR 0020 — Wire Pure Output Equations](../ADRs/0020-wire-pure-output-equations.md) —
   deterministic CorePure output equations
+- [ADR 0034 — Pure Selectors and Restricted Actualization Authority](../ADRs/0034-wire-pure-select-actualization-authority.md)
+  — pure branch choice without general rewrite authority
 - [Wire Grammar](../Reference/Wire/grammar.md) — normative grammar
 - [Cortex Terminology](../Reference/terminology.md) — accepted vocabulary
 - [Consumer examples](../Consumers/) — downstream binding examples

--- a/docs/Architecture/07-rewrites-and-materialization.md
+++ b/docs/Architecture/07-rewrites-and-materialization.md
@@ -57,6 +57,19 @@ evidence-gathering branch. `AppendAfter` inserts a subgraph downstream of a node
 validation once the anchor finishes. `InsertBefore`, `PruneSubgraph`, `AddJoin`, and `ReplaceNode`
 are recognized future forms but not part of the admitted alphabet.
 
+Those constructors are the current runtime alphabet, not the full conceptual vocabulary. Cortex
+keeps the boundary laws explicit:
+
+| Boundary law                     | Current realization           | Resource effect                                                                                              |
+| -------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Contract-preserving substitution | `ExpandNode anchor mode spec` | Consumes the anchor rewrite slot and boundary obligation; the replacement must expose the promised boundary. |
+| Append continuation              | `AppendAfter anchor spec`     | Consumes the anchor rewrite slot while retaining the anchor and using its output as continuation input.      |
+| Conditional branch actualization | `AppendAfter anchor spec`     | When the anchor is a conditional owner, retained-owner lowering makes the selected guarded branch live.      |
+
+The conditional row names the resource law, not a separate v1 `GraphRewrite` constructor. The
+compiler-side vocabulary may call the restricted capability `SelectActualize owner selectedArm`, but
+the current runtime persists ordinary admitted rewrite rows for the selected branch.
+
 A `SubgraphSpec` is a self-contained fragment: local topology, stage definitions for every local
 node, explicit entry nodes where inbound edges attach, explicit exit nodes where outbound edges
 continue. Entry and exit declarations are serialized lists but semantically sets, so duplicates are
@@ -101,6 +114,12 @@ Each admitted rewrite consumes a natural-valued `RewriteCost` computed staticall
 invalid before admission. Runaway rewrite elaboration becomes a runtime impossibility rather than an
 executor-discipline problem. Gas is visible in run history: operators can inspect remaining budget,
 each rewrite's cost, and the rewrite that exhausted a dimension.
+
+Latent branches use **selected-cost** accounting in the current runtime. A compiled branch family is
+validated as a closed set of possibilities, but unselected arms do not prepay or consume runtime
+rewrite budget. The selected arm consumes ordinary rewrite budget when it is actualized. This is
+deliberately weaker than a reserved-capacity policy: Cortex does not yet guarantee that every
+compiled latent arm can still materialize after unrelated rewrites have spent the remaining budget.
 
 ## Admission policy
 
@@ -172,6 +191,11 @@ See the
 [rewrite materialization and recovery plan](../Roadmap/Plans/rewrite-materialization-and-recovery.md)
 for the formal treatment of the materialization boundary and recovery invariants.
 
+For selected branches, recovery replays the same admitted selected rewrite from durable state. It
+does not materialize unselected alternatives and does not invent a separate "discard branch" event.
+If branch selection occurred but materialization did not finish, resume must finish the admitted
+selected branch before scheduling against the new topology.
+
 ## Provenance of rewrite events
 
 This chapter covers provenance of **structural events**; provenance of **values** flowing through
@@ -191,8 +215,13 @@ This layer enforces:
 - stages and planners propose; only the runtime admits.
 - rewrites stay inside the closed executor alphabet, contract registry, endpoint compatibility, DAG
   validity, and the five-dimensional gas budget.
+- conceptual boundary laws stay distinct even when v1 realizes them through the same runtime
+  constructor. Substitution, append continuation, and branch actualization consume different
+  boundary resources.
 - same-wave rewrite proposals are admitted in deterministic order against shared remaining budget;
   ordinary node execution across the frontier is still concurrent.
+- latent branch actualization follows selected-cost semantics: only the selected branch spends
+  rewrite budget and becomes live; unselected branches remain sealed alternatives for the artifact.
 - the rewrite log is append-only, and watermark and remaining budget update atomically with the
   node-state changes they imply.
 - static DAGs and linear stage paths remain valid programs — a run with no rewrites is a degenerate
@@ -207,12 +236,14 @@ to [Chapter 06](./06-pulse-runtime.md), value-envelope provenance to
 
 New rewrite forms enter by adding constructors to `GraphRewrite` and extending the validator — not
 by letting stages emit arbitrary edits. `InsertBefore`, `PruneSubgraph`, `AddJoin`, and
-`ReplaceNode` lie along this path. Richer gas dimensions (semantic weighting, effect classes,
-irreversibility boundaries) enter by extending `RewriteBudget` and the static cost estimator with a
-matching durability migration. Hierarchical subgraphs — composite nodes owning nested budgets — are
-the planned composition extension once the flat algebra has been proven on a real task. Planner
-integration proceeds by registering planner-capable nodes with a policy-gated, budget-aware
-contract, not by loosening admission checks.
+`ReplaceNode` lie along this path. New latent structural control operators are separate: each needs
+its own boundary law, actualization authority, budget policy, recovery story, and theorem target
+before it can lower into ordinary rewrite materialization. Richer gas dimensions (semantic
+weighting, effect classes, irreversibility boundaries) enter by extending `RewriteBudget` and the
+static cost estimator with a matching durability migration. Hierarchical subgraphs — composite nodes
+owning nested budgets — are the planned composition extension once the flat algebra has been proven
+on a real task. Planner integration proceeds by registering planner-capable nodes with a
+policy-gated, budget-aware contract, not by loosening admission checks.
 
 ## Related
 
@@ -221,6 +252,12 @@ contract, not by loosening admission checks.
   [./05-wire-language.md](./05-wire-language.md), [./06-pulse-runtime.md](./06-pulse-runtime.md),
   [./08-artifacts-and-provenance.md](./08-artifacts-and-provenance.md)
 - [../Reference/terminology.md](../Reference/terminology.md) — normative vocabulary.
+- [../Reference/rewrites.md](../Reference/rewrites.md) — normative rewrite algebra and boundary
+  laws.
+- [../Reference/Wire/conditionality.md](../Reference/Wire/conditionality.md) — `select(...)`,
+  guarded-affine collapse, and selected-cost branch actualization.
+- [../ADRs/0034-wire-pure-select-actualization-authority.md](../ADRs/0034-wire-pure-select-actualization-authority.md)
+  — pure selectors and restricted actualization authority.
 - [../Roadmap/Plans/rewrite-materialization-and-recovery.md](../Roadmap/Plans/rewrite-materialization-and-recovery.md),
   [../Publications/Paper-3-graph-substitution-semantics/manuscript.md](../Publications/Paper-3-graph-substitution-semantics/manuscript.md)
   — formal treatment.

--- a/docs/Reference/Wire/conditionality.md
+++ b/docs/Reference/Wire/conditionality.md
@@ -24,6 +24,7 @@ The short version is:
 
 - conditionality is not ordinary fan-out
 - conditionality is **exclusive-output reduction**
+- the formal resource model is **guarded-affine collapse**
 - the canonical surface is postfix `select(...)`
 - branches are **latent continuations** until one is selected
 - output labels are the canonical arm keys, with unique contract names accepted as fallback keys
@@ -53,7 +54,7 @@ This page therefore does five things:
 - specifies the target semantic model for conditionality
 - specifies the target `select(...)` surface
 - defines latent branches in the target model
-- states the main typing, composition, and budgeting rules
+- states the main typing, composition, resource, and budgeting rules
 - records how the current Cortex implementation realizes a narrower subset today
 
 This page does not repeat the full EBNF for `select(...)`; that lives in [grammar.md](grammar.md).
@@ -81,6 +82,12 @@ It is better understood as:
 - with an exclusive output boundary
 - reduced by `select(...)` into a graph `x'`
 - where `x'` has one actualized continuation path
+
+The resource term for this reduction is **guarded-affine collapse**. Before selection, each arm is a
+guarded continuation: it is validated as a possible future, but it is not live topology. It is
+affine because at most one guarded arm can be promoted for the run. Selection collapses the
+exclusive boundary by promoting the chosen arm into the live linear context and discarding the
+unchosen arms.
 
 This is also why parentheses are natural in branch bodies:
 
@@ -346,6 +353,8 @@ The reduced graph simply continues through the already-correct boundary.
 - **Owner remains** — The anchor stays visible for provenance and lineage.
 - **Latent until selected** — Unselected branches are not eligible under ordinary readiness rules;
   conditionality never lowers to ordinary fan-out.
+- **Guarded-affine resources** — Branch-local boundary obligations are checked under their arm key
+  before selection and become ordinary live obligations only for the selected arm.
 
 ## 8. Typing and Composition
 
@@ -555,19 +564,23 @@ So the current implementation status is:
 This page treats that narrower implementation as a subset of the intended model, not as the final
 shape of the language.
 
-## 11. Gas, Budget, and Provenance
+## 11. Resources, Budget, and Provenance
 
 Three truths should be kept explicit.
 
-### 11.1 The whole branch set should not count by sum
+### 11.1 The whole branch set is guarded-affine, not sum-prepaid
 
-For closed-world latent alternatives, the right intuition is:
+For closed-world latent alternatives, the right resource intuition is:
 
-- branch reserve is `max`, not `sum`
+- branch validation is universal: every arm must be valid if chosen
+- branch execution is exclusive: only one arm can become live
+- branch-local obligations are guarded and affine before selection
 
-because only one branch can actualize.
+That means Cortex should not charge `sum(allBranchCosts)` up front. The current runtime goes one
+step narrower: it does not reserve `max(branchCosts)` either. It charges the selected branch when
+the branch is actualized.
 
-### 11.2 Current runtime does not yet reserve latent capacity
+### 11.2 Current runtime uses selected-cost accounting
 
 Today, selected latent branches still consume ordinary rewrite budget because they are operationally
 realized through `AppendAfter`.
@@ -576,13 +589,16 @@ So current Cortex already gives:
 
 - no “sum of all branches” cost up front
 - truthful latent-branch semantics
+- selected-cost admission through the ordinary durable rewrite path
 
 but does **not yet** give:
 
 - guaranteed reserved capacity for any later-selected branch regardless of prior open rewrites
 
 If Cortex later decides that compiled latent alternatives must be guaranteed, that is an
-architectural choice beyond this chapter and likely ADR-worthy.
+architectural choice beyond this chapter and likely ADR-worthy. That future policy would need to say
+whether it reserves `max(branchCosts)`, reserves per branch family, or changes the rewrite-budget
+algebra.
 
 ### 11.3 Provenance remains attached to the owner
 
@@ -649,6 +665,7 @@ This chapter makes the following commitments unless later superseded:
 7. Shared continuation should usually live outside `select(...)`.
 8. Productive arms converge to a common downstream boundary.
 9. The current Cortex implementation is a narrower subset of this target model.
+10. The current runtime uses selected-cost branch actualization, not reserved latent capacity.
 
 ## 14. Deferred
 
@@ -673,6 +690,12 @@ alongside the accepted grammar.
 - [../rewrites.md](../rewrites.md) — runtime rewrite algebra and current `AppendAfter` realization.
 - [../../ADRs/0007-latent-branch-conditional-lowering.md](../../ADRs/0007-latent-branch-conditional-lowering.md)
   — accepted latent-branch architecture decision.
+- [../../ADRs/0033-wire-select-guarded-affine-collapse.md](../../ADRs/0033-wire-select-guarded-affine-collapse.md)
+  — guarded-affine collapse vocabulary.
+- [../../ADRs/0034-wire-pure-select-actualization-authority.md](../../ADRs/0034-wire-pure-select-actualization-authority.md)
+  — pure selectors and restricted actualization authority.
+- [../../ADRs/0036-wire-latent-branch-budget-recovery.md](../../ADRs/0036-wire-latent-branch-budget-recovery.md)
+  — selected-cost latent branch policy.
 - [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md) — Wire substrate
   architecture.
 - [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md)

--- a/docs/Reference/rewrites.md
+++ b/docs/Reference/rewrites.md
@@ -12,6 +12,10 @@ related:
   - docs/Architecture/07-rewrites-and-materialization.md
   - docs/ADRs/0005-budgeted-rewrite-admission-and-materialization.md
   - docs/ADRs/0009-rewrite-provenance-and-topology-integrity.md
+  - docs/ADRs/0032-wire-boundary-contract-resources.md
+  - docs/ADRs/0034-wire-pure-select-actualization-authority.md
+  - docs/ADRs/0035-wire-rewrite-algebra-forms.md
+  - docs/ADRs/0036-wire-latent-branch-budget-recovery.md
 ---
 
 # Rewrites Reference
@@ -80,6 +84,26 @@ The following constructors are recognized future forms but **not part of the adm
 v1**: `InsertBefore`, `PruneSubgraph`, `AddJoin`, `ReplaceNode`. Introducing any of them requires a
 new ADR and a runtime-version bump.
 
+### 1.4 Boundary laws and runtime constructors
+
+The v1 constructors are operational forms. The conceptual boundary laws are the stable semantic
+vocabulary:
+
+| Boundary law                     | v1 realization                | Contract/resource effect                                                                           |
+| -------------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------- |
+| Contract-preserving substitution | `ExpandNode anchor mode spec` | Consumes one rewrite slot and the anchor boundary; the replacement exposes the consumed boundary.  |
+| Append continuation              | `AppendAfter anchor spec`     | Consumes one rewrite slot while retaining the anchor; the continuation consumes the anchor output. |
+| Conditional branch actualization | `AppendAfter anchor spec`     | When the anchor is a conditional owner, the selected guarded branch becomes live topology.         |
+
+`SelectActualize owner selectedArm` is the compiler/proof vocabulary for the restricted
+actualization capability of a compiled `select(...)`. It is not a v1 `GraphRewrite` constructor and
+is not a separately persisted runtime token. Current runtime materialization records the admitted
+selected branch as an ordinary rewrite row.
+
+Observation/instrumentation is future boundary-law vocabulary only. There is no admitted v1
+constructor for it, and observers must not consume or alter the anchor boundary unless a later ADR
+adds a resource path.
+
 ## 2. Stage-result extension
 
 Stages signal rewrite proposals through a richer `StageResult`:
@@ -134,7 +158,20 @@ The proof contract is the leader here: runtime `RewriteBudget` and `RewriteCost`
 natural-vector shape as the mechanized rewrite-admission model, and runtime validation rejects list
 or JSON shapes that cannot denote the proof-side sets and natural numbers.
 
-### 3.3 Budget visibility
+### 3.3 Selected-cost latent branches
+
+Latent branch families use selected-cost accounting in the current runtime:
+
+- unselected arms do not consume runtime rewrite budget;
+- the selected arm consumes ordinary rewrite budget when actualized;
+- branch actualization is admitted or rejected through the same durable rewrite admission path as
+  other topology changes;
+- the runtime does not yet reserve capacity for every compiled latent arm.
+
+This differs from max-reserved capacity. A future reservation policy would need to say whether it
+reserves `max(branchCosts)`, reserves per branch family, or changes the rewrite-budget algebra.
+
+### 3.4 Budget visibility
 
 Remaining budget is persisted in graph state and surfaced on operator surfaces (run detail, rewrite
 history). Each admitted rewrite records budget-before and budget-after snapshots so operators can
@@ -239,6 +276,10 @@ Pre-watermark rewrite-capable runs are **legacy** and not guaranteed resumable. 
 schema change requires a runtime-version bump (see
 [ADR 0011](./../ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md)).
 
+For selected branches, the admitted selected rewrite is the durable fact replayed by recovery.
+Unselected latent arms remain sealed alternatives in the compiled artifact and are not materialized
+for that run. The current model has no durable "discard branch" event.
+
 ## 6. Hydration
 
 ### 6.1 Keying
@@ -293,6 +334,14 @@ admin-visibility decisions track ([ADR 0008](../ADRs/0008-pulse-operator-visibil
   — provenance and integrity decision.
 - [../ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md](../ADRs/0011-compatibility-barriers-and-fresh-run-recovery.md)
   — watermark version discipline.
+- [../ADRs/0032-wire-boundary-contract-resources.md](../ADRs/0032-wire-boundary-contract-resources.md)
+  — boundary obligations as planning resources.
+- [../ADRs/0034-wire-pure-select-actualization-authority.md](../ADRs/0034-wire-pure-select-actualization-authority.md)
+  — pure selectors and restricted actualization authority.
+- [../ADRs/0035-wire-rewrite-algebra-forms.md](../ADRs/0035-wire-rewrite-algebra-forms.md) —
+  conceptual boundary laws and v1 runtime constructors.
+- [../ADRs/0036-wire-latent-branch-budget-recovery.md](../ADRs/0036-wire-latent-branch-budget-recovery.md)
+  — selected-cost branch actualization and recovery policy.
 
 ---
 

--- a/docs/Roadmap/Plans/rewrite-materialization-and-recovery.md
+++ b/docs/Roadmap/Plans/rewrite-materialization-and-recovery.md
@@ -101,6 +101,11 @@ Recovery should:
 
 This is closer to projection-checkpoint recovery than to raw log replay.
 
+For selected latent branches, the admitted selected rewrite is the recovery fact. Recovery must
+replay that same selected branch and must not materialize unselected branch alternatives. The
+current model has no durable "discard branch" event; unselected arms remain sealed possibilities in
+the compiled artifact rather than becoming runtime state for the run.
+
 ## Rewrite Admission Contract
 
 Admitted rewrites must satisfy explicit structural conditions:
@@ -119,6 +124,12 @@ The current shipped rejection policy is intentionally narrow:
 Configurable fallback or planner-visible rejection handling is future work, not part of the current
 contract.
 
+Conditional branch actualization is a restricted case of the same admission path in the current
+runtime. Conceptually it consumes an owner-bound actualization capability for one sealed branch, but
+v1 materialization persists an ordinary admitted rewrite row for the selected branch. The selected
+branch consumes ordinary rewrite budget at actualization time; unselected branches do not prepay or
+consume budget.
+
 ## Proof Obligations
 
 The plan centers on the new proof burdens:
@@ -128,6 +139,10 @@ The plan centers on the new proof burdens:
 3. hydration safety from persisted template identity back to executable semantics
 4. dataflow preservation for output-preserving rewrite modes
 5. admitted-rewrite-before-termination correctness
+6. selected-branch replay determinism: recovery materializes the same admitted selected branch
+   without making unselected alternatives live
+7. selected-cost budget preservation: only the admitted selected branch consumes runtime rewrite
+   budget, and no sum-prepayment for the latent family is implied
 
 The fixed-topology theorem can be reused only inside a single materialized topology epoch.
 
@@ -161,6 +176,8 @@ The following are explicitly outside the current shipped and theory contract:
 - configurable rewrite rejection fallback instead of fail-fast only
 - richer operator-facing graph visualization and rewrite provenance
 - hierarchical child workflows with explicit sub-budget assignment
+- reserved latent-branch capacity, including max-branch reservation or escrow rules for every
+  compiled branch family
 - integrity witnesses stronger than the current watermark model, such as materialized-graph
   checksums
 
@@ -172,3 +189,7 @@ The following are explicitly outside the current shipped and theory contract:
   — implementation-independent substitution theory.
 - [../../Architecture/07-rewrites-and-materialization.md](../../Architecture/07-rewrites-and-materialization.md)
   — canonical runtime architecture chapter.
+- [../../Reference/Wire/conditionality.md](../../Reference/Wire/conditionality.md) — guarded-affine
+  `select(...)` and selected-cost branch semantics.
+- [../../ADRs/0036-wire-latent-branch-budget-recovery.md](../../ADRs/0036-wire-latent-branch-budget-recovery.md)
+  — current latent-branch budget and recovery policy.


### PR DESCRIPTION
## Summary
Propagate the accepted Wire boundary-resource ADR vocabulary into canonical architecture and reference docs, keeping ADR 0038 as the theorem-target ledger rather than the semantic authority.

## Plan
- [x] Update architecture chapters 03, 05, and 07 with boundary resources, guarded-affine select collapse, actualization authority, rewrite forms, and recovery policy.
- [x] Update Wire reference docs for conditionality, rewrites, and materialization/recovery.
- [x] Run docs validation.

## Checklist
- [x] Implementation complete
- [x] Tests added/updated where relevant (docs-only; validation run)
- [x] `just docs-check` passes locally
- [x] Ready for review

## Issue
Closes #118
