### PR TITLE
ci: harden self-hosted runner usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -31,7 +32,10 @@ env:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: [self-hosted, nix, mercury, cortex]
+    # Pull requests may contain untrusted code, so this workflow keeps PR jobs on
+    # GitHub-hosted runners. Self-hosted Nix jobs below are gated to trusted
+    # push/workflow_dispatch events before runner allocation.
+    runs-on: ubuntu-24.04
     outputs:
       code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
@@ -110,7 +114,7 @@ jobs:
 
   commit-provenance:
     name: Commit Provenance
-    runs-on: [self-hosted, nix, mercury, cortex]
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Restore workspace permissions
@@ -121,17 +125,28 @@ jobs:
         with:
           clean: false
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Check commit provenance
         env:
           BEFORE: ${{ github.event.before }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.clone_url }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             git fetch --no-tags origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
-            RANGE="origin/${GITHUB_BASE_REF}..HEAD"
+            git fetch --no-tags "$PR_HEAD_REPOSITORY" "+refs/heads/${PR_HEAD_REF}:refs/remotes/pr/head"
+
+            actual_head="$(git rev-parse refs/remotes/pr/head)"
+            if [[ "$actual_head" != "$PR_HEAD_SHA" ]]; then
+              echo "PR head moved while checking provenance: expected $PR_HEAD_SHA, got $actual_head" >&2
+              exit 1
+            fi
+
+            RANGE="origin/${GITHUB_BASE_REF}..refs/remotes/pr/head"
           else
             if [[ "${BEFORE:-}" =~ ^0+$ || -z "${BEFORE:-}" ]]; then
               RANGE="$GITHUB_SHA"
@@ -144,7 +159,7 @@ jobs:
 
   repository-merge-policy:
     name: Repository Merge Policy
-    runs-on: [self-hosted, nix, mercury, cortex]
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Restore workspace permissions
@@ -154,16 +169,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Check GitHub merge policy
         env:
           GH_TOKEN: ${{ github.token }}
-        run: nix develop -c scripts/check-github-merge-policy
+        run: python3 scripts/check-github-merge-policy
 
   conventional-commits:
     name: Conventional commits
     if: github.event_name == 'pull_request'
-    runs-on: [self-hosted, nix, mercury, cortex]
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Restore workspace permissions
@@ -182,7 +198,7 @@ jobs:
   conventional-pr-title:
     name: Conventional PR title
     if: github.event_name == 'pull_request'
-    runs-on: [self-hosted, nix, mercury, cortex]
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Restore workspace permissions
@@ -202,7 +218,13 @@ jobs:
     name: Format Check
     runs-on: [self-hosted, nix, mercury, cortex]
     needs: [changes]
-    if: needs.changes.outputs.code != 'false' || needs.changes.outputs.docs != 'false'
+    if: |
+      github.event_name != 'pull_request' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        needs.changes.outputs.code != 'false' ||
+        needs.changes.outputs.docs != 'false'
+      )
     timeout-minutes: 15
     steps:
       - name: Restore workspace permissions
@@ -234,8 +256,10 @@ jobs:
     needs: [changes, format-check]
     if: |
       always() &&
