### PR TITLE
fix(ci): restore repo-docs lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -750,11 +750,11 @@
         "tree-sitter-json": "tree-sitter-json"
       },
       "locked": {
-        "lastModified": 1777874563,
-        "narHash": "sha256-WulZrxZqeYCgAZhO7ByDa/ZvaMyI9dk+VoYomUS5wko=",
+        "lastModified": 1777658993,
+        "narHash": "sha256-eqCdEcutu2dneCez0wMIkhlyt2/Sery1A/Shlmdwoz8=",
         "owner": "Digimuoto",
         "repo": "repo-docs",
-        "rev": "72429489f259f939e0e94e49724a30348e028c78",
+        "rev": "50cefb4464772c47ae7fe5adaba294452856d6cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- restore the repo-docs flake input to the last known-good revision
- unblocks docs-site/default-site evaluation on main

## Verification

- nix build .#docs-site --print-build-logs
- nix flake check --print-build-logs
- just check-commit-provenance origin/main..HEAD

## Root cause

The previous branch included a repo-docs lock bump to Digimuoto/repo-docs@72429489f259f939e0e94e49724a30348e028c78. That revision has package-lock.json out of sync with the fixed-output npm dependency derivation, so Nix fails default-site with an npmDepsHash/package-lock mismatch. This restores Digimuoto/repo-docs@50cefb4464772c47ae7fe5adaba294452856d6cf until repo-docs republishes a consistent lock/hash pair.