### PR TITLE
chore(nix): forward-bump repo-docs to 8d4ecfd

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -750,11 +750,11 @@
         "tree-sitter-json": "tree-sitter-json"
       },
       "locked": {
-        "lastModified": 1777658993,
-        "narHash": "sha256-eqCdEcutu2dneCez0wMIkhlyt2/Sery1A/Shlmdwoz8=",
+        "lastModified": 1777909576,
+        "narHash": "sha256-pA/eilqp3iMgYs6n01s9B9bfzSKk5PLZgmB7enTcBJo=",
         "owner": "Digimuoto",
         "repo": "repo-docs",
-        "rev": "50cefb4464772c47ae7fe5adaba294452856d6cf",
+        "rev": "8d4ecfd33f17035ae7f084e5a1ade1ebf105f930",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Forward-bumps `repo-docs` flake input from `50cefb4` (the temporary hold from PR #164 / commit 17984f7) to upstream `8d4ecfd33f17035ae7f084e5a1ade1ebf105f930`.
- Upstream `8d4ecfd` is the `repo-docs` fix titled _fix(nix): update npm deps hash for template lockfile_, which regenerated `npmDepsHash` in `nix/lib.nix` to match the current template `package-lock.json` — the exact mismatch that originally took down our docs build.

## Test plan

- [x] `nix build .#docs-site .#checks.x86_64-linux.default-site -L` (passes locally; full Astro build of 420 pages, search index, haddock copy)
- [x] `just check-commit-provenance origin/main..HEAD`
- [x] Commit signed (ED25519) and signed off
- [ ] CI green: build, Deploy Documentation, CodeQL