### PR TITLE
feat(wire): add CorePure JSON parsing

### DIFF
--- a/docs/ADRs/0029-corepure-structured-serialization.md
+++ b/docs/ADRs/0029-corepure-structured-serialization.md
@@ -45,10 +45,11 @@ deterministic serialization primitive.
 
 ## Decision
 
-CorePure should add one structured serialization primitive:
+CorePure should add two structured serialization primitives:
 
 ```text
 toJson : JsonSerializable -> String
+fromJson : String -> JsonValue
 ```
 
 `JsonSerializable` is the recursive subset of CorePure values that can be represented as JSON:
@@ -89,10 +90,14 @@ String interpolation remains scalar-only. Authors serialize structured values ex
 This is a serialization function, not a schema validator. It does not check that a value satisfies a
 Wire contract. Contract validation remains a Wire/runtime boundary concern.
 
+`fromJson` accepts standard JSON text and returns the corresponding CorePure JSON value. It is a
+parser, not a contract validator: malformed JSON is a typed pure failure, and valid JSON still needs
+any contract checks required by a later boundary.
+
 ### Budget And Failures
 
-Serialization is budgeted. Cost must account for traversal and emitted output size. Budget
-exhaustion is a typed CorePure failure under ADR 0026.
+Serialization and parsing are budgeted. Cost must account for traversal and emitted or consumed text
+size. Budget exhaustion is a typed CorePure failure under ADR 0026.
 
 Serializing a non-serializable value is a typed CorePure failure. Because `toJson` is ordinary
 CorePure, the failure occurs during elaboration when the argument is statically known and during
@@ -131,7 +136,7 @@ renderers can be proposed later as explicit closed stdlib additions.
 
 ### Obligations
 
-- Add `toJson` to the closed CorePure stdlib.
+- Add `toJson` and `fromJson` to the closed CorePure stdlib.
 - Add canonical JSON golden tests for key ordering, escaping, nesting, and numbers.
 - Add typed failure tests for lambdas and non-serializable future values.
 - Add budget tests based on traversal and output size.

--- a/docs/Reference/Wire/grammar.md
+++ b/docs/Reference/Wire/grammar.md
@@ -359,7 +359,7 @@ The closed builtin environment is:
 
 ```text
 map filter fmap zip zipWith length sum min max abs clamp all any
-concat toString joinWith toJson
+concat toString joinWith toJson fromJson
 ```
 
 Stdlib functions intended for piping are data-last. `zip` and `zipWith` take the piped list as their
@@ -376,8 +376,12 @@ Interpolation desugars to `concat [...]` with `toString` on each interpolated ex
 (`String`, `Number`, `Bool`) stringify directly. Structured values require explicit serialization,
 usually `toJson`.
 
-`toJson` emits canonical compact JSON with lexicographic object keys. It is deterministic and
-intended for text/config construction, not host authority.
+`toJson` emits canonical compact JSON with lexicographic object keys. `fromJson` parses a JSON
+string back into a structured CorePure value. Both are deterministic and intended for text/config
+construction, not host authority.
+
+Division uses finite `Float64` semantics rather than exact rational or `Scientific` quotient
+construction. Division by zero and non-finite float results are typed CorePure failures.
 
 ## 9. Imports And File Returns
 

--- a/docs/Reference/Wire/pure-execution.md
+++ b/docs/Reference/Wire/pure-execution.md
@@ -207,6 +207,10 @@ Implemented expression forms:
 - `if ... then ... else ...`;
 - string interpolation: `"Score: ${item.score}"`.
 
+`/` uses finite `Float64` division over numeric values. It never constructs an exact rational or
+`Scientific` quotient, so quotients such as `1 / 3` round to a finite float instead of forcing
+non-terminating decimal construction.
+
 Disallowed:
 
 - `@` executor applications;
@@ -238,6 +242,7 @@ The implemented builtin environment is closed:
 | `toString` | 1     | Converts strings, numbers, and booleans to strings.                  |
 | `joinWith` | 2     | Joins an array of strings with a separator; separator first.         |
 | `toJson`   | 1     | Canonical compact JSON serialization for structured values.          |
+| `fromJson` | 1     | Parses a JSON string into a structured CorePure value.               |
 
 Every builtin is ordinary CorePure function application. Builtins do not receive host authority.
 Functions intended for pipe use are data-last.
@@ -248,6 +253,7 @@ Pure execution fails deterministically. The evaluator reports typed failures, in
 
 - missing variables;
 - division by zero;
