### PR TITLE
feat(wire): add quantum eraser experiment

### DIFF
--- a/docs/Consumers/Quantum.md
+++ b/docs/Consumers/Quantum.md
@@ -218,6 +218,70 @@ nix run .#wire-quantum-ipea -- --hardware --shots 100 --confirm-hardware
 Because each round is a separate provider job, this demo spends hardware budget per measured phase
 bit. Use `--dry-run` first to inspect the generated rounds and OpenQASM 3.
 
+## Quantum Eraser Wire Experiment
+
+[`../../examples/wire/quantum-eraser-experiment.wire`](../../examples/wire/quantum-eraser-experiment.wire)
+is the source of truth for the full delayed-choice quantum eraser sweep. It is an executable Wire
+scaffold and a circuit catalog in one file: the nine hardware circuits are exported graph values,
+the pure planning node builds nine `std.io.command` leaves that select those values with
+`wire build --return`, the topology sequences the jobs, and a final pure node parses and summarizes
+the run with `fromJson`. The final report is printed and written to
+`./wire-quantum-eraser-report.txt` through `std.io.writeFile`.
+
+The example is a gate-model analogue of the delayed-choice quantum eraser, framed as a correlation
+experiment rather than retrocausality: the later marker-basis choice does not change the
+unconditional screen statistics. Interference is recovered only after sorting the results by the
+marker outcome.
+
+The full scaffold is a hardware sweep and queues nine IBM Runtime sampler jobs:
+
+```sh
+nix run .#wire-quantum-eraser -- --confirm-hardware
+```
+
+The app runs the Wire file through `wire run` and places `wire-quantum-ibm-rest` on `PATH` for the
+command leaves. The command leaves request JSON output, and the final pure Wire analyzer renders a
+compact table framed around the three-circular-polarizer analogy: path marking flattens the
+unconditional screen, while eraser-basis marker slices recover complementary fringes. The experiment
+executes these exported graph values from the same Wire source:
+
+- `open_phase_{0,1_4,1_2}`
+- `which_path_phase_{0,1_4,1_2}`
+- `eraser_phase_{0,1_4,1_2}`
+
+The source keeps graph-valued `let`s for the circuit fragments. For example, each eraser graph names
+the screen split/recombine fragments, the marker path-marking fragments, and the delayed
+eraser-basis readout:
+
+```wire
+let recombine_screen =
+  recombine_rz_a
+    => recombine_sx
+    => recombine_rz_b
+    => measure_screen;
+
+let marker_eraser_readout =
+  z_marker_eraser_rz_a
+    => z_marker_eraser_sx
+    => z_marker_eraser_rz_b
+    => z_measure_marker;
+```
+
+To inspect an individual circuit before spending provider time, select the graph value through the
+IBM REST bridge in dry-run mode. Dry-run compiles the selected graph and emits the OpenQASM 3
+request without provider submission:
+
+```sh
+nix run .#wire-quantum-ibm-rest -- examples/wire/quantum-eraser-experiment.wire --return eraser_phase_0 --dry-run --config examples/wire/quantum-ibm-runtime.config.example.json
+```
+
+Hardware execution of an individual row submits the selected Wire-authored circuit as one provider
+job:
+
+```sh
+nix run .#wire-quantum-ibm-rest -- examples/wire/quantum-eraser-experiment.wire --return eraser_phase_0 --shots 100 --confirm-hardware
+```
+
 ## Linearity Caveat
 
 Current Wire admission validates typed ports and cardinality-one inputs, but it does not make a

--- a/examples/wire/quantum-eraser-eraser-phase-1_2.wire
+++ b/examples/wire/quantum-eraser-eraser-phase-1_2.wire
@@ -1,0 +1,143 @@
+# Quantum eraser Wire example: eraser-basis circuit at phase 1/2.
+#
+# The screen marginal is the no-signalling view. In eraser mode, interference
+# only appears after conditioning on the later marker-basis result.
+
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+
+node prepare_screen
+  <- config: IBMQuantumConfig;
+  -> control: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+
+node prepare_marker
+  -> target: Qubit = @quantum.prepare_zero { index = 1; } (null);
+
+node split_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node split_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node split_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node phase_screen
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 3.141592653589793; } (control);
+
+node mark_pre_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node mark_pre_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node mark_pre_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node mark_cz
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @quantum.cz {} ({ inherit control; inherit target; });
+
+node z_mark_post_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node z_mark_post_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node z_mark_post_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node recombine_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node recombine_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node recombine_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node measure_screen
+  <- control: Qubit;
+  -> screen: Bit = @quantum.measure_z {} (control);
+
+node z_marker_eraser_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node z_marker_eraser_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node z_marker_eraser_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node z_measure_marker
+  <- target: Qubit;
+  -> marker: Bit = @quantum.measure_z {} (target);
+
+let split_path =
+  split_rz_a
+    => split_sx
+    => split_rz_b
+    => phase_screen;
+
+let mark_marker_pre =
+  mark_pre_rz_a
+    => mark_pre_sx
+    => mark_pre_rz_b;
+
+let mark_marker_post =
+  z_mark_post_rz_a
+    => z_mark_post_sx
+    => z_mark_post_rz_b;
+
+let recombine_screen =
+  recombine_rz_a
+    => recombine_sx
+    => recombine_rz_b
+    => measure_screen;
+
+let marker_eraser_readout =
+  z_marker_eraser_rz_a
+    => z_marker_eraser_sx
+    => z_marker_eraser_rz_b
+    => z_measure_marker;
+
+ibm_runtime_config
+  => (
+    (
+      prepare_screen
+        => split_path
+        => mark_cz
+        => recombine_screen
+    )
+    <>
+    (
+      prepare_marker
+        => mark_marker_pre
+        => mark_cz
+        => mark_marker_post
+        => marker_eraser_readout
+    )
+)

--- a/examples/wire/quantum-eraser-eraser-phase-1_4.wire
+++ b/examples/wire/quantum-eraser-eraser-phase-1_4.wire
@@ -1,0 +1,143 @@
+# Quantum eraser Wire example: eraser-basis circuit at phase 1/4.
+#
+# The screen marginal is the no-signalling view. In eraser mode, interference
+# only appears after conditioning on the later marker-basis result.
+
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+
+node prepare_screen
+  <- config: IBMQuantumConfig;
+  -> control: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+
+node prepare_marker
+  -> target: Qubit = @quantum.prepare_zero { index = 1; } (null);
+
+node split_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node split_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node split_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node phase_screen
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node mark_pre_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node mark_pre_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node mark_pre_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node mark_cz
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @quantum.cz {} ({ inherit control; inherit target; });
+
+node z_mark_post_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node z_mark_post_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node z_mark_post_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node recombine_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node recombine_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node recombine_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node measure_screen
+  <- control: Qubit;
+  -> screen: Bit = @quantum.measure_z {} (control);
+
+node z_marker_eraser_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node z_marker_eraser_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node z_marker_eraser_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node z_measure_marker
+  <- target: Qubit;
+  -> marker: Bit = @quantum.measure_z {} (target);
+
+let split_path =
+  split_rz_a
+    => split_sx
+    => split_rz_b
+    => phase_screen;
+
+let mark_marker_pre =
+  mark_pre_rz_a
+    => mark_pre_sx
+    => mark_pre_rz_b;
+
+let mark_marker_post =
+  z_mark_post_rz_a
+    => z_mark_post_sx
+    => z_mark_post_rz_b;
+
+let recombine_screen =
+  recombine_rz_a
+    => recombine_sx
+    => recombine_rz_b
+    => measure_screen;
+
+let marker_eraser_readout =
+  z_marker_eraser_rz_a
+    => z_marker_eraser_sx
+    => z_marker_eraser_rz_b
+    => z_measure_marker;
+
+ibm_runtime_config
+  => (
+    (
+      prepare_screen
+        => split_path
+        => mark_cz
+        => recombine_screen
+    )
+    <>
+    (
+      prepare_marker
+        => mark_marker_pre
+        => mark_cz
+        => mark_marker_post
+        => marker_eraser_readout
+    )
+)

