### PR TITLE
feat(wire): add std.io files and graph returns

### DIFF
--- a/app/wire/Main.hs
+++ b/app/wire/Main.hs
@@ -14,7 +14,7 @@ module Main (main) where
 
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
-import Control.Exception (IOException, try)
+import Control.Exception (IOException, displayException, try, uninterruptibleMask_)
 import Control.Monad (foldM, unless, when, zipWithM)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Encode.Pretty qualified as AesonPretty
@@ -61,8 +61,6 @@ import Cortex.Wire
   , Record (..)
   , SumVariant (..)
   , TopForm (..)
-  , UseItem (..)
-  , UseSpec (..)
   , WireFile (..)
   , WireInputBundle (..)
   , WireInputCardinality (..)
@@ -73,24 +71,30 @@ import Cortex.Wire
   , WireValue (..)
   , WireValueSet (..)
   , compileWireFile
+  , compileWireFileWithReturn
   , evaluatePureTaskOutputs
   , parseWireFile
   , renderParseError
   , renderPureEvalError
-  , renderQName
   , renderWireError
   , stdIoCommandExecutorId
-  , stdIoContractIdForName
-  , stdIoExecutorIdForLeaf
-  , stdIoNamespace
+  , stdIoReadFileExecutorId
   , stdIoStdinExecutorId
   , stdIoStdoutExecutorId
+  , stdIoWriteFileExecutorId
   , wireInputBundleFromStageInputs
   , wirePayloadKindMediaType
   )
+import Cortex.Wire.Use
+  ( WireUseError (..)
+  , WireUseScope
+  , applyWireUseSpecs
+  , resolveWireContract
+  , resolveWireExecutorQName
+  )
 
 data Command
-  = CommandBuild !FilePath
+  = CommandBuild !(Maybe Text) !FilePath
   | CommandRun !FilePath
   | CommandHelp
   deriving stock (Eq, Show)
@@ -124,12 +128,8 @@ data BuiltinExecutor
   = BuiltinExecutorStdin
   | BuiltinExecutorStdout
   | BuiltinExecutorCommand
-  deriving stock (Eq, Show)
-
-data RunUseScope = RunUseScope
-  { runUseExecutors :: !(Map Text Text)
-  , runUseContracts :: !(Map Text Text)
-  }
+  | BuiltinExecutorReadFile
+  | BuiltinExecutorWriteFile
   deriving stock (Eq, Show)
 
 data CommandSpec = CommandSpec
@@ -160,7 +160,7 @@ main = do
   case command of
     Left errText -> dieText errText
     Right CommandHelp -> TIO.putStr usageText
-    Right (CommandBuild path) -> buildWire path
+    Right (CommandBuild maybeSelectedReturn path) -> buildWire maybeSelectedReturn path
     Right (CommandRun path) -> runWire path
 
 parseCommand :: [String] -> Either Text Command
@@ -168,10 +168,12 @@ parseCommand = \case
   [] -> Right CommandHelp
   ["--help"] -> Right CommandHelp
   ["-h"] -> Right CommandHelp
-  ["build", path] -> Right (CommandBuild path)
+  ["build", path] -> Right (CommandBuild Nothing path)
+  ["build", "--return", selectedReturn, path] ->
+    Right (CommandBuild (Just (T.pack selectedReturn)) path)
   ["run", path] -> Right (CommandRun path)
   [path] -> Right (CommandRun path)
-  "build" : _ -> Left "usage: wire build FILE"
+  "build" : _ -> Left "usage: wire build [--return NAME] FILE"
   "run" : _ -> Left "usage: wire run FILE"
   _ -> Left usageText
 
@@ -183,15 +185,17 @@ usageText =
     , "usage:"
     , "  wire FILE"
     , "  wire run FILE"
-    , "  wire build FILE"
+    , "  wire build [--return NAME] FILE"
     , ""
     , "The local runner currently supports stdin/stdout executors plus CorePure DAG frontiers."
     ]
 
-buildWire :: FilePath -> IO ()
-buildWire path = do
+buildWire :: Maybe Text -> FilePath -> IO ()
+buildWire maybeSelectedReturn path = do
   wireFile <- readAndParseWireFile path
-  compiled <- either (dieText . renderWireError) pure (compileWireFile wireFile)
+  let compile =
+        maybe compileWireFile compileWireFileWithReturn maybeSelectedReturn
+  compiled <- either (dieText . renderWireError) pure (compile wireFile)
   BSL.putStr (AesonPretty.encodePretty compiled)
   BSL.putStr "\n"
 
@@ -219,7 +223,7 @@ emptyRunState =
 
 runNodeLevel
   :: MVar ()
-  -> RunUseScope
+  -> WireUseScope
   -> [CorePureBinding]
   -> CompiledCircuit
   -> RunState
@@ -233,7 +237,7 @@ runNodeLevel outputLock useScope pureBindings compiled state nodeDecls = do
               nodeId = NodeId nodeDecl.nodeDeclName
               directPredecessors =
                 Set.toAscList (predecessors compiled.compiledCircuitTopology nodeRef)
-          nodeInputs <- either dieText pure (nodeInputsFromState state directPredecessors)
+          nodeInputs <- either (dieTextLocked outputLock) pure (nodeInputsFromState state directPredecessors)
           outputs <- runNode outputLock useScope pureBindings nodeInputs nodeDecl
           pure (nodeId, outputs)
       )
@@ -245,33 +249,35 @@ runNodeLevel outputLock useScope pureBindings compiled state nodeDecls = do
       }
 
 runNode
-  :: MVar () -> RunUseScope -> [CorePureBinding] -> NodeInputs -> NodeDecl -> IO (Map Text WireValue)
+  :: MVar () -> WireUseScope -> [CorePureBinding] -> NodeInputs -> NodeDecl -> IO (Map Text WireValue)
 runNode outputLock useScope pureBindings nodeInputs nodeDecl = do
-  loweredPorts <- either dieText pure (lowerPortSignature useScope nodeDecl.nodeDeclPortSig)
+  loweredPorts <-
+    either (dieTextLocked outputLock) pure (lowerPortSignature useScope nodeDecl.nodeDeclPortSig)
   let ports = wirePortsFromLowered loweredPorts
   case nodeDecl.nodeDeclBody of
     NodeBodyPure pureBody ->
-      runPureNode useScope pureBindings nodeInputs ports loweredPorts pureBody
+      runPureNode outputLock useScope pureBindings nodeInputs ports loweredPorts pureBody
     NodeBodyExecutor _whereExpr executorCall ->
       runExecutorNode outputLock useScope nodeDecl.nodeDeclName nodeInputs ports executorCall
 
 runPureNode
-  :: RunUseScope
+  :: MVar ()
+  -> WireUseScope
   -> [CorePureBinding]
   -> NodeInputs
   -> WirePorts
   -> LoweredPorts
   -> NodePureBody
   -> IO (Map Text WireValue)
-runPureNode useScope pureBindings nodeInputs ports loweredPorts pureBody = do
+runPureNode outputLock useScope pureBindings nodeInputs ports loweredPorts pureBody = do
   outputExprs <-
     either
-      dieText
+      (dieTextLocked outputLock)
       pure
       (pureOutputConfigMap useScope loweredPorts.loweredOutputs pureBody.nodePureBodyOutputs)
   outputValues <-
     either