+- non-finite float division;
 - unsupported pure input ports;
 - repeated same-contract input ports without explicit labels;
 - missing or ambiguous input values;
@@ -260,6 +266,7 @@ Pure execution fails deterministically. The evaluator reports typed failures, in
 - function arity mismatches;
 - duplicate binding names within one scope;
 - duplicate lambda parameters.
+- invalid JSON passed to `fromJson`;
 - `where` expressions that do not evaluate to records.
 
 These failures are runtime pure-task failures after the graph has been admitted. Source and binding

--- a/src/Cortex/Wire/Pure.hs
+++ b/src/Cortex/Wire/Pure.hs
@@ -54,6 +54,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Data.Vector qualified as Vector
 import GHC.Generics (Generic)
 
@@ -82,6 +83,7 @@ import Cortex.Wire.Value (WirePayloadKind (..), WireValue (..), renderWirePayloa
 data PureEvalError
   = PureMissingVariable !Text
   | PureDivisionByZero
+  | PureNonFiniteFloatDivision !PureNonFiniteFloatDivisionOperands
   | PureInputPortUnsupported !Text !Text
   | PureInputPortRequiresLabel !Text !Text
   | PureInputPortMissing !Text !Text
@@ -97,11 +99,18 @@ data PureEvalError
   | PureDuplicateBinding !Text
   | PureDuplicateLambdaParam !Text
   | PureDuplicateRecordFieldPath ![Text] ![Text]
+  | PureJsonParseError !Text
   | PureWhereExpectedRecord !Text
   | PureStaticFieldSetUndeterminable
   | PureStaticBindingCycle !Text
   | PureStaticLetShadowsStatic !Text
   deriving stock (Eq, Show, Generic)
+
+data PureNonFiniteFloatDivisionOperands = PureNonFiniteFloatDivisionOperands
+  { pnffNumerator :: !Text
+  , pnffDenominator :: !Text
+  }
+  deriving stock (Eq, Show)
 
 data CorePureBuiltinAuthority
   = CorePureBuiltinPureValue
@@ -141,6 +150,12 @@ renderPureEvalError = \case
     "Pure expression references missing variable " <> variableName <> "."
   PureDivisionByZero ->
     "Pure expression attempted division by zero."
+  PureNonFiniteFloatDivision PureNonFiniteFloatDivisionOperands {pnffNumerator, pnffDenominator} ->
+    "Pure expression attempted finite Float64 division outside finite range: "
+      <> pnffNumerator
+      <> " / "
+      <> pnffDenominator
+      <> "."
   PureInputPortUnsupported portName reason ->
     "Pure input port " <> portName <> " is unsupported: " <> reason <> "."
   PureInputPortRequiresLabel portName contractId ->
@@ -201,6 +216,8 @@ renderPureEvalError = \case
       <> " and "
       <> renderRecordPath rightPath
       <> "."
+  PureJsonParseError reason ->
+    "Pure expression could not parse JSON: " <> reason <> "."
   PureWhereExpectedRecord actual ->
     "Pure where-clause must evaluate to a record, but received " <> actual <> "."
   PureStaticFieldSetUndeterminable ->
@@ -458,6 +475,11 @@ evaluatePreparedPureTaskOutputs
 evaluatePreparedPureTaskOutputs preparedTask inputBundle = do
   inputEnv <- bindPreparedPureInputValues CorePureJson preparedTask.preparedPureTaskInputs inputBundle
   let baseEnv = corePureEnvFromInputValues inputEnv
+  -- Fast paths are optional specializations for common CorePure AST shapes.
+  -- Each recognizer must decline when user bindings shadow the builtin names it
+  -- depends on, then the generic evaluator below remains the source of truth.
+  -- Any matched path must preserve the same errors and output JSON shape as the
+  -- slow path; tests cover both shadowing and error-equivalence cases.
   case evaluateCollectionSummaryFastPath baseEnv preparedTask of
     Just result ->
       result
@@ -718,6 +740,8 @@ corePureEnvFromInputValues =
 
 corePureEnvLookup :: Text -> CorePureEnv -> Maybe CorePureValue
 corePureEnvLookup name env =
+  -- Overlay scopes are small and hot during lambda application; linear lookup
+  -- avoids rebuilding Map unions while preserving nearest-binding precedence.
   case List.lookup name env.corePureEnvOverlay of
     Just value -> Just value
     Nothing -> Map.lookup name env.corePureEnvBase
@@ -960,12 +984,8 @@ evaluateCorePureBinary binaryOp lhs rhs =
     CorePureAdd -> numericBinary (+) lhs rhs
     CorePureSubtract -> numericBinary (-) lhs rhs
     CorePureMultiply -> numericBinary (*) lhs rhs
-    CorePureDivide -> do
-      lhsNumber <- corePureNumber lhs
-      rhsNumber <- corePureNumber rhs
-      if rhsNumber == 0
-        then Left PureDivisionByZero
-        else Right (CorePureJson (Aeson.Number (lhsNumber / rhsNumber)))
+    CorePureDivide ->
+      numericFloatDivide lhs rhs
     CorePureMerge -> do
       lhsObject <- corePureObject lhs
       rhsObject <- corePureObject rhs
@@ -995,6 +1015,34 @@ numericBinary
 numericBinary op lhs rhs =
   CorePureJson . Aeson.Number <$> (op <$> corePureNumber lhs <*> corePureNumber rhs)
 
+numericFloatDivide
+  :: CorePureValue
+  -> CorePureValue
+  -> Either PureEvalError CorePureValue
+numericFloatDivide lhs rhs = do
+  lhsNumber <- corePureNumber lhs
+  rhsNumber <- corePureNumber rhs
+  if rhsNumber == 0
+    then Left PureDivisionByZero
+    else do
+      let lhsFloat = Scientific.toRealFloat lhsNumber :: Double
+          rhsFloat = Scientific.toRealFloat rhsNumber :: Double
+          result = lhsFloat / rhsFloat
+      if finiteFloat lhsFloat && finiteFloat rhsFloat && finiteFloat result
+        then Right (CorePureJson (Aeson.Number (Scientific.fromFloatDigits result)))
+        else
+          Left
+            ( PureNonFiniteFloatDivision
+                PureNonFiniteFloatDivisionOperands
+                  { pnffNumerator = canonicalNumber lhsNumber
+                  , pnffDenominator = canonicalNumber rhsNumber
+                  }
+            )
+
+finiteFloat :: Double -> Bool
+finiteFloat value =
+  not (isNaN value || isInfinite value)
+
 numericCompare
   :: (Scientific -> Scientific -> Bool)
   -> CorePureValue
@@ -1023,6 +1071,8 @@ applyCorePureValue :: CorePureValue -> [CorePureValue] -> Either PureEvalError C
 applyCorePureValue functionValue argumentValues =
   case functionValue of
     CorePureClosure params body closureEnv
+      -- Closure parameters were validated when the lambda expression was
+      -- admitted by validateCorePureExpr; apply only enforces arity.
       | NE.length params == length argumentValues ->
           evaluateCorePureExpr
             (corePureEnvPrepend (zip (NE.toList params) argumentValues) closureEnv)
@@ -1071,6 +1121,7 @@ corePureBuiltinSpecs =
   , builtin "toString" 1 corePureToString
   , builtin "joinWith" 2 corePureJoinWith
   , builtin "toJson" 1 corePureToJson
+  , builtin "fromJson" 1 corePureFromJson
   ]
   where
     builtin name arity implementation =