--- a/examples/wire/quantum-eraser-experiment.wire
+++ b/examples/wire/quantum-eraser-experiment.wire
@@ -1,0 +1,537 @@
+# Full delayed-choice quantum eraser experiment scaffold over IBM Runtime REST.
+#
+# Run:
+#
+#   nix run .#wire-quantum-eraser -- --confirm-hardware
+#
+# The experiment graph is Wire. Each command leaf selects one exported circuit
+# graph value from this file and submits it through the IBM Runtime REST bridge.
+# The final analyzer is a pure Wire node that parses JSON stdout with fromJson.
+
+use std.io.{@stdout, @command, @writeFile, CommandSpec, CommandResult};
+
+contract ExperimentStart;
+contract ExperimentReport;
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+let phase_zero = 0.0;
+let phase_quarter = 1.5707963267948966;
+let phase_half = 3.141592653589793;
+let quantum_sx = @quantum.sx {};
+let quantum_cz = @quantum.cz {};
+let quantum_measure_z = @quantum.measure_z {};
+
+kind qubit_gate(label: PortLabel, gate: ConfiguredExecutor) =
+  <- label: Qubit;
+  -> label: Qubit = gate (label);
+
+kind rz_gate(label: PortLabel, angle: Value) =
+  <- label: Qubit;
+  -> label: Qubit = @quantum.rz { inherit angle; } (label);
+
+kind qubit_measure(input: PortLabel, output: PortLabel) =
+  <- input: Qubit;
+  -> output: Bit = quantum_measure_z (input);
+
+kind two_qubit_gate(control: PortLabel, target: PortLabel, gate: ConfiguredExecutor) =
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = gate ({ inherit control; inherit target; });
+
+kind run_command(spec: PortLabel, result: PortLabel) =
+  <- spec: CommandSpec;
+  -> result: CommandResult = @command {} (spec);
+
+kind command_gate(spec: PortLabel, previous: PortLabel, ready: PortLabel) =
+  <- spec: CommandSpec;
+  <- previous: CommandResult;
+  -> ready: CommandSpec = pure (spec);
+
+# Hardware circuit graph forms for the eraser sweep.
+#
+# Each exported graph is selected with `wire build --return NAME` by the
+# IBM REST command leaves below. The default file-return at the bottom
+# remains the experiment orchestration graph.
+
+form quarter_turn(label: PortLabel) = {
+  node rz_a = rz_gate(label, phase_quarter);
+  node sx = qubit_gate(label, quantum_sx);
+  node rz_b = rz_gate(label, phase_quarter);
+
+  rz_a
+    => sx
+    => rz_b;
+};
+
+form open_circuit(phase_angle: Value) = {
+  node ibm_runtime_config
+    -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+  node prepare_screen
+    <- config: IBMQuantumConfig;
+    -> screen: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+  node phase_screen = rz_gate(screen, phase_angle);
+  node measure_screen = qubit_measure(screen, screen);
+
+  let split_path = quarter_turn(screen);
+  let recombine_turn = quarter_turn(screen);
+  let recombine_path =
+    phase_screen
+      => recombine_turn
+      => measure_screen;
+
+  ibm_runtime_config
+    => prepare_screen
+    => split_path
+    => recombine_path;
+};
+
+form marked_circuit(phase_angle: Value, marker_readout: Graph) = {
+  node ibm_runtime_config
+    -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+  node prepare_screen
+    <- config: IBMQuantumConfig;
+    -> control: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+  node prepare_marker
+    -> target: Qubit = @quantum.prepare_zero { index = 1; } (null);
+  node phase_screen = rz_gate(control, phase_angle);
+  node mark_cz = two_qubit_gate(control, target, quantum_cz);
+  node measure_screen = qubit_measure(control, screen);
+
+  let split_turn = quarter_turn(control);
+  let mark_marker_pre = quarter_turn(target);
+  let mark_marker_post = quarter_turn(target);
+  let recombine_turn = quarter_turn(control);
+  let split_path =
+    split_turn
+      => phase_screen;
+  let recombine_screen =
+    recombine_turn
+      => measure_screen;
+
+  ibm_runtime_config
+    => (
+      (
+        prepare_screen
+          => split_path
+          => mark_cz
+          => recombine_screen
+      )
+      <>
+      (
+        prepare_marker
+          => mark_marker_pre
+          => mark_cz
+          => mark_marker_post
+          => marker_readout
+      )
+  );
+};
+
+form which_path_circuit(phase_angle: Value) = {
+  node z_measure_marker = qubit_measure(target, marker);
+
+  let marker_readout = z_measure_marker;
+  let circuit = marked_circuit(phase_angle, marker_readout);
+
+  circuit;
+};
+
+form eraser_circuit(phase_angle: Value) = {
+  node z_measure_marker = qubit_measure(target, marker);
+
+  let marker_eraser_basis = quarter_turn(target);
+  let marker_eraser_readout =
+    marker_eraser_basis
+      => z_measure_marker;
+  let circuit = marked_circuit(phase_angle, marker_eraser_readout);
+
+  circuit;
+};
+
+export let open_phase_0 = open_circuit(phase_zero);
+export let open_phase_1_4 = open_circuit(phase_quarter);
+export let open_phase_1_2 = open_circuit(phase_half);
+
+export let which_path_phase_0 = which_path_circuit(phase_zero);
+export let which_path_phase_1_4 = which_path_circuit(phase_quarter);
+export let which_path_phase_1_2 = which_path_circuit(phase_half);
+
+export let eraser_phase_0 = eraser_circuit(phase_zero);
+export let eraser_phase_1_4 = eraser_circuit(phase_quarter);
+export let eraser_phase_1_2 = eraser_circuit(phase_half);
+
+node start_experiment
+  -> start: ExperimentStart = pure ("start");
+
+node plan_experiment
+  <- start: ExperimentStart;
+  -> open0Spec: CommandSpec = pure (open0Spec);
+  -> open14Spec: CommandSpec = pure (open14Spec);
+  -> open12Spec: CommandSpec = pure (open12Spec);
+  -> which0Spec: CommandSpec = pure (which0Spec);
+  -> which14Spec: CommandSpec = pure (which14Spec);
+  -> which12Spec: CommandSpec = pure (which12Spec);
+  -> eraser0Spec: CommandSpec = pure (eraser0Spec);
+  -> eraser14Spec: CommandSpec = pure (eraser14Spec);
+  -> eraser12Spec: CommandSpec = pure (eraser12Spec);
+  where let
+    shots = "100";
+    source = "examples/wire/quantum-eraser-experiment.wire";
+    hardwareSpec = name: returnName: {
+      inherit name;
+      target = "${source}#${returnName}";
+      argv = [
+        "wire-quantum-ibm-rest",
+        source,
+        "--return",
+        returnName,
+        "--shots",
+        shots,
+        "--confirm-hardware",
+        "--json"
+      ];
+      cwd = ".";
+      required = true;
+      skip = false;
+      echo = false;
+    };
+    open0Spec = hardwareSpec "open phase 0" "open_phase_0";
+    open14Spec = hardwareSpec "open phase 1/4" "open_phase_1_4";
+    open12Spec = hardwareSpec "open phase 1/2" "open_phase_1_2";
+    which0Spec = hardwareSpec "which-path phase 0" "which_path_phase_0";
+    which14Spec = hardwareSpec "which-path phase 1/4" "which_path_phase_1_4";
+    which12Spec = hardwareSpec "which-path phase 1/2" "which_path_phase_1_2";
+    eraser0Spec = hardwareSpec "eraser phase 0" "eraser_phase_0";
+    eraser14Spec = hardwareSpec "eraser phase 1/4" "eraser_phase_1_4";
+    eraser12Spec = hardwareSpec "eraser phase 1/2" "eraser_phase_1_2";
+  in
+  { inherit open0Spec open14Spec open12Spec which0Spec which14Spec which12Spec eraser0Spec eraser14Spec eraser12Spec; };
+
+node run_open_0 = run_command(open0Spec, open0);
+node gate_open_14 = command_gate(open14Spec, open0, open14Ready);
+node run_open_14 = run_command(open14Ready, open14);
+node gate_open_12 = command_gate(open12Spec, open14, open12Ready);
+node run_open_12 = run_command(open12Ready, open12);
+node gate_which_0 = command_gate(which0Spec, open12, which0Ready);
+node run_which_0 = run_command(which0Ready, which0);
+node gate_which_14 = command_gate(which14Spec, which0, which14Ready);
+node run_which_14 = run_command(which14Ready, which14);
+node gate_which_12 = command_gate(which12Spec, which14, which12Ready);
+node run_which_12 = run_command(which12Ready, which12);
+node gate_eraser_0 = command_gate(eraser0Spec, which12, eraser0Ready);
+node run_eraser_0 = run_command(eraser0Ready, eraser0);
+node gate_eraser_14 = command_gate(eraser14Spec, eraser0, eraser14Ready);
+node run_eraser_14 = run_command(eraser14Ready, eraser14);
+node gate_eraser_12 = command_gate(eraser12Spec, eraser14, eraser12Ready);
+node run_eraser_12 = run_command(eraser12Ready, eraser12);
+
+node summarize_experiment
+  <- open0: CommandResult;
+  <- open14: CommandResult;
+  <- open12: CommandResult;
+  <- which0: CommandResult;
+  <- which14: CommandResult;
+  <- which12: CommandResult;
+  <- eraser0: CommandResult;
+  <- eraser14: CommandResult;
+  <- eraser12: CommandResult;
+  -> summary: ExperimentReport = pure (summary);
+  where let
+    runs = [open0, open14, open12, which0, which14, which12, eraser0, eraser14, eraser12];
+    failures = runs |> filter (run: !run.ok);
+    statuses = runs |> map (run: "${run.name}=${run.status}") |> joinWith ", ";
+    targets = runs |> map (run: run.target) |> joinWith "\n  ";
+    empty = "";
+    space = " ";
+    noneText = "none";
+    noStderr = "(empty)";
+    failureDetails =
+      failures
+        |> map (run: ''
+          ${run.name}
+            exit: ${if run.exitCode == null then noneText else run.exitCode}
+            target: ${run.target}
+            argv: ${run.argv |> joinWith space}
+            stderr: ${if run.stderr == empty then noStderr else run.stderr}
+
+        '')
+        |> joinWith "";
+    success = length failures == 0;
+    summary = if success then
+      let
+        decoded = runs |> map (run: fromJson(run.stdout));
+        open0Json = decoded[0];
+        open14Json = decoded[1];
+        open12Json = decoded[2];
+        which0Json = decoded[3];
+        which14Json = decoded[4];
+        which12Json = decoded[5];
+        eraser0Json = decoded[6];
+        eraser14Json = decoded[7];
+        eraser12Json = decoded[8];
+        hasCounts = decoded |> all (result: result.complete_counts != null);
+      in
+      if hasCounts then
+        let
+          oneBit = result:
+            let
+              counts = result.complete_counts;
+              c0 = counts["0"];
+              c1 = counts["1"];
+              shots = result.shots;
+            in
+            { inherit c0 c1 shots; };
+          twoBit = result:
+            let
+              counts = result.complete_counts;
+              c00 = counts["00"];
+              c01 = counts["01"];
+              c10 = counts["10"];
+              c11 = counts["11"];
+              shots = result.shots;
+              screenZero = c00 + c10;
+              marker0Total = c00 + c01;
+              marker1Total = c10 + c11;
+            in
+            { inherit c00 c01 c10 c11 shots screenZero marker0Total marker1Total; };
+          oneRow = mode: phase: expected: bit:
+            "  ${mode} | ${phase} | ${bit.c0}/${bit.shots} | ${expected} | - | - | 0:${bit.c0},1:${bit.c1}\n";
+          twoRow = mode: phase: expected: bit:
+            "  ${mode} | ${phase} | ${bit.screenZero}/${bit.shots} | ${expected} | ${bit.c00}/${bit.marker0Total} | ${bit.c10}/${bit.marker1Total} | 00:${bit.c00},01:${bit.c01},10:${bit.c10},11:${bit.c11}\n";
+          openBits = [open0Json, open14Json, open12Json] |> map oneBit;
+          whichPathBits = [which0Json, which14Json, which12Json] |> map twoBit;
+          eraserBits = [eraser0Json, eraser14Json, eraser12Json] |> map twoBit;
+          open0Bits = openBits[0];
+          open14Bits = openBits[1];
+          open12Bits = openBits[2];
+          which0Bits = whichPathBits[0];
+          which14Bits = whichPathBits[1];
+          which12Bits = whichPathBits[2];
+          eraser0Bits = eraserBits[0];
+          eraser14Bits = eraserBits[1];
+          eraser12Bits = eraserBits[2];
+          resultRows = [
+            "  mode | phase | screen=0 | expected screen | marker=0 screen=0 | marker=1 screen=0 | raw counts\n",
+            "  ---- | ----- | -------- | --------------- | ----------------- | ----------------- | ----------\n",
+            oneRow "open" "0" "bright" open0Bits,
+            oneRow "open" "1/4" "balanced" open14Bits,
+            oneRow "open" "1/2" "dark" open12Bits,
+            twoRow "which_path" "0" "balanced" which0Bits,
+            twoRow "which_path" "1/4" "balanced" which14Bits,
+            twoRow "which_path" "1/2" "balanced" which12Bits,
+            twoRow "eraser" "0" "balanced before sorting" eraser0Bits,
+            twoRow "eraser" "1/4" "balanced before sorting" eraser14Bits,
+            twoRow "eraser" "1/2" "balanced before sorting" eraser12Bits
+          ] |> joinWith "";
+          openReading = ''
+            Open graph: no middle circular tag
+              No path marker is inserted between the splitter and recombiner.
+              In the circular-polarizer picture, this is the reference stack:
+              the screen behaves like the final analyzer with no middle
+              which-path filter left in the beam.
+
+              Phase 0: screen=0 appeared ${open0Bits.c0}/${open0Bits.shots} times, the bright fringe.
+              Phase 1/4: screen=0 appeared ${open14Bits.c0}/${open14Bits.shots} times, the halfway setting.
+              Phase 1/2: screen=0 appeared ${open12Bits.c0}/${open12Bits.shots} times, the dark fringe.
+
+              Those three numbers are the reference interference fringe.
+
+          '';
+          whichPathReading = ''
+            Which-path graph: opposite circular tags left in place
+              The marker is the middle polarizer. It tags the two alternatives
+              as opposite circular polarizations, so the screen alone can no
+              longer combine them into a phase fringe.
+
+              Unsorted screen=0 counts:
+                phase 0: ${which0Bits.screenZero}/${which0Bits.shots}
+                phase 1/4: ${which14Bits.screenZero}/${which14Bits.shots}
+                phase 1/2: ${which12Bits.screenZero}/${which12Bits.shots}
+
+              Instead of following the open fringe ${open0Bits.c0}/${open0Bits.shots}
+              -> ${open14Bits.c0}/${open14Bits.shots} -> ${open12Bits.c0}/${open12Bits.shots},
+              all three which-path rows sit around half.
+
+              Sorting by the readable marker still does not recover the clean
+              fringe:
+                phase 0 marker=0: ${which0Bits.c00}/${which0Bits.marker0Total}
+                phase 0 marker=1: ${which0Bits.c10}/${which0Bits.marker1Total}
+                phase 1/2 marker=0: ${which12Bits.c00}/${which12Bits.marker0Total}
+                phase 1/2 marker=1: ${which12Bits.c10}/${which12Bits.marker1Total}
+
+              The circular path labels are still present, so the alternatives
+              remain distinguishable.
+
+          '';
+          eraserReading = ''
+            Eraser graph: final analyzer erases the circular tag
+              The eraser adds the third polarizer: a final marker analyzer that
+              projects the left/right circular tags into a common basis.
+
+              Before sorting by marker, the screen still respects no-signalling:
+                phase 0 screen=0: ${eraser0Bits.screenZero}/${eraser0Bits.shots}
+                phase 1/4 screen=0: ${eraser14Bits.screenZero}/${eraser14Bits.shots}
+                phase 1/2 screen=0: ${eraser12Bits.screenZero}/${eraser12Bits.shots}
+
+              Those unsorted numbers stay near half, so the later analyzer did
+              not rewrite the earlier screen distribution.
+
+              The interference returns only after conditioning on the marker.
+                phase 0 marker=0: ${eraser0Bits.c00}/${eraser0Bits.marker0Total}
+                phase 0 marker=1: ${eraser0Bits.c10}/${eraser0Bits.marker1Total}
+                phase 1/2 marker=0: ${eraser12Bits.c00}/${eraser12Bits.marker0Total}
+                phase 1/2 marker=1: ${eraser12Bits.c10}/${eraser12Bits.marker1Total}
+                phase 1/4 marker=0: ${eraser14Bits.c00}/${eraser14Bits.marker0Total}
+                phase 1/4 marker=1: ${eraser14Bits.c10}/${eraser14Bits.marker1Total}
+
+              Phase 0 is bright in marker=0 and dark in marker=1. Phase 1/2
+              trades those roles. Phase 1/4 crosses near the middle.
+
+              That is the quantum eraser in the polarized-filter picture: the
+              middle circular marker destroys the visible screen fringe, and
+              the final analyzer recovers two opposite fringes only when the
+              data is sorted by its marker result.
+
+          '';
+        in
+        ''
+          Wire delayed-choice quantum eraser experiment
+          =============================================
+
+          Run
+            source: examples/wire/quantum-eraser-experiment.wire
+            execution: one Wire orchestration graph + std.io.command leaves
+            backend: IBM Quantum Runtime REST hardware
+            shots: 100 per circuit
+            circuits: 9 exported graph values selected from this same Wire file
+            report file: ./wire-quantum-eraser-report.txt
+
+          Circuit graph values submitted
+            ${targets}
+
+          What Wire did
+            Wire planned the sweep, sequenced nine hardware command leaves,
+            selected each circuit with wire build --return, parsed each REST
+            JSON result with fromJson, and rendered this analyzer report in a
+            pure Wire node. No Qiskit simulator path is used for the experiment.
+
+          Results
+          ${resultRows}
+
+          Reading the numbers through three circular polarizers
+          ${openReading}${whichPathReading}${eraserReading}Run gate: complete
+        ''
+      else
+        ''
+          Wire delayed-choice quantum eraser experiment
+          =============================================
+
+          Run
+            source: examples/wire/quantum-eraser-experiment.wire
+            execution: one Wire orchestration graph + std.io.command leaves
+            backend: IBM Quantum Runtime REST hardware
+            shots: 100 per circuit
+            circuits: 9 exported graph values selected from this same Wire file
+            report file: ./wire-quantum-eraser-report.txt
+
+          Circuit graph values submitted
+            ${targets}
+
+          The IBM REST runner completed, but at least one result did not contain decoded counts.
+          Re-run the failed circuit directly with --json and inspect raw_result.
+
+          Results
+            ${statuses}
+
+          Run gate: result decoder needs attention
+        ''
+    else
+      ''
+        Wire delayed-choice quantum eraser experiment
+        =============================================
+
+        Run
+          source: examples/wire/quantum-eraser-experiment.wire
+          execution: one Wire orchestration graph + std.io.command leaves
+          backend: IBM Quantum Runtime REST hardware
+          shots: 100 per circuit
+          circuits: 9 exported graph values selected from this same Wire file
+          report file: ./wire-quantum-eraser-report.txt
+
+        Circuit graph values submitted
+          ${targets}
+
+        At least one hardware command failed before analysis, so the pure Wire analyzer did not parse stdout.
+
+        Results
+          ${statuses}
+
+        Failed rows
+        ${failureDetails}Run gate: failed
+      '';
+  in
+  { inherit summary; };
+
+node print_report
+  <- summary: ExperimentReport;
+  = @stdout { newline = true; } (summary);
+
+node write_report
+  <- summary: ExperimentReport;
+  = @writeFile { path = "./wire-quantum-eraser-report.txt"; } (summary);
+
+let command_nodes =
+  run_open_0
+  <> gate_open_14
+  <> run_open_14
+  <> gate_open_12
+  <> run_open_12
+  <> gate_which_0
+  <> run_which_0
+  <> gate_which_14
+  <> run_which_14
+  <> gate_which_12
+  <> run_which_12
+  <> gate_eraser_0
+  <> run_eraser_0
+  <> gate_eraser_14
+  <> run_eraser_14
+  <> gate_eraser_12
+  <> run_eraser_12;
+
+let command_sequence =
+  run_open_0
+    => gate_open_14
+    => run_open_14
+    => gate_open_12
+    => run_open_12
+    => gate_which_0
+    => run_which_0
+    => gate_which_14
+    => run_which_14
+    => gate_which_12
+    => run_which_12
+    => gate_eraser_0
+    => run_eraser_0
+    => gate_eraser_14
+    => run_eraser_14
+    => gate_eraser_12
+    => run_eraser_12;
+
+(
+  start_experiment
+    => plan_experiment
+    => command_nodes
+)
+<>
+command_sequence
+<>
+(
+  command_nodes
+    => summarize_experiment
+    => (print_report <> write_report)
+)