-      (dieText . renderPureEvalError)
+      (dieTextLocked outputLock . renderPureEvalError)
       pure
       ( evaluatePureTaskOutputs
           ports
@@ -283,49 +289,50 @@ runPureNode useScope pureBindings nodeInputs ports loweredPorts pureBody = do
   pure (wrapOutputs Nothing ports outputValues)
 
 runExecutorNode
-  :: MVar () -> RunUseScope -> Text -> NodeInputs -> WirePorts -> ExecutorCall -> IO (Map Text WireValue)
+  :: MVar ()
+  -> WireUseScope
+  -> Text
+  -> NodeInputs
+  -> WirePorts
+  -> ExecutorCall
+  -> IO (Map Text WireValue)
 runExecutorNode outputLock useScope nodeName nodeInputs ports = \case
   ExecutorCallInline executorName record inputExpr ->
     case builtinExecutorFromQName useScope executorName of
-      Just BuiltinExecutorStdin ->
+      Right BuiltinExecutorStdin ->
         runStdinNode outputLock ports record
-      Just BuiltinExecutorStdout ->
+      Right BuiltinExecutorStdout ->
         runStdoutNode outputLock nodeInputs record inputExpr
-      Just BuiltinExecutorCommand ->
+      Right BuiltinExecutorCommand ->
         runCommandNode outputLock nodeInputs ports record inputExpr
-      Nothing ->
-        dieText $
-          "wire run does not yet support executor @"
-            <> renderQName executorName
-            <> " in node "
-            <> nodeName
-            <> "."
+      Right BuiltinExecutorReadFile ->
+        runReadFileNode outputLock nodeInputs ports record inputExpr
+      Right BuiltinExecutorWriteFile ->
+        runWriteFileNode outputLock nodeInputs record inputExpr
+      Left errText ->
+        dieTextLocked outputLock (errText <> " Node: " <> nodeName <> ".")
   ExecutorCallConfigured configuredName _inputExpr ->
-    dieText $
+    dieTextLocked outputLock $
       "wire run does not yet support configured executor "
         <> configuredName
         <> " in node "
         <> nodeName
         <> "."
 
-builtinExecutorFromQName :: RunUseScope -> QName -> Maybe BuiltinExecutor
-builtinExecutorFromQName useScope executorName =
-  case resolveRunExecutorQName useScope executorName of
-    Just executorId
-      | executorId == stdIoStdinExecutorId -> Just BuiltinExecutorStdin
-      | executorId == stdIoStdoutExecutorId -> Just BuiltinExecutorStdout
-      | executorId == stdIoCommandExecutorId -> Just BuiltinExecutorCommand
-    _ -> Nothing
-
-resolveRunExecutorQName :: RunUseScope -> QName -> Maybe Text
-resolveRunExecutorQName useScope qname@(QName segments) =
-  case segments of
-    localName NE.:| [] ->
-      case Map.lookup localName useScope.runUseExecutors of
-        Just executorId -> Just executorId
-        Nothing -> Just (renderQName qname)
-    _ ->
-      Just (renderQName qname)
+builtinExecutorFromQName :: WireUseScope -> QName -> Either Text BuiltinExecutor
+builtinExecutorFromQName useScope executorName = do
+  executorId <-
+    case resolveWireExecutorQName useScope executorName of
+      Right resolved -> Right resolved
+      Left outOfScope ->
+        Left ("Executor " <> outOfScope <> " is not in Wire source scope; import it with `use` first.")
+  case executorId of
+    _ | executorId == stdIoStdinExecutorId -> Right BuiltinExecutorStdin
+    _ | executorId == stdIoStdoutExecutorId -> Right BuiltinExecutorStdout
+    _ | executorId == stdIoCommandExecutorId -> Right BuiltinExecutorCommand
+    _ | executorId == stdIoReadFileExecutorId -> Right BuiltinExecutorReadFile
+    _ | executorId == stdIoWriteFileExecutorId -> Right BuiltinExecutorWriteFile
+    _ -> Left ("wire run does not yet support executor @" <> executorId)
 
 runStdinNode :: MVar () -> WirePorts -> Record -> IO (Map Text WireValue)
 runStdinNode outputLock ports record = do
@@ -335,11 +342,11 @@ runStdinNode outputLock ports record = do
       TIO.putStr promptText
       hFlush stdout
   inputText <- TIO.getLine
-  wrapSingleOutput "std.io.stdin" ports (Aeson.String inputText)
+  wrapSingleOutput outputLock "std.io.stdin" ports (Aeson.String inputText)
 
 runStdoutNode :: MVar () -> NodeInputs -> Record -> CorePureExpr -> IO (Map Text WireValue)
 runStdoutNode outputLock nodeInputs record inputExpr = do
-  value <- either dieText pure (lookupExecutorInput nodeInputs inputExpr)
+  value <- either (dieTextLocked outputLock) pure (lookupExecutorInput nodeInputs inputExpr)
   let rendered = renderOutputValue value.wireValueValue
       newline = fromMaybe True (lookupBoolField "newline" record)
   withMVar outputLock $ \() ->
@@ -351,23 +358,54 @@ runStdoutNode outputLock nodeInputs record inputExpr = do
 runCommandNode
   :: MVar () -> NodeInputs -> WirePorts -> Record -> CorePureExpr -> IO (Map Text WireValue)
 runCommandNode outputLock nodeInputs ports record inputExpr = do
-  maybeInput <- either dieText pure (lookupOptionalExecutorInput nodeInputs inputExpr)
-  commandSpec <- either dieText pure (commandSpecFromInput record maybeInput)
+  maybeInput <-
+    either (dieTextLocked outputLock) pure (lookupOptionalExecutorInput nodeInputs inputExpr)
+  commandSpec <- either (dieTextLocked outputLock) pure (commandSpecFromInput record maybeInput)
   commandResult <- executeCommandSpec commandSpec
   when commandSpec.commandSpecEcho $
     echoCommandResult outputLock commandSpec commandResult
   let result = commandResultValue commandSpec commandResult
-  wrapSingleOutput "std.io.command" ports result
+  wrapSingleOutput outputLock "std.io.command" ports result
 
-wrapSingleOutput :: Text -> WirePorts -> Aeson.Value -> IO (Map Text WireValue)
-wrapSingleOutput executorName ports value =
+runReadFileNode
+  :: MVar () -> NodeInputs -> WirePorts -> Record -> CorePureExpr -> IO (Map Text WireValue)
+runReadFileNode outputLock nodeInputs ports record inputExpr = do
+  maybeInput <-
+    either (dieTextLocked outputLock) pure (lookupOptionalExecutorInput nodeInputs inputExpr)
+  path <-
+    either
+      (dieTextLocked outputLock)
+      pure
+      (filePathFromConfigOrInput "std.io.readFile" record maybeInput)
+  result <- try @IOException (TIO.readFile path)
+  content <-
+    case result of
+      Right text -> pure text
+      Left err ->
+        dieTextLocked outputLock ("std.io.readFile failed for " <> T.pack path <> ": " <> exceptionText err)
+  wrapSingleOutput outputLock "std.io.readFile" ports (Aeson.String content)
+
+runWriteFileNode :: MVar () -> NodeInputs -> Record -> CorePureExpr -> IO (Map Text WireValue)
+runWriteFileNode outputLock nodeInputs record inputExpr = do
+  value <- either (dieTextLocked outputLock) pure (lookupExecutorInput nodeInputs inputExpr)
+  path <- either (dieTextLocked outputLock) pure (filePathFromConfig "std.io.writeFile" record)
+  result <- try @IOException (TIO.writeFile path (renderOutputValue value.wireValueValue))
+  case result of
+    Right () -> noOutputs
+    Left err ->
+      dieTextLocked
+        outputLock
+        ("std.io.writeFile failed for " <> T.pack path <> ": " <> exceptionText err)
+
+wrapSingleOutput :: MVar () -> Text -> WirePorts -> Aeson.Value -> IO (Map Text WireValue)
+wrapSingleOutput outputLock executorName ports value =
   case Map.toList ports.wirePortsOutputs of
     [(portName, _port)] ->
       pure (wrapOutputs Nothing ports (Map.singleton portName value))
     [] ->
       noOutputs
     outputs ->
-      dieText $
+      dieTextLocked outputLock $
         executorName
           <> " expects zero or one output port in the local runner, got "
           <> tshow (length outputs)
@@ -567,6 +605,42 @@ commandNameFromArgv = \case
   [] -> "command"
   program : args -> T.unwords (program : args)
 
+filePathFromConfigOrInput :: Text -> Record -> Maybe WireValue -> Either Text FilePath
+filePathFromConfigOrInput executorName record maybeInput =
+  case maybeInput of
+    Just wireValue ->
+      case wireValue.wireValueValue of
+        Aeson.Object objectValue -> T.unpack <$> requiredObjectTextField executorName "path" objectValue
+        _ -> filePathFromConfig executorName record
+    Nothing ->
+      filePathFromConfig executorName record
+
+filePathFromConfig :: Text -> Record -> Either Text FilePath
+filePathFromConfig executorName record =
+  case lookupTextField "path" record of
+    Just path
+      | not (T.null path) -> Right (T.unpack path)
+      | otherwise -> Left (executorName <> " config field path must not be empty.")
+    Nothing -> Left (executorName <> " requires a path field in config.")
+
+requiredObjectTextField :: Text -> Text -> Aeson.Object -> Either Text Text
+requiredObjectTextField executorName fieldName objectValue =
+  case AesonKeyMap.lookup (AesonKey.fromText fieldName) objectValue of
+    Just (Aeson.String text)
+      | not (T.null text) -> Right text
+      | otherwise -> Left (executorName <> " input field " <> fieldName <> " must not be empty.")
+    Just value ->
+      Left
+        ( executorName
+            <> " input field "
+            <> fieldName
+            <> " must be a string, got "
+            <> renderOutputValue value
+            <> "."
+        )
+    Nothing ->
+      Left (executorName <> " requires input field " <> fieldName <> ".")
+
 nodeInputsFromState :: RunState -> [CircuitNodeRef] -> Either Text NodeInputs
 nodeInputsFromState state producerRefs = do
   producerOutputs <-
@@ -664,60 +738,30 @@ topLevelPureBindings wireFile =
   | TopLet _visibility name (LetRhsCorePure expr) <- wireFile.wireFileTopForms
   ]
 
-emptyRunUseScope :: RunUseScope
-emptyRunUseScope =
-  RunUseScope
-    { runUseExecutors = Map.empty
-    , runUseContracts = Map.empty
-    }
-
-useScopeFromWireFile :: WireFile -> Either Text RunUseScope
+useScopeFromWireFile :: WireFile -> Either Text WireUseScope
 useScopeFromWireFile wireFile =
-  foldM
-    lowerUseSpec
-    emptyRunUseScope
-    [ useSpec
-    | TopUse useSpec <- wireFile.wireFileTopForms
-    ]
-
-lowerUseSpec :: RunUseScope -> UseSpec -> Either Text RunUseScope
-lowerUseSpec useScope useSpec = do
-  when (renderQName useSpec.useSpecNamespace /= stdIoNamespace) $
-    Left ("wire run does not know use namespace " <> renderQName useSpec.useSpecNamespace <> ".")
-  foldM lowerUseItem useScope (NE.toList useSpec.useSpecItems)
+  case applyWireUseSpecs (const False) useSpecs of
+    Left err -> Left (renderRunUseError err)
+    Right scope -> Right scope
   where
