### PR TITLE
chore: drop Logos input and publicize platform source

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,16 @@ app/cortex-pulse/         Pulse executor binary
 editors/tree-sitter-wire/ Wire tree-sitter grammar
 theory/                   Lean mechanization scaffold
 docs/                     Published Cortex documentation
-agents/                   Provider-neutral agent context and skills
+nix/agent-*.nix           Cortex-local overlays for external agent context
 ```
 
-Cortex depends on the private upstream `Digimuoto/haskell-platform` repository through the flake.
-The downstream private `Digimuoto/logos` repository is locked as a flake input for migration
-visibility; Logos is not built from this repository. Because these inputs are private SSH Git
-sources, `nix build`, `nix develop`, and flake evaluation require GitHub SSH credentials with read
-access to both repositories until the passive Logos lock is removed.
+Cortex depends on the public `Digimuoto/haskell-platform` repository through the
+`haskell-platform-src` flake input. Logos is a downstream consumer and is not a Cortex flake input,
+package dependency, or exported source snapshot.
+
+Shared agent skills and archetypes are supplied by the public `Digimuoto/agents` flake. Provider
+files such as `AGENTS.md` and `CLAUDE.md` are generated, gitignored symlinks from the local
+`just agent-link-*` commands.
 
 ## License
 

--- a/flake.lock
+++ b/flake.lock
@@ -263,15 +263,15 @@
       "locked": {
         "lastModified": 1777641191,
         "narHash": "sha256-LnEBgrjwr2IP0OA9vR8yVbef7eK8QwnPpFWCm+uBN3U=",
-        "ref": "refs/heads/main",
+        "owner": "Digimuoto",
+        "repo": "haskell-platform",
         "rev": "325efb75fcee214c84af7cd3993009ede6c83a73",
-        "revCount": 43,
-        "type": "git",
-        "url": "ssh://git@github.com/Digimuoto/haskell-platform.git"
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "ssh://git@github.com/Digimuoto/haskell-platform.git"
+        "owner": "Digimuoto",
+        "repo": "haskell-platform",
+        "type": "github"
       }
     },
     "hls": {
@@ -544,22 +544,6 @@
         "type": "github"
       }
     },
-    "logos-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1777486467,
-        "narHash": "sha256-NXhsA2NnE+eaR9kR0ZhFo+8JYPbZ45CSmqrIajcLEyo=",
-        "ref": "refs/heads/main",
-        "rev": "3dd3e26211c0bcd003cdaa3753f7f44fa36c4ed8",
-        "revCount": 1,
-        "type": "git",
-        "url": "ssh://git@github.com/Digimuoto/logos.git"
-      },
-      "original": {
-        "type": "git",
-        "url": "ssh://git@github.com/Digimuoto/logos.git"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1776877367,
@@ -766,11 +750,11 @@
         "tree-sitter-json": "tree-sitter-json"
       },
       "locked": {
-        "lastModified": 1777512366,
-        "narHash": "sha256-LX9WP7JKosuyarH5o9KW50zAHh0Hrqz0ST8jW5/QS0Y=",
+        "lastModified": 1777658993,
+        "narHash": "sha256-eqCdEcutu2dneCez0wMIkhlyt2/Sery1A/Shlmdwoz8=",
         "owner": "Digimuoto",
         "repo": "repo-docs",
-        "rev": "7d648d5c38832603b31bceeab95d6e61edd960b3",
+        "rev": "50cefb4464772c47ae7fe5adaba294452856d6cf",
         "type": "github"
       },
       "original": {
@@ -784,7 +768,6 @@
         "flake-parts": "flake-parts",
         "haskell-nix": "haskell-nix",
         "haskell-platform-src": "haskell-platform-src",
-        "logos-src": "logos-src",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks",
         "repo-docs": "repo-docs",

--- a/flake.nix
+++ b/flake.nix
@@ -32,11 +32,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     haskell-platform-src = {
-      url = "git+ssh://git@github.com/Digimuoto/haskell-platform.git";
-      flake = false;
-    };
-    logos-src = {
-      url = "git+ssh://git@github.com/Digimuoto/logos.git";
+      url = "github:Digimuoto/haskell-platform";
       flake = false;
     };
   };

--- a/nix/agent-root.nix
+++ b/nix/agent-root.nix
@@ -26,10 +26,9 @@ in
 
       - `src/Cortex/` is the main library. Public roots are `Cortex.Algebra`, `Cortex.Wire`,
         `Cortex.Pulse`, `Cortex.Capability`, and `Cortex.Artifact`.
-      - Private upstream `Digimuoto/haskell-platform` provides runtime support through the
+      - Public upstream `Digimuoto/haskell-platform` provides runtime support through the
         `haskell-platform-src` flake input.
-      - Private downstream `Digimuoto/logos` owns reasoning-library code and is locked as
-        `logos-src` for migration visibility.
+      - Downstream `Logos` owns reasoning-library code and consumes Cortex as a separate package.
       - `app/cortex-pulse/` is the substrate shell executable.
       - `editors/tree-sitter-wire/` is the Wire grammar used by docs and editors.
       - `theory/` is the Lean proof track.
@@ -74,8 +73,7 @@ in
       Non-goals: no downstream product code, no frontend or REST server, and no consumer-specific
       docs in Cortex canon unless the page is explicitly about downstream integration examples.
 
-      Private flake inputs use SSH Git URLs, so flake evaluation requires GitHub SSH credentials
-      with read access to `Digimuoto/haskell-platform` and `Digimuoto/logos`.
+      Cortex flake evaluation does not require access to downstream consumer repositories.
 
       Project-specific skills remain local for Cortex-only surfaces: Haskell style, Lean proof style,
       theorem attack, architecture, document review, and research synthesis.

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -85,12 +85,9 @@
       cortex-pulse = projectFlake.packages."cortex:exe:cortex-pulse" or null;
       # Test suite (built, not run — `nix run .#cortex-tests` to execute).
       cortex-tests = projectFlake.packages."cortex:test:cortex-test" or null;