--- a/examples/wire/quantum-eraser-open-phase-0.wire
+++ b/examples/wire/quantum-eraser-open-phase-0.wire
@@ -1,0 +1,61 @@
+# Quantum eraser control circuit: open interferometer at phase 0.
+
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+
+node prepare_screen
+  <- config: IBMQuantumConfig;
+  -> screen: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+
+node split_rz_a
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node split_sx
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.sx {} (screen);
+
+node split_rz_b
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node phase_screen
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 0.0; } (screen);
+
+node recombine_rz_a
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node recombine_sx
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.sx {} (screen);
+
+node recombine_rz_b
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node measure_screen
+  <- screen: Qubit;
+  -> screen: Bit = @quantum.measure_z {} (screen);
+
+let split_path =
+  split_rz_a
+    => split_sx
+    => split_rz_b;
+
+let recombine_path =
+  phase_screen
+    => recombine_rz_a
+    => recombine_sx
+    => recombine_rz_b
+    => measure_screen;
+
+ibm_runtime_config
+  => prepare_screen
+  => split_path
+  => recombine_path

--- a/examples/wire/quantum-eraser-open-phase-1_2.wire
+++ b/examples/wire/quantum-eraser-open-phase-1_2.wire
@@ -1,0 +1,61 @@
+# Quantum eraser control circuit: open interferometer at phase 1/2.
+
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+
+node prepare_screen
+  <- config: IBMQuantumConfig;
+  -> screen: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+
+node split_rz_a
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node split_sx
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.sx {} (screen);
+
+node split_rz_b
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node phase_screen
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 3.141592653589793; } (screen);
+
+node recombine_rz_a
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node recombine_sx
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.sx {} (screen);
+
+node recombine_rz_b
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node measure_screen
+  <- screen: Qubit;
+  -> screen: Bit = @quantum.measure_z {} (screen);
+
+let split_path =
+  split_rz_a
+    => split_sx
+    => split_rz_b;
+
+let recombine_path =
+  phase_screen
+    => recombine_rz_a
+    => recombine_sx
+    => recombine_rz_b
+    => measure_screen;
+
+ibm_runtime_config
+  => prepare_screen
+  => split_path
+  => recombine_path