-    lowerUseItem state = \case
-      UseExecutor itemName maybeAlias -> do
-        executorId <-
-          maybe
-            (Left ("wire run does not know std.io executor @" <> itemName <> "."))
-            Right
-            (stdIoExecutorIdForLeaf itemName)
-        let localName = fromMaybe itemName maybeAlias
-        Right
-          state
-            { runUseExecutors = Map.insert localName executorId state.runUseExecutors
-            }
-      UseContract itemName maybeAlias -> do
-        contractId <-
-          maybe
-            (Left ("wire run does not know std.io contract " <> itemName <> "."))
-            Right
-            (stdIoContractIdForName itemName)
-        let localName = fromMaybe itemName maybeAlias
-        Right
-          state
-            { runUseContracts = Map.insert localName contractId state.runUseContracts
-            }
+    useSpecs =
+      [ useSpec
+      | TopUse useSpec <- wireFile.wireFileTopForms
+      ]
 
-resolveRunContract :: RunUseScope -> Text -> Text
-resolveRunContract useScope contractName =
-  Map.findWithDefault contractName contractName useScope.runUseContracts
+renderRunUseError :: WireUseError -> Text
+renderRunUseError = \case
+  WireUseUnknownNamespace namespace ->
+    "wire run does not know use namespace " <> namespace <> "."
+  WireUseUnknownItem namespace itemName ->
+    "wire run does not know use item " <> itemName <> " in namespace " <> namespace <> "."
+  WireUseDuplicateBinding name ->
+    "Wire file binds name " <> name <> " more than once."
 
-lowerPortSignature :: RunUseScope -> [PortDecl] -> Either Text LoweredPorts
+lowerPortSignature :: WireUseScope -> [PortDecl] -> Either Text LoweredPorts
 lowerPortSignature useScope portSig = do
   let inputs =