+      github.event_name != 'pull_request' &&
       (needs.format-check.result == 'success' || needs.format-check.result == 'skipped') &&
       (
+        github.event_name == 'workflow_dispatch' ||
         needs.changes.outputs.haskell != 'false' ||
         needs.changes.outputs.theory != 'false' ||
         needs.changes.outputs.editor != 'false' ||
@@ -269,7 +293,7 @@ jobs:
           echo "All supported Cortex outputs built" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Push build outputs to Attic
-        if: success()
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         continue-on-error: true
         env:
           ATTIC_AUTH_TOKEN: ${{ secrets.ATTIC_AUTH_TOKEN }}
@@ -301,8 +325,12 @@ jobs:
     needs: [changes, supported-build]
     if: |
       always() &&
+      github.event_name != 'pull_request' &&
       (needs.supported-build.result == 'success' || needs.supported-build.result == 'skipped') &&
-      needs.changes.outputs.haskell != 'false'
+      (
+        github.event_name == 'workflow_dispatch' ||
+        needs.changes.outputs.haskell != 'false'
+      )
     timeout-minutes: 20
     steps:
       - name: Restore workspace permissions
@@ -331,8 +359,13 @@ jobs:
     needs: [changes, supported-build]
     if: |
       always() &&
+      github.event_name != 'pull_request' &&
       (needs.supported-build.result == 'success' || needs.supported-build.result == 'skipped') &&
-      (needs.changes.outputs.theory != 'false' || needs.changes.outputs.nix != 'false')
+      (
+        github.event_name == 'workflow_dispatch' ||
+        needs.changes.outputs.theory != 'false' ||
+        needs.changes.outputs.nix != 'false'
+      )
     timeout-minutes: 10
     steps:
       - name: Restore workspace permissions
@@ -352,9 +385,14 @@ jobs:
     needs: [changes, supported-build, lean-lint]
     if: |
       always() &&
+      github.event_name != 'pull_request' &&
       (needs.supported-build.result == 'success' || needs.supported-build.result == 'skipped') &&
       (needs.lean-lint.result == 'success' || needs.lean-lint.result == 'skipped') &&
-      (needs.changes.outputs.theory != 'false' || needs.changes.outputs.nix != 'false')
+      (
+        github.event_name == 'workflow_dispatch' ||
+        needs.changes.outputs.theory != 'false' ||
+        needs.changes.outputs.nix != 'false'
+      )
     timeout-minutes: 20
     steps:
       - name: Restore workspace permissions
@@ -374,8 +412,10 @@ jobs:
     needs: [changes, supported-build]
     if: |
       always() &&
+      github.event_name != 'pull_request' &&
       (needs.supported-build.result == 'success' || needs.supported-build.result == 'skipped') &&
       (
+        github.event_name == 'workflow_dispatch' ||
         needs.changes.outputs.haskell != 'false' ||
         needs.changes.outputs.theory != 'false' ||
         needs.changes.outputs.editor != 'false' ||
@@ -417,8 +457,12 @@ jobs:
     needs: [changes, supported-build]
     if: |
       always() &&
+      github.event_name != 'pull_request' &&
       (needs.supported-build.result == 'success' || needs.supported-build.result == 'skipped') &&
-      needs.changes.outputs.haskell != 'false'
+      (
+        github.event_name == 'workflow_dispatch' ||
+        needs.changes.outputs.haskell != 'false'
+      )
     timeout-minutes: 45
     steps:
       - name: Restore workspace permissions
@@ -436,7 +480,13 @@ jobs:
     name: Lint Docs
     runs-on: [self-hosted, nix, mercury, cortex]
     needs: [changes]
-    if: needs.changes.outputs.docs != 'false' || needs.changes.outputs.nix != 'false'
+    if: |
+      github.event_name != 'pull_request' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        needs.changes.outputs.docs != 'false' ||
+        needs.changes.outputs.nix != 'false'
+      )
     timeout-minutes: 10
     steps:
       - name: Restore workspace permissions
@@ -456,8 +506,12 @@ jobs:
     needs: [changes, docs-lint]
     if: |
       always() &&
+      github.event_name != 'pull_request' &&
       (needs.docs-lint.result == 'success' || needs.docs-lint.result == 'skipped') &&
-      needs.changes.outputs.site != 'false'
+      (
+        github.event_name == 'workflow_dispatch' ||
+        needs.changes.outputs.site != 'false'
+      )
     timeout-minutes: 30
     steps:
       - name: Restore workspace permissions
@@ -473,7 +527,7 @@ jobs:
 
   ci-success:
     name: CI Success
-    runs-on: [self-hosted, nix, mercury, cortex]
+    runs-on: ubuntu-24.04
     if: always()
     needs:
       - changes

--- a/docs/Reference/development.md
+++ b/docs/Reference/development.md
@@ -56,6 +56,21 @@ Do not use Linear or a downstream product tracker as active Cortex planning stat
 may retain external issue IDs when they explain past migration context, but new Cortex work belongs
 in this repository's GitHub issue system.
 
+## CI Runner Trust Boundary
+
+Public pull-request workflows are treated as untrusted code. They run only lightweight checks on
+GitHub-hosted runners and must not dispatch arbitrary PR code to private self-hosted runners.
+
+Self-hosted runners such as Mercury are reserved for trusted events: `push` to protected internal
+branches, documentation deployment, cache publication, release work, and explicit
+`workflow_dispatch` runs started by maintainers. Full Nix builds require private flake inputs, so
+maintainers can use the manual CI dispatch path for trusted PR branches after reviewing the code
+that will execute.
+
+If Cortex later adds public pull-request Nix smoke checks, keep them on GitHub-hosted runners and
+install Nix explicitly, for example with the Determinate Nix installer action. Those checks must not
+use repository secrets, private SSH credentials, or private flake inputs.
+
 ## Lean Theory
 
 | Command           | Purpose                                               |


### PR DESCRIPTION
## Summary
Separate public pull-request validation from trusted self-hosted runner execution so untrusted fork code cannot run on private Mercury runners.

## Plan
- [x] Inspect current CI/docs workflows and self-hosted runner labels.
- [x] Move untrusted `pull_request` checks to GitHub-hosted runners or restrict self-hosted jobs to trusted events.
- [x] Keep self-hosted runners for trusted `push`, `workflow_dispatch`, and deployment/cache paths.
- [x] Document the trust boundary in the development workflow docs.
- [x] Validate workflow syntax and local formatting/docs checks.

## Notes
- Public PR metadata checks run on pinned GitHub-hosted `ubuntu-24.04` runners.
- Full Nix jobs remain on `[self-hosted, nix, mercury, cortex]`, but are gated away from `pull_request` before runner allocation.
- Commit provenance and merge-policy jobs run trusted base-branch scripts on PRs; the provenance job fetches the PR head separately and verifies it matches the event SHA.
- Attic cache publication is restricted to successful `push` runs on `main`.
- Future public Nix smoke checks should use a GitHub-hosted runner plus an explicit Nix installer, without secrets or private flake inputs.

## Checklist
- [x] Implementation complete
- [x] Tests added/updated where applicable
- [x] Focused CI checks pass locally
- [x] Ready for review

## Issue
No tracking issue; direct CI hardening follow-up.