@@ -1322,6 +1373,14 @@ corePureToJson [value] = do
   jsonValue <- corePureValueToJson value
   Right (CorePureJson (Aeson.String (canonicalJson jsonValue)))
 corePureToJson args = impossibleBuiltinArity "toJson" 1 args
+
+corePureFromJson :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureFromJson [value] = do
+  text <- corePureStringValue value
+  case Aeson.eitherDecodeStrict (TE.encodeUtf8 text) of
+    Right jsonValue -> Right (CorePureJson jsonValue)
+    Left reason -> Left (PureJsonParseError (T.pack reason))
+corePureFromJson args = impossibleBuiltinArity "fromJson" 1 args
 
 applyJsonFunction :: CorePureValue -> Aeson.Value -> Either PureEvalError CorePureValue
 applyJsonFunction functionValue value =

--- a/test/Cortex/Wire/PureSpec.hs
+++ b/test/Cortex/Wire/PureSpec.hs
@@ -16,8 +16,10 @@ import Data.Aeson qualified as Aeson
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Map.Strict qualified as Map
 import Data.Scientific (Scientific, scientific)
+import Data.Scientific qualified as Scientific
 import Data.Set qualified as Set
 import Data.Text (Text)
+import Data.Text qualified as T
 import Test.Hspec
 
 import Cortex.Pulse.Node (NodeId (..))