--- a/examples/wire/quantum-eraser-open-phase-1_4.wire
+++ b/examples/wire/quantum-eraser-open-phase-1_4.wire
@@ -1,0 +1,61 @@
+# Quantum eraser control circuit: open interferometer at phase 1/4.
+
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+
+node prepare_screen
+  <- config: IBMQuantumConfig;
+  -> screen: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+
+node split_rz_a
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node split_sx
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.sx {} (screen);
+
+node split_rz_b
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node phase_screen
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node recombine_rz_a
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node recombine_sx
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.sx {} (screen);
+
+node recombine_rz_b
+  <- screen: Qubit;
+  -> screen: Qubit = @quantum.rz { angle = 1.5707963267948966; } (screen);
+
+node measure_screen
+  <- screen: Qubit;
+  -> screen: Bit = @quantum.measure_z {} (screen);
+
+let split_path =
+  split_rz_a
+    => split_sx
+    => split_rz_b;
+
+let recombine_path =
+  phase_screen
+    => recombine_rz_a
+    => recombine_sx
+    => recombine_rz_b
+    => measure_screen;
+
+ibm_runtime_config
+  => prepare_screen
+  => split_path
+  => recombine_path

--- a/examples/wire/quantum-eraser-round.wire
+++ b/examples/wire/quantum-eraser-round.wire
@@ -1,0 +1,143 @@
+# Quantum eraser Wire example: eraser-basis circuit at phase 0.
+#
+# The screen marginal is the no-signalling view. In eraser mode, interference
+# only appears after conditioning on the later marker-basis result.
+
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+
+node prepare_screen
+  <- config: IBMQuantumConfig;
+  -> control: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+
+node prepare_marker
+  -> target: Qubit = @quantum.prepare_zero { index = 1; } (null);
+
+node split_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node split_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node split_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node phase_screen
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 0.0; } (control);
+
+node mark_pre_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node mark_pre_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node mark_pre_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node mark_cz
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @quantum.cz {} ({ inherit control; inherit target; });
+
+node z_mark_post_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node z_mark_post_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node z_mark_post_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node recombine_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node recombine_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node recombine_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node measure_screen
+  <- control: Qubit;
+  -> screen: Bit = @quantum.measure_z {} (control);
+
+node z_marker_eraser_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node z_marker_eraser_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node z_marker_eraser_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node z_measure_marker
+  <- target: Qubit;
+  -> marker: Bit = @quantum.measure_z {} (target);
+
+let split_path =
+  split_rz_a
+    => split_sx
+    => split_rz_b
+    => phase_screen;
+
+let mark_marker_pre =
+  mark_pre_rz_a
+    => mark_pre_sx
+    => mark_pre_rz_b;
+
+let mark_marker_post =
+  z_mark_post_rz_a
+    => z_mark_post_sx
+    => z_mark_post_rz_b;
+
+let recombine_screen =
+  recombine_rz_a
+    => recombine_sx
+    => recombine_rz_b
+    => measure_screen;
+
+let marker_eraser_readout =
+  z_marker_eraser_rz_a
+    => z_marker_eraser_sx
+    => z_marker_eraser_rz_b
+    => z_measure_marker;
+
+ibm_runtime_config
+  => (
+    (
+      prepare_screen
+        => split_path
+        => mark_cz
+        => recombine_screen
+    )
+    <>
+    (
+      prepare_marker
+        => mark_marker_pre
+        => mark_cz
+        => mark_marker_post
+        => marker_eraser_readout
+    )
+)