-      # Locked upstream source snapshots for downstream migration visibility.
+      # Locked upstream source snapshot for dependency visibility.
       haskell-platform-source = pkgs.runCommand "haskell-platform-source" {} ''
         ln -s ${inputs.haskell-platform-src.outPath} "$out"
-      '';
-      logos-source = pkgs.runCommand "logos-source" {} ''
-        ln -s ${inputs.logos-src.outPath} "$out"
       '';
     };
 


### PR DESCRIPTION
## Summary
Remove the stale Logos flake input/export from Cortex and update the haskell-platform source input now that it is public. Also include the current repo-docs flake bump already needed by this branch.

## Plan
- [x] Remove `logos-src` from `flake.nix` and `flake.lock`.
- [x] Stop exporting `packages.logos-source`.
- [x] Change `haskell-platform-src` from SSH Git to public GitHub URL.
- [x] Include the repo-docs lock bump to `50cefb4`.
- [x] Update repo-local agent/docs references that describe private flake input requirements.
- [x] Validate flake evaluation/build surfaces.

## Notes
- `nix flake metadata` shows no `logos-src` root input.
- `haskell-platform-src` now locks as `github:Digimuoto/haskell-platform` at the same platform commit as before.
- `repo-docs` is bumped from `7d648d5` to `50cefb4`.
- Cortex still has the `check-logos-boundary` CI helper; that is an import-boundary check, not a Logos source export.

## Validation
- [x] `nix flake metadata --json`
- [x] `nix eval --json .#packages.x86_64-linux --apply builtins.attrNames`
- [x] `nix build .#haskell-platform-source --no-link --print-build-logs`
- [x] `just fmt-check`
- [x] `just docs-check`
- [x] `just check`
- [x] `just check-commit-provenance origin/main..HEAD`

## Checklist
- [x] Implementation complete
- [x] Tests/checks updated where applicable
- [x] Focused Nix/docs checks pass locally
- [x] Ready for review

## Issue
No tracking issue; dependency cleanup requested directly.