-        [ (label, resolveRunContract useScope contractName, WireInputCardinalityOne)
+        [ (label, resolveWireContract useScope contractName, WireInputCardinalityOne)
         | PortInputDecl label (ContractId contractName) <- portSig
         ]
       outputs =
@@ -760,9 +804,9 @@ lowerPortSignature useScope portSig = do
       concatMap
         ( \case
             PortOutputDecl label (ContractId contractName) ->
-              [(label, resolveRunContract useScope contractName)]
+              [(label, resolveWireContract useScope contractName)]
             PortOutputSumDecl variants ->
-              [ (variant.svLabel, resolveRunContract useScope variant.svContract.unContractId)
+              [ (variant.svLabel, resolveWireContract useScope variant.svContract.unContractId)
               | variant <- NE.toList variants
               ]
             PortInputDecl {} ->
@@ -794,7 +838,7 @@ wirePortsFromLowered loweredPorts =
     }
 
 pureOutputConfigMap
-  :: RunUseScope -> [LoweredPort] -> NonEmpty PureOutputEquation -> Either Text (Map Text CorePureExpr)
+  :: WireUseScope -> [LoweredPort] -> NonEmpty PureOutputEquation -> Either Text (Map Text CorePureExpr)
 pureOutputConfigMap useScope outputPorts outputEquations = do
   let outputEquationList = NE.toList outputEquations
   when (length outputPorts /= length outputEquationList) $
@@ -803,7 +847,7 @@ pureOutputConfigMap useScope outputPorts outputEquations = do
   where
     matchOutput port outputEquation = do
       let ContractId rawContractName = outputEquation.pureOutputEquationContract
-          contractName = resolveRunContract useScope rawContractName
+          contractName = resolveWireContract useScope rawContractName
       when
         ( port.loweredPortLabel /= outputEquation.pureOutputEquationLabel
             || port.loweredPortContract /= contractName
@@ -877,7 +921,20 @@ tshow :: Show a => a -> Text
 tshow =
   T.pack . show
 
+exceptionText :: IOException -> Text
+exceptionText =
+  T.pack . displayException
+
 dieText :: Text -> IO a
 dieText errText = do
   TIO.hPutStrLn stderr errText
   exitFailure
+
+dieTextLocked :: MVar () -> Text -> IO a
+dieTextLocked outputLock errText =
+  -- Mask so sibling cancellation cannot interleave this stderr write.
+  uninterruptibleMask_ $ do
+    withMVar outputLock $ \() -> do
+      TIO.hPutStrLn stderr errText
+      hFlush stderr
+    exitFailure

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -173,6 +173,7 @@ library
         Cortex.Wire.Pure
         Cortex.Wire.Std
         Cortex.Wire.Syntax
+        Cortex.Wire.Use
         Cortex.Wire.Circuit
         Cortex.Wire.Circuit.Artifact
         Cortex.Wire.Circuit.Compile

--- a/docs/ADRs/0042-wire-standard-effect-executors.md
+++ b/docs/ADRs/0042-wire-standard-effect-executors.md
@@ -56,11 +56,13 @@ Cortex should provide a small standard executor pack for host-local effects. The
 effects are:
 
 ```wire
-use std.io.{@stdin, @stdout, @command, CommandSpec, CommandResult};
+use std.io.{@stdin, @stdout, @command, @readFile, @writeFile, CommandSpec, CommandResult};
 
 @stdin
 @stdout
 @command
+@readFile
+@writeFile
 ```
 
 These are ordinary Wire executors:
@@ -76,11 +78,13 @@ that mentions them has explicitly named host IO authority.
 
 The initial shapes are:
 
-| Executor          | Boundary shape                        | Runtime behavior                                    |
-| ----------------- | ------------------------------------- | --------------------------------------------------- |
-| `@std.io.stdin`   | zero inputs, exactly one output port  | optionally prints a prompt, reads one line          |
-| `@std.io.stdout`  | exactly one input port, zero outputs  | prints the input payload, optionally with newline   |
-| `@std.io.command` | zero or one input, zero or one output | executes one argv vector and captures stdout/stderr |
+| Executor            | Boundary shape                        | Runtime behavior                                    |
+| ------------------- | ------------------------------------- | --------------------------------------------------- |
+| `@std.io.stdin`     | zero inputs, exactly one output port  | optionally prints a prompt, reads one line          |
+| `@std.io.stdout`    | exactly one input port, zero outputs  | prints the input payload, optionally with newline   |
+| `@std.io.command`   | zero or one input, zero or one output | executes one argv vector and captures stdout/stderr |
+| `@std.io.readFile`  | zero or one input, exactly one output | reads UTF-8 text from a configured/input `path`     |
+| `@std.io.writeFile` | exactly one input port, zero outputs  | writes the input payload as UTF-8 text to `path`    |
 
 These executors should accept inert config records only. The initial stdin config may include
 `prompt`. The initial stdout config may include `newline`.
@@ -98,6 +102,9 @@ as an input record or by inert executor config. The initial command spec include
 - `echo`;
 - `successExitCodes`.
 
+`std.io.readFile` and `std.io.writeFile` are text-only file effects. They require an explicit `path`
+field, either in inert config for `readFile`/`writeFile` or as an input object for `readFile`.
+
 The command result includes the command name, target, argv, cwd, required/skipped markers, boolean
 success, status, exit code, stdout, stderr, and echo marker. A skipped command returns a structured
 result instead of executing. A failed command returns `ok = false`; the local runner does not throw
@@ -107,7 +114,7 @@ When `echo = true`, the local runner prints the captured stdout/stderr for that 
 process exits. Frontier commands may run concurrently, so echoed output is emitted as one atomic
 block per command rather than as interleaved live streaming.
 
-Additional terminal behavior, streaming, binary IO, files, shell expansion, TTY control, environment
+Additional terminal behavior, streaming, binary IO, shell expansion, TTY control, environment
 mutation, and interactive protocols are out of scope for v1. Shell semantics, if added later, should
 use a separate and visibly authority-bearing executor such as `std.io.shell`.
 
@@ -154,7 +161,8 @@ empty ingress or empty egress is still an explicit phase, not an exception to no
 ### Obligations
 
 - Mark standard-effect stages as irreversible or otherwise replay-unsafe in runtime metadata.
-- Keep their executor IDs stable: `std.io.stdin`, `std.io.stdout`, and `std.io.command`.
+- Keep their executor IDs stable: `std.io.stdin`, `std.io.stdout`, `std.io.command`,
+  `std.io.readFile`, and `std.io.writeFile`.
 - Keep the standard pack source-scoped through `use std.io.{...};` as defined by ADR 0044.
 - Enforce the structural port constraints at binding time even when the registry projection admits
   author-declared ports.

--- a/docs/ADRs/0044-wire-namespace-use-imports.md
+++ b/docs/ADRs/0044-wire-namespace-use-imports.md
@@ -45,7 +45,7 @@ should remain intact: runtime authority is admitted by the host registry, not by
 Wire gains a top-level registry-namespace import form:
 
 ```wire
-use std.io.{@stdin, @stdout, @command, CommandSpec, CommandResult};
+use std.io.{@stdin, @stdout, @command, @readFile, @writeFile, CommandSpec, CommandResult};
 ```
 
 Selectors are explicit. Executor leaves carry the `@` marker; contracts do not:
@@ -69,9 +69,10 @@ which standard-pack names are referenceable in a Wire file. The host still decid
 For v1:
 
 - `std.io` is the only implemented registry namespace.
-- `@std.io.stdin`, `@std.io.stdout`, and `@std.io.command` require an explicit `use std.io.{...};`
-  in the same file before they can be referenced.
-- Bare `@stdin`, `@stdout`, and `@command` resolve only when imported by `use`.
+- `@std.io.stdin`, `@std.io.stdout`, `@std.io.command`, `@std.io.readFile`, and `@std.io.writeFile`
+  require an explicit `use std.io.{...};` in the same file before they can be referenced.
+- Bare `@stdin`, `@stdout`, `@command`, `@readFile`, and `@writeFile` resolve only when imported by
+  `use`.
 - Imported aliases lower to canonical executor and contract IDs in compiled metadata.
 - `use` does not propagate across file imports; each source file declares its own registry namespace
   dependencies.

--- a/docs/Reference/Wire/executors-and-alphabet.md
+++ b/docs/Reference/Wire/executors-and-alphabet.md
@@ -39,7 +39,7 @@ value that can be reused in explicit node implementation bodies.
 Standard-pack executors are source-scoped through `use`:
 
 ```wire
-use std.io.{@stdin, @stdout, @command};
+use std.io.{@stdin, @stdout, @command, @readFile, @writeFile};
 
 node read_mode
   -> answer: UserInput = @stdin { prompt = "Planning mode (high/safe): "; } (null);
@@ -47,6 +47,16 @@ node read_mode
 
 The `use` form brings names into source scope; it does not bind host authority by itself. The host
 registry still admits and binds the canonical executor ID, such as `std.io.stdin`.
+
+The local `wire run` interpreter recognizes these standard IO executor leaves:
+
+| Executor           | Boundary shape                        | Runtime behavior                                 |
+| ------------------ | ------------------------------------- | ------------------------------------------------ |
+| `std.io.stdin`     | zero inputs, exactly one output       | optionally prints a prompt and reads one line    |
+| `std.io.stdout`    | exactly one input, zero outputs       | prints the input payload                         |
+| `std.io.command`   | zero or one input, zero or one output | executes one argv vector and captures the result |
+| `std.io.readFile`  | zero or one input, exactly one output | reads UTF-8 text from a configured/input `path`  |
+| `std.io.writeFile` | exactly one input, zero outputs       | writes the input payload as UTF-8 text to `path` |
 
 ## Three Layers
 

--- a/docs/Reference/Wire/grammar.md
+++ b/docs/Reference/Wire/grammar.md
@@ -90,7 +90,7 @@ namespace imports are distinct: `import` loads another `.wire` file; `use` selec
 executor and contract names. The initial implemented namespace is `std.io`:
 
 ```wire
-use std.io.{@stdin, @stdout, @command, CommandSpec, CommandResult};
+use std.io.{@stdin, @stdout, @command, @readFile, @writeFile, CommandSpec, CommandResult};
 ```
 
 Executor selectors carry `@` at the leaf because they import executor authority names. Contract

--- a/docs/Reference/Wire/modules-imports-and-file-returns.md
+++ b/docs/Reference/Wire/modules-imports-and-file-returns.md
@@ -36,12 +36,21 @@ classify
 The last expression without a trailing semicolon is the file-return value. If there is no
 file-return expression, the file is declaration-only.
 
+The CLI can compile a named graph-valued binding instead of the default file-return:
+
+```sh
+wire build --return exported_planner ./pipeline.wire
+```
+
+This is useful for files that serve as a catalog of exported graph values while still having a
+default executable file-return.
+
 ## Imports
 
 Registry namespace imports use `use`:
 
 ```wire
-use std.io.{@stdin, @stdout, @command, CommandSpec, CommandResult};
+use std.io.{@stdin, @stdout, @command, @readFile, @writeFile, CommandSpec, CommandResult};
 use std.io.{@command as @shell, CommandSpec as Spec};
 ```
 

--- a/nix/materialized/cortex/.plan.nix/cortex.nix
+++ b/nix/materialized/cortex/.plan.nix/cortex.nix
@@ -139,6 +139,7 @@
           "Cortex/Wire/Pure"
           "Cortex/Wire/Std"
           "Cortex/Wire/Syntax"
+          "Cortex/Wire/Use"
           "Cortex/Wire/Circuit"
           "Cortex/Wire/Circuit/Artifact"
           "Cortex/Wire/Circuit/Compile"

--- a/src/Cortex/Wire.hs
+++ b/src/Cortex/Wire.hs
@@ -16,6 +16,7 @@ module Cortex.Wire
   , module Cortex.Wire.Executor
   , module Cortex.Wire.Pure
   , module Cortex.Wire.Std
+  , module Cortex.Wire.Use
   , WireCompileEnv (..)
   , WireProjectionMode (..)
   , WireContractSpec (..)
@@ -63,10 +64,14 @@ module Cortex.Wire
   , renderParseError
   , compileWireFile
   , compileWireFileWithEnv
+  , compileWireFileWithReturn
+  , compileWireFileWithReturnAndEnv
   , compileWireFragmentFile
   , compileWireFragmentFileWithEnv
   , compileWireText
   , compileWireTextWithEnv
+  , compileWireTextWithReturn
+  , compileWireTextWithReturnAndEnv
   , compileWireFragmentText
   , compileWireFragmentTextWithEnv
   )
@@ -76,12 +81,16 @@ import Cortex.Wire.Circuit
 import Cortex.Wire.Compile
   ( compileWireFile
   , compileWireFileWithEnv
+  , compileWireFileWithReturn
+  , compileWireFileWithReturnAndEnv
   , compileWireFragmentFile
   , compileWireFragmentFileWithEnv
   , compileWireFragmentText
   , compileWireFragmentTextWithEnv
   , compileWireText
   , compileWireTextWithEnv
+  , compileWireTextWithReturn
+  , compileWireTextWithReturnAndEnv
   )
 import Cortex.Wire.Contract
   ( WireCompileEnv (..)
@@ -130,6 +139,7 @@ import Cortex.Wire.Runtime
   )
 import Cortex.Wire.Std
 import Cortex.Wire.Syntax
+import Cortex.Wire.Use
 import Cortex.Wire.Value
   ( WirePayloadKind (..)
   , WireValue (..)

--- a/src/Cortex/Wire/AST.hs
+++ b/src/Cortex/Wire/AST.hs
@@ -204,7 +204,7 @@ data WireError
   | WireUnknownLetBinding !Text
   | WireUnknownUseNamespace !Text
   | WireUnknownUseItem !Text !Text
-  | WireDuplicateUseBinding !Text
+  | WireDuplicateBinding !Text
   | WireExecutorNotInScope !Text
   | WireTypeMismatchInConcat !Text !Text
   | WireFieldTypeMismatch !Text !Text !Text
@@ -316,8 +316,8 @@ renderWireError = \case
     "`use` references unknown registry namespace " <> namespace <> "."
   WireUnknownUseItem namespace itemName ->
     "`use` references unknown item " <> itemName <> " in namespace " <> namespace <> "."
-  WireDuplicateUseBinding name ->
-    "`use` imports name " <> name <> " more than once in this file."
+  WireDuplicateBinding name ->
+    "Wire file binds name " <> name <> " more than once."
   WireExecutorNotInScope executorName ->
     "Executor " <> executorName <> " is not in Wire source scope; import it with `use` first."
   WireTypeMismatchInConcat left right ->

--- a/src/Cortex/Wire/Compile.hs
+++ b/src/Cortex/Wire/Compile.hs
@@ -13,10 +13,14 @@ Wire modules own authoring and compilation mechanics while host authority stays 
 module Cortex.Wire.Compile
   ( compileWireFile
   , compileWireFileWithEnv
+  , compileWireFileWithReturn
+  , compileWireFileWithReturnAndEnv
   , compileWireFragmentFile
   , compileWireFragmentFileWithEnv
   , compileWireText
   , compileWireTextWithEnv
+  , compileWireTextWithReturn
+  , compileWireTextWithReturnAndEnv
   , compileWireFragmentText
   , compileWireFragmentTextWithEnv
   )
@@ -107,14 +111,26 @@ import Cortex.Wire.Pure
   )
 import Cortex.Wire.Std
   ( stdIoCommandExecutorId
-  , stdIoContractIdForName
-  , stdIoExecutorIdForLeaf
-  , stdIoExecutorLeaves
-  , stdIoNamespace
+  , stdIoCommandShapeMessage
+  , stdIoReadFileExecutorId
+  , stdIoReadFileShapeMessage
   , stdIoStdinExecutorId
+  , stdIoStdinShapeMessage
   , stdIoStdoutExecutorId
+  , stdIoStdoutShapeMessage
+  , stdIoWriteFileExecutorId
+  , stdIoWriteFileShapeMessage
   )
 import Cortex.Wire.Syntax
+import Cortex.Wire.Use
+  ( WireUseError (..)
+  , WireUseScope (..)
+  , applyWireUseSpec
+  , emptyWireUseScope
+  , resolveWireContract
+  , resolveWireExecutorQName
+  , wireUseDeclaredContracts
+  )
 
 compileWireText :: Text -> Either WireCore.WireError CompiledCircuit
 compileWireText =
@@ -127,6 +143,19 @@ compileWireTextWithEnv compileEnv sourceText = do
       (WireCore.WireParseError . renderParseError)
       (parseWireFile "wire" sourceText)
   compileWireFileWithEnv compileEnv wireFile
+
+compileWireTextWithReturn :: Text -> Text -> Either WireCore.WireError CompiledCircuit
+compileWireTextWithReturn =
+  compileWireTextWithReturnAndEnv emptyWireCompileEnv
+
+compileWireTextWithReturnAndEnv
+  :: WireCompileEnv -> Text -> Text -> Either WireCore.WireError CompiledCircuit
+compileWireTextWithReturnAndEnv compileEnv selectedReturn sourceText = do
+  wireFile <-
+    mapLeft
+      (WireCore.WireParseError . renderParseError)
+      (parseWireFile "wire" sourceText)
+  compileWireFileWithReturnAndEnv compileEnv selectedReturn wireFile
 
 compileWireFragmentText :: Text -> Either WireCore.WireError CompiledCircuit
 compileWireFragmentText =
@@ -149,6 +178,21 @@ compileWireFileWithEnv :: WireCompileEnv -> WireFile -> Either WireCore.WireErro
 compileWireFileWithEnv compileEnv wireFile = do
   lowered <- lowerWireFile compileEnv wireFile
   compileLoweredWireFile compileEnv True wireFile lowered
+
+compileWireFileWithReturn :: Text -> WireFile -> Either WireCore.WireError CompiledCircuit
+compileWireFileWithReturn =
+  compileWireFileWithReturnAndEnv emptyWireCompileEnv
+
+compileWireFileWithReturnAndEnv
+  :: WireCompileEnv -> Text -> WireFile -> Either WireCore.WireError CompiledCircuit
+compileWireFileWithReturnAndEnv compileEnv selectedReturn wireFile =
+  let selectedWireFile =
+        wireFile
+          { wireFileReturn = Just (ExprIdent (QName (selectedReturn :| [])))
+          }
+   in do
+        lowered <- lowerWireFileWithUnusedPolicy compileEnv AllowUnusedDeclaredNodes selectedWireFile
+        compileLoweredWireFile compileEnv True selectedWireFile lowered
 
 compileWireFragmentFile :: WireFile -> Either WireCore.WireError CompiledCircuit
 compileWireFragmentFile =
@@ -207,16 +251,20 @@ data LoweredWireFile = LoweredWireFile
   , lwfDeclaredContracts :: !(Set.Set Text)
   }
 
+data UnusedNodePolicy
+  = RequireAllDeclaredNodesUsed
+  | AllowUnusedDeclaredNodes
+  deriving stock (Eq, Show)
+
 data LoweringState = LoweringState
   { lsBindings :: !(Map Text EvalValue)
   , lsPureBindings :: ![CorePureBinding]
   , lsGraphBindings :: !(Map Text GraphFragment)
+  , lsExportedGraphNodeRefs :: !(Set.Set CircuitNodeRef)
   , lsNamedNodes :: !(Map Text LoweredNode)
   , lsAnonCounter :: !Int
   , lsDeclaredContracts :: !(Set.Set Text)
-  , lsExecutorUses :: !(Map Text Text)
-  , lsStdExecutorsInScope :: !(Set.Set Text)
-  , lsContractUses :: !(Map Text Text)
+  , lsUseScope :: !WireUseScope
   }
 
 emptyLoweringState :: LoweringState
@@ -225,12 +273,11 @@ emptyLoweringState =
     { lsBindings = Map.empty
     , lsPureBindings = []
     , lsGraphBindings = Map.empty
+    , lsExportedGraphNodeRefs = Set.empty
     , lsNamedNodes = Map.empty
     , lsAnonCounter = 0
     , lsDeclaredContracts = Set.empty
-    , lsExecutorUses = Map.empty
-    , lsStdExecutorsInScope = Set.empty
-    , lsContractUses = Map.empty
+    , lsUseScope = emptyWireUseScope
     }
 
 data EvalValue
@@ -245,7 +292,7 @@ data EvalValue
   deriving stock (Eq, Show)
 
 data ConfiguredExecutor = ConfiguredExecutor
-  { ceExecutor :: !Text
+  { ceExecutorId :: !Text
   , ceFields :: !(Map (NonEmpty Text) EvalValue)
   }
   deriving stock (Eq, Show)
@@ -310,17 +357,32 @@ emptyFragment =
     }
 
 lowerWireFile :: WireCompileEnv -> WireFile -> Either WireCore.WireError LoweredWireFile
-lowerWireFile compileEnv wireFile = do
+lowerWireFile compileEnv =
+  lowerWireFileWithUnusedPolicy compileEnv RequireAllDeclaredNodesUsed
+
+lowerWireFileWithUnusedPolicy
+  :: WireCompileEnv -> UnusedNodePolicy -> WireFile -> Either WireCore.WireError LoweredWireFile
+lowerWireFileWithUnusedPolicy compileEnv unusedNodePolicy wireFile = do
   loweredState <-
     foldlM (lowerTopForm compileEnv) emptyLoweringState wireFile.wireFileTopForms
   fileReturn <- maybe (Left WireCore.WireMissingCircuit) Right wireFile.wireFileReturn
   (resultFragment, maybeMetadata, loweredState') <- lowerFileReturn loweredState fileReturn
-  let usedNodeRefs = foldMap loweredNodeRefs resultFragment.gfNodes
+  let usedNodeRefs =
+        foldMap loweredNodeRefs resultFragment.gfNodes
+          <> loweredState'.lsExportedGraphNodeRefs
       declaredNodeRefs = Set.fromList (fmap (.lnRef) (Map.elems loweredState'.lsNamedNodes))
       unusedNodeRefs = Set.toAscList (Set.difference declaredNodeRefs usedNodeRefs)
-  case unusedNodeRefs of
-    unusedRef : _ -> Left (WireCore.WireUnusedNodeRef unusedRef)
-    [] ->
+  case (unusedNodePolicy, unusedNodeRefs) of
+    (RequireAllDeclaredNodesUsed, unusedRef : _) -> Left (WireCore.WireUnusedNodeRef unusedRef)
+    (RequireAllDeclaredNodesUsed, []) ->
+      Right
+        LoweredWireFile
+          { lwfFragment = resultFragment
+          , lwfMetadata = maybeMetadata
+          , lwfCircuitId = fromMaybe "wire" (extractCircuitId maybeMetadata)
+          , lwfDeclaredContracts = loweredState'.lsDeclaredContracts
+          }
+    (AllowUnusedDeclaredNodes, _) ->
       Right
         LoweredWireFile
           { lwfFragment = resultFragment
@@ -364,14 +426,14 @@ lowerTopForm
   :: WireCompileEnv -> LoweringState -> TopForm -> Either WireCore.WireError LoweringState
 lowerTopForm compileEnv st = \case
   TopContract contractId ->
-    if Map.member contractId.unContractId st.lsContractUses
-      then Left (WireCore.WireDuplicateUseBinding contractId.unContractId)
+    if topLevelBindingNameTaken st contractId.unContractId
+      then Left (WireCore.WireDuplicateBinding contractId.unContractId)
       else Right st {lsDeclaredContracts = Set.insert contractId.unContractId st.lsDeclaredContracts}
   TopUse useSpec ->
     lowerUseSpec st useSpec
   TopImport _ ->
     Left (WireCore.WireParseError "Wire imports are not compiled yet.")
-  TopLet _visibility name rhs -> do
+  TopLet visibility name rhs -> do
     if topLevelBindingNameTaken st name
       then Left (WireCore.WireDuplicateLetBinding name)
       else case rhs of
@@ -387,7 +449,7 @@ lowerTopForm compileEnv st = \case
                        ]
               }
         LetRhsWire expr ->
-          lowerWireLetBinding st name expr
+          lowerWireLetBinding visibility st name expr
   TopNode nodeDecl -> do
     loweredNode <- lowerNamedNode compileEnv st nodeDecl
     let nodeName = nodeDecl.nodeDeclName
@@ -398,75 +460,57 @@ lowerTopForm compileEnv st = \case
           st
             { lsNamedNodes = Map.insert nodeName loweredNode st.lsNamedNodes
             }
-  where
-    topLevelBindingNameTaken state name =
-      Map.member name state.lsBindings
-        || Map.member name state.lsGraphBindings
-        || Map.member name state.lsNamedNodes
-        || Map.member name state.lsExecutorUses
-        || Map.member name state.lsContractUses
-        || any (\existing -> existing.corePureBindingName == name) state.lsPureBindings
+
+topLevelBindingNameTaken :: LoweringState -> Text -> Bool
+topLevelBindingNameTaken state name =
+  Map.member name state.lsBindings
+    || Map.member name state.lsGraphBindings
+    || Map.member name state.lsNamedNodes
+    || Map.member name state.lsUseScope.wireUseExecutors
+    || Map.member name state.lsUseScope.wireUseContracts
+    || Set.member name state.lsDeclaredContracts
+    || any (\existing -> existing.corePureBindingName == name) state.lsPureBindings
 
 lowerUseSpec :: LoweringState -> UseSpec -> Either WireCore.WireError LoweringState
 lowerUseSpec st useSpec = do
-  when (renderQName useSpec.useSpecNamespace /= stdIoNamespace) $
-    Left (WireCore.WireUnknownUseNamespace (renderQName useSpec.useSpecNamespace))
-  foldlM lowerUseItem st (NE.toList useSpec.useSpecItems)
-  where
-    lowerUseItem state = \case
-      UseExecutor itemName maybeAlias -> do
-        canonical <- stdIoExecutorId itemName
-        let localName = fromMaybe itemName maybeAlias
-        ensureUseNameFresh localName state
-        Right
-          state
-            { lsExecutorUses = Map.insert localName canonical state.lsExecutorUses
-            , lsStdExecutorsInScope = Set.insert canonical state.lsStdExecutorsInScope
-            }
-      UseContract itemName maybeAlias -> do
-        canonical <- stdIoContractId itemName
-        let localName = fromMaybe itemName maybeAlias
-        ensureUseNameFresh localName state
-        Right
-          state
-            { lsContractUses = Map.insert localName canonical state.lsContractUses
-            , lsDeclaredContracts = Set.insert canonical state.lsDeclaredContracts
-            }
+  useScope <-
+    mapLeft wireUseErrorToWireError $
+      applyWireUseSpec (topLevelBindingNameTaken st) st.lsUseScope useSpec
+  Right
+    st
+      { lsUseScope = useScope
+      , lsDeclaredContracts = st.lsDeclaredContracts <> wireUseDeclaredContracts useScope
+      }
 
-    ensureUseNameFresh localName state =
-      when
-        ( Map.member localName state.lsExecutorUses
-            || Map.member localName state.lsContractUses
-            || Map.member localName state.lsBindings
-            || Map.member localName state.lsGraphBindings
-            || Map.member localName state.lsNamedNodes
-            || Set.member localName state.lsDeclaredContracts
-        )
-        (Left (WireCore.WireDuplicateUseBinding localName))
-
-stdIoExecutorId :: Text -> Either WireCore.WireError Text
-stdIoExecutorId itemName =
-  maybe
-    (Left (WireCore.WireUnknownUseItem stdIoNamespace ("@" <> itemName)))
-    Right
-    (stdIoExecutorIdForLeaf itemName)
-
-stdIoContractId :: Text -> Either WireCore.WireError Text
-stdIoContractId itemName =
-  maybe
-    (Left (WireCore.WireUnknownUseItem stdIoNamespace itemName))
-    Right
-    (stdIoContractIdForName itemName)
+wireUseErrorToWireError :: WireUseError -> WireCore.WireError
+wireUseErrorToWireError = \case
+  WireUseUnknownNamespace namespace ->
+    WireCore.WireUnknownUseNamespace namespace
+  WireUseUnknownItem namespace itemName ->
+    WireCore.WireUnknownUseItem namespace itemName
+  WireUseDuplicateBinding name ->
+    WireCore.WireDuplicateBinding name
 
 lowerWireLetBinding
-  :: LoweringState
+  :: LetVisibility
+  -> LoweringState
   -> Text
   -> Expr
   -> Either WireCore.WireError LoweringState
-lowerWireLetBinding st name expr
+lowerWireLetBinding visibility st name expr
   | isGraphLetExpr st expr = do
       graphValue <- lowerGraphExpr st expr
-      Right st {lsGraphBindings = Map.insert name graphValue st.lsGraphBindings}
+      let exportedNodeRefs =
+            case visibility of
+              LetExported ->
+                foldMap loweredNodeRefs graphValue.gfNodes
+              LetPrivate ->
+                Set.empty
+      Right
+        st
+          { lsGraphBindings = Map.insert name graphValue st.lsGraphBindings
+          , lsExportedGraphNodeRefs = st.lsExportedGraphNodeRefs <> exportedNodeRefs
+          }
   | otherwise = do
       value <- evalValue st expr
       let st' = st {lsBindings = Map.insert name value st.lsBindings}
@@ -1261,7 +1305,7 @@ loweredNodeFromExecutorCall compileEnv st nodeRef ports whereExpr executorCallVa
       label = lookupMaybeTextField "label" exactFields
       genericFields = genericConfigFields exactFields knownSimpleFields
       runtimePorts = taskWirePortsFromLowered ports
-      executorId = configuredExecutor.ceExecutor
+      executorId = configuredExecutor.ceExecutorId
       maybeSignal = lookupMaybeTextField "on" exactFields
       maybeKind = lookupMaybeTextField "kind" exactFields
       maybeTarget = lookupMaybeQNameField "to" exactFields
@@ -1684,7 +1728,7 @@ lowerPortSignature st nodeRef portSig = do
 
 resolveContractId :: LoweringState -> Text -> Text
 resolveContractId st contractName =
-  Map.findWithDefault contractName contractName st.lsContractUses
+  resolveWireContract st.lsUseScope contractName
 
 allocatedPortName :: Bool -> Int -> PortLabel -> Text -> Int -> Text
 allocatedPortName isInput idx portLabel contractName totalPorts =
@@ -2237,24 +2281,9 @@ qnameToQualifiedRef (QName segments) =
     }
 
 resolveExecutorQName :: LoweringState -> QName -> Either WireCore.WireError Text
-resolveExecutorQName st qname@(QName segments) =
-  case segments of
-    localName :| []
-      | Just canonical <- Map.lookup localName st.lsExecutorUses ->
-          Right canonical
-      | Set.member localName stdIoExecutorLeaves ->
-          Left (WireCore.WireExecutorNotInScope ("@" <> localName))
-      | otherwise ->
-          Right rendered
-    _
-      | "std.io." `T.isPrefixOf` rendered ->
-          if Set.member rendered st.lsStdExecutorsInScope
-            then Right rendered
-            else Left (WireCore.WireExecutorNotInScope ("@" <> rendered))
-      | otherwise ->
-          Right rendered
-  where
-    rendered = renderQName qname
+resolveExecutorQName st qname =
+  mapLeft WireCore.WireExecutorNotInScope $
+    resolveWireExecutorQName st.lsUseScope qname
 
 validateExecutorProjection
   :: WireCompileEnv
@@ -2283,11 +2312,15 @@ validateStdIoExecutorShape
   :: CircuitNodeRef -> Text -> WireCore.WirePorts -> Either WireCore.WireError ()
 validateStdIoExecutorShape nodeRef executorId ports
   | executorId == stdIoStdinExecutorId =
-      requireShape 0 1 "std.io.stdin expects zero input ports and exactly one output port."
+      requireShape 0 1 stdIoStdinShapeMessage
   | executorId == stdIoStdoutExecutorId =
-      requireShape 1 0 "std.io.stdout expects exactly one input port and zero output ports."
+      requireShape 1 0 stdIoStdoutShapeMessage
   | executorId == stdIoCommandExecutorId =
-      requireAtMostOneEach "std.io.command expects zero or one input port and zero or one output port."
+      requireAtMostOneEach stdIoCommandShapeMessage
+  | executorId == stdIoReadFileExecutorId =
+      requireInputAtMostOutputExactOne stdIoReadFileShapeMessage
+  | executorId == stdIoWriteFileExecutorId =
+      requireShape 1 0 stdIoWriteFileShapeMessage
   | otherwise =
       Right ()
   where
@@ -2300,6 +2333,10 @@ validateStdIoExecutorShape nodeRef executorId ports
 
     requireAtMostOneEach message =
       unless (inputCount <= 1 && outputCount <= 1) $
+        Left (WireCore.WireInvalidPorts nodeRef message)
+
+    requireInputAtMostOutputExactOne message =
+      unless (inputCount <= 1 && outputCount == 1) $
         Left (WireCore.WireInvalidPorts nodeRef message)
 
 mapLeft :: (a -> b) -> Either a c -> Either b c

--- a/src/Cortex/Wire/Parser.hs
+++ b/src/Cortex/Wire/Parser.hs
@@ -835,7 +835,7 @@ useStmt = do
 
 useItem :: Parser UseItem
 useItem =
-  try useExecutorItem <|> useContractItem
+  useExecutorItem <|> useContractItem
   where
     useExecutorItem = do
       _ <- symbol "@"

--- a/src/Cortex/Wire/Proposal.hs
+++ b/src/Cortex/Wire/Proposal.hs
@@ -82,6 +82,16 @@ wireProposalErrorCategory = \case
 wireCompileErrorCategory :: WireError -> Text
 wireCompileErrorCategory = \case
   WireParseError {} -> "wire_parse_rejected"
+  WireMissingCircuit {} -> "wire_lowering_rejected"
+  WireDuplicateNodeRef {} -> "wire_lowering_rejected"
+  WireMissingRequiredField {} -> "wire_lowering_rejected"
+  WireUnknownNodeRef {} -> "wire_lowering_rejected"
+  WireUnusedNodeRef {} -> "wire_lowering_rejected"
+  WireDisconnectedTopology {} -> "wire_lowering_rejected"
+  WireInvalidTopology {} -> "wire_lowering_rejected"
+  WireEmptyCircuit {} -> "wire_lowering_rejected"
+  WireInvalidPorts {} -> "wire_lowering_rejected"
+  WireMissingPortsForNode {} -> "wire_lowering_rejected"
   WireNoCompatiblePorts {} -> "wire_type_rejected"
   WirePortContractMismatch {} -> "wire_type_rejected"
   WireAmbiguousCompatiblePorts {} -> "wire_type_rejected"
@@ -89,7 +99,19 @@ wireCompileErrorCategory = \case
   WireMissingDefaultOutputPort {} -> "wire_type_rejected"
   WireUnknownPort {} -> "wire_type_rejected"
   WireUnknownContract {} -> "wire_type_rejected"
-  _ -> "wire_lowering_rejected"
+  WireMissingRequiredInputPort {} -> "wire_type_rejected"
+  WireInputPortCardinalityViolation {} -> "wire_type_rejected"
+  WireUnknownExecutor {} -> "wire_lowering_rejected"
+  WireExecutorPortsMismatch {} -> "wire_type_rejected"
+  WireUnknownConditionRef {} -> "wire_scope_rejected"
+  WireDuplicateLetBinding {} -> "wire_scope_rejected"
+  WireUnknownLetBinding {} -> "wire_scope_rejected"
+  WireUnknownUseNamespace {} -> "wire_scope_rejected"
+  WireUnknownUseItem {} -> "wire_scope_rejected"
+  WireDuplicateBinding {} -> "wire_scope_rejected"
+  WireExecutorNotInScope {} -> "wire_scope_rejected"
+  WireTypeMismatchInConcat {} -> "wire_type_rejected"
+  WireFieldTypeMismatch {} -> "wire_type_rejected"
 
 renderWireProposalError :: WireProposalError -> Text
 renderWireProposalError = \case

--- a/src/Cortex/Wire/Std.hs
+++ b/src/Cortex/Wire/Std.hs
@@ -16,11 +16,19 @@ module Cortex.Wire.Std
   , stdIoStdinExecutorId
   , stdIoStdoutExecutorId
   , stdIoCommandExecutorId
+  , stdIoReadFileExecutorId
+  , stdIoWriteFileExecutorId
   , stdIoExecutorLeaves
+  , stdIoExecutorIds
   , stdIoExecutorIdForLeaf
   , isStdIoExecutorId
+  , stdIoCommandShapeMessage
   , stdIoCommandSpecContractId
   , stdIoCommandResultContractId
+  , stdIoReadFileShapeMessage
+  , stdIoStdinShapeMessage
+  , stdIoStdoutShapeMessage
+  , stdIoWriteFileShapeMessage
   , stdIoContractIdForName
   , stdIoContractSpecs
   , stdIoContractRegistry
@@ -67,25 +75,60 @@ stdIoStdoutExecutorId = "std.io.stdout"
 stdIoCommandExecutorId :: Text
 stdIoCommandExecutorId = "std.io.command"
 
+stdIoReadFileExecutorId :: Text
+stdIoReadFileExecutorId = "std.io.readFile"
+
+stdIoWriteFileExecutorId :: Text
+stdIoWriteFileExecutorId = "std.io.writeFile"
+
+-- Leaf names are authored inside `use std.io.{...}`; canonical ids are the
+-- executor targets stored in compiled artifacts and runtime registries.
 stdIoExecutorLeaves :: Set Text
 stdIoExecutorLeaves =
-  Set.fromList ["stdin", "stdout", "command"]
+  Set.fromList ["stdin", "stdout", "command", "readFile", "writeFile"]
+
+stdIoExecutorIds :: Set Text
+stdIoExecutorIds =
+  Set.fromList
+    [ stdIoStdinExecutorId
+    , stdIoStdoutExecutorId
+    , stdIoCommandExecutorId
+    , stdIoReadFileExecutorId
+    , stdIoWriteFileExecutorId
+    ]
 
 stdIoExecutorIdForLeaf :: Text -> Maybe Text
 stdIoExecutorIdForLeaf = \case
   "stdin" -> Just stdIoStdinExecutorId
   "stdout" -> Just stdIoStdoutExecutorId
   "command" -> Just stdIoCommandExecutorId
+  "readFile" -> Just stdIoReadFileExecutorId
+  "writeFile" -> Just stdIoWriteFileExecutorId
   _ -> Nothing
 
 isStdIoExecutorId :: Text -> Bool
 isStdIoExecutorId executorId =
-  executorId
-    `Set.member` Set.fromList
-      [ stdIoStdinExecutorId
-      , stdIoStdoutExecutorId
-      , stdIoCommandExecutorId
-      ]
+  executorId `Set.member` stdIoExecutorIds
+
+stdIoStdinShapeMessage :: Text
+stdIoStdinShapeMessage =
+  "std.io.stdin expects zero input ports and exactly one output port."
+
+stdIoStdoutShapeMessage :: Text
+stdIoStdoutShapeMessage =
+  "std.io.stdout expects exactly one input port and zero output ports."
+
+stdIoCommandShapeMessage :: Text
+stdIoCommandShapeMessage =
+  "std.io.command expects zero or one input port and zero or one output port."
+
+stdIoReadFileShapeMessage :: Text
+stdIoReadFileShapeMessage =
+  "std.io.readFile expects zero or one input port and exactly one output port."
+
+stdIoWriteFileShapeMessage :: Text
+stdIoWriteFileShapeMessage =
+  "std.io.writeFile expects exactly one input port and zero output ports."
 
 stdIoCommandSpecContractId :: Text
 stdIoCommandSpecContractId = "std.io.CommandSpec.v1"
@@ -126,6 +169,8 @@ stdIoExecutorProjections =
   [ stdIoProjection stdIoStdinExecutorId
   , stdIoProjection stdIoStdoutExecutorId
   , stdIoProjection stdIoCommandExecutorId
+  , stdIoProjection stdIoReadFileExecutorId
+  , stdIoProjection stdIoWriteFileExecutorId
   ]
 
 stdIoExecutorRegistry :: WireExecutorRegistry

--- a/src/Cortex/Wire/Use.hs
+++ b/src/Cortex/Wire/Use.hs
@@ -1,0 +1,152 @@
+{- |
+Module      : Cortex.Wire.Use
+Description : Shared Wire registry use-scope resolution.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The module belongs to Cortex's upstream runtime and library surface.
+
+Wire `use` declarations are source-scope declarations. Compilation and local
+execution both consume the same resolved scope so registry import semantics do
+not drift between build and run paths.
+-}
+module Cortex.Wire.Use
+  ( WireUseError (..)
+  , WireUseScope (..)
+  , applyWireUseSpec
+  , applyWireUseSpecs
+  , emptyWireUseScope
+  , resolveWireContract
+  , resolveWireExecutorQName
+  , wireUseDeclaredContracts
+  )
+where
+
+import Control.Monad (foldM, when)
+import Data.List.NonEmpty qualified as NE
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+
+import Cortex.Wire.Std
+  ( stdIoContractIdForName
+  , stdIoExecutorIdForLeaf
+  , stdIoExecutorIds
+  , stdIoExecutorLeaves
+  , stdIoNamespace
+  )
+import Cortex.Wire.Syntax
+  ( QName (..)
+  , UseItem (..)
+  , UseSpec (..)
+  , renderQName
+  )
+
+data WireUseError
+  = WireUseUnknownNamespace !Text
+  | WireUseUnknownItem !Text !Text
+  | WireUseDuplicateBinding !Text
+  deriving stock (Eq, Show)
+
+data WireUseScope = WireUseScope
+  { wireUseExecutors :: !(Map Text Text)
+  , wireUseContracts :: !(Map Text Text)
+  , wireUseStdExecutorsInScope :: !(Set Text)
+  }
+  deriving stock (Eq, Show)
+
+emptyWireUseScope :: WireUseScope
+emptyWireUseScope =
+  WireUseScope
+    { wireUseExecutors = Map.empty
+    , wireUseContracts = Map.empty
+    , wireUseStdExecutorsInScope = Set.empty
+    }
+
+applyWireUseSpecs :: (Text -> Bool) -> [UseSpec] -> Either WireUseError WireUseScope
+applyWireUseSpecs externalNameTaken =
+  foldM (applyWireUseSpec externalNameTaken) emptyWireUseScope
+
+applyWireUseSpec
+  :: (Text -> Bool) -> WireUseScope -> UseSpec -> Either WireUseError WireUseScope
+applyWireUseSpec externalNameTaken scope useSpec = do
+  when (renderQName useSpec.useSpecNamespace /= stdIoNamespace) $
+    Left (WireUseUnknownNamespace (renderQName useSpec.useSpecNamespace))
+  foldM lowerUseItem scope (NE.toList useSpec.useSpecItems)
+  where
+    lowerUseItem state = \case
+      UseExecutor itemName maybeAlias -> do
+        canonical <- stdIoExecutorId itemName
+        let localName = fromMaybe itemName maybeAlias
+        ensureUseNameFresh localName state
+        Right
+          state
+            { wireUseExecutors = Map.insert localName canonical state.wireUseExecutors
+            , wireUseStdExecutorsInScope =
+                Set.insert canonical state.wireUseStdExecutorsInScope
+            }
+      UseContract itemName maybeAlias -> do
+        canonical <- stdIoContractId itemName
+        let localName = fromMaybe itemName maybeAlias
+        ensureUseNameFresh localName state
+        Right
+          state
+            { wireUseContracts = Map.insert localName canonical state.wireUseContracts
+            }
+
+    ensureUseNameFresh localName state =
+      when (wireUseLocalNameTaken externalNameTaken state localName) $
+        Left (WireUseDuplicateBinding localName)
+
+wireUseLocalNameTaken :: (Text -> Bool) -> WireUseScope -> Text -> Bool
+wireUseLocalNameTaken externalNameTaken scope localName =
+  externalNameTaken localName
+    || Map.member localName scope.wireUseExecutors
+    || Map.member localName scope.wireUseContracts
+
+stdIoExecutorId :: Text -> Either WireUseError Text
+stdIoExecutorId itemName =
+  maybe
+    (Left (WireUseUnknownItem stdIoNamespace ("@" <> itemName)))
+    Right
+    (stdIoExecutorIdForLeaf itemName)
+
+stdIoContractId :: Text -> Either WireUseError Text
+stdIoContractId itemName =
+  maybe
+    (Left (WireUseUnknownItem stdIoNamespace itemName))
+    Right
+    (stdIoContractIdForName itemName)
+
+wireUseDeclaredContracts :: WireUseScope -> Set Text
+wireUseDeclaredContracts scope =
+  Set.fromList (Map.elems scope.wireUseContracts)
+
+resolveWireContract :: WireUseScope -> Text -> Text
+resolveWireContract scope contractName =
+  Map.findWithDefault contractName contractName scope.wireUseContracts
+
+resolveWireExecutorQName :: WireUseScope -> QName -> Either Text Text
+resolveWireExecutorQName scope qname@(QName segments) =
+  case segments of
+    localName NE.:| []
+      | Just canonical <- Map.lookup localName scope.wireUseExecutors ->
+          Right canonical
+      | Set.member localName stdIoExecutorLeaves ->
+          Left ("@" <> localName)
+      | otherwise ->
+          Right rendered
+    _
+      | Set.member rendered stdIoExecutorIds ->
+          if Set.member rendered scope.wireUseStdExecutorsInScope
+            then Right rendered
+            else Left ("@" <> rendered)
+      | otherwise ->
+          Right rendered
+  where
+    rendered = renderQName qname

--- a/test/Cortex/Wire/CompileSpec.hs
+++ b/test/Cortex/Wire/CompileSpec.hs
@@ -30,7 +30,12 @@ import Cortex.Wire.Circuit.Artifact
   , CompiledCircuitNode (..)
   )
 import Cortex.Wire.Circuit.IR (CircuitNodeRef (..), CircuitTaskNode (..))
-import Cortex.Wire.Compile (compileWireFragmentText, compileWireText, compileWireTextWithEnv)
+import Cortex.Wire.Compile
+  ( compileWireFragmentText
+  , compileWireText
+  , compileWireTextWithEnv
+  , compileWireTextWithReturn
+  )
 import Cortex.Wire.Contract
   ( WireCompileEnv (..)
   , WireContractSpec (..)
@@ -45,6 +50,11 @@ import Cortex.Wire.Executor
   , wireExecutorRegistryFromList
   )
 import Cortex.Wire.Pure (pureWireExecutorProjection)
+import Cortex.Wire.Std
+  ( stdIoReadFileShapeMessage
+  , stdIoStdoutShapeMessage
+  , stdIoWriteFileShapeMessage
+  )
 import Cortex.Wire.Syntax (WireError (..), WireOutputPort (..), WirePorts (..))
 
 spec :: Spec
@@ -85,6 +95,16 @@ spec = describe "Cortex.Wire.Compile" $ do
     compiled.compiledCircuitExitNodes `shouldBe` [CircuitNodeRef "analyst"]
     successors compiled.compiledCircuitTopology (CircuitNodeRef "planner")
       `shouldBe` Set.singleton (CircuitNodeRef "analyst")
+
+  it "allows exported graph libraries outside the default file return" $ do
+    compiled <- requireRight (compileWireText exportedGraphLibrarySourceText)
+    compiled.compiledCircuitEntryNodes `shouldBe` [CircuitNodeRef "main"]
+    Map.keysSet compiled.compiledCircuitNodes `shouldBe` Set.singleton (CircuitNodeRef "main")
+
+  it "compiles a selected graph-valued return" $ do
+    compiled <- requireRight (compileWireTextWithReturn "library_graph" exportedGraphLibrarySourceText)
+    compiled.compiledCircuitEntryNodes `shouldBe` [CircuitNodeRef "library"]
+    Map.keysSet compiled.compiledCircuitNodes `shouldBe` Set.singleton (CircuitNodeRef "library")
 
   it "lowers executor where records into executor config" $ do
     compiled <- requireRight (compileWireText executorWhereSourceText)
@@ -260,12 +280,45 @@ spec = describe "Cortex.Wire.Compile" $ do
       compileWireText stdIoCanonicalWithoutUseSourceText
         `shouldBe` Left (WireExecutorNotInScope "@std.io.command")
 
+    it "rejects use names that collide with local contracts" $
+      compileWireText stdIoUseContractCollisionSourceText
+        `shouldBe` Left (WireDuplicateBinding "CommandSpec")
+
     it "enforces standard stdout port shape" $
       compileWireText stdIoStdoutBadShapeSourceText
         `shouldBe` Left
           ( WireInvalidPorts
               (CircuitNodeRef "bad_stdout")
-              "std.io.stdout expects exactly one input port and zero output ports."
+              stdIoStdoutShapeMessage
+          )
+
+    it "lowers std.io file executors" $ do
+      compiled <- requireRight (compileWireText stdIoFileExecutorsSourceText)
+      case Map.lookup (CircuitNodeRef "read_report") compiled.compiledCircuitNodes of
+        Just (CompiledCircuitTask taskNode) ->
+          taskNode.circuitTaskNodeMetadata `shouldSatisfy` metadataHasExecutorTarget "std.io.readFile"
+        other ->
+          expectationFailure ("expected read_report task node, got: " <> show other)
+      case Map.lookup (CircuitNodeRef "write_report") compiled.compiledCircuitNodes of
+        Just (CompiledCircuitTask taskNode) ->
+          taskNode.circuitTaskNodeMetadata `shouldSatisfy` metadataHasExecutorTarget "std.io.writeFile"
+        other ->
+          expectationFailure ("expected write_report task node, got: " <> show other)
+
+    it "enforces standard readFile port shape" $
+      compileWireText stdIoReadFileBadShapeSourceText
+        `shouldBe` Left
+          ( WireInvalidPorts
+              (CircuitNodeRef "bad_read")
+              stdIoReadFileShapeMessage
+          )
+
+    it "enforces standard writeFile port shape" $
+      compileWireText stdIoWriteFileBadShapeSourceText
+        `shouldBe` Left
+          ( WireInvalidPorts
+              (CircuitNodeRef "bad_write")
+              stdIoWriteFileShapeMessage
           )
 
   describe "fixtures" $ do
@@ -345,6 +398,17 @@ graphLetSourceText =
     , "  -> analysis: AnalysisFragment = @review.analyst (plan) ;"
     , "let pipeline = planner => analyst ;"
     , "pipeline"
+    ]
+
+exportedGraphLibrarySourceText :: T.Text
+exportedGraphLibrarySourceText =
+  T.unlines
+    [ "node library"
+    , "  -> out: LibraryOutput = @review.library ({}) ;"
+    , "node main"
+    , "  -> out: MainOutput = @review.main ({}) ;"
+    , "export let library_graph = library ;"
+    , "main"
     ]
 
 zeroOutputSourceText :: T.Text
@@ -587,6 +651,13 @@ stdIoCanonicalWithoutUseSourceText =
     , "run"
     ]
 
+stdIoUseContractCollisionSourceText :: T.Text
+stdIoUseContractCollisionSourceText =
+  T.unlines
+    [ "use std.io.{CommandSpec};"
+    , "contract CommandSpec;"
+    ]
+
 stdIoStdoutBadShapeSourceText :: T.Text
 stdIoStdoutBadShapeSourceText =
   T.unlines
@@ -594,6 +665,39 @@ stdIoStdoutBadShapeSourceText =
     , "node bad_stdout"
     , "  -> printed: Printed = @stdout {} (null) ;"
     , "bad_stdout"
+    ]
+
+stdIoFileExecutorsSourceText :: T.Text
+stdIoFileExecutorsSourceText =
+  T.unlines
+    [ "use std.io.{@readFile, @writeFile};"
+    , "contract Report;"
+    , "node read_report"
+    , "  -> report: Report = @readFile { path = \"/tmp/wire-report.txt\"; } (null) ;"
+    , "node write_report"
+    , "  <- report: Report;"
+    , "  = @writeFile { path = \"/tmp/wire-report-copy.txt\"; } (report) ;"
+    , "read_report => write_report"
+    ]
+
+stdIoReadFileBadShapeSourceText :: T.Text
+stdIoReadFileBadShapeSourceText =
+  T.unlines
+    [ "use std.io.{@readFile};"
+    , "node bad_read"
+    , "  = @readFile { path = \"/tmp/wire-report.txt\"; } (null) ;"
+    , "bad_read"
+    ]
+
+stdIoWriteFileBadShapeSourceText :: T.Text
+stdIoWriteFileBadShapeSourceText =
+  T.unlines
+    [ "use std.io.{@writeFile};"
+    , "contract Report;"
+    , "node bad_write"
+    , "  <- report: Report;"
+    , "  -> written: Report = @writeFile { path = \"/tmp/wire-report.txt\"; } (report) ;"
+    , "bad_write"
     ]
 
 requireRight :: Show err => Either err a -> IO a


### PR DESCRIPTION
Stacked on #157. Split from #152.\n\nThis slice adds standard file IO leaves and explicit graph return selection.\n\nIncludes:\n- std.io.readFile and std.io.writeFile executors\n- wire build --return NAME\n- shared registry use-scope resolution\n- CLI output-lock cleanup\n- tests and reference docs\n\nValidation run locally:\n- just test