--- a/examples/wire/quantum-eraser-which-path-phase-0.wire
+++ b/examples/wire/quantum-eraser-which-path-phase-0.wire
@@ -1,0 +1,127 @@
+# Quantum eraser circuit: which-path marking at phase 0.
+#
+# The marker stores path information, so the unconditional screen marginal is flat.
+
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+
+node prepare_screen
+  <- config: IBMQuantumConfig;
+  -> control: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+
+node prepare_marker
+  -> target: Qubit = @quantum.prepare_zero { index = 1; } (null);
+
+node split_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node split_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node split_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node phase_screen
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 0.0; } (control);
+
+node mark_pre_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node mark_pre_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node mark_pre_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node mark_cz
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @quantum.cz {} ({ inherit control; inherit target; });
+
+node z_mark_post_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node z_mark_post_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node z_mark_post_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node recombine_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node recombine_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node recombine_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node measure_screen
+  <- control: Qubit;
+  -> screen: Bit = @quantum.measure_z {} (control);
+
+node z_measure_marker
+  <- target: Qubit;
+  -> marker: Bit = @quantum.measure_z {} (target);
+
+let split_path =
+  split_rz_a
+    => split_sx
+    => split_rz_b
+    => phase_screen;
+
+let mark_marker_pre =
+  mark_pre_rz_a
+    => mark_pre_sx
+    => mark_pre_rz_b;
+
+let mark_marker_post =
+  z_mark_post_rz_a
+    => z_mark_post_sx
+    => z_mark_post_rz_b;
+
+let recombine_screen =
+  recombine_rz_a
+    => recombine_sx
+    => recombine_rz_b
+    => measure_screen;
+
+let marker_which_path_readout =
+  z_measure_marker;
+
+ibm_runtime_config
+  => (
+    (
+      prepare_screen
+        => split_path
+        => mark_cz
+        => recombine_screen
+    )
+    <>
+    (
+      prepare_marker
+        => mark_marker_pre
+        => mark_cz
+        => mark_marker_post
+        => marker_which_path_readout
+    )
+)

--- a/examples/wire/quantum-eraser-which-path-phase-1_2.wire
+++ b/examples/wire/quantum-eraser-which-path-phase-1_2.wire
@@ -1,0 +1,127 @@
+# Quantum eraser circuit: which-path marking at phase 1/2.
+#
+# The marker stores path information, so the unconditional screen marginal is flat.
+
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+
+node prepare_screen
+  <- config: IBMQuantumConfig;
+  -> control: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+
+node prepare_marker
+  -> target: Qubit = @quantum.prepare_zero { index = 1; } (null);
+
+node split_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node split_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node split_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node phase_screen
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 3.141592653589793; } (control);
+
+node mark_pre_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node mark_pre_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node mark_pre_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node mark_cz
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @quantum.cz {} ({ inherit control; inherit target; });
+
+node z_mark_post_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node z_mark_post_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node z_mark_post_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node recombine_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node recombine_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node recombine_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node measure_screen
+  <- control: Qubit;
+  -> screen: Bit = @quantum.measure_z {} (control);
+
+node z_measure_marker
+  <- target: Qubit;
+  -> marker: Bit = @quantum.measure_z {} (target);
+
+let split_path =
+  split_rz_a
+    => split_sx
+    => split_rz_b
+    => phase_screen;
+
+let mark_marker_pre =
+  mark_pre_rz_a
+    => mark_pre_sx
+    => mark_pre_rz_b;
+
+let mark_marker_post =
+  z_mark_post_rz_a
+    => z_mark_post_sx
+    => z_mark_post_rz_b;
+
+let recombine_screen =
+  recombine_rz_a
+    => recombine_sx
+    => recombine_rz_b
+    => measure_screen;
+
+let marker_which_path_readout =
+  z_measure_marker;
+
+ibm_runtime_config
+  => (
+    (
+      prepare_screen
+        => split_path
+        => mark_cz
+        => recombine_screen
+    )
+    <>
+    (
+      prepare_marker
+        => mark_marker_pre
+        => mark_cz
+        => mark_marker_post
+        => marker_which_path_readout
+    )
+)

--- a/examples/wire/quantum-eraser-which-path-phase-1_4.wire
+++ b/examples/wire/quantum-eraser-which-path-phase-1_4.wire
@@ -1,0 +1,127 @@
+# Quantum eraser circuit: which-path marking at phase 1/4.
+#
+# The marker stores path information, so the unconditional screen marginal is flat.
+
+contract IBMQuantumConfig;
+contract Qubit;
+contract Bit;
+
+node ibm_runtime_config
+  -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+
+node prepare_screen
+  <- config: IBMQuantumConfig;
+  -> control: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
+
+node prepare_marker
+  -> target: Qubit = @quantum.prepare_zero { index = 1; } (null);
+
+node split_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node split_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node split_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node phase_screen
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node mark_pre_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node mark_pre_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node mark_pre_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node mark_cz
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @quantum.cz {} ({ inherit control; inherit target; });
+
+node z_mark_post_rz_a
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node z_mark_post_sx
+  <- target: Qubit;
+  -> target: Qubit = @quantum.sx {} (target);
+
+node z_mark_post_rz_b
+  <- target: Qubit;
+  -> target: Qubit = @quantum.rz { angle = 1.5707963267948966; } (target);
+
+node recombine_rz_a
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node recombine_sx
+  <- control: Qubit;
+  -> control: Qubit = @quantum.sx {} (control);
+
+node recombine_rz_b
+  <- control: Qubit;
+  -> control: Qubit = @quantum.rz { angle = 1.5707963267948966; } (control);
+
+node measure_screen
+  <- control: Qubit;
+  -> screen: Bit = @quantum.measure_z {} (control);
+
+node z_measure_marker
+  <- target: Qubit;
+  -> marker: Bit = @quantum.measure_z {} (target);
+
+let split_path =
+  split_rz_a
+    => split_sx
+    => split_rz_b
+    => phase_screen;
+
+let mark_marker_pre =
+  mark_pre_rz_a
+    => mark_pre_sx
+    => mark_pre_rz_b;
+
+let mark_marker_post =
+  z_mark_post_rz_a
+    => z_mark_post_sx
+    => z_mark_post_rz_b;
+
+let recombine_screen =
+  recombine_rz_a
+    => recombine_sx
+    => recombine_rz_b
+    => measure_screen;
+
+let marker_which_path_readout =
+  z_measure_marker;
+
+ibm_runtime_config
+  => (
+    (
+      prepare_screen
+        => split_path
+        => mark_cz
+        => recombine_screen
+    )
+    <>
+    (
+      prepare_marker
+        => mark_marker_pre
+        => mark_cz
+        => mark_marker_post
+        => marker_which_path_readout
+    )
+)

--- a/nix/quantum.nix
+++ b/nix/quantum.nix
@@ -42,11 +42,26 @@
           "$@"
       '';
     };
+
+    wire-quantum-eraser = pkgs.writeShellApplication {
+      name = "wire-quantum-eraser";
+      text = ''
+        set -euo pipefail
+        if [ "$#" -ne 1 ] || [ "$1" != "--confirm-hardware" ]; then
+          echo "usage: wire-quantum-eraser --confirm-hardware" >&2
+          echo "runs nine selected circuit graphs from examples/wire/quantum-eraser-experiment.wire as IBM Runtime REST hardware jobs" >&2
+          exit 64
+        fi
+        export PATH="${wire-quantum-ibm-rest}/bin:$PATH"
+        exec ${config.packages.wire}/bin/wire run examples/wire/quantum-eraser-experiment.wire
+      '';
+    };
   in {
     packages = {
       wire-quantum-qiskit = wire-quantum-qiskit;
       wire-quantum-ibm-rest = wire-quantum-ibm-rest;
       wire-quantum-ipea = wire-quantum-ipea;
+      wire-quantum-eraser = wire-quantum-eraser;
     };
 
     apps = {
@@ -64,6 +79,11 @@
         type = "app";
         program = "${wire-quantum-ipea}/bin/wire-quantum-ipea";
         meta.description = "Run iterative phase estimation as composed Wire quantum rounds";
+      };
+      wire-quantum-eraser = {
+        type = "app";
+        program = "${wire-quantum-eraser}/bin/wire-quantum-eraser";
+        meta.description = "Run the delayed-choice quantum eraser Wire sweep on IBM Runtime REST hardware";
       };
     };
   };

--- a/scripts/wire-quantum-ibm-rest.py
+++ b/scripts/wire-quantum-ibm-rest.py
@@ -63,6 +63,11 @@ def main() -> int:
         help="Wire CLI to use when the input is a .wire source file.",
     )
     parser.add_argument(
+        "--return",
+        dest="wire_return",
+        help="Compile the named Wire file-return or graph binding from a .wire source file.",
+    )
+    parser.add_argument(
         "--config",
         help="Override the config path carried by @quantum.ibm_runtime_config.",
     )
@@ -110,8 +115,9 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        compiled = quantum.load_compiled_circuit(args.input, args.wire_bin)
+        compiled = quantum.load_compiled_circuit(args.input, args.wire_bin, args.wire_return)
         plan = quantum.build_quantum_plan(compiled)
+        plan["backend_family"] = "ibm_quantum_runtime_rest"
         config_path = select_config_path(args.input, args.config, plan, quantum)
         will_submit = not args.dry_run and not args.emit_request
         if will_submit and not args.confirm_hardware:
@@ -195,6 +201,9 @@ def main() -> int:
         raw_result = fetch_job_results(config, token, job_id, quantum)
         metrics = fetch_job_metrics(config, token, job_id, quantum)
         counts = extract_counts(raw_result, plan["measurements"])
+        complete_counts = (
+            quantum.complete_counts(counts, len(plan["measurements"])) if counts else None
+        )
         result = {
             "execution": "hardware",
             "source": args.input,
@@ -206,8 +215,14 @@ def main() -> int:
             "shots": args.shots,
             "plan": plan,
             "counts": counts,
+            "complete_counts": complete_counts,
             "labeled_counts": (
                 quantum.labeled_counts(counts, plan["measurements"]) if counts else None
+            ),
+            "complete_labeled_counts": (
+                quantum.labeled_counts(complete_counts, plan["measurements"])
+                if complete_counts
+                else None
             ),
             "qpu_usage_seconds": qpu_usage_seconds(metrics),
         }
@@ -549,7 +564,11 @@ def poll_job(
         normalized = status.lower()
         if normalized in TERMINAL_JOB_STATUSES:
             if normalized != "completed":
-                raise quantum.WireQuantumError(f"IBM job {job_id} ended with status {status}")
+                detail = job_failure_detail(job)
+                suffix = f": {detail}" if detail else ""
+                raise quantum.WireQuantumError(
+                    f"IBM job {job_id} ended with status {status}{suffix}"
+                )
             return job
         if time.monotonic() >= deadline:
             raise quantum.WireQuantumError(
@@ -716,6 +735,40 @@ def job_status(job: Any) -> str:
 def public_job_status(job: Any) -> str:
     normalized = job_status(job).strip().lower()
     return JOB_STATUS_LABELS.get(normalized, "Unknown")
+
+
+def job_failure_detail(job: Any) -> str | None:
+    if not isinstance(job, dict):
+        return None
+    state = job.get("state")
+    if isinstance(state, dict):
+        detail = first_public_detail(
+            state,
+            ["reason", "message", "error_message", "status_message", "failure_reason"],
+        )
+        if detail is not None:
+            return detail
+    return first_public_detail(
+        job,
+        ["reason", "message", "error_message", "status_message", "failure_reason", "error"],
+    )
+
+
+def first_public_detail(value: JSON, fields: list[str]) -> str | None:
+    for field in fields:
+        detail = public_detail_text(value.get(field))
+        if detail is not None:
+            return detail
+    return None
+
+
+def public_detail_text(value: Any) -> str | None:
+    if isinstance(value, str):
+        detail = " ".join(value.split())
+        return detail[:500] if detail else None
+    if isinstance(value, dict):
+        return first_public_detail(value, ["message", "reason", "code", "name"])
+    return None
 
 
 def extract_counts(raw_result: Any, measurements: list[JSON]) -> dict[str, int] | None:

--- a/scripts/wire-quantum-qiskit.py
+++ b/scripts/wire-quantum-qiskit.py
@@ -49,6 +49,11 @@ def main() -> int:
         help="Wire CLI to use when the input is a .wire source file.",
     )
     parser.add_argument(
+        "--return",
+        dest="wire_return",
+        help="Compile the named Wire file-return or graph binding from a .wire source file.",
+    )
+    parser.add_argument(
         "--backend",
         default="aer_simulator",
         help="Qiskit backend. Only 'aer_simulator' is enabled by this local runner.",
@@ -69,7 +74,7 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        compiled = load_compiled_circuit(args.input, args.wire_bin)
+        compiled = load_compiled_circuit(args.input, args.wire_bin, args.wire_return)
         plan = build_quantum_plan(compiled)
         if args.emit_plan:
             if args.json_output:
@@ -224,14 +229,24 @@ def format_result_table(counts: dict[str, int], measurements: list[JSON], shots:
     return "\n".join(lines)
 
 
-def load_compiled_circuit(input_path: str, wire_bin: str) -> JSON:
+def load_compiled_circuit(
+    input_path: str,
+    wire_bin: str,
+    wire_return: str | None = None,
+) -> JSON:
     if input_path == "-":
+        if wire_return is not None:
+            raise WireQuantumError("--return cannot be used when reading compiled JSON from stdin")
         return json.load(sys.stdin)
 
     path = Path(input_path)
     if path.suffix == ".wire":
+        command = [wire_bin, "build"]
+        if wire_return is not None:
+            command.extend(["--return", wire_return])
+        command.append(str(path))
         proc = subprocess.run(
-            [wire_bin, "build", str(path)],
+            command,
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -816,6 +831,7 @@ def execute_qiskit_plan(plan: JSON, backend_name: str, shots: int, seed: int | N
     backend = AerSimulator(**backend_kwargs)
     compiled = transpile(circuit, backend)
     counts = backend.run(compiled, **run_kwargs).result().get_counts(compiled)
+    complete = complete_counts(counts, len(measurements))
 
     return {
         "backend": backend_name,
@@ -826,7 +842,16 @@ def execute_qiskit_plan(plan: JSON, backend_name: str, shots: int, seed: int | N
         "seed": seed,
         "plan": plan,
         "counts": dict(sorted(counts.items())),
+        "complete_counts": complete,
         "labeled_counts": labeled_counts(counts, measurements),
+        "complete_labeled_counts": labeled_counts(complete, measurements),
+    }
+
+
+def complete_counts(counts: dict[str, int], width: int) -> dict[str, int]:
+    return {
+        format(index, f"0{width}b"): int(counts.get(format(index, f"0{width}b"), 0))
+        for index in range(2**width)
     }
 
 

--- a/test/Cortex/Wire/CompileSpec.hs
+++ b/test/Cortex/Wire/CompileSpec.hs
@@ -396,6 +396,37 @@ spec = describe "Cortex.Wire.Compile" $ do
       successors compiled.compiledCircuitTopology (CircuitNodeRef "phase_rzz")
         `shouldBe` Set.fromList [CircuitNodeRef "feedback_control_rz"]
 
+    it "compiles the quantum eraser round example with primitive executors" $ do
+      source <- TIO.readFile "examples/wire/quantum-eraser-round.wire"
+      compiled <- requireRight (compileWireTextWithEnv quantumExecutorEnv source)
+      Set.fromList compiled.compiledCircuitEntryNodes
+        `shouldBe` Set.fromList
+          [ CircuitNodeRef "ibm_runtime_config"
+          , CircuitNodeRef "prepare_marker"
+          ]
+      Set.fromList compiled.compiledCircuitExitNodes
+        `shouldBe` Set.fromList [CircuitNodeRef "measure_screen", CircuitNodeRef "z_measure_marker"]
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "mark_cz")
+        `shouldBe` Set.fromList
+          [ CircuitNodeRef "recombine_rz_a"
+          , CircuitNodeRef "z_mark_post_rz_a"
+          ]
+
+    it "compiles the full quantum eraser experiment scaffold" $ do
+      source <- TIO.readFile "examples/wire/quantum-eraser-experiment.wire"
+      compiled <- requireRight (compileWireText source)
+      Set.fromList compiled.compiledCircuitEntryNodes
+        `shouldBe` Set.fromList [CircuitNodeRef "start_experiment"]
+      Set.fromList compiled.compiledCircuitExitNodes
+        `shouldBe` Set.fromList [CircuitNodeRef "print_report", CircuitNodeRef "write_report"]
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "run_open_0")
+        `shouldBe` Set.fromList [CircuitNodeRef "gate_open_14", CircuitNodeRef "summarize_experiment"]
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "gate_open_14")
+        `shouldBe` Set.fromList [CircuitNodeRef "run_open_14"]
+
+    it "compiles the quantum eraser sweep circuit examples with primitive executors" $
+      mapM_ compileQuantumEraserFixture quantumEraserSweepFixtures
+
     it "compiles the pure output equations fixture" $ do
       source <- TIO.readFile "test/fixtures/wire/pure-output-equations.wire"
       compileWireText source `shouldSatisfy` isRight
@@ -811,6 +842,23 @@ requireRight :: Show err => Either err a -> IO a
 requireRight = \case
   Left err -> expectationFailure ("expected Right, got Left: " <> show err) >> error "unreachable"
   Right ok -> pure ok
+
+compileQuantumEraserFixture :: FilePath -> Expectation
+compileQuantumEraserFixture path = do
+  source <- TIO.readFile path
+  compileWireTextWithEnv quantumExecutorEnv source `shouldSatisfy` isRight
+
+quantumEraserSweepFixtures :: [FilePath]
+quantumEraserSweepFixtures =
+  [ "examples/wire/quantum-eraser-open-phase-0.wire"
+  , "examples/wire/quantum-eraser-open-phase-1_4.wire"
+  , "examples/wire/quantum-eraser-open-phase-1_2.wire"
+  , "examples/wire/quantum-eraser-which-path-phase-0.wire"
+  , "examples/wire/quantum-eraser-which-path-phase-1_4.wire"
+  , "examples/wire/quantum-eraser-which-path-phase-1_2.wire"
+  , "examples/wire/quantum-eraser-eraser-phase-1_4.wire"
+  , "examples/wire/quantum-eraser-eraser-phase-1_2.wire"
+  ]
 
 metadataConfigHasNumber :: Key.Key -> ScientificLiteral -> Aeson.Value -> Bool
 metadataConfigHasNumber fieldName expected = \case

--- a/test/Cortex/Wire/ParserSpec.hs
+++ b/test/Cortex/Wire/ParserSpec.hs
@@ -48,6 +48,18 @@ topFormName topForm =
     TopImport {} ->
       Nothing
 
+quantumEraserSweepFixtures :: [FilePath]
+quantumEraserSweepFixtures =
+  [ "examples/wire/quantum-eraser-open-phase-0.wire"
+  , "examples/wire/quantum-eraser-open-phase-1_4.wire"
+  , "examples/wire/quantum-eraser-open-phase-1_2.wire"
+  , "examples/wire/quantum-eraser-which-path-phase-0.wire"
+  , "examples/wire/quantum-eraser-which-path-phase-1_4.wire"
+  , "examples/wire/quantum-eraser-which-path-phase-1_2.wire"
+  , "examples/wire/quantum-eraser-eraser-phase-1_4.wire"
+  , "examples/wire/quantum-eraser-eraser-phase-1_2.wire"
+  ]
+
 graphFormSourceText :: Text
 graphFormSourceText =
   T.unlines
@@ -72,17 +84,23 @@ spec = describe "Cortex.Wire.Parser" $ do
     it "parses the mini build-system example" $
       parseWireFixture "examples/wire/mini-build-system.wire"
 
-    it "parses the quantum Bell-state example" $ do
-      source <- TIO.readFile "examples/wire/quantum-bell-state.wire"
-      parseWireFile "examples/wire/quantum-bell-state.wire" source `shouldSatisfy` isRight
+    it "parses the quantum Bell-state example" $
+      parseWireFixture "examples/wire/quantum-bell-state.wire"
 
-    it "parses the IBM REST quantum Bell-state example" $ do
-      source <- TIO.readFile "examples/wire/quantum-bell-state-ibm-rest.wire"
-      parseWireFile "examples/wire/quantum-bell-state-ibm-rest.wire" source `shouldSatisfy` isRight
+    it "parses the IBM REST quantum Bell-state example" $
+      parseWireFixture "examples/wire/quantum-bell-state-ibm-rest.wire"
 
-    it "parses the quantum IPEA round example" $ do
-      source <- TIO.readFile "examples/wire/quantum-ipea-round.wire"
-      parseWireFile "examples/wire/quantum-ipea-round.wire" source `shouldSatisfy` isRight
+    it "parses the quantum IPEA round example" $
+      parseWireFixture "examples/wire/quantum-ipea-round.wire"
+
+    it "parses the quantum eraser round example" $
+      parseWireFixture "examples/wire/quantum-eraser-round.wire"
+
+    it "parses the full quantum eraser experiment scaffold" $
+      parseWireFixture "examples/wire/quantum-eraser-experiment.wire"
+
+    it "parses the quantum eraser sweep circuit examples" $
+      mapM_ parseWireFixture quantumEraserSweepFixtures
 
   describe "guardrails" $ do
     it "rejects legacy colon node declarations" $


### PR DESCRIPTION
Stacked on #160. Split from #152.\n\nThis slice adds the delayed-choice quantum eraser Wire demonstration.\n\nIncludes:\n- full Wire orchestration graph and exported circuit catalog\n- nine checked-in eraser sweep circuit files\n- pure Wire analyzer/report writer using fromJson and std.io.writeFile\n- wire-quantum-eraser Nix app\n- eraser-specific docs and fixture tests\n\nValidation run locally:\n- just test\n- just docs-lint\n- nix build .#wire-quantum-eraser