@@ -151,6 +153,16 @@ spec = describe "Cortex.Wire.Pure" $ do
       Nothing
       (Map.singleton "score" (bin CorePureDivide (num 1) (num 0)))
       `shouldBe` Left PureDivisionByZero
+
+  it "evaluates division with finite Float64 semantics" $
+    evaluatePureTaskOutputs
+      scorePorts
+      scoreInputs
+      []
+      Nothing
+      (Map.singleton "score" (bin CorePureDivide (num 1) (num 3)))
+      `shouldBe` Right
+        (Map.singleton "score" (Aeson.Number (Scientific.fromFloatDigits (1 / 3 :: Double))))
 
   it "rejects duplicate CorePure binding names in the same scope" $
     evaluatePureTaskOutputs
@@ -872,6 +884,35 @@ spec = describe "Cortex.Wire.Pure" $ do
       )
       `shouldBe` Right (Map.singleton "score" (Aeson.toJSON [Aeson.Number 2]))
 
+  it "parses JSON strings through fromJson" $
+    evaluatePureTaskOutputs
+      scorePorts
+      scoreInputs
+      []
+      Nothing
+      (Map.singleton "score" (call (var "fromJson") [str "{\"b\":2,\"a\":[true,null]}"]))
+      `shouldBe` Right
+        ( Map.singleton
+            "score"
+            ( Aeson.object
+                [ "a" Aeson..= [Aeson.Bool True, Aeson.Null]
+                , "b" Aeson..= Aeson.Number 2
+                ]
+            )
+        )
+
+  it "reports invalid JSON strings from fromJson as typed pure failures" $
+    case evaluatePureTaskOutputs
+      scorePorts
+      scoreInputs
+      []
+      Nothing
+      (Map.singleton "score" (call (var "fromJson") [str "{"])) of
+      Left (PureJsonParseError reason) ->
+        reason `shouldSatisfy` (not . T.null)
+      other ->
+        expectationFailure ("expected PureJsonParseError, got: " <> show other)
+
   it "keeps the CorePure builtin authority-review signature explicit" $
     corePureBuiltinSignature
       `shouldBe` [ ("map", 2)
@@ -891,6 +932,7 @@ spec = describe "Cortex.Wire.Pure" $ do
                  , ("toString", 1)
                  , ("joinWith", 2)
                  , ("toJson", 1)
+                 , ("fromJson", 1)
                  ]
 
   it "keeps the CorePure builtin authority report closed and authority-free" $ do
@@ -920,6 +962,7 @@ spec = describe "Cortex.Wire.Pure" $ do
                  , ("toString", 1, CorePureBuiltinPureValue)
                  , ("joinWith", 2, CorePureBuiltinPureValue)
                  , ("toJson", 1, CorePureBuiltinPureValue)
+                 , ("fromJson", 1, CorePureBuiltinPureValue)
                  ]
 
   it "establishes CorePure static context from top-level record bindings" $ do

--- a/theory/Cortex/Wire/Pure.lean
+++ b/theory/Cortex/Wire/Pure.lean
@@ -158,6 +158,7 @@ def closedBuiltinEnv : List BuiltinSpec :=
   , { name := "toString", arity := 1, authority := BuiltinAuthority.pureValue }
   , { name := "joinWith", arity := 2, authority := BuiltinAuthority.pureValue }
   , { name := "toJson", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "fromJson", arity := 1, authority := BuiltinAuthority.pureValue }
   ]
 
 /-- Name/arity projection of the proof-side closed builtin mirror. -/
@@ -184,6 +185,7 @@ theorem closedBuiltinSignature_eq :
       , ("toString", 1)
       , ("joinWith", 2)
       , ("toJson", 1)
+      , ("fromJson", 1)
       ] :=
   rfl
 
@@ -194,7 +196,9 @@ theorem closedBuiltinEnv_authorityFree :
   simp [closedBuiltinEnv] at hSpec
   rcases hSpec with
     hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec |
-      hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec
+      hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec
+  · cases hSpec
+    rfl
   · cases hSpec
     rfl
   · cases hSpec


### PR DESCRIPTION
Split from #152.\n\nThis stack slice adds CorePure JSON parsing and finite Float64 division semantics.\n\nIncludes:\n- CorePure fromJson builtin and typed JSON parse errors\n- finite Float64 numeric division guard\n- reference/ADR/test/Lean updates\n\nValidation run locally:\n- just test\n- just check-commit-provenance origin/main..HEAD