### PR TITLE
feat(wire): add quantum runners

### DIFF
--- a/docs/Consumers/Quantum.md
+++ b/docs/Consumers/Quantum.md
@@ -1,0 +1,237 @@
+---
+title: Quantum Consumer Binding Example
+description:
+  How a quantum host can bind Wire circuits to PennyLane, Qiskit, Cirq, or another backend without
+  making Cortex own quantum semantics.
+sidebar:
+  label: Quantum
+  order: 3
+status: draft
+---
+
+# Quantum Consumer Binding Example
+
+This page is a consumer binding example. It shows how a quantum host can use Wire to author circuit
+topology while keeping quantum semantics, simulator choice, hardware access, and job policy outside
+the Cortex substrate.
+
+The important boundary is the same as every Wire executor boundary:
+
+| Cortex owns                                                                                  | Quantum host owns                                                                                                |
+| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Wire parsing, graph composition, typed ports, executor projection admission, and Pulse runs. | Quantum contracts, gate vocabulary, backend binding, provider credentials, queue policy, shots, and result data. |
+| Projection data structures and registry admission checks.                                    | Runtime implementations for `@quantum.*`, for example through PennyLane, Qiskit, Cirq, or a hardware provider.   |
+
+Wire source can reference quantum gates exactly because they are ordinary registered executors:
+
+```wire
+contract Qubit;
+contract Bit;
+
+node hadamard_control
+  <- control: Qubit;
+  -> control: Qubit = @quantum.h {} (control);
+
+node entangle
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @quantum.cnot ({ inherit control; inherit target; });
+```
+
+`@quantum.h` and `@quantum.cnot` are not Wire keywords. A host registers them in the executor
+projection registry, binds `Qubit` and `Bit` contracts to host codecs, and supplies the runtime
+interpreter that turns admitted nodes into backend operations.
+
+## Minimal Shape
+
+A useful first vocabulary is:
+
+| Executor                | Port shape                                        | Host behavior                                 |
+| ----------------------- | ------------------------------------------------- | --------------------------------------------- |
+| `@quantum.prepare_zero` | zero inputs, one `Qubit` output                   | Introduce a backend qubit initialized to `0`. |
+| `@quantum.rz`           | one `Qubit` input, one `Qubit` output             | Apply a Z-axis rotation.                      |
+| `@quantum.sx`           | one `Qubit` input, one `Qubit` output             | Apply a square-root X gate.                   |
+| `@quantum.x`            | one `Qubit` input, one `Qubit` output             | Apply an X gate.                              |
+| `@quantum.h`            | one `Qubit` input, one `Qubit` output             | Apply a Hadamard gate.                        |
+| `@quantum.rx`           | `Qubit` plus `RotationAngle`, one `Qubit` output  | Apply a parameterized X rotation.             |
+| `@quantum.cz`           | `control` and `target` `Qubit` inputs and outputs | Apply a controlled-Z gate.                    |
+| `@quantum.rzz`          | `control` and `target` `Qubit` inputs and outputs | Apply a parameterized ZZ interaction.         |
+| `@quantum.cnot`         | `control` and `target` `Qubit` inputs and outputs | Apply a controlled-not gate.                  |
+| `@quantum.measure_z`    | one `Qubit` input, one `Bit` output               | Measure in the Z basis.                       |
+
+The example circuit at
+[`../../examples/wire/quantum-bell-state.wire`](../../examples/wire/quantum-bell-state.wire) authors
+a Bell-state topology with this model.
+
+## Runtime Binding
+
+A Python-backed consumer can compile Wire with strict executor projections, then bind the admitted
+nodes to a backend-specific circuit builder:
+
+1. The host registers `@quantum.*` executor projections and `Qubit`, `Bit`, and `RotationAngle`
+   contracts.
+2. Wire compiles the source to a validated Circuit with typed node boundaries.
+3. The host interpreter walks the materialized nodes and appends operations to the selected quantum
+   backend circuit.
+4. Measurement nodes return `Bit` payloads or structured result records through ordinary Wire output
+   ports.
+
+This keeps PennyLane/Qiskit/Cirq APIs out of Cortex. Cortex sees executor IDs, config records,
+ports, contracts, and run results.
+
+## Local Qiskit Runner
+
+The repository includes a Nix-backed local simulator bridge for the example vocabulary:
+
+```sh
+nix run .#wire-quantum-qiskit -- examples/wire/quantum-bell-state.wire --shots 1024 --seed 7
+```
+
+The runner:
+
+- compiles `.wire` input with the flake's `wire` executable;
+- carries `Qubit` ports as symbolic Qiskit wire indices;
+- builds one `QuantumCircuit`;
+- executes it on Qiskit Aer `aer_simulator`;
+- prints a concise run summary with label-decoded counts.
+
+Machine-readable output is available with `--json`:
+
+```sh
+nix run .#wire-quantum-qiskit -- examples/wire/quantum-bell-state.wire --json
+```
+
+Plan inspection without simulator execution is also available:
+
+```sh
+nix run .#wire-quantum-qiskit -- examples/wire/quantum-bell-state.wire --emit-plan
+```
+
+The runner supports only the local Aer simulator. It refuses non-local backend names so an account
+or provider credentials cannot accidentally queue hardware jobs. Hardware execution should be added
+as a separate explicit binding with provider, credential, queue, cost, and audit policy in its own
+config path.
+
+## IBM Quantum Runtime REST Runner
+
+The repository also includes an explicit hardware runner that talks to IBM Quantum Runtime through
+REST:
+
+```sh
+nix run .#wire-quantum-ibm-rest -- examples/wire/quantum-bell-state-ibm-rest.wire --dry-run --config examples/wire/quantum-ibm-runtime.config.example.json
+```
+
+That example starts with a config node:
+
+```wire
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+```
+
+The runner treats that node as the source of the provider config path. The config path is resolved
+relative to the `.wire` file. The example threads the config token into the first prepare node only
+to make the Wire graph connected; the runner treats it as orchestration data, not quantum state. The
+hardware example authors the Bell circuit from backend primitive gates: `h` is decomposed as
+`rz(pi/2) => sx => rz(pi/2)`, and `cnot` as `h(target) => cz => h(target)`. `*.local.json` files are
+ignored by git, so real credentials should live in `examples/wire/quantum-ibm-runtime.local.json`.
+The tracked template at
+[`../../examples/wire/quantum-ibm-runtime.config.example.json`](../../examples/wire/quantum-ibm-runtime.config.example.json)
+shows the expected shape:
+
+```json
+{
+  "api_key_env": "QISKIT_IBM_API_KEY",
+  "instance_crn": "REPLACE_WITH_IBM_QUANTUM_RUNTIME_SERVICE_CRN",
+  "backend": "least_busy"
+}
+```
+
+`api_key_env` keeps the API key in the environment. A local config may instead use an `api_key`
+field, but that file should remain untracked. `instance_crn` is the IBM Quantum Runtime service CRN
+used in the REST `Service-CRN` header. The default API base URL is
+`https://quantum.cloud.ibm.com/api/v1`; `eu-de` instances should use
+`https://eu-de.quantum.cloud.ibm.com/api/v1`.
+
+Hardware submission is opt-in:
+
+```sh
+nix run .#wire-quantum-ibm-rest -- examples/wire/quantum-bell-state-ibm-rest.wire --shots 100 --confirm-hardware
+```
+
+Without `--confirm-hardware`, the runner refuses to submit. With `--dry-run` or `--emit-request`, it
+builds the OpenQASM 3 sampler request locally without requesting an IAM token and without queueing a
+job. `backend = "least_busy"` asks the runner to choose an online non-simulator backend with enough
+qubits; a concrete backend can be selected with the config `backend` field or the `--backend` flag.
+
+## Iterative Phase Estimation Runner
+
+The `wire-quantum-ipea` app demonstrates adaptive phase estimation as a sequence of fresh Wire
+rounds. Each round compiles a new Wire graph, executes one quantum measurement, carries that
+measured bit back into classical Python state, and uses the accumulated bits to choose the next
+round's feedback angle. This is adaptive circuit authoring, not hidden mid-circuit backend feedback.
+
+Local simulation is the default:
+
+```sh
+nix run .#wire-quantum-ipea -- --shots 100 --seed 7
+```
+
+The default target phase is `5/8` with `3` measured bits, so an ideal run estimates bitstring `101`.
+The generated round shape is represented by
+[`../../examples/wire/quantum-ipea-round.wire`](../../examples/wire/quantum-ipea-round.wire). The
+Wire round uses `rz`, `sx`, `x`, and `rzz` executor nodes. For IBM Runtime REST, the OpenQASM
+lowerer expands `rzz` into `rz/sx/cz` operations because IBM's current standard QASM loaders do not
+define an `rzz` gate name. The Wire file binds the round fragments with graph-valued `let`s:
+
+```wire
+let h_control =
+  h_control_rz_a
+    => h_control_sx
+    => h_control_rz_b;
+
+let controlled_phase =
+  (phase_control_rz <> phase_target_rz)
+    => phase_rzz;
+
+let feedback_and_readout =
+  feedback_control_rz
+    => readout_h
+    => measure_phase;
+```
+
+Dry-run mode compiles every generated round and can persist the generated Wire without simulation or
+provider submission:
+
+```sh
+nix run .#wire-quantum-ipea -- --dry-run --emit-round-wire /tmp/wire-ipea-rounds
+```
+
+Hardware execution uses the same ignored IBM Runtime config file as the Bell example and still
+requires explicit confirmation:
+
+```sh
+nix run .#wire-quantum-ipea -- --hardware --shots 100 --confirm-hardware
+```
+
+Because each round is a separate provider job, this demo spends hardware budget per measured phase
+bit. Use `--dry-run` first to inspect the generated rounds and OpenQASM 3.
+
+## Linearity Caveat
+
+Current Wire admission validates typed ports and cardinality-one inputs, but it does not make a
+generic "one output may have only one consumer" guarantee. A real quantum host must reject illegal
+`Qubit` fan-out in its projection/admission layer or introduce a Cortex-level linear-resource
+decision before treating `Qubit` as a no-cloning resource.
+
+Mid-circuit measurement with adaptive classical feedback is also a separate design question. It
+would need to state how measurement results authorize later topology, likely through the existing
+rewrite and `select(...)` surfaces rather than through hidden backend callbacks.
+
+## Related
+
+- [../Architecture/02-ownership-and-boundaries.md](../Architecture/02-ownership-and-boundaries.md)
+- [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md)
+- [../Reference/Wire/executors-and-alphabet.md](../Reference/Wire/executors-and-alphabet.md)
+- [../Reference/Wire/configured-executors-and-execution-boundary.md](../Reference/Wire/configured-executors-and-execution-boundary.md)

--- a/docs/Consumers/index.md
+++ b/docs/Consumers/index.md
@@ -19,6 +19,9 @@ runtimes. These pages show binding patterns without making any consumer the fram
   archetypes, memory, and patterns sit above Cortex without becoming substrate runtime authority.
 - **[Portman](Portman.md)** - private downstream example. Shows how one product binds Cortex to
   product policy, artifacts, persistence, and Pulse host actions.
+- **[Quantum](Quantum.md)** - consumer binding example. Shows how Wire can author quantum circuit
+  topology while a host owns gate semantics and backend execution, including a local Qiskit
+  simulator bridge.
 
 ## What belongs here
 

--- a/examples/wire/quantum-bell-state-ibm-rest.wire
+++ b/examples/wire/quantum-bell-state-ibm-rest.wire
@@ -1,0 +1,101 @@
+# Quantum Wire example for IBM Quantum Runtime REST hardware execution.
+#
+# The first node carries the provider config file path. The config file should
+# be an ignored local JSON file, not a committed secret-bearing artifact.
+
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+
+node prepare_control
+  <- config: IBMQuantumConfig;
+  -> control: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+
+node prepare_target
+  -> target: Qubit = @quantum.prepare_zero { index = 1; } (null);
+
+node h_control_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node h_control_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node h_control_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node cnot_target_h_pre_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node cnot_target_h_pre_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node cnot_target_h_pre_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node entangle_cz
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @quantum.cz ({ inherit control; inherit target; });
+
+node cnot_target_h_post_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node cnot_target_h_post_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node cnot_target_h_post_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node measure_control
+  <- control: Qubit;
+  -> control: Bit = @quantum.measure_z {} (control);
+
+node measure_target
+  <- target: Qubit;
+  -> target: Bit = @quantum.measure_z {} (target);
+
+ibm_runtime_config
+  => (
+    (
+      prepare_control
+        => h_control_rz_a
+        => h_control_sx
+        => h_control_rz_b
+        => entangle_cz
+    )
+    <>
+    (
+      prepare_target
+        => cnot_target_h_pre_rz_a
+        => cnot_target_h_pre_sx
+        => cnot_target_h_pre_rz_b
+        => entangle_cz
+    )
+    <>
+    (
+      entangle_cz
+        => measure_control
+    )
+    <>
+    (
+      entangle_cz
+        => cnot_target_h_post_rz_a
+        => cnot_target_h_post_sx
+        => cnot_target_h_post_rz_b
+        => measure_target
+    )
+)

--- a/examples/wire/quantum-bell-state.wire
+++ b/examples/wire/quantum-bell-state.wire
@@ -1,0 +1,50 @@
+# Quantum Wire example for a consumer-registered executor binding.
+#
+# This file demonstrates that quantum circuits can be authored as ordinary
+# Wire topology. A host must provide the `@quantum.*` executor projections,
+# contract codecs, and runtime binding to PennyLane, Qiskit, Cirq, or another
+# backend.
+
+contract Qubit;
+contract Bit;
+
+node prepare_control
+  -> control: Qubit = @quantum.prepare_zero { index = 0; } (null);
+
+node prepare_target
+  -> target: Qubit = @quantum.prepare_zero { index = 1; } (null);
+
+node hadamard_control
+  <- control: Qubit;
+  -> control: Qubit = @quantum.h {} (control);
+
+node entangle
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @quantum.cnot ({ inherit control; inherit target; });
+
+node measure_control
+  <- control: Qubit;
+  -> control: Bit = @quantum.measure_z {} (control);
+
+node measure_target
+  <- target: Qubit;
+  -> target: Bit = @quantum.measure_z {} (target);
+
+(
+  prepare_control
+    => hadamard_control
+    => entangle
+)
+<>
+(
+  prepare_target
+    => entangle
+)
+<>
+(
+  entangle
+    => (measure_control <> measure_target)
+)

--- a/examples/wire/quantum-ibm-runtime.config.example.json
+++ b/examples/wire/quantum-ibm-runtime.config.example.json
@@ -1,0 +1,10 @@
+{
+  "api_key_env": "QISKIT_IBM_API_KEY",
+  "instance_crn": "REPLACE_WITH_IBM_QUANTUM_RUNTIME_SERVICE_CRN",
+  "api_base_url": "https://quantum.cloud.ibm.com/api/v1",
+  "iam_token_url": "https://iam.cloud.ibm.com/identity/token",
+  "api_version": "2026-03-15",
+  "backend": "least_busy",
+  "poll_interval_seconds": 10,
+  "timeout_seconds": 900
+}

--- a/examples/wire/quantum-ipea-round.wire
+++ b/examples/wire/quantum-ipea-round.wire
@@ -1,0 +1,108 @@
+# Iterative phase estimation Wire round for the quantum consumer binding.
+#
+# This is the first 3-bit IPEA round for target phase 5/8. It measures bit
+# position 3 with controlled-U^4. The complete runner generates one such Wire
+# file per adaptive round and carries the previous measured bits classically.
+
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+
+node prepare_control
+  <- config: IBMQuantumConfig;
+  -> control: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+
+node prepare_target
+  -> target: Qubit = @quantum.prepare_zero { index = 1; } (null);
+
+node target_x
+  <- target: Qubit;
+  -> target: Qubit = @quantum.x {} (target);
+
+node h_control_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node h_control_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node h_control_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node phase_control_rz
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = -1.5707963267948966; } (control);
+
+node phase_target_rz
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = -1.5707963267948966; } (target);
+
+node phase_rzz
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @quantum.rzz { angle = 1.5707963267948966; } ({ inherit control; inherit target; });
+
+node feedback_control_rz
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 0.0; } (control);
+
+node readout_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node readout_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node readout_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node measure_phase
+  <- control: Qubit;
+  -> phase_bit: Bit = @quantum.measure_z {} (control);
+
+let prepare_eigenstate =
+  prepare_target
+    => target_x;
+
+let h_control =
+  h_control_rz_a
+    => h_control_sx
+    => h_control_rz_b;
+
+let controlled_phase =
+  (phase_control_rz <> phase_target_rz)
+    => phase_rzz;
+
+let readout_h =
+  readout_rz_a
+    => readout_sx
+    => readout_rz_b;
+
+let feedback_and_readout =
+  feedback_control_rz
+    => readout_h
+    => measure_phase;
+
+ibm_runtime_config
+  => (
+    (
+      prepare_control
+        => h_control
+        => controlled_phase
+        => feedback_and_readout
+    )
+    <>
+    (
+      prepare_eigenstate
+        => controlled_phase
+    )
+)

--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ test:
 # Run tests matching a pattern
 test-match PATTERN:
     @echo "🧪 Running tests matching '{{ PATTERN }}'..."
-    nix develop -c cabal test cortex-test --test-option='-m' --test-option='{{ PATTERN }}'
+    nix run .#cortex-tests -- -m '{{ PATTERN }}'
 
 # Run flake checks (format + build + test)
 check:

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -16,6 +16,7 @@
     ./haskell.nix
     ./lean.nix
     ./devshell.nix
+    ./quantum.nix
     ./docs.nix
     ./editors.nix
     ./ci

--- a/nix/quantum.nix
+++ b/nix/quantum.nix
@@ -1,0 +1,70 @@
+{...}: {
+  perSystem = {
+    config,
+    pkgs,
+    ...
+  }: let
+    qiskitPython =
+      pkgs.python313.withPackages
+      (ps: [
+        ps.qiskit
+        ps.qiskit-aer
+      ]);
+
+    wire-quantum-qiskit = pkgs.writeShellApplication {
+      name = "wire-quantum-qiskit";
+      text = ''
+        set -euo pipefail
+        exec ${qiskitPython}/bin/python ${../scripts/wire-quantum-qiskit.py} \
+          --wire-bin ${config.packages.wire}/bin/wire \
+          "$@"
+      '';
+    };
+
+    wire-quantum-ibm-rest = pkgs.writeShellApplication {
+      name = "wire-quantum-ibm-rest";
+      text = ''
+        set -euo pipefail
+        scripts_dir="${../scripts}"
+        exec ${pkgs.python313}/bin/python "$scripts_dir/wire-quantum-ibm-rest.py" \
+          --wire-bin ${config.packages.wire}/bin/wire \
+          "$@"
+      '';
+    };
+
+    wire-quantum-ipea = pkgs.writeShellApplication {
+      name = "wire-quantum-ipea";
+      text = ''
+        set -euo pipefail
+        scripts_dir="${../scripts}"
+        exec ${qiskitPython}/bin/python "$scripts_dir/wire-quantum-ipea.py" \
+          --wire-bin ${config.packages.wire}/bin/wire \
+          "$@"
+      '';
+    };
+  in {
+    packages = {
+      wire-quantum-qiskit = wire-quantum-qiskit;
+      wire-quantum-ibm-rest = wire-quantum-ibm-rest;
+      wire-quantum-ipea = wire-quantum-ipea;
+    };
+
+    apps = {
+      wire-quantum-qiskit = {
+        type = "app";
+        program = "${wire-quantum-qiskit}/bin/wire-quantum-qiskit";
+        meta.description = "Run Wire quantum examples through a local Qiskit Aer simulator";
+      };
+      wire-quantum-ibm-rest = {
+        type = "app";
+        program = "${wire-quantum-ibm-rest}/bin/wire-quantum-ibm-rest";
+        meta.description = "Submit Wire quantum examples to IBM Quantum Runtime REST";
+      };
+      wire-quantum-ipea = {
+        type = "app";
+        program = "${wire-quantum-ipea}/bin/wire-quantum-ipea";
+        meta.description = "Run iterative phase estimation as composed Wire quantum rounds";
+      };
+    };
+  };
+}

--- a/scripts/wire-quantum-ibm-rest.py
+++ b/scripts/wire-quantum-ibm-rest.py
@@ -1,0 +1,1010 @@
+#!/usr/bin/env python3
+"""Submit Wire-authored quantum circuits to IBM Quantum Runtime REST.
+
+This runner is intentionally separate from the local Qiskit Aer bridge. It
+requires an explicit credentials config path and an explicit hardware
+confirmation flag before it can queue a provider job.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import importlib.util
+import json
+import math
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+JSON = dict[str, Any]
+IBM_API_BASE_URL = "https://quantum.cloud.ibm.com/api/v1"
+IBM_IAM_TOKEN_URL = "https://iam.cloud.ibm.com/identity/token"
+IBM_API_VERSION = "2026-03-15"
+IAM_API_KEY_GRANT = "urn:ibm:params:oauth:grant-type:apikey"
+PLACEHOLDER_MARKERS = ("REPLACE_WITH", "YOUR_", "<")
+BITSTRING_RE = re.compile(r"^[01][01 ]*$")
+USER_AGENT = "cortex-wire-quantum/0.1"
+HALF_PI = math.pi / 2
+PUBLIC_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
+JOB_STATUS_LABELS = {
+    "completed": "Completed",
+    "done": "Completed",
+    "failed": "Failed",
+    "cancelled": "Cancelled",
+    "canceled": "Cancelled",
+    "queued": "Queued",
+    "running": "Running",
+    "pending": "Pending",
+}
+TERMINAL_JOB_STATUSES = {"completed", "failed", "cancelled", "canceled"}
+
+
+def main() -> int:
+    quantum = load_quantum_support()
+    parser = argparse.ArgumentParser(
+        description="Run a Wire quantum circuit on IBM Quantum Runtime through REST.",
+    )
+    parser.add_argument(
+        "input",
+        help="Wire source file, compiled Wire JSON artifact, or '-' for compiled JSON on stdin.",
+    )
+    parser.add_argument(
+        "--wire-bin",
+        default=os.environ.get("WIRE_BIN", "wire"),
+        help="Wire CLI to use when the input is a .wire source file.",
+    )
+    parser.add_argument(
+        "--config",
+        help="Override the config path carried by @quantum.ibm_runtime_config.",
+    )
+    parser.add_argument(
+        "--backend",
+        help="Override the config backend. Use 'least_busy' to auto-select online hardware.",
+    )
+    parser.add_argument("--shots", type=positive_int, default=100)
+    parser.add_argument(
+        "--poll-interval",
+        type=positive_int,
+        help="Polling interval in seconds. Defaults to the config file value or 10.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=positive_int,
+        help="Polling timeout in seconds. Defaults to the config file value or 900.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build the REST request locally without requesting credentials or queueing a job.",
+    )
+    parser.add_argument(
+        "--emit-request",
+        action="store_true",
+        help="Include the REST sampler payload in the output without submitting it.",
+    )
+    parser.add_argument(
+        "--submit-only",
+        action="store_true",
+        help="Submit the job and print its id without polling for results.",
+    )
+    parser.add_argument(
+        "--confirm-hardware",
+        action="store_true",
+        help="Required before this runner can queue an IBM Quantum hardware job.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Print machine-readable JSON instead of the human summary.",
+    )
+    args = parser.parse_args()
+
+    try:
+        compiled = quantum.load_compiled_circuit(args.input, args.wire_bin)
+        plan = quantum.build_quantum_plan(compiled)
+        config_path = select_config_path(args.input, args.config, plan, quantum)
+        will_submit = not args.dry_run and not args.emit_request
+        if will_submit and not args.confirm_hardware:
+            raise quantum.WireQuantumError(
+                "refusing to submit an IBM Quantum hardware job without "
+                "--confirm-hardware; use --dry-run to inspect the request locally"
+            )
+        config = load_runtime_config(
+            config_path,
+            require_credentials=will_submit,
+            quantum=quantum,
+        )
+        qasm = build_openqasm3(plan, quantum)
+        backend_request = args.backend or config["backend"]
+        payload = build_sampler_payload(backend_request, qasm, args.shots)
+
+        if args.dry_run or args.emit_request:
+            result = {
+                "execution": "dry_run",
+                "source": args.input,
+                "config_path": str(config_path),
+                "backend_request": backend_request,
+                "shots": args.shots,
+                "plan": plan,
+                "openqasm3": qasm,
+                "request_payload": payload,
+            }
+            if args.json_output:
+                quantum.print_json(result)
+            else:
+                print_request_summary(
+                    source=args.input,
+                    config_path=str(config_path),
+                    backend_request=backend_request,
+                    shots=args.shots,
+                    plan=plan,
+                    openqasm3=qasm,
+                    request_payload=payload if args.emit_request else None,
+                )
+            return 0
+
+        token = fetch_iam_token(config, quantum)
+        backend = resolve_backend(backend_request, config, token, plan, quantum)
+        payload = build_sampler_payload(backend, qasm, args.shots)
+        submitted = submit_job(config, token, payload, quantum)
+        job_id = submitted["job_id"]
+
+        if args.submit_only:
+            result = {
+                "execution": "submitted",
+                "source": args.input,
+                "config_path": str(config_path),
+                "backend": backend,
+                "job_id": job_id,
+                "shots": args.shots,
+                "plan": plan,
+            }
+            if args.json_output:
+                quantum.print_json(result)
+            else:
+                print_submission_summary(
+                    source=args.input,
+                    config_path=str(config_path),
+                    backend=backend,
+                    job_id=job_id,
+                    shots=args.shots,
+                )
+            return 0
+
+        poll_interval = args.poll_interval or config["poll_interval_seconds"]
+        timeout_seconds = args.timeout or config["timeout_seconds"]
+        final_job = poll_job(
+            config,
+            token,
+            job_id,
+            poll_interval,
+            timeout_seconds,
+            quiet=args.json_output,
+            quantum=quantum,
+        )
+        raw_result = fetch_job_results(config, token, job_id, quantum)
+        metrics = fetch_job_metrics(config, token, job_id, quantum)
+        counts = extract_counts(raw_result, plan["measurements"])
+        result = {
+            "execution": "hardware",
+            "source": args.input,
+            "config_path": str(config_path),
+            "backend": backend,
+            "backend_family": "ibm_quantum_runtime_rest",
+            "job_id": job_id,
+            "status": public_job_status(final_job),
+            "shots": args.shots,
+            "plan": plan,
+            "counts": counts,
+            "labeled_counts": (
+                quantum.labeled_counts(counts, plan["measurements"]) if counts else None
+            ),
+            "qpu_usage_seconds": qpu_usage_seconds(metrics),
+        }
+        if args.json_output:
+            quantum.print_json(result)
+        else:
+            print_hardware_run_summary(
+                source=args.input,
+                config_path=str(config_path),
+                backend=backend,
+                job_id=job_id,
+                status=result["status"],
+                shots=args.shots,
+                plan=plan,
+                counts=counts,
+                qpu_usage=result["qpu_usage_seconds"],
+                quantum=quantum,
+            )
+        return 0
+    except quantum.WireQuantumError as exc:
+        print(f"wire-quantum-ibm-rest: {exc}", file=sys.stderr)
+        return 1
+
+
+def load_quantum_support() -> Any:
+    scripts_dir = Path(
+        os.environ.get("WIRE_QUANTUM_SCRIPTS_DIR", str(Path(__file__).resolve().parent))
+    )
+    module_path = scripts_dir / "wire-quantum-qiskit.py"
+    spec = importlib.util.spec_from_file_location("wire_quantum_qiskit_support", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load quantum support module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def positive_int(raw: str) -> int:
+    value = int(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return value
+
+
+def select_config_path(
+    input_path: str,
+    override: str | None,
+    plan: JSON,
+    quantum: Any,
+) -> Path:
+    runtime_config = plan.get("runtime_config")
+    if override is not None:
+        return resolve_cli_config_path(override)
+    if not isinstance(runtime_config, dict):
+        raise quantum.WireQuantumError(
+            "hardware execution requires @quantum.ibm_runtime_config { path = ...; } "
+            "as the first Wire node, or an explicit --config override"
+        )
+    topological_order = plan.get("topological_order", [])
+    if not topological_order or topological_order[0] != runtime_config.get("node"):
+        raise quantum.WireQuantumError(
+            "@quantum.ibm_runtime_config must be the first topological node in the "
+            "hardware Wire graph"
+        )
+    return resolve_config_path(input_path, str(runtime_config["path"]))
+
+
+def resolve_cli_config_path(raw_path: str) -> Path:
+    path = Path(raw_path).expanduser()
+    if path.is_absolute():
+        return path
+    return path.resolve()
+
+
+def resolve_config_path(input_path: str, raw_path: str) -> Path:
+    path = Path(raw_path).expanduser()
+    if path.is_absolute():
+        return path
+    if input_path != "-":
+        source_path = Path(input_path)
+        if source_path.suffix == ".wire":
+            return (source_path.resolve().parent / path).resolve()
+    return path.resolve()
+
+
+def load_runtime_config(path: Path, require_credentials: bool, quantum: Any) -> JSON:
+    if not path.exists():
+        raise quantum.WireQuantumError(
+            f"IBM Quantum config file not found: {path}. "
+            "Use an ignored *.local.json config for credentials."
+        )
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise quantum.WireQuantumError(f"invalid IBM Quantum config JSON at {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise quantum.WireQuantumError(f"IBM Quantum config must be a JSON object: {path}")
+
+    api_key, api_key_source = resolve_api_key(raw)
+    instance_crn = optional_string(raw, "instance_crn")
+    if is_placeholder(instance_crn):
+        instance_crn = None
+
+    if require_credentials and not api_key:
+        raise quantum.WireQuantumError(
+            "IBM Quantum config needs an api_key field or an api_key_env field "
+            "that points at an environment variable"
+        )
+    if require_credentials and not instance_crn:
+        raise quantum.WireQuantumError(
+            "IBM Quantum config needs instance_crn for Runtime REST requests"
+        )
+
+    return {
+        "api_key": api_key,
+        "api_key_source": api_key_source,
+        "instance_crn": instance_crn,
+        "api_base_url": string_or_default(raw, "api_base_url", IBM_API_BASE_URL),
+        "iam_token_url": string_or_default(raw, "iam_token_url", IBM_IAM_TOKEN_URL),
+        "api_version": string_or_default(raw, "api_version", IBM_API_VERSION),
+        "backend": string_or_default(raw, "backend", "least_busy"),
+        "poll_interval_seconds": int_or_default(raw, "poll_interval_seconds", 10),
+        "timeout_seconds": int_or_default(raw, "timeout_seconds", 900),
+    }
+
+
+def resolve_api_key(raw: JSON) -> tuple[str | None, str]:
+    env_name = optional_string(raw, "api_key_env")
+    if env_name:
+        env_value = os.environ.get(env_name)
+        if env_value and not is_placeholder(env_value):
+            return env_value, f"env:{env_name}"
+
+    api_key = optional_string(raw, "api_key")
+    if api_key and not is_placeholder(api_key):
+        return api_key, "config:api_key"
+
+    if env_name:
+        return None, f"env:{env_name} (unset)"
+    return None, "missing"
+
+
+def optional_string(raw: JSON, field: str) -> str | None:
+    value = raw.get(field)
+    return value if isinstance(value, str) and value else None
+
+
+def string_or_default(raw: JSON, field: str, default: str) -> str:
+    value = optional_string(raw, field)
+    return value if value and not is_placeholder(value) else default
+
+
+def int_or_default(raw: JSON, field: str, default: int) -> int:
+    value = raw.get(field)
+    if isinstance(value, int) and value > 0:
+        return value
+    return default
+
+
+def is_placeholder(value: str | None) -> bool:
+    if value is None:
+        return False
+    return any(marker in value for marker in PLACEHOLDER_MARKERS)
+
+
+def build_openqasm3(plan: JSON, quantum: Any) -> str:
+    if not plan["measurements"]:
+        raise quantum.WireQuantumError("IBM sampler execution requires at least one measurement")
+    lines = [
+        "OPENQASM 3.0;",
+        'include "stdgates.inc";',
+        f"qubit[{plan['num_qubits']}] q;",
+        f"bit[{len(plan['measurements'])}] c;",
+    ]
+    for operation in plan["operations"]:
+        gate = operation["gate"]
+        if gate == "prepare_zero":
+            continue
+        if gate == "h":
+            raise quantum.WireQuantumError(
+                "IBM hardware runner requires primitive Wire gates; decompose "
+                "quantum.h as quantum.rz(pi/2) => quantum.sx => quantum.rz(pi/2)"
+            )
+        elif gate == "rz":
+            lines.append(f"rz({operation['angle']}) q[{operation['wire']}];")
+        elif gate == "sx":
+            lines.append(f"sx q[{operation['wire']}];")
+        elif gate == "x":
+            lines.append(f"x q[{operation['wire']}];")
+        elif gate == "cnot":
+            raise quantum.WireQuantumError(
+                "IBM hardware runner requires primitive Wire gates; decompose "
+                "quantum.cnot as h(target) => quantum.cz => h(target)"
+            )
+        elif gate == "cz":
+            lines.append(f"cz q[{operation['control']}], q[{operation['target']}];")
+        elif gate == "rzz":
+            append_rzz_decomposition(
+                lines,
+                operation["angle"],
+                operation["control"],
+                operation["target"],
+            )
+        elif gate == "measure_z":
+            lines.append(
+                f"c[{operation['classical_bit']}] = measure q[{operation['wire']}];"
+            )
+        else:
+            raise quantum.WireQuantumError(f"unsupported planned gate {gate}")
+    return "\n".join(lines) + "\n"
+
+
+def append_rzz_decomposition(lines: list[str], angle: float, control: int, target: int) -> None:
+    append_cnot_decomposition(lines, control, target)
+    lines.append(f"rz({angle}) q[{target}];")
+    append_cnot_decomposition(lines, control, target)
+
+
+def append_cnot_decomposition(lines: list[str], control: int, target: int) -> None:
+    append_h_decomposition(lines, target)
+    lines.append(f"cz q[{control}], q[{target}];")
+    append_h_decomposition(lines, target)
+
+
+def append_h_decomposition(lines: list[str], wire: int) -> None:
+    lines.append(f"rz({HALF_PI}) q[{wire}];")
+    lines.append(f"sx q[{wire}];")
+    lines.append(f"rz({HALF_PI}) q[{wire}];")
+
+
+def build_sampler_payload(backend: str, qasm: str, shots: int) -> JSON:
+    return {
+        "program_id": "sampler",
+        "backend": backend,
+        "params": {
+            "pubs": [[qasm, {}, shots]],
+            "shots": shots,
+            "version": 2,
+            "support_qiskit": False,
+        },
+        "tags": ["cortex", "wire", "quantum-example"],
+    }
+
+
+def fetch_iam_token(config: JSON, quantum: Any) -> str:
+    form = urllib.parse.urlencode(
+        {"grant_type": IAM_API_KEY_GRANT, "apikey": config["api_key"]}
+    ).encode("utf-8")
+    response = request_json(
+        "POST",
+        config["iam_token_url"],
+        {
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": USER_AGENT,
+        },
+        data=form,
+        quantum=quantum,
+    )
+    token = response.get("access_token")
+    if not isinstance(token, str) or not token:
+        raise quantum.WireQuantumError("IBM IAM token response did not include access_token")
+    return token
+
+
+def resolve_backend(
+    backend_request: str,
+    config: JSON,
+    token: str,
+    plan: JSON,
+    quantum: Any,
+) -> str:
+    if backend_request != "least_busy":
+        return backend_request
+
+    response = request_json(
+        "GET",
+        api_url(config, "backends"),
+        runtime_headers(config, token),
+        quantum=quantum,
+    )
+    devices = response.get("devices") if isinstance(response, dict) else response
+    if not isinstance(devices, list):
+        raise quantum.WireQuantumError("IBM backends response did not include a devices list")
+
+    candidates = []
+    for device in devices:
+        if not isinstance(device, dict):
+            continue
+        name = device.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        if bool(device.get("is_simulator")):
+            continue
+        if status_name(device) != "online":
+            continue
+        if qubit_count(device) < int(plan["num_qubits"]):
+            continue
+        candidates.append(device)
+
+    if not candidates:
+        raise quantum.WireQuantumError(
+            "no online IBM Quantum hardware backend has enough qubits for this plan"
+        )
+
+    selected = min(candidates, key=backend_sort_key)
+    return str(selected["name"])
+
+
+def submit_job(config: JSON, token: str, payload: JSON, quantum: Any) -> JSON:
+    response = request_json(
+        "POST",
+        api_url(config, "jobs"),
+        runtime_headers(config, token, content_type="application/json"),
+        payload=payload,
+        quantum=quantum,
+    )
+    job_id = first_string(response, ["id", "job_id", "jobId"])
+    if job_id is None:
+        raise quantum.WireQuantumError("IBM job submission response did not include a job id")
+    return {"job_id": public_identifier(job_id, "IBM job id", quantum)}
+
+
+def poll_job(
+    config: JSON,
+    token: str,
+    job_id: str,
+    poll_interval: int,
+    timeout_seconds: int,
+    quiet: bool,
+    quantum: Any,
+) -> JSON:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        job = fetch_job(config, token, job_id, quantum)
+        status = public_job_status(job)
+        normalized = status.lower()
+        if normalized in TERMINAL_JOB_STATUSES:
+            if normalized != "completed":
+                raise quantum.WireQuantumError(f"IBM job {job_id} ended with status {status}")
+            return job
+        if time.monotonic() >= deadline:
+            raise quantum.WireQuantumError(
+                f"timed out waiting for IBM job {job_id}; last status was {status}"
+            )
+        if not quiet:
+            sys.stderr.write("IBM job is not terminal; polling again.\n")
+        time.sleep(poll_interval)
+
+
+def fetch_job(config: JSON, token: str, job_id: str, quantum: Any) -> JSON:
+    return request_json(
+        "GET",
+        api_url(config, f"jobs/{urllib.parse.quote(job_id, safe='')}"),
+        runtime_headers(config, token),
+        quantum=quantum,
+    )
+
+
+def fetch_job_results(config: JSON, token: str, job_id: str, quantum: Any) -> Any:
+    return request_json(
+        "GET",
+        api_url(config, f"jobs/{urllib.parse.quote(job_id, safe='')}/results"),
+        runtime_headers(config, token),
+        quantum=quantum,
+    )
+
+
+def fetch_job_metrics(config: JSON, token: str, job_id: str, quantum: Any) -> JSON | None:
+    try:
+        return request_json(
+            "GET",
+            api_url(config, f"jobs/{urllib.parse.quote(job_id, safe='')}/metrics"),
+            runtime_headers(config, token),
+            quantum=quantum,
+        )
+    except quantum.WireQuantumError:
+        return None
+
+
+def request_json(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    quantum: Any,
+    payload: Any | None = None,
+    data: bytes | None = None,
+) -> Any:
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raise quantum.WireQuantumError(
+            f"IBM Runtime REST {method} {url} failed with HTTP {exc.code}; "
+            "response body omitted"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise quantum.WireQuantumError(
+            f"IBM Runtime REST {method} {url} failed: {exc.reason}"
+        ) from exc
+    if not body:
+        return {}
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise quantum.WireQuantumError(
+            f"IBM Runtime REST {method} {url} returned non-JSON response"
+        ) from exc
+
+
+def api_url(config: JSON, path: str) -> str:
+    return config["api_base_url"].rstrip("/") + "/" + path.lstrip("/")
+
+
+def runtime_headers(
+    config: JSON,
+    token: str,
+    content_type: str | None = None,
+) -> dict[str, str]:
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {token}",
+        "IBM-API-Version": config["api_version"],
+        "Service-CRN": config["instance_crn"] or "",
+        "User-Agent": USER_AGENT,
+    }
+    if content_type is not None:
+        headers["Content-Type"] = content_type
+    return headers
+
+
+def status_name(device: JSON) -> str:
+    status = device.get("status")
+    if isinstance(status, dict):
+        name = status.get("name")
+    else:
+        name = status
+    return str(name).lower() if name is not None else ""
+
+
+def qubit_count(device: JSON) -> int:
+    for key in ("qubits", "num_qubits", "n_qubits"):
+        value = device.get(key)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, list):
+            return len(value)
+    return 0
+
+
+def backend_sort_key(device: JSON) -> tuple[float, float, str]:
+    return (
+        numeric_value(device.get("queue_length"), default=math.inf),
+        numeric_value(device.get("wait_time_seconds"), default=math.inf),
+        str(device.get("name")),
+    )
+
+
+def numeric_value(value: Any, default: float) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, dict):
+        numeric_values = [
+            float(item) for item in value.values() if isinstance(item, (int, float))
+        ]
+        if numeric_values:
+            return min(numeric_values)
+    return default
+
+
+def first_string(value: Any, fields: list[str]) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    for field in fields:
+        found = value.get(field)
+        if isinstance(found, str) and found:
+            return found
+    return None
+
+
+def public_identifier(value: str, label: str, quantum: Any) -> str:
+    if PUBLIC_IDENTIFIER_RE.fullmatch(value):
+        return value
+    raise quantum.WireQuantumError(f"{label} used an unexpected format")
+
+
+def job_status(job: Any) -> str:
+    if not isinstance(job, dict):
+        return "unknown"
+    state = job.get("state")
+    if isinstance(state, dict):
+        status = state.get("status") or state.get("name")
+        if status is not None:
+            return str(status)
+    if state is not None and not isinstance(state, dict):
+        return str(state)
+    status = job.get("status")
+    return str(status) if status is not None else "unknown"
+
+
+def public_job_status(job: Any) -> str:
+    normalized = job_status(job).strip().lower()
+    return JOB_STATUS_LABELS.get(normalized, "Unknown")
+
+
+def extract_counts(raw_result: Any, measurements: list[JSON]) -> dict[str, int] | None:
+    width = len(measurements)
+    direct_counts = find_direct_counts(raw_result, width)
+    if direct_counts is not None:
+        return direct_counts
+    sample_counts = find_sample_counts(raw_result, width)
+    if sample_counts is not None:
+        return sample_counts
+    for tensor in iter_tensors(raw_result):
+        tensor_counts = counts_from_bool_tensor(tensor, width)
+        if tensor_counts is not None:
+            return tensor_counts
+    return None
+
+
+def find_direct_counts(value: Any, width: int) -> dict[str, int] | None:
+    if isinstance(value, dict):
+        for key in ("counts", "quasi_dists"):
+            candidate = normalize_counts(value.get(key), width)
+            if candidate is not None:
+                return candidate
+        candidate = normalize_counts(value, width)
+        if candidate is not None:
+            return candidate
+        for child in value.values():
+            found = find_direct_counts(child, width)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for child in value:
+            found = find_direct_counts(child, width)
+            if found is not None:
+                return found
+    return None
+
+
+def normalize_counts(value: Any, width: int) -> dict[str, int] | None:
+    if not isinstance(value, dict) or not value:
+        return None
+    counts: dict[str, int] = {}
+    for raw_bits, raw_count in value.items():
+        if not isinstance(raw_bits, str):
+            return None
+        bits = raw_bits.replace(" ", "")
+        if len(bits) != width or BITSTRING_RE.fullmatch(raw_bits) is None:
+            return None
+        if isinstance(raw_count, bool) or not isinstance(raw_count, (int, float)):
+            return None
+        if isinstance(raw_count, float) and not raw_count.is_integer():
+            return None
+        counts[bits] = int(raw_count)
+    return dict(sorted(counts.items()))
+
+
+def find_sample_counts(value: Any, width: int) -> dict[str, int] | None:
+    if isinstance(value, dict):
+        candidate = normalize_samples(value, width)
+        if candidate is not None:
+            return candidate
+        for child in value.values():
+            found = find_sample_counts(child, width)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for child in value:
+            found = find_sample_counts(child, width)
+            if found is not None:
+                return found
+    return None
+
+
+def normalize_samples(value: Any, width: int) -> dict[str, int] | None:
+    if not isinstance(value, dict):
+        return None
+    samples = value.get("samples")
+    num_bits = value.get("num_bits", width)
+    if not isinstance(samples, list) or not isinstance(num_bits, int) or num_bits < width:
+        return None
+
+    counter: Counter[str] = Counter()
+    for sample in samples:
+        bits = sample_to_bitstring(sample, num_bits)
+        if bits is None:
+            return None
+        counter[bits[-width:]] += 1
+    return dict(sorted(counter.items()))
+
+
+def sample_to_bitstring(sample: Any, width: int) -> str | None:
+    if isinstance(sample, int) and sample >= 0:
+        return format(sample, f"0{width}b")
+    if not isinstance(sample, str):
+        return None
+    if sample.startswith(("0x", "0X")):
+        try:
+            return format(int(sample, 16), f"0{width}b")
+        except ValueError:
+            return None
+    if sample.startswith(("0b", "0B")):
+        bits = sample[2:]
+    else:
+        bits = sample.replace(" ", "")
+    if len(bits) <= width and set(bits) <= {"0", "1"}:
+        return bits.zfill(width)
+    return None
+
+
+def iter_tensors(value: Any) -> Any:
+    if isinstance(value, dict):
+        if {"data", "shape", "dtype"}.issubset(value):
+            yield value
+        for child in value.values():
+            yield from iter_tensors(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from iter_tensors(child)
+
+
+def counts_from_bool_tensor(tensor: JSON, width: int) -> dict[str, int] | None:
+    if tensor.get("dtype") != "bool" or width <= 0:
+        return None
+    shape = tensor.get("shape")
+    encoded = tensor.get("data")
+    if not isinstance(shape, list) or not all(isinstance(dim, int) for dim in shape):
+        return None
+    if not isinstance(encoded, str) or not shape:
+        return None
+    total = math.prod(shape)
+    if total <= 0:
+        return None
+    if shape[-1] != width and width != 1:
+        return None
+
+    try:
+        raw = base64.b64decode(encoded)
+    except ValueError:
+        return None
+
+    if len(raw) == total:
+        bits = [1 if item else 0 for item in raw]
+    else:
+        bits = []
+        for byte in raw:
+            for bit_index in range(8):
+                bits.append((byte >> bit_index) & 1)
+        bits = bits[:total]
+    if len(bits) < total:
+        return None
+
+    row_width = width
+    counter: Counter[str] = Counter()
+    for offset in range(0, total, row_width):
+        row = bits[offset : offset + row_width]
+        if len(row) != row_width:
+            return None
+        # The shared formatter expects Qiskit's rendered bitstring convention:
+        # highest classical bit on the left, classical bit 0 on the right.
+        counter["".join(str(bit) for bit in row)[::-1]] += 1
+    return dict(sorted(counter.items()))
+
+
+def print_request_summary(
+    source: str,
+    config_path: str,
+    backend_request: str,
+    shots: int,
+    plan: JSON,
+    openqasm3: str,
+    request_payload: JSON | None,
+) -> None:
+    print("Wire IBM Quantum request")
+    emit_field("source", source)
+    print("execution: dry run (not submitted)")
+    emit_field("config", config_path)
+    emit_field("backend", backend_request)
+    emit_field("shots", shots)
+    emit_field("qubits", plan["num_qubits"])
+    emit_field("measurements", format_measurements(plan))
+    print()
+    print("What would happen:")
+    print("Wire compiles the graph into typed quantum executor nodes.")
+    print("This runner lowers those nodes into one OpenQASM 3 sampler job.")
+    print("No IAM token was requested and no IBM Quantum job was queued.")
+    print()
+    print("OpenQASM 3:")
+    emit_block(openqasm3)
+    if request_payload is not None:
+        print()
+        print("REST payload:")
+        emit_line(json.dumps(request_payload, indent=2, sort_keys=True))
+
+
+def print_submission_summary(
+    source: str,
+    config_path: str,
+    backend: str,
+    job_id: str,
+    shots: int,
+) -> None:
+    print("Wire IBM Quantum job")
+    emit_field("source", source)
+    print("execution: submitted (not polled)")
+    emit_field("config", config_path)
+    emit_field("backend", backend)
+    emit_field("job", job_id)
+    emit_field("shots", shots)
+    print()
+    print("The job is now queued with IBM Quantum Runtime.")
+
+
+def print_hardware_run_summary(
+    source: str,
+    config_path: str,
+    backend: str,
+    job_id: str,
+    status: str,
+    shots: int,
+    plan: JSON,
+    counts: dict[str, int] | None,
+    qpu_usage: float | None,
+    quantum: Any,
+) -> None:
+    print("Wire IBM Quantum run")
+    emit_field("source", source)
+    print("execution: IBM Quantum hardware via Runtime REST")
+    emit_field("config", config_path)
+    emit_field("backend", backend)
+    emit_field("job", job_id)
+    emit_field("status", status)
+    emit_field("shots", shots)
+    emit_field("qubits", plan["num_qubits"])
+    emit_field("measurements", format_measurements(plan))
+    if qpu_usage is not None:
+        emit_field("qpu usage", f"{qpu_usage:.3f}s")
+    print()
+    print("What happened:")
+    print("Wire compiled the graph into typed quantum executor nodes.")
+    print("The runner lowered the admitted gates into OpenQASM 3 and submitted")
+    print("that circuit to IBM Quantum Runtime REST as a sampler job.")
+    print("Credentials came from the config file path carried by the first Wire node.")
+    print()
+    print("Result:")
+    if counts:
+        emit_line(quantum.format_result_table(counts, plan["measurements"], shots))
+    else:
+        print("  IBM returned a result shape this example decoder did not recognize.")
+        print("  No raw provider payload is printed because it can contain account data.")
+
+
+def emit_field(label: str, value: Any) -> None:
+    emit_raw(f"{label}: {value}\n")
+
+
+def emit_line(value: str) -> None:
+    emit_raw(value)
+    if not value.endswith("\n"):
+        emit_raw("\n")
+
+
+def emit_block(value: str) -> None:
+    emit_raw(value)
+
+
+def emit_raw(value: str) -> None:
+    sys.stdout.flush()
+    os.write(sys.stdout.fileno(), value.encode("utf-8"))
+
+
+def qpu_usage_seconds(metrics: Any) -> float | None:
+    if not isinstance(metrics, dict):
+        return None
+    usage = metrics.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    value = usage.get("qpu_charge_time_seconds")
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def format_measurements(plan: JSON) -> str:
+    measurements = plan["measurements"]
+    if not measurements:
+        return "none"
+    return ", ".join(
+        f"{measurement['output']}=q[{measurement['wire']}]"
+        for measurement in measurements
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wire-quantum-ipea.py
+++ b/scripts/wire-quantum-ipea.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""Run iterative phase estimation as Wire-authored quantum rounds."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import os
+import sys
+import tempfile
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+
+JSON = dict[str, Any]
+DEFAULT_PHASE = Fraction(5, 8)
+DEFAULT_CONFIG = "examples/wire/quantum-ibm-runtime.local.json"
+HALF_PI = math.pi / 2
+
+
+class IpeaError(Exception):
+    """User-facing error for the Wire IPEA runner."""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run iterative phase estimation through Wire quantum rounds.",
+    )
+    parser.add_argument(
+        "--wire-bin",
+        default=os.environ.get("WIRE_BIN", "wire"),
+        help="Wire CLI used to compile generated round sources.",
+    )
+    parser.add_argument(
+        "--phase",
+        default=str(DEFAULT_PHASE),
+        help="Target eigenphase in [0,1), as a fraction or decimal.",
+    )
+    parser.add_argument("--bits", type=positive_int, default=3)
+    parser.add_argument("--shots", type=positive_int, default=100)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument(
+        "--hardware",
+        action="store_true",
+        help="Run on IBM Quantum hardware instead of the local Aer simulator.",
+    )
+    parser.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG,
+        help="IBM Quantum config path embedded into generated Wire rounds.",
+    )
+    parser.add_argument(
+        "--backend",
+        help="IBM backend override. Use 'least_busy' to auto-select online hardware.",
+    )
+    parser.add_argument(
+        "--confirm-hardware",
+        action="store_true",
+        help="Required with --hardware unless --dry-run is also set.",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=positive_int,
+        help="Hardware polling interval in seconds.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=positive_int,
+        help="Hardware polling timeout in seconds.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate and compile rounds without simulation or hardware submission.",
+    )
+    parser.add_argument(
+        "--emit-round-wire",
+        help="Directory where generated round .wire files should be written.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Print machine-readable JSON instead of the human summary.",
+    )
+    args = parser.parse_args()
+
+    try:
+        scripts_dir = Path(
+            os.environ.get("WIRE_QUANTUM_SCRIPTS_DIR", str(Path(__file__).resolve().parent))
+        )
+        quantum = load_module(scripts_dir / "wire-quantum-qiskit.py", "wire_quantum_qiskit")
+        ibm = load_module(scripts_dir / "wire-quantum-ibm-rest.py", "wire_quantum_ibm_rest")
+        phase = normalize_phase(parse_phase(args.phase))
+        if args.hardware and not args.dry_run and not args.confirm_hardware:
+            raise IpeaError(
+                "refusing to submit IBM Quantum jobs without --confirm-hardware; "
+                "use --dry-run to inspect generated rounds"
+            )
+
+        emit_dir = Path(args.emit_round_wire).resolve() if args.emit_round_wire else None
+        if emit_dir is not None:
+            emit_dir.mkdir(parents=True, exist_ok=True)
+
+        hardware = prepare_hardware(args, ibm, quantum) if args.hardware and not args.dry_run else None
+        result = run_ipea(args, phase, quantum, ibm, emit_dir, hardware)
+        if args.json_output:
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print_summary(result)
+        return 0
+    except (IpeaError, quantum_error()) as exc:
+        print(f"wire-quantum-ipea: {exc}", file=sys.stderr)
+        return 1
+
+
+def quantum_error() -> type[Exception]:
+    try:
+        module = sys.modules["wire_quantum_qiskit"]
+        return module.WireQuantumError
+    except KeyError:
+        return IpeaError
+
+
+def load_module(path: Path, module_name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise IpeaError(f"could not load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def positive_int(raw: str) -> int:
+    value = int(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return value
+
+
+def parse_phase(raw: str) -> Fraction:
+    try:
+        return Fraction(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("phase must be a fraction or decimal") from exc
+
+
+def normalize_phase(phase: Fraction) -> Fraction:
+    return phase % 1
+
+
+def prepare_hardware(args: argparse.Namespace, ibm: Any, quantum: Any) -> JSON:
+    config_path = Path(args.config).expanduser().resolve()
+    config = ibm.load_runtime_config(config_path, require_credentials=True, quantum=quantum)
+    token = ibm.fetch_iam_token(config, quantum)
+    return {"config_path": config_path, "config": config, "token": token, "backend": None}
+
+
+def run_ipea(
+    args: argparse.Namespace,
+    phase: Fraction,
+    quantum: Any,
+    ibm: Any,
+    emit_dir: Path | None,
+    hardware: JSON | None,
+) -> JSON:
+    rounds: list[JSON] = []
+    measured_bits: dict[int, int] = {}
+    total_qpu_usage = 0.0
+    config_path = Path(args.config).expanduser().resolve()
+
+    with tempfile.TemporaryDirectory(prefix="wire-ipea-") as tmpdir:
+        tmp_path = Path(tmpdir)
+        for ix, bit_position in enumerate(range(args.bits, 0, -1), start=1):
+            power = 2 ** (bit_position - 1)
+            feedback_fraction = lower_bit_feedback_fraction(measured_bits, bit_position, args.bits)
+            feedback_angle = -2 * math.pi * float(feedback_fraction)
+            theta = normalize_angle(2 * math.pi * float(phase) * power)
+            wire_source = render_round_wire(
+                config_path,
+                theta,
+                feedback_angle,
+                round_index=ix,
+                bit_position=bit_position,
+                power=power,
+            )
+            round_path = write_round_source(wire_source, tmp_path, emit_dir, ix, bit_position)
+            compiled = quantum.load_compiled_circuit(str(round_path), args.wire_bin)
+            plan = quantum.build_quantum_plan(compiled)
+            qasm = ibm.build_openqasm3(plan, quantum)
+
+            round_result: JSON = {
+                "round": ix,
+                "bit_position": bit_position,
+                "power": power,
+                "feedback_fraction": str(feedback_fraction),
+                "feedback_angle": feedback_angle,
+                "controlled_phase_angle": theta,
+                "wire_path": str(round_path),
+                "openqasm3": qasm,
+            }
+
+            if args.dry_run:
+                bit = ideal_phase_bit(phase, bit_position)
+                round_result.update(
+                    {
+                        "execution": "dry_run",
+                        "chosen_bit": bit,
+                        "chosen_bit_source": "ideal_phase_for_planning",
+                    }
+                )
+            elif hardware is not None:
+                hw_result = execute_hardware_round(
+                    args,
+                    ibm,
+                    quantum,
+                    hardware,
+                    plan,
+                    qasm,
+                )
+                bit = choose_majority_bit(hw_result["counts"])
+                usage = hw_result["qpu_usage_seconds"]
+                total_qpu_usage += usage
+                round_result.update(hw_result)
+                round_result.update({"chosen_bit": bit})
+            else:
+                sim_result = quantum.execute_qiskit_plan(
+                    plan,
+                    backend_name="aer_simulator",
+                    shots=args.shots,
+                    seed=args.seed + ix - 1,
+                )
+                bit = choose_majority_bit(sim_result["counts"])
+                round_result.update(
+                    {
+                        "execution": "local_simulation",
+                        "backend": "aer_simulator",
+                        "counts": sim_result["counts"],
+                        "labeled_counts": sim_result["labeled_counts"],
+                        "seed": args.seed + ix - 1,
+                        "chosen_bit": bit,
+                    }
+                )
+
+            measured_bits[bit_position] = bit
+            round_result["estimate_after_round"] = float(estimate_phase(measured_bits, args.bits))
+            rounds.append(round_result)
+
+    estimated = estimate_phase(measured_bits, args.bits)
+    return {
+        "algorithm": "iterative_phase_estimation",
+        "execution": execution_label(args),
+        "phase": str(phase),
+        "phase_decimal": float(phase),
+        "bits": args.bits,
+        "shots": args.shots,
+        "estimated_bits": bit_string(measured_bits, args.bits),
+        "estimated_phase": str(estimated),
+        "estimated_phase_decimal": float(estimated),
+        "absolute_error": abs(float(phase) - float(estimated)),
+        "rounds": rounds,
+        "qpu_usage_seconds": total_qpu_usage if hardware is not None else None,
+    }
+
+
+def execute_hardware_round(
+    args: argparse.Namespace,
+    ibm: Any,
+    quantum: Any,
+    hardware: JSON,
+    plan: JSON,
+    qasm: str,
+) -> JSON:
+    config = hardware["config"]
+    token = hardware["token"]
+    if hardware["backend"] is None:
+        backend_request = args.backend or config["backend"]
+        hardware["backend"] = ibm.resolve_backend(backend_request, config, token, plan, quantum)
+    payload = ibm.build_sampler_payload(hardware["backend"], qasm, args.shots)
+    submitted = ibm.submit_job(config, token, payload, quantum)
+    job_id = submitted["job_id"]
+    final_job = ibm.poll_job(
+        config,
+        token,
+        job_id,
+        args.poll_interval or config["poll_interval_seconds"],
+        args.timeout or config["timeout_seconds"],
+        quiet=False,
+        quantum=quantum,
+    )
+    raw_result = ibm.fetch_job_results(config, token, job_id, quantum)
+    metrics = ibm.fetch_job_metrics(config, token, job_id, quantum)
+    counts = ibm.extract_counts(raw_result, plan["measurements"])
+    if counts is None:
+        raise IpeaError(f"IBM job {job_id} returned an unsupported result shape")
+    return {
+        "execution": "hardware",
+        "backend": hardware["backend"],
+        "job_id": job_id,
+        "status": ibm.public_job_status(final_job),
+        "counts": counts,
+        "labeled_counts": quantum.labeled_counts(counts, plan["measurements"]),
+        "qpu_usage_seconds": qpu_usage_seconds(ibm, metrics),
+    }
+
+
+def qpu_usage_seconds(ibm: Any, metrics: Any) -> float:
+    usage = ibm.qpu_usage_seconds(metrics)
+    return float(usage) if usage is not None else 0.0
+
+
+def write_round_source(
+    source: str,
+    tmp_path: Path,
+    emit_dir: Path | None,
+    round_index: int,
+    bit_position: int,
+) -> Path:
+    directory = emit_dir if emit_dir is not None else tmp_path
+    path = directory / f"ipea-round-{round_index}-bit-{bit_position}.wire"
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def render_round_wire(
+    config_path: Path,
+    theta: float,
+    feedback_angle: float,
+    round_index: int,
+    bit_position: int,
+    power: int,
+) -> str:
+    half_theta = theta / 2
+    return f"""# Iterative phase estimation round {round_index}.
+#
+# This round measures phase bit position {bit_position} using controlled-U^{power}.
+# The graph-valued lets are aliases for named fragments, not macro instantiations.
+
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config {{ path = \"{config_path}\"; }} (null);
+
+node prepare_control
+  <- config: IBMQuantumConfig;
+  -> control: Qubit = @quantum.prepare_zero {{ index = 0; }} ({{ inherit config; }});
+
+node prepare_target
+  -> target: Qubit = @quantum.prepare_zero {{ index = 1; }} (null);
+
+node target_x
+  <- target: Qubit;
+  -> target: Qubit = @quantum.x {{}} (target);
+
+node h_control_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz {{ angle = {format_angle(HALF_PI)}; }} (control);
+
+node h_control_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {{}} (control);
+
+node h_control_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz {{ angle = {format_angle(HALF_PI)}; }} (control);
+
+node phase_control_rz
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz {{ angle = {format_angle(half_theta)}; }} (control);
+
+node phase_target_rz
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz {{ angle = {format_angle(half_theta)}; }} (target);
+
+node phase_rzz
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @quantum.rzz {{ angle = {format_angle(-half_theta)}; }} ({{ inherit control; inherit target; }});
+
+node feedback_control_rz
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz {{ angle = {format_angle(feedback_angle)}; }} (control);
+
+node readout_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz {{ angle = {format_angle(HALF_PI)}; }} (control);
+
+node readout_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {{}} (control);
+
+node readout_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz {{ angle = {format_angle(HALF_PI)}; }} (control);
+
+node measure_phase
+  <- control: Qubit;
+  -> phase_bit: Bit = @quantum.measure_z {{}} (control);
+
+let prepare_eigenstate =
+  prepare_target
+    => target_x;
+
+let h_control =
+  h_control_rz_a
+    => h_control_sx
+    => h_control_rz_b;
+
+let controlled_phase =
+  (phase_control_rz <> phase_target_rz)
+    => phase_rzz;
+
+let readout_h =
+  readout_rz_a
+    => readout_sx
+    => readout_rz_b;
+
+let feedback_and_readout =
+  feedback_control_rz
+    => readout_h
+    => measure_phase;
+
+ibm_runtime_config
+  => (
+    (
+      prepare_control
+        => h_control
+        => controlled_phase
+        => feedback_and_readout
+    )
+    <>
+    (
+      prepare_eigenstate
+        => controlled_phase
+    )
+)
+"""
+
+
+def format_angle(angle: float) -> str:
+    if abs(angle) < 1e-15:
+        return "0.0"
+    return format(angle, ".17g")
+
+
+def normalize_angle(angle: float) -> float:
+    normalized = (angle + math.pi) % (2 * math.pi) - math.pi
+    if abs(normalized) < 1e-15:
+        return 0.0
+    return normalized
+
+
+def lower_bit_feedback_fraction(
+    measured_bits: dict[int, int],
+    bit_position: int,
+    total_bits: int,
+) -> Fraction:
+    total = Fraction(0, 1)
+    for lower_position in range(bit_position + 1, total_bits + 1):
+        bit = measured_bits.get(lower_position, 0)
+        total += Fraction(bit, 2 ** (lower_position - bit_position + 1))
+    return total
+
+
+def ideal_phase_bit(phase: Fraction, bit_position: int) -> int:
+    return int(phase * (2 ** bit_position)) % 2
+
+
+def choose_majority_bit(counts: dict[str, int]) -> int:
+    zero = counts.get("0", 0)
+    one = counts.get("1", 0)
+    if zero == 0 and one == 0:
+        raise IpeaError(f"IPEA round expected one-bit counts, got {counts}")
+    return 1 if one > zero else 0
+
+
+def estimate_phase(measured_bits: dict[int, int], total_bits: int) -> Fraction:
+    return sum(Fraction(measured_bits.get(position, 0), 2**position) for position in range(1, total_bits + 1))
+
+
+def bit_string(measured_bits: dict[int, int], total_bits: int) -> str:
+    return "".join(str(measured_bits.get(position, 0)) for position in range(1, total_bits + 1))
+
+
+def execution_label(args: argparse.Namespace) -> str:
+    if args.dry_run:
+        return "dry_run"
+    if args.hardware:
+        return "ibm_quantum_hardware"
+    return "local_simulation"
+
+
+def print_summary(result: JSON) -> None:
+    print("Wire iterative phase estimation")
+    print(f"execution: {result['execution']}")
+    print(f"target phase: {result['phase']} ({result['phase_decimal']:.6f})")
+    print(f"bits: {result['bits']}")
+    print(f"shots per round: {result['shots']}")
+    if result.get("qpu_usage_seconds") is not None:
+        print(f"qpu usage: {result['qpu_usage_seconds']:.3f}s")
+    print()
+    print("Rounds:")
+    rows = []
+    for item in result["rounds"]:
+        counts = item.get("counts")
+        if counts is None:
+            counts_text = "dry-run"
+        else:
+            counts_text = ",".join(f"{bits}:{count}" for bits, count in sorted(counts.items()))
+        rows.append(
+            (
+                str(item["round"]),
+                str(item["bit_position"]),
+                str(item["power"]),
+                f"{item['feedback_angle']:.6f}",
+                str(item["chosen_bit"]),
+                counts_text,
+                f"{item['estimate_after_round']:.6f}",
+            )
+        )
+    print_table(
+        ("round", "bit", "power", "feedback", "chosen", "counts", "estimate"),
+        rows,
+    )
+    print()
+    print("Result:")
+    print(f"  estimated bits: {result['estimated_bits']}")
+    print(
+        "  estimated phase: "
+        f"{result['estimated_phase']} ({result['estimated_phase_decimal']:.6f})"
+    )
+    print(f"  absolute error: {result['absolute_error']:.6f}")
+
+
+def print_table(headers: tuple[str, ...], rows: list[tuple[str, ...]]) -> None:
+    widths = [
+        max([len(headers[index]), *(len(row[index]) for row in rows)])
+        for index in range(len(headers))
+    ]
+    print("  " + "  ".join(f"{header:<{widths[index]}}" for index, header in enumerate(headers)))
+    for row in rows:
+        print("  " + "  ".join(f"{value:<{widths[index]}}" for index, value in enumerate(row)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wire-quantum-qiskit.py
+++ b/scripts/wire-quantum-qiskit.py
@@ -1,0 +1,855 @@
+#!/usr/bin/env python3
+"""Run Wire-authored quantum circuits through a local Qiskit simulator.
+
+This is a consumer-side bridge. Cortex/Wire still owns parsing and typed
+topology; this script owns the quantum backend interpretation for the
+`@quantum.*` executor vocabulary used by the examples.
+"""
+
+from __future__ import annotations
+
+import argparse
+import heapq
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+JSON = dict[str, Any]
+
+
+class WireQuantumError(Exception):
+    """User-facing error for unsupported or invalid quantum Wire artifacts."""
+
+
+@dataclass(frozen=True)
+class QuantumValue:
+    kind: str
+    wire: int | None
+    contract: str
+    source_node: str
+    source_port: str
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run a compiled Wire quantum circuit on Qiskit Aer.",
+    )
+    parser.add_argument(
+        "input",
+        help="Wire source file, compiled Wire JSON artifact, or '-' for compiled JSON on stdin.",
+    )
+    parser.add_argument(
+        "--wire-bin",
+        default=os.environ.get("WIRE_BIN", "wire"),
+        help="Wire CLI to use when the input is a .wire source file.",
+    )
+    parser.add_argument(
+        "--backend",
+        default="aer_simulator",
+        help="Qiskit backend. Only 'aer_simulator' is enabled by this local runner.",
+    )
+    parser.add_argument("--shots", type=positive_int, default=1024)
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument(
+        "--emit-plan",
+        action="store_true",
+        help="Print the backend-neutral quantum plan without executing Qiskit.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Print machine-readable JSON instead of the human summary.",
+    )
+    args = parser.parse_args()
+
+    try:
+        compiled = load_compiled_circuit(args.input, args.wire_bin)
+        plan = build_quantum_plan(compiled)
+        if args.emit_plan:
+            if args.json_output:
+                print_json(plan)
+            else:
+                print_plan_summary(args.input, plan)
+            return 0
+        result = execute_qiskit_plan(
+            plan,
+            backend_name=args.backend,
+            shots=args.shots,
+            seed=args.seed,
+        )
+        if args.json_output:
+            print_json(result)
+        else:
+            print_run_summary(args.input, result)
+        return 0
+    except WireQuantumError as exc:
+        print(f"wire-quantum-qiskit: {exc}", file=sys.stderr)
+        return 1
+
+
+def positive_int(raw: str) -> int:
+    value = int(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return value
+
+
+def print_json(value: JSON) -> None:
+    print(json.dumps(value, indent=2, sort_keys=True))
+
+
+def print_plan_summary(input_path: str, plan: JSON) -> None:
+    measurements = plan["measurements"]
+    print("Wire quantum plan")
+    print(f"source: {input_path}")
+    print("execution: not run")
+    print("backend family: Qiskit")
+    runtime_config = plan.get("runtime_config")
+    if isinstance(runtime_config, dict):
+        print(
+            "runtime config: "
+            f"{runtime_config['node']} -> {runtime_config['path']}"
+        )
+    print(f"qubits: {plan['num_qubits']}")
+    print(f"measurements: {format_measurements(measurements)}")
+    print()
+    print("Operations:")
+    for operation in plan["operations"]:
+        print(f"  - {format_operation(operation)}")
+    print()
+    print("This only inspected the compiled Wire graph; no simulator or hardware job ran.")
+
+
+def print_run_summary(input_path: str, result: JSON) -> None:
+    plan = result["plan"]
+    measurements = plan["measurements"]
+    shots = result["shots"]
+
+    print("Wire quantum run")
+    print(f"source: {input_path}")
+    print("execution: local simulation (not real hardware)")
+    print(f"backend: Qiskit Aer {result['backend']}")
+    print(f"shots: {shots}")
+    print(f"seed: {result['seed'] if result['seed'] is not None else 'random'}")
+    print(f"qiskit: {result['qiskit_version']} / aer: {result['qiskit_aer_version']}")
+    print(f"qubits: {plan['num_qubits']}")
+    print(f"measurements: {format_measurements(measurements)}")
+    print()
+    print("What happened:")
+    print("Wire compiled the graph into typed quantum executor nodes.")
+    print("The runner mapped the admitted @quantum.* gates into one Qiskit circuit.")
+    print("It sampled that circuit on the local Aer simulator.")
+    print("No provider account was used and no real quantum hardware job was queued.")
+    print()
+    print("Result:")
+    print(format_result_table(result["counts"], measurements, shots))
+
+
+def format_measurements(measurements: list[JSON]) -> str:
+    if not measurements:
+        return "none"
+    return ", ".join(
+        f"{measurement['output']}=q[{measurement['wire']}]"
+        for measurement in measurements
+    )
+
+
+def format_operation(operation: JSON) -> str:
+    gate = operation["gate"]
+    node = operation["node"]
+    if gate == "prepare_zero":
+        return f"{node}: prepare_zero q[{operation['wire']}]"
+    if gate == "h":
+        return f"{node}: h q[{operation['wire']}]"
+    if gate == "rz":
+        return f"{node}: rz({operation['angle']}) q[{operation['wire']}]"
+    if gate == "sx":
+        return f"{node}: sx q[{operation['wire']}]"
+    if gate == "x":
+        return f"{node}: x q[{operation['wire']}]"
+    if gate == "cnot":
+        return f"{node}: cnot q[{operation['control']}], q[{operation['target']}]"
+    if gate == "cz":
+        return f"{node}: cz q[{operation['control']}], q[{operation['target']}]"
+    if gate == "rzz":
+        return (
+            f"{node}: rzz({operation['angle']}) "
+            f"q[{operation['control']}], q[{operation['target']}]"
+        )
+    if gate == "measure_z":
+        return (
+            f"{node}: measure_z q[{operation['wire']}] "
+            f"-> {operation['output']} (c[{operation['classical_bit']}])"
+        )
+    return f"{node}: {gate}"
+
+
+def format_result_table(counts: dict[str, int], measurements: list[JSON], shots: int) -> str:
+    rows = []
+    for bits, count in sorted(counts.items()):
+        label = label_bits(bits, measurements)
+        percent = (count / shots * 100) if shots else 0
+        rows.append((bits, label, str(count), f"{percent:.2f}%"))
+    if not rows:
+        return "  (no measurement counts)"
+
+    headers = ("bits", "outputs", "shots", "percent")
+    widths = [
+        max([len(headers[0]), *(len(row[0]) for row in rows)]),
+        max([len(headers[1]), *(len(row[1]) for row in rows)]),
+        max([len(headers[2]), *(len(row[2]) for row in rows)]),
+        max([len(headers[3]), *(len(row[3]) for row in rows)]),
+    ]
+    lines = [
+        "  "
+        + f"{headers[0]:<{widths[0]}}  "
+        + f"{headers[1]:<{widths[1]}}  "
+        + f"{headers[2]:>{widths[2]}}  "
+        + f"{headers[3]:>{widths[3]}}"
+    ]
+    for bits, label, count, percent in rows:
+        lines.append(
+            "  "
+            + f"{bits:<{widths[0]}}  "
+            + f"{label:<{widths[1]}}  "
+            + f"{count:>{widths[2]}}  "
+            + f"{percent:>{widths[3]}}"
+        )
+    return "\n".join(lines)
+
+
+def load_compiled_circuit(input_path: str, wire_bin: str) -> JSON:
+    if input_path == "-":
+        return json.load(sys.stdin)
+
+    path = Path(input_path)
+    if path.suffix == ".wire":
+        proc = subprocess.run(
+            [wire_bin, "build", str(path)],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if proc.returncode != 0:
+            raise WireQuantumError(
+                "wire build failed for "
+                f"{path}:\n{proc.stderr.strip() or proc.stdout.strip()}"
+            )
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise WireQuantumError(f"wire build did not return JSON: {exc}") from exc
+
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def build_quantum_plan(compiled: JSON) -> JSON:
+    nodes = compiled.get("compiledCircuitNodes")
+    topology = compiled.get("compiledCircuitTopology")
+    if not isinstance(nodes, dict) or not isinstance(topology, dict):
+        raise WireQuantumError("input is not a compiled Wire circuit artifact")
+
+    edges = parse_edges(topology)
+    order = topological_order(sorted(nodes), edges)
+    validate_qubit_linearity(nodes, edges)
+
+    node_outputs: dict[str, dict[str, QuantumValue]] = {}
+    operations: list[JSON] = []
+    measurements: list[JSON] = []
+    qubit_wires: set[int] = set()
+    allocated_qubits: dict[int, str] = {}
+    runtime_config: JSON | None = None
+
+    for node_ref in order:
+        metadata = task_metadata(nodes, node_ref)
+        target = executor_target(metadata)
+        inputs = resolve_inputs(node_ref, metadata, predecessors(node_ref, edges), node_outputs)
+        output_ports = metadata_ports(metadata, "outputs")
+        config = metadata.get("config", {})
+        if not isinstance(config, dict):
+            raise WireQuantumError(f"node {node_ref} has non-object config")
+
+        if target == "quantum.ibm_runtime_config":
+            if inputs:
+                raise WireQuantumError(f"{node_ref}: ibm_runtime_config expects no inputs")
+            output = single_output(
+                node_ref,
+                output_ports,
+                "IBMQuantumConfig",
+                "quantum.ibm_runtime_config",
+            )
+            if runtime_config is not None:
+                raise WireQuantumError(
+                    "quantum plan declares more than one IBM runtime config node"
+                )
+            runtime_config = {
+                "node": node_ref,
+                "path": string_config(node_ref, config, "path"),
+                "output": output["name"],
+            }
+            node_outputs[node_ref] = {
+                output["name"]: QuantumValue(
+                    "config",
+                    None,
+                    "IBMQuantumConfig",
+                    node_ref,
+                    output["name"],
+                )
+            }
+        elif target == "quantum.prepare_zero":
+            allow_only_config_inputs(node_ref, inputs, "quantum.prepare_zero")
+            if len(output_ports) != 1:
+                raise WireQuantumError(f"{node_ref}: prepare_zero expects exactly one Qubit output")
+            output = output_ports[0]
+            require_contract(node_ref, output, "Qubit")
+            wire = int_config(node_ref, config, "index")
+            allocate_qubit(node_ref, wire, allocated_qubits)
+            qubit_wires.add(wire)
+            node_outputs[node_ref] = {
+                output["name"]: QuantumValue("qubit", wire, "Qubit", node_ref, output["name"])
+            }
+            operations.append(
+                {
+                    "node": node_ref,
+                    "executor": target,
+                    "gate": "prepare_zero",
+                    "wire": wire,
+                    "output": output["name"],
+                }
+            )
+        elif target == "quantum.h":
+            input_value = single_qubit_input(node_ref, inputs, "quantum.h")
+            output = single_output(node_ref, output_ports, "Qubit", "quantum.h")
+            input_wire = require_wire(node_ref, input_value)
+            qubit_wires.add(input_wire)
+            node_outputs[node_ref] = {
+                output["name"]: QuantumValue(
+                    "qubit",
+                    input_wire,
+                    "Qubit",
+                    node_ref,
+                    output["name"],
+                )
+            }
+            operations.append(
+                {
+                    "node": node_ref,
+                    "executor": target,
+                    "gate": "h",
+                    "wire": input_wire,
+                }
+            )
+        elif target == "quantum.rz":
+            input_value = single_qubit_input(node_ref, inputs, "quantum.rz")
+            output = single_output(node_ref, output_ports, "Qubit", "quantum.rz")
+            input_wire = require_wire(node_ref, input_value)
+            qubit_wires.add(input_wire)
+            node_outputs[node_ref] = {
+                output["name"]: QuantumValue(
+                    "qubit",
+                    input_wire,
+                    "Qubit",
+                    node_ref,
+                    output["name"],
+                )
+            }
+            operations.append(
+                {
+                    "node": node_ref,
+                    "executor": target,
+                    "gate": "rz",
+                    "wire": input_wire,
+                    "angle": number_config(node_ref, config, "angle"),
+                }
+            )
+        elif target == "quantum.sx":
+            input_value = single_qubit_input(node_ref, inputs, "quantum.sx")
+            output = single_output(node_ref, output_ports, "Qubit", "quantum.sx")
+            input_wire = require_wire(node_ref, input_value)
+            qubit_wires.add(input_wire)
+            node_outputs[node_ref] = {
+                output["name"]: QuantumValue(
+                    "qubit",
+                    input_wire,
+                    "Qubit",
+                    node_ref,
+                    output["name"],
+                )
+            }
+            operations.append(
+                {
+                    "node": node_ref,
+                    "executor": target,
+                    "gate": "sx",
+                    "wire": input_wire,
+                }
+            )
+        elif target == "quantum.x":
+            input_value = single_qubit_input(node_ref, inputs, "quantum.x")
+            output = single_output(node_ref, output_ports, "Qubit", "quantum.x")
+            input_wire = require_wire(node_ref, input_value)
+            qubit_wires.add(input_wire)
+            node_outputs[node_ref] = {
+                output["name"]: QuantumValue(
+                    "qubit",
+                    input_wire,
+                    "Qubit",
+                    node_ref,
+                    output["name"],
+                )
+            }
+            operations.append(
+                {
+                    "node": node_ref,
+                    "executor": target,
+                    "gate": "x",
+                    "wire": input_wire,
+                }
+            )
+        elif target == "quantum.cnot":
+            control = named_qubit_input(node_ref, inputs, "control", "quantum.cnot")
+            target_qubit = named_qubit_input(node_ref, inputs, "target", "quantum.cnot")
+            require_output_names(
+                node_ref,
+                output_ports,
+                ["control", "target"],
+                "Qubit",
+                "quantum.cnot",
+            )
+            control_wire = require_wire(node_ref, control)
+            target_wire = require_wire(node_ref, target_qubit)
+            if control_wire == target_wire:
+                raise WireQuantumError(f"{node_ref}: cnot control and target must be distinct")
+            qubit_wires.update([control_wire, target_wire])
+            node_outputs[node_ref] = {
+                "control": QuantumValue("qubit", control_wire, "Qubit", node_ref, "control"),
+                "target": QuantumValue("qubit", target_wire, "Qubit", node_ref, "target"),
+            }
+            operations.append(
+                {
+                    "node": node_ref,
+                    "executor": target,
+                    "gate": "cnot",
+                    "control": control_wire,
+                    "target": target_wire,
+                }
+            )
+        elif target == "quantum.cz":
+            control = named_qubit_input(node_ref, inputs, "control", "quantum.cz")
+            target_qubit = named_qubit_input(node_ref, inputs, "target", "quantum.cz")
+            require_output_names(
+                node_ref,
+                output_ports,
+                ["control", "target"],
+                "Qubit",
+                "quantum.cz",
+            )
+            control_wire = require_wire(node_ref, control)
+            target_wire = require_wire(node_ref, target_qubit)
+            if control_wire == target_wire:
+                raise WireQuantumError(f"{node_ref}: cz control and target must be distinct")
+            qubit_wires.update([control_wire, target_wire])
+            node_outputs[node_ref] = {
+                "control": QuantumValue("qubit", control_wire, "Qubit", node_ref, "control"),
+                "target": QuantumValue("qubit", target_wire, "Qubit", node_ref, "target"),
+            }
+            operations.append(
+                {
+                    "node": node_ref,
+                    "executor": target,
+                    "gate": "cz",
+                    "control": control_wire,
+                    "target": target_wire,
+                }
+            )
+        elif target == "quantum.rzz":
+            control = named_qubit_input(node_ref, inputs, "control", "quantum.rzz")
+            target_qubit = named_qubit_input(node_ref, inputs, "target", "quantum.rzz")
+            require_output_names(
+                node_ref,
+                output_ports,
+                ["control", "target"],
+                "Qubit",
+                "quantum.rzz",
+            )
+            control_wire = require_wire(node_ref, control)
+            target_wire = require_wire(node_ref, target_qubit)
+            if control_wire == target_wire:
+                raise WireQuantumError(f"{node_ref}: rzz qubits must be distinct")
+            qubit_wires.update([control_wire, target_wire])
+            node_outputs[node_ref] = {
+                "control": QuantumValue("qubit", control_wire, "Qubit", node_ref, "control"),
+                "target": QuantumValue("qubit", target_wire, "Qubit", node_ref, "target"),
+            }
+            operations.append(
+                {
+                    "node": node_ref,
+                    "executor": target,
+                    "gate": "rzz",
+                    "control": control_wire,
+                    "target": target_wire,
+                    "angle": number_config(node_ref, config, "angle"),
+                }
+            )
+        elif target == "quantum.measure_z":
+            input_value = single_qubit_input(node_ref, inputs, "quantum.measure_z")
+            output = single_output(node_ref, output_ports, "Bit", "quantum.measure_z")
+            qubit_wire = require_wire(node_ref, input_value)
+            classical_bit = len(measurements)
+            measurement = {
+                "node": node_ref,
+                "executor": target,
+                "gate": "measure_z",
+                "wire": qubit_wire,
+                "classical_bit": classical_bit,
+                "output": output["name"],
+            }
+            measurements.append(measurement)
+            operations.append(measurement)
+            node_outputs[node_ref] = {
+                output["name"]: QuantumValue("bit", None, "Bit", node_ref, output["name"])
+            }
+        else:
+            raise WireQuantumError(f"node {node_ref} uses unsupported quantum executor @{target}")
+
+    if not qubit_wires:
+        raise WireQuantumError("quantum plan did not allocate any qubits")
+
+    plan = {
+        "backend_family": "qiskit",
+        "topological_order": order,
+        "num_qubits": max(qubit_wires) + 1,
+        "qubits": sorted(qubit_wires),
+        "operations": operations,
+        "measurements": measurements,
+    }
+    if runtime_config is not None:
+        plan["runtime_config"] = runtime_config
+    return plan
+
+
+def parse_edges(topology: JSON) -> list[tuple[str, str]]:
+    raw_edges = topology.get("relEdges", [])
+    if not isinstance(raw_edges, list):
+        raise WireQuantumError("compiled topology relEdges must be a list")
+    edges = []
+    for raw in raw_edges:
+        if not isinstance(raw, list) or len(raw) != 2:
+            raise WireQuantumError(f"invalid topology edge: {raw!r}")
+        edges.append((str(raw[0]), str(raw[1])))
+    return edges
+
+
+def topological_order(node_refs: list[str], edges: list[tuple[str, str]]) -> list[str]:
+    successors: dict[str, list[str]] = {node: [] for node in node_refs}
+    indegree: dict[str, int] = {node: 0 for node in node_refs}
+    for src, dst in edges:
+        if src not in successors or dst not in indegree:
+            raise WireQuantumError(f"topology references unknown node in edge {src} -> {dst}")
+        successors[src].append(dst)
+        indegree[dst] += 1
+
+    ready = [node for node in node_refs if indegree[node] == 0]
+    heapq.heapify(ready)
+    order = []
+    while ready:
+        node = heapq.heappop(ready)
+        order.append(node)
+        for dst in sorted(successors[node]):
+            indegree[dst] -= 1
+            if indegree[dst] == 0:
+                heapq.heappush(ready, dst)
+
+    if len(order) != len(node_refs):
+        raise WireQuantumError("compiled topology is cyclic")
+    return order
+
+
+def predecessors(node_ref: str, edges: list[tuple[str, str]]) -> list[str]:
+    return sorted(src for src, dst in edges if dst == node_ref)
+
+
+def task_metadata(nodes: dict[str, Any], node_ref: str) -> JSON:
+    node = nodes[node_ref]
+    if node.get("tag") != "CompiledCircuitTask":
+        raise WireQuantumError(f"node {node_ref} is not a task node")
+    contents = node.get("contents", {})
+    metadata = contents.get("circuitTaskNodeMetadata")
+    if not isinstance(metadata, dict):
+        raise WireQuantumError(f"node {node_ref} is missing task metadata")
+    return metadata
+
+
+def executor_target(metadata: JSON) -> str:
+    executor = metadata.get("executor")
+    if not isinstance(executor, dict) or executor.get("kind") != "native":
+        raise WireQuantumError("quantum runner only supports native executor metadata")
+    target = executor.get("target")
+    if not isinstance(target, str):
+        raise WireQuantumError("native executor metadata is missing target")
+    return target
+
+
+def metadata_ports(metadata: JSON, direction: str) -> list[JSON]:
+    ports = metadata.get("ports", {})
+    values = ports.get(direction)
+    if not isinstance(values, list):
+        raise WireQuantumError(f"metadata ports.{direction} must be a list")
+    return values
+
+
+def resolve_inputs(
+    node_ref: str,
+    metadata: JSON,
+    predecessor_refs: list[str],
+    node_outputs: dict[str, dict[str, QuantumValue]],
+) -> dict[str, QuantumValue]:
+    resolved: dict[str, QuantumValue] = {}
+    for input_port in metadata_ports(metadata, "inputs"):
+        input_name = input_port.get("name")
+        accepts = input_port.get("accepts", [])
+        if not isinstance(input_name, str) or not isinstance(accepts, list):
+            raise WireQuantumError(f"node {node_ref} has invalid input port metadata")
+        matches = []
+        for pred in predecessor_refs:
+            for output_name, value in node_outputs.get(pred, {}).items():
+                if output_name == input_name and value.contract in accepts:
+                    matches.append(value)
+        if len(matches) != 1:
+            raise WireQuantumError(
+                f"node {node_ref} input {input_name} expected one "
+                f"predecessor output, got {len(matches)}"
+            )
+        resolved[input_name] = matches[0]
+    return resolved
+
+
+def validate_qubit_linearity(nodes: dict[str, Any], edges: list[tuple[str, str]]) -> None:
+    consumers: dict[tuple[str, str], list[str]] = {}
+    for src, dst in edges:
+        src_outputs = metadata_ports(task_metadata(nodes, src), "outputs")
+        dst_inputs = metadata_ports(task_metadata(nodes, dst), "inputs")
+        for output in src_outputs:
+            if output.get("contract") != "Qubit":
+                continue
+            output_name = output.get("name")
+            for input_port in dst_inputs:
+                if (
+                    input_port.get("name") == output_name
+                    and "Qubit" in input_port.get("accepts", [])
+                ):
+                    consumers.setdefault((src, output_name), []).append(dst)
+
+    violations = [
+        (src, output, dsts)
+        for (src, output), dsts in consumers.items()
+        if len(dsts) > 1
+    ]
+    if violations:
+        src, output, dsts = violations[0]
+        raise WireQuantumError(
+            f"Qubit output {src}.{output} fans out to {', '.join(sorted(dsts))}; "
+            "this runner requires linear qubit use"
+        )
+
+
+def int_config(node_ref: str, config: JSON, field: str) -> int:
+    value = config.get(field)
+    if not isinstance(value, int) or value < 0:
+        raise WireQuantumError(
+            f"node {node_ref} config field {field} must be a non-negative integer"
+        )
+    return value
+
+
+def number_config(node_ref: str, config: JSON, field: str) -> float:
+    value = config.get(field)
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise WireQuantumError(f"node {node_ref} config field {field} must be a number")
+    return float(value)
+
+
+def string_config(node_ref: str, config: JSON, field: str) -> str:
+    value = config.get(field)
+    if not isinstance(value, str) or not value:
+        raise WireQuantumError(f"node {node_ref} config field {field} must be a string")
+    return value
+
+
+def allocate_qubit(node_ref: str, wire: int, allocated_qubits: dict[int, str]) -> None:
+    previous = allocated_qubits.get(wire)
+    if previous is not None:
+        raise WireQuantumError(
+            f"node {node_ref} reuses qubit index {wire} already allocated by {previous}"
+        )
+    allocated_qubits[wire] = node_ref
+
+
+def require_contract(node_ref: str, port: JSON, contract: str) -> None:
+    if port.get("contract") != contract:
+        raise WireQuantumError(
+            f"node {node_ref} output {port.get('name')} must have contract {contract}"
+        )
+
+
+def single_qubit_input(
+    node_ref: str,
+    inputs: dict[str, QuantumValue],
+    executor: str,
+) -> QuantumValue:
+    if len(inputs) != 1:
+        raise WireQuantumError(f"{node_ref}: {executor} expects exactly one Qubit input")
+    value = next(iter(inputs.values()))
+    if value.contract != "Qubit" or value.kind != "qubit":
+        raise WireQuantumError(f"{node_ref}: {executor} input must be a Qubit")
+    return value
+
+
+def named_qubit_input(
+    node_ref: str,
+    inputs: dict[str, QuantumValue],
+    name: str,
+    executor: str,
+) -> QuantumValue:
+    value = inputs.get(name)
+    if value is None or value.contract != "Qubit" or value.kind != "qubit":
+        raise WireQuantumError(f"{node_ref}: {executor} expects Qubit input {name}")
+    return value
+
+
+def allow_only_config_inputs(
+    node_ref: str,
+    inputs: dict[str, QuantumValue],
+    executor: str,
+) -> None:
+    for name, value in inputs.items():
+        if value.contract != "IBMQuantumConfig" or value.kind != "config":
+            raise WireQuantumError(
+                f"{node_ref}: {executor} input {name} must be IBMQuantumConfig "
+                "when used as a hardware orchestration dependency"
+            )
+
+
+def single_output(node_ref: str, outputs: list[JSON], contract: str, executor: str) -> JSON:
+    if len(outputs) != 1:
+        raise WireQuantumError(f"{node_ref}: {executor} expects exactly one {contract} output")
+    require_contract(node_ref, outputs[0], contract)
+    return outputs[0]
+
+
+def require_output_names(
+    node_ref: str,
+    outputs: list[JSON],
+    names: list[str],
+    contract: str,
+    executor: str,
+) -> None:
+    actual = {output.get("name"): output for output in outputs}
+    for name in names:
+        output = actual.get(name)
+        if output is None:
+            raise WireQuantumError(f"{node_ref}: {executor} expects output {name}")
+        require_contract(node_ref, output, contract)
+
+
+def require_wire(node_ref: str, value: QuantumValue) -> int:
+    if value.wire is None:
+        raise WireQuantumError(f"node {node_ref} expected a qubit wire")
+    return value.wire
+
+
+def execute_qiskit_plan(plan: JSON, backend_name: str, shots: int, seed: int | None) -> JSON:
+    if backend_name != "aer_simulator":
+        raise WireQuantumError(
+            "only backend 'aer_simulator' is supported by this local runner; "
+            "hardware/provider backends need a separate explicit binding"
+        )
+
+    try:
+        import qiskit
+        import qiskit_aer
+        from qiskit import QuantumCircuit, transpile
+        from qiskit_aer import AerSimulator
+    except ImportError as exc:
+        raise WireQuantumError(
+            "Qiskit is not available. Run through `nix run .#wire-quantum-qiskit`."
+        ) from exc
+
+    measurements = plan["measurements"]
+    circuit = QuantumCircuit(plan["num_qubits"], len(measurements))
+    for operation in plan["operations"]:
+        gate = operation["gate"]
+        if gate == "prepare_zero":
+            continue
+        if gate == "h":
+            circuit.h(operation["wire"])
+        elif gate == "rz":
+            circuit.rz(operation["angle"], operation["wire"])
+        elif gate == "sx":
+            circuit.sx(operation["wire"])
+        elif gate == "x":
+            circuit.x(operation["wire"])
+        elif gate == "cnot":
+            circuit.cx(operation["control"], operation["target"])
+        elif gate == "cz":
+            circuit.cz(operation["control"], operation["target"])
+        elif gate == "rzz":
+            circuit.rzz(operation["angle"], operation["control"], operation["target"])
+        elif gate == "measure_z":
+            circuit.measure(operation["wire"], operation["classical_bit"])
+        else:
+            raise WireQuantumError(f"unsupported planned gate {gate}")
+
+    backend_kwargs = {}
+    run_kwargs = {"shots": shots}
+    if seed is not None:
+        backend_kwargs["seed_simulator"] = seed
+        run_kwargs["seed_simulator"] = seed
+    backend = AerSimulator(**backend_kwargs)
+    compiled = transpile(circuit, backend)
+    counts = backend.run(compiled, **run_kwargs).result().get_counts(compiled)
+
+    return {
+        "backend": backend_name,
+        "backend_family": "qiskit",
+        "qiskit_version": qiskit.__version__,
+        "qiskit_aer_version": qiskit_aer.__version__,
+        "shots": shots,
+        "seed": seed,
+        "plan": plan,
+        "counts": dict(sorted(counts.items())),
+        "labeled_counts": labeled_counts(counts, measurements),
+    }
+
+
+def labeled_counts(counts: dict[str, int], measurements: list[JSON]) -> dict[str, int]:
+    labeled: dict[str, int] = {}
+    for raw_bits, count in counts.items():
+        labeled[label_bits(raw_bits, measurements)] = count
+    return dict(sorted(labeled.items()))
+
+
+def label_bits(raw_bits: str, measurements: list[JSON]) -> str:
+    bits = raw_bits.replace(" ", "")
+    width = len(measurements)
+    if len(bits) != width:
+        raise WireQuantumError(f"unexpected Qiskit bitstring width: {raw_bits}")
+    fields = []
+    for measurement in measurements:
+        classical_bit = measurement["classical_bit"]
+        # Qiskit renders classical bit n-1 on the left and bit 0 on the right.
+        bit = bits[width - classical_bit - 1]
+        fields.append(f"{measurement['output']}={bit}")
+    return ",".join(fields)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/Cortex/Wire/CompileSpec.hs
+++ b/test/Cortex/Wire/CompileSpec.hs
@@ -44,8 +44,11 @@ import Cortex.Wire.Contract
   , wireContractRegistryFromList
   )
 import Cortex.Wire.Executor
-  ( WireExecutorEffect (..)
+  ( WireExecutorConfigShape (..)
+  , WireExecutorEffect (..)
   , WireExecutorId (..)
+  , WireExecutorPortPolicy (..)
+  , WireExecutorProjection (..)
   , wireExecutorProjectionFromPorts
   , wireExecutorRegistryFromList
   )
@@ -352,6 +355,46 @@ spec = describe "Cortex.Wire.Compile" $ do
     it "compiles the mini build-system example" $ do
       source <- TIO.readFile "examples/wire/mini-build-system.wire"
       compileWireText source `shouldSatisfy` isRight
+
+    it "compiles the quantum Bell-state example with consumer executor projections" $ do
+      source <- TIO.readFile "examples/wire/quantum-bell-state.wire"
+      compiled <- requireRight (compileWireTextWithEnv quantumExecutorEnv source)
+      Set.fromList compiled.compiledCircuitEntryNodes
+        `shouldBe` Set.fromList [CircuitNodeRef "prepare_control", CircuitNodeRef "prepare_target"]
+      Set.fromList compiled.compiledCircuitExitNodes
+        `shouldBe` Set.fromList [CircuitNodeRef "measure_control", CircuitNodeRef "measure_target"]
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "entangle")
+        `shouldBe` Set.fromList [CircuitNodeRef "measure_control", CircuitNodeRef "measure_target"]
+
+    it "compiles the IBM REST quantum Bell-state example with a config node" $ do
+      source <- TIO.readFile "examples/wire/quantum-bell-state-ibm-rest.wire"
+      compiled <- requireRight (compileWireTextWithEnv quantumExecutorEnv source)
+      Set.fromList compiled.compiledCircuitEntryNodes
+        `shouldBe` Set.fromList
+          [ CircuitNodeRef "ibm_runtime_config"
+          , CircuitNodeRef "prepare_target"
+          ]
+      case Map.lookup (CircuitNodeRef "ibm_runtime_config") compiled.compiledCircuitNodes of
+        Just (CompiledCircuitTask taskNode) ->
+          taskNode.circuitTaskNodeMetadata
+            `shouldSatisfy` metadataConfigHasString
+              "path"
+              "quantum-ibm-runtime.local.json"
+        other ->
+          expectationFailure ("expected task node, got: " <> show other)
+
+    it "compiles the quantum IPEA round example with primitive executors" $ do
+      source <- TIO.readFile "examples/wire/quantum-ipea-round.wire"
+      compiled <- requireRight (compileWireTextWithEnv quantumExecutorEnv source)
+      Set.fromList compiled.compiledCircuitEntryNodes
+        `shouldBe` Set.fromList
+          [ CircuitNodeRef "ibm_runtime_config"
+          , CircuitNodeRef "prepare_target"
+          ]
+      Set.fromList compiled.compiledCircuitExitNodes
+        `shouldBe` Set.fromList [CircuitNodeRef "measure_phase"]
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "phase_rzz")
+        `shouldBe` Set.fromList [CircuitNodeRef "feedback_control_rz"]
 
     it "compiles the pure output equations fixture" $ do
       source <- TIO.readFile "test/fixtures/wire/pure-output-equations.wire"
@@ -778,6 +821,15 @@ metadataConfigHasNumber fieldName expected = \case
       _ -> False
   _ -> False
 
+metadataConfigHasString :: Key.Key -> T.Text -> Aeson.Value -> Bool
+metadataConfigHasString fieldName expected = \case
+  Aeson.Object obj ->
+    case KeyMap.lookup "config" obj of
+      Just (Aeson.Object configObj) ->
+        KeyMap.lookup fieldName configObj == Just (Aeson.String expected)
+      _ -> False
+  _ -> False
+
 metadataConfigHasKey :: Key.Key -> Aeson.Value -> Bool
 metadataConfigHasKey fieldName = \case
   Aeson.Object obj ->
@@ -915,6 +967,37 @@ strictExecutorEnv =
           , pureWireExecutorProjection
           ]
     , wireCompileEnvProjectionMode = WireProjectionStrict
+    }
+
+quantumExecutorEnv :: WireCompileEnv
+quantumExecutorEnv =
+  emptyWireCompileEnv
+    { wireCompileEnvExecutorRegistry =
+        wireExecutorRegistryFromList
+          [ quantumExecutorProjection "quantum.prepare_zero"
+          , quantumExecutorProjection "quantum.h"
+          , quantumExecutorProjection "quantum.rz"
+          , quantumExecutorProjection "quantum.sx"
+          , quantumExecutorProjection "quantum.x"
+          , quantumExecutorProjection "quantum.cnot"
+          , quantumExecutorProjection "quantum.cz"
+          , quantumExecutorProjection "quantum.rzz"
+          , quantumExecutorProjection "quantum.measure_z"
+          , quantumExecutorProjection "quantum.ibm_runtime_config"
+          ]
+    , wireCompileEnvProjectionMode = WireProjectionStrict
+    }
+
+quantumExecutorProjection :: T.Text -> WireExecutorProjection
+quantumExecutorProjection executorId =
+  WireExecutorProjection
+    { wireExecutorProjectionId = WireExecutorId executorId
+    , wireExecutorProjectionPorts = WirePorts Map.empty Map.empty
+    , wireExecutorProjectionVocabulary =
+        Set.fromList ["Qubit", "Bit", "RotationAngle", "IBMQuantumConfig"]
+    , wireExecutorProjectionEffect = WireExecutorHostEffect
+    , wireExecutorProjectionConfigShape = WireExecutorConfigUnchecked
+    , wireExecutorProjectionPortPolicy = WireExecutorAuthorDeclaredPorts
     }
 
 projectedExecutorPorts :: WirePorts

--- a/test/Cortex/Wire/ParserSpec.hs
+++ b/test/Cortex/Wire/ParserSpec.hs
@@ -72,6 +72,18 @@ spec = describe "Cortex.Wire.Parser" $ do
     it "parses the mini build-system example" $
       parseWireFixture "examples/wire/mini-build-system.wire"
 
+    it "parses the quantum Bell-state example" $ do
+      source <- TIO.readFile "examples/wire/quantum-bell-state.wire"
+      parseWireFile "examples/wire/quantum-bell-state.wire" source `shouldSatisfy` isRight
+
+    it "parses the IBM REST quantum Bell-state example" $ do
+      source <- TIO.readFile "examples/wire/quantum-bell-state-ibm-rest.wire"
+      parseWireFile "examples/wire/quantum-bell-state-ibm-rest.wire" source `shouldSatisfy` isRight
+
+    it "parses the quantum IPEA round example" $ do
+      source <- TIO.readFile "examples/wire/quantum-ipea-round.wire"
+      parseWireFile "examples/wire/quantum-ipea-round.wire" source `shouldSatisfy` isRight
+
   describe "guardrails" $ do
     it "rejects legacy colon node declarations" $
       parseWireFile "test" "node n : -> out: T = @review.x ({});"


### PR DESCRIPTION
Stacked on #159. Split from #152.\n\nThis slice adds the quantum consumer runners and non-eraser examples.\n\nIncludes:\n- local Qiskit Aer runner\n- IBM Quantum Runtime REST runner\n- iterative phase estimation runner\n- Bell-state and IPEA Wire examples\n- Nix apps and consumer docs\n- quantum fixture parser/compiler tests\n\nValidation run locally:\n- just test (passed via local Nix run after remote Cachix HTTP 500)\n- nix build .#wire-quantum-qiskit .#wire-quantum-ibm-rest .#wire-quantum-ipea