### PR TITLE
docs: sketch Cortex usage guide

### DIFF
--- a/docs/Architecture/index.md
+++ b/docs/Architecture/index.md
@@ -10,8 +10,11 @@ sidebar:
 
 # Cortex Architecture
 
-Canonical chapters. Enumerated `NN-` for reading order. Each chapter explains how the system fits
-together at its layer and what its design commitments are.
+Canonical explanation chapters. Enumerated `NN-` for reading order. Each chapter explains how the
+system fits together at its layer and what its design commitments are.
+
+If you are trying to build, run, or deploy Cortex before reading the design story, start with
+[Usage/](../Usage/) instead.
 
 ## Reading paths
 
@@ -46,6 +49,7 @@ needed.
 ## Related
 
 - [../Reference/](../Reference/) — normative specs.
+- [../Usage/](../Usage/) — practical guide for building, running, and deploying.
 - [../ADRs/](../ADRs/) — decision records.
 - [../Consumers/Logos/](../Consumers/Logos/) — downstream reasoning-library docs built on Cortex.
 - [../Roadmap/](../Roadmap/) — active engineering work.

--- a/docs/Reference/index.md
+++ b/docs/Reference/index.md
@@ -9,7 +9,8 @@ sidebar:
 # Cortex Reference
 
 Consultable material. Designed to be jumped into for a specific rule or workflow rather than read
-front-to-back.
+front-to-back. If you are trying to do a task rather than look up a rule, start with
+[Usage/](../Usage/).
 
 ## Contents
 
@@ -44,5 +45,6 @@ architecture book for context.
 ## Related
 
 - [../Architecture/](../Architecture/) — canonical architecture chapters.
+- [../Usage/](../Usage/) — practical user guide.
 - [../glossary.md](../glossary.md) — quick-reference term lookup.
 - [../taxonomy.md](../taxonomy.md) — conceptual classification.

--- a/docs/Usage/01-quickstart.md
+++ b/docs/Usage/01-quickstart.md
@@ -1,0 +1,73 @@
+---
+title: Quickstart
+description: Build Cortex, inspect the Pulse executable, and find the next working step.
+sidebar:
+  label: 01. Quickstart
+  order: 1
+---
+
+# Quickstart
+
+This page gets you from a checkout to the main Cortex surfaces. It does not assume you know the
+architecture yet.
+
+## Prerequisites
+
+Cortex builds through Nix. Use the repository `just` commands rather than calling Cabal or GHC
+directly.
+
+```bash
+just --list
+```
+
+The common development checks are:
+
+```bash
+just build
+just build-pulse
+just test
+just docs-check
+```
+
+## Build The Library
+
+```bash
+just build
+```
+
+This builds the Cortex Haskell library: Algebra, Wire, Pulse, and Capability.
+
+## Build The Pulse Binary
+
+```bash
+just build-pulse
+```
+
+The `cortex-pulse` executable is the substrate runtime shell. It starts Pulse with an empty task
+registry. That is intentional: Cortex does not ship downstream tasks, model providers, or host
+tools.
+
+Inspect its runtime options:
+
+```bash
+./result/bin/cortex-pulse --help
+```
+
+`nix run .#cortex-pulse -- --help` also works and rebuilds the flake output if needed.
+
+## Understand The Boundary
+
+For a useful run, a consumer binary must provide:
+
+- a task registry
+- a Postgres database
+- secret files for runner tokens and service credentials
+- task definitions or compiled circuits inserted through the host integration path
+
+The rest of this Usage chapter sketches those pieces in order.
+
+## Next Step
+
+If you are trying to author workflows, read [Your first Wire workflow](02-first-wire-workflow.md).
+
+If you are trying to operate the runtime, read [Running Pulse](03-running-pulse.md).

--- a/docs/Usage/02-first-wire-workflow.md
+++ b/docs/Usage/02-first-wire-workflow.md
@@ -1,0 +1,89 @@
+---
+title: Your First Wire Workflow
+description: A gentle first-pass tour of Wire source shape without the full language reference.
+sidebar:
+  label: 02. First Wire workflow
+  order: 2
+---
+
+# Your First Wire Workflow
+
+Wire describes a graph of typed node boundaries. Each node says what it consumes, what it produces,
+and which registered executor or pure body implements it.
+
+The smallest useful mental model is:
+
+```text
+contract declarations
+node declarations
+edges between node ports
+```
+
+## A Tiny Workflow
+
+```wire
+contract Topic;
+contract Outline;
+contract Result;
+
+node plan
+  <- topic: Topic ;
+  -> outline: Outline = @workflow.plan (topic) ;
+
+node run
+  <- outline: Outline ;
+  -> result: Result = @workflow.execute (outline) ;
+
+plan => run
+```
+
+This source says:
+
+- `Topic`, `Outline`, and `Result` are named contracts.
+- `plan` consumes a `Topic` and produces an `Outline`.
+- `run` consumes an `Outline` and produces a `Result`.
+- `@workflow.plan` and `@workflow.execute` are executor references supplied by a registry.
+- `plan => run` connects compatible boundaries.
+
+## What Wire Does Not Do
+
+Wire does not invent executor implementations. The leading `@` is the authority boundary: the name
+must be registered by the host or consumer library.
+
+Wire also does not run the workflow directly. It compiles source into a circuit artifact. Pulse runs
+the materialized circuit.
+
+## Compiling From Haskell
+
+The current public surface is the Haskell API:
+
+```haskell
+import Data.Text (Text)
+
+import Cortex.Wire
+
+compileExample :: Text -> Either WireError CompiledCircuit
+compileExample =
+  compileWireTextWithEnv emptyWireCompileEnv
+```
+
+The empty environment is useful for loose examples and early exploration. Most real consumers
+construct a strict `WireCompileEnv` with their contract and executor registries before compiling:
+
+```haskell
+env :: WireCompileEnv
+env =
+  strictWireCompileEnv executorRegistry contractRegistry
+```
+
+The registries are consumer-owned values. A production environment should be strict about the
+registered alphabet it accepts.
+
+## Where To Look Up Syntax
+
+This page is a teaching sketch. Use the reference pages when you need exact rules:
+
+- [Wire grammar](../Reference/Wire/grammar.md)
+- [Contracts, ports, and matching](../Reference/Wire/contracts-ports-and-matching.md)
+- [Executors and alphabet](../Reference/Wire/executors-and-alphabet.md)
+- [Pure execution](../Reference/Wire/pure-execution.md)

--- a/docs/Usage/03-running-pulse.md
+++ b/docs/Usage/03-running-pulse.md
@@ -1,0 +1,65 @@
+---
+title: Running Pulse
+description:
+  Runtime inputs, database expectations, and what the stock Pulse shell can and cannot run.
+sidebar:
+  label: 03. Running Pulse
+  order: 3
+---
+
+# Running Pulse
+
+Pulse is the durable runtime for compiled circuits. It stores task definitions, runs, stage state,
+events, checkpoints, signals, and recovery metadata in Postgres.
+
+## Runtime Inputs
+
+A Pulse process needs:
+
+| Input                       | CLI or source                                                            | Purpose                                                                |
+| --------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| Postgres connection         | `--db-host`, `--db-port`, `--db-user`, `--db-name`, `--db-password-file` | Stores task definitions, runs, checkpoints, signals, and event logs.   |
+| Lease owner                 | `--lease-owner`                                                          | Identifies the logical Pulse instance that owns active work.           |
+| JWT signing secret          | `--jwt-secret-file`                                                      | Mints runner tokens for host calls.                                    |
+| Service credential          | `--service-credential-file`                                              | Authenticates internal Pulse-to-host actions.                          |
+| Task registry               | Haskell value passed to `runPulse`                                       | Maps task kinds to Haskell executors.                                  |
+| Host API URL                | `--api-url`                                                              | Endpoint Pulse calls when a task runner needs host-owned side effects. |
+| Hot-loadable workflow input | `--workflow-dir`                                                         | Optional directory containing hot-loadable `.cr` workflows.            |
+
+The stock `cortex-pulse` binary supplies an empty task registry. Use it to inspect runtime
+configuration and health wiring; use a consumer-bound binary for real task execution.
+
+## Start The Shell
+
+The executable requires a JWT secret file. Database password and service credential files are
+optional at the CLI level, but real deployments should provide them through files or equivalent
+secret mounts.
+
+```bash
+printf 'dev-jwt-secret' > /tmp/cortex-jwt-secret
+
+nix run .#cortex-pulse -- \
+  --db-host localhost \
+  --db-port 5432 \
+  --db-user cortex \
+  --db-name cortex \
+  --jwt-secret-file /tmp/cortex-jwt-secret \
+  --health-port 9090
+```
+
+For a useful run, replace this shell with a binary that calls `Cortex.Pulse.runPulse` with a
+non-empty registry.
+
+## What Pulse Records
+
+Pulse is intentionally observable. A run leaves behind:
+
+- current graph state
+- stage attempts
+- checkpoint envelopes
+- run events
+- signal waits and deliveries
+- final outcome
+
+Use [Pulse schema](../Reference/Pulse/schema.md), [events](../Reference/Pulse/events.md), and
+[signals](../Reference/Pulse/signals.md) for exact storage and event semantics.

--- a/docs/Usage/04-deploying-pulse.md
+++ b/docs/Usage/04-deploying-pulse.md
@@ -1,0 +1,57 @@
+---
+title: Deploying Pulse
+description: First-pass deployment checklist for a consumer-bound Pulse runtime.
+sidebar:
+  label: 04. Deploying Pulse
+  order: 4
+---
+
+# Deploying Pulse
+
+Production Pulse deployments are consumer-bound. Cortex supplies the runtime library and substrate
+shell; your application supplies the registry, secrets, host API, and operational policy.
+
+## Deployment Checklist
+
+1. Build a consumer binary that imports Cortex and passes a populated task registry to
+   `Cortex.Pulse.runPulse`.
+2. Provision Postgres and apply the Cortex schema expected by the running version. See
+   [Pulse schema](../Reference/Pulse/schema.md).
+3. Mount secret files for JWT signing and service credentials.
+4. Set a stable `--lease-owner` for each logical runtime instance.
+5. Configure concurrency:
+   - `--max-concurrent-tasks`
+   - `--max-frontier-concurrency`
+   - repeated `--task-type-max-concurrent TYPE=N`
+6. Expose the health endpoint.
+7. Connect observability according to the platform runtime environment.
+8. Decide how task definitions and compiled circuits enter the database.
+
+Rule of thumb: `--max-concurrent-tasks` caps the whole worker, `--max-frontier-concurrency` caps one
+run's active frontier, and `--task-type-max-concurrent` is a repeatable per-task-type override.
+
+## Runtime Shape
+
+```text
+consumer binary
+  imports Cortex.Pulse
+  provides task registry
+  reads PulseConfig
+  starts runPulse
+
+Postgres
+  stores task definitions, runs, checkpoints, signals, and events
+
+host API
+  owns side effects and product policy
+```
+
+## Operational Notes
+
+- Keep `lease-owner` stable across restarts of the same logical worker so startup recovery can
+  reclaim owned runs.
+- Use distinct lease owners for independent workers.
+- Keep host actions idempotent where Pulse may retry or resume work.
+- Treat the database as the durable source of runtime truth.
+
+The detailed runtime contract lives in [Pulse reference](../Reference/Pulse/).

--- a/docs/Usage/05-integrating-from-haskell.md
+++ b/docs/Usage/05-integrating-from-haskell.md
@@ -1,0 +1,65 @@
+---
+title: Integrating From Haskell
+description: Minimal shape of a Haskell consumer that compiles Wire and runs Pulse.
+sidebar:
+  label: 05. Integrating from Haskell
+  order: 5
+---
+
+# Integrating From Haskell
+
+A Haskell consumer typically uses Cortex in two places:
+
+1. Compile Wire source with a strict contract and executor registry.
+2. Run Pulse with a task registry that interprets admitted task kinds.
+
+## Wire Compilation
+
+Use `Cortex.Wire` to compile source text or parsed files:
+
+```haskell
+import Data.Text (Text)
+
+import Cortex.Wire
+
+compileWorkflow
+  :: WireExecutorRegistry
+  -> WireContractRegistry
+  -> Text
+  -> Either WireError CompiledCircuit
+compileWorkflow executorRegistry contractRegistry =
+  compileWireTextWithEnv (strictWireCompileEnv executorRegistry contractRegistry)
+```
+
+The important production choice is the `WireCompileEnv`. It is where the host decides which
+contracts and executor names are valid. `executorRegistry` and `contractRegistry` are consumer-owned
+values built through Cortex.Wire's executor and contract registry surface.
+
+## Pulse Runtime
+
+Use `Cortex.Pulse` to start the runtime:
+
+```haskell
+import Cortex.Pulse
+import Cortex.Pulse.Types
+
+main :: IO ()
+main = do
+  config <- loadConfig
+  registry <- loadTaskRegistry
+  runPulse registry config
+```
+
+`loadConfig` and `loadTaskRegistry` are consumer-owned. Cortex ships the runtime entrypoint, not a
+domain-specific registry or configuration loader.
+
+The stock `app/cortex-pulse` executable does the same thing with an empty registry. A consumer
+binary uses the same substrate entrypoint with real task definitions.
+
+## Boundary Rule
+
+Cortex should stay provider-neutral. Put model clients, product tools, document renderers, and
+domain policies in the consumer library. Register only the executor authority Cortex needs to
+compile and run the graph.
+
+See [Consumers/](../Consumers/) for downstream binding examples.

--- a/docs/Usage/06-troubleshooting.md
+++ b/docs/Usage/06-troubleshooting.md
@@ -1,0 +1,75 @@
+---
+title: Troubleshooting
+description: First-pass map from common usage symptoms to the right Cortex reference surface.
+sidebar:
+  label: 06. Troubleshooting
+  order: 6
+---
+
+# Troubleshooting
+
+This page maps common symptoms to the part of Cortex that owns the answer.
+
+## The Wire File Does Not Parse
+
+Check the exact grammar first:
+
+- [Wire grammar](../Reference/Wire/grammar.md)
+- [Modules, imports, and file returns](../Reference/Wire/modules-imports-and-file-returns.md)
+
+The parser error should tell you where syntax stopped matching. If the source parses but does not
+compile, move to the next section.
+
+## The Wire File Parses But Does Not Compile
+
+Common causes:
+
+- an executor name is not in the registry
+- a contract name is not declared or registered
+- a required singular input is not connected
+- output ports do not match downstream input requirements
+- a pure expression references a name outside its scope
+
+Relevant references:
+
+- [Contracts, ports, and matching](../Reference/Wire/contracts-ports-and-matching.md)
+- [Executors and alphabet](../Reference/Wire/executors-and-alphabet.md)
+- [Configured executors](../Reference/Wire/configured-executors-and-execution-boundary.md)
+- [Pure execution](../Reference/Wire/pure-execution.md)
+
+## Pulse Starts But Does No Useful Work
+
+The stock `cortex-pulse` binary has an empty task registry. If the process is healthy but no task
+kinds can run, confirm that you are using a consumer binary that passes a populated registry to
+`runPulse`.
+
+Also check:
+
+- database connection settings
+- `--lease-owner`
+- task definition rows
+- scheduler polling interval (`--poll-interval`)
+- per-task-type concurrency limits
+
+## A Run Is Waiting
+
+Waiting is usually explicit. Check signal state and host delivery:
+
+- [Signals](../Reference/Pulse/signals.md)
+- [Host actions](../Reference/Pulse/host-actions.md)
+- [Events](../Reference/Pulse/events.md)
+
+## A Run Fails During Resume
+
+Resume failures usually indicate a persisted state or compatibility problem. Check:
+
+- checkpoint envelope version
+- graph state consistency
+- task definition availability
+- executor registry compatibility
+
+Relevant references:
+
+- [Pulse schema](../Reference/Pulse/schema.md)
+- [Pulse types](../Reference/Pulse/types.md)
+- [Pulse events](../Reference/Pulse/events.md)

--- a/docs/Usage/index.md
+++ b/docs/Usage/index.md
@@ -1,0 +1,67 @@
+---
+title: Cortex Usage Guide
+description:
+  Practical guide for installing Cortex, writing a first Wire workflow, running Pulse, and deploying
+  a consumer-bound runtime.
+sidebar:
+  label: Usage
+  order: 1
+---
+
+# Cortex Usage Guide
+
+This chapter is for people who want to use Cortex before they study its architecture.
+
+Cortex has three practical jobs:
+
+1. Write workflow topology in Wire.
+2. Bind that topology to registered executors.
+3. Run the compiled circuit with Pulse.
+
+You do not need the graph algebra or Lean proof story to start. Those explain why the substrate is
+shaped the way it is. This guide starts with the working path and links to the deeper material only
+when it matters.
+
+## The Working Model
+
+```text
+.wire source
+  -> compiled circuit
+  -> Pulse task definition
+  -> durable run state
+  -> events, outputs, checkpoints, and provenance
+```
+
+Wire is the authoring language. Pulse is the durable runtime. A host or consumer library provides
+the executor registry that gives node bodies their authority.
+
+The stock `cortex-pulse` binary is intentionally a substrate shell with an empty task registry. It
+is useful for checking the runtime surface and health behavior. Real deployments usually link Cortex
+from a consumer repo and pass a populated registry to `Cortex.Pulse.runPulse`.
+
+## Reading Path
+
+| If you want to...                    | Start with                                                 |
+| ------------------------------------ | ---------------------------------------------------------- |
+| Build the repo and see the surfaces  | [Quickstart](01-quickstart.md)                             |
+| Understand the shape of a Wire file  | [Your first Wire workflow](02-first-wire-workflow.md)      |
+| Learn what Pulse needs at runtime    | [Running Pulse](03-running-pulse.md)                       |
+| Prepare an operator-facing service   | [Deploying Pulse](04-deploying-pulse.md)                   |
+| Embed Cortex in another Haskell repo | [Integrating from Haskell](05-integrating-from-haskell.md) |
+| Diagnose common failures             | [Troubleshooting](06-troubleshooting.md)                   |
+| Look up exact syntax or schemas      | [Reference](../Reference/)                                 |
+| Understand the design commitments    | [Architecture overview](../Architecture/01-overview.md)    |
+
+## What This First Pass Covers
+
+This Usage chapter is intentionally a light working guide. It deliberately avoids becoming the Wire
+book. Writing Wire deserves its own teaching sequence because the language has nodes, ports,
+contracts, CorePure expressions, executor authority, configured executor values, signals, and
+rewrites. The Usage chapter should teach the shortest operational path; the Wire book should teach
+the language properly.
+
+## Related
+
+- [../Reference/](../Reference/) - exact rules and schemas.
+- [../Architecture/](../Architecture/) - why the substrate is designed this way.
+- [../Consumers/](../Consumers/) - examples of downstream bindings.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,9 +10,9 @@ sidebar:
 
 # Cortex Documentation
 
-Cortex is a standalone Haskell substrate for graph-shaped durable workflows. It gives you algebraic
-topology, a small language for authoring workflows, a durable runtime for executing them, and
-value-provenance surfaces for explaining what happened.
+Cortex is a standalone Haskell substrate for graph-shaped durable workflows. It gives you a small
+language for authoring workflows, a durable runtime for executing them, and value-provenance
+surfaces for explaining what happened.
 
 The boundary is deliberate: Cortex owns reusable mechanics; downstream products own domain
 semantics, policy, tools, operators, transport, and persistence.
@@ -89,6 +89,15 @@ flowchart LR
     P --> A[Artifacts + provenance]
 ```
 
+## If You Just Want To Use It
+
+Start with [Usage/](Usage/). It is the practical guide: build Cortex, inspect the Pulse runtime,
+write a first Wire workflow, deploy a consumer-bound Pulse binary, and find the right
+troubleshooting surface.
+
+The architecture chapters explain why Cortex is designed this way. The reference pages state exact
+rules. Usage should be the first stop when the question is "what do I do next?"
+
 ## Architectural Ideas
 
 - **Algebraic topology is the semantic object.** Cortex treats graph structure as execution
@@ -104,21 +113,23 @@ flowchart LR
 
 ## Read First
 
-1. **[Architecture overview](Architecture/01-overview.md)** - system frame and ownership boundary.
-2. **[Ownership and boundaries](Architecture/02-ownership-and-boundaries.md)** - what belongs in
+1. **[Usage guide](Usage/)** - practical path for building, authoring, running, and deploying.
+2. **[Architecture overview](Architecture/01-overview.md)** - system frame and ownership boundary.
+3. **[Ownership and boundaries](Architecture/02-ownership-and-boundaries.md)** - what belongs in
    Cortex versus a downstream product.
-3. **[Wire language](Architecture/05-wire-language.md)** - how source programs describe executable
+4. **[Wire language](Architecture/05-wire-language.md)** - how source programs describe executable
    topology.
-4. **[Wire grammar](Reference/Wire/grammar.md)** - the normative language surface.
-5. **[Pulse runtime](Architecture/06-pulse-runtime.md)** - durable execution, events, signals,
+5. **[Wire grammar](Reference/Wire/grammar.md)** - the normative language surface.
+6. **[Pulse runtime](Architecture/06-pulse-runtime.md)** - durable execution, events, signals,
    retries, and host actions.
-6. **[Rewrites and materialization](Architecture/07-rewrites-and-materialization.md)** - controlled
+7. **[Rewrites and materialization](Architecture/07-rewrites-and-materialization.md)** - controlled
    topology evolution.
-7. **[Artifacts and provenance](Architecture/08-artifacts-and-provenance.md)** - structured outputs
+8. **[Artifacts and provenance](Architecture/08-artifacts-and-provenance.md)** - structured outputs
    and explanation.
 
 ## Explore The Canon
 
+- **[Usage/](Usage/)** - practical guide for using Cortex.
 - **[Architecture/](Architecture/)** - conceptual chapters for the substrate.
 - **[Reference/](Reference/)** - normative specifications for Wire, Pulse, rewrites, terminology,
   and contributor workflow.

--- a/docs/map.md
+++ b/docs/map.md
@@ -15,6 +15,7 @@ here.
 
 | Kind                           | Where                                      | Lifetime                              | Dated? |
 | ------------------------------ | ------------------------------------------ | ------------------------------------- | ------ |
+| Usage guide                    | [Usage/](Usage/)                           | Long-term canon                       | No     |
 | Canonical architecture chapter | [Architecture/](Architecture/)             | Long-term canon                       | No     |
 | Normative specification        | [Reference/](Reference/)                   | Long-term canon                       | No     |
 | Code style guide               | [Style.md](Style.md)                       | Long-term canon                       | No     |
@@ -37,6 +38,10 @@ here.
 
 **Where do I write up the Wire grammar surface?** Use `Reference/Wire/`. Canonical language rules
 live in reference docs, not research notes.
+
+**Where do I explain how to use Cortex?** Use `Usage/`. Usage pages should lead with working paths,
+commands, and decision points. Link to `Architecture/` for rationale and `Reference/` for exact
+rules.
 
 **Where do I document runtime architecture?** Use `Architecture/06-pulse-runtime.md` for the stable
 model and `Architecture/07-rewrites-and-materialization.md` for topology evolution.

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -108,11 +108,11 @@ contracts, ports, templates, prompts, memory presets, and evaluation policy.
 
 Docs are classified on two axes:
 
-|                         | Stable canon                             | Dated artifacts   |
-| ----------------------- | ---------------------------------------- | ----------------- |
-| **Canonical authority** | `Architecture/`, `Reference/`, `ADRs/`   | none              |
-| **Project working**     | `Roadmap/Epics/`, `Roadmap/Plans/`       | `Research-notes/` |
-| **Historical**          | `Roadmap/Completed/`, `Roadmap/Archive/` | `Experiments/`    |
+|                         | Stable canon                                     | Dated artifacts   |
+| ----------------------- | ------------------------------------------------ | ----------------- |
+| **Canonical authority** | `Usage/`, `Architecture/`, `Reference/`, `ADRs/` | none              |
+| **Project working**     | `Roadmap/Epics/`, `Roadmap/Plans/`               | `Research-notes/` |
+| **Historical**          | `Roadmap/Completed/`, `Roadmap/Archive/`         | `Experiments/`    |
 
 Cross-cutting canon: `Templates/`, `index.md`, `map.md`, `glossary.md`, `taxonomy.md`
 Consumer-specific: `Consumers/{consumer}.md`, or `Consumers/{consumer}/` for a larger public binding

--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -43,6 +43,7 @@
           # folder order. Nested sections mostly carry their own numbered or
           # frontmatter order.
           topLevelOrder = [
+            "Usage"
             "Architecture"
             "Reference"
             "ADRs"


### PR DESCRIPTION
## Summary
Adds the first-pass `Usage/` chapter so people who want to use Cortex have a practical path before they enter architecture or reference material.

## Scope
- Add `docs/Usage/` with quickstart, first Wire workflow, running Pulse, deployment, Haskell integration, and troubleshooting pages.
- Put Usage before Architecture in docs navigation.
- Update the docs landing page, map, taxonomy, Architecture index, and Reference index to route readers by intent.

## Validation
- [x] `git diff --check`
- [x] `just fmt-check`
- [x] `just docs-lint`
- [x] `just docs-check`
- [x] `just check-commit-provenance origin/main..HEAD`

## Follow-up
This PR intentionally sketches only the Usage chapter. A separate Wire Book can teach the language chapter-by-chapter without overloading Usage or Reference.