### PR TITLE
docs(wire): introduce linear-port frontier and fan-topology ADRs

### DIFF
--- a/docs/ADRs/0024-typed-executor-node-interface.md
+++ b/docs/ADRs/0024-typed-executor-node-interface.md
@@ -24,6 +24,7 @@ related:
   - docs/ADRs/0021-wire-source-elaborates-to-circuits.md
   - docs/ADRs/0022-wire-node-clause-grammar.md
   - docs/ADRs/0023-corepure-expression-surface.md
+  - docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
 ---
 
 # ADR 0024 - Typed Executor Node Interface
@@ -125,13 +126,15 @@ node analyst
 The node declaration is the vertex. The executor RHS is the implementation body behind that typed
 signature.
 
-Fan-out is therefore topology, not executor-context behavior: one typed output may feed several
-downstream nodes. Fan-in is not implicit aggregation. A list-valued input receives one list-typed
-value, not a variadic set of incoming edges. If a shape needs projection, packing, filtering, prompt
-assembly, list construction, or record reshaping, that shape is expressed as a `pure (...)` node
-rather than as contextual interpretation by an executor or hidden edge semantics. Later Wire syntax
-may add sugar for common packing cases, but the admitted graph must still contain the explicit
-transformation vertex.
+Distribution is therefore topology, not executor-context behavior: one node may expose several
+distinct typed outputs for several downstream nodes, but one output port may not be implicitly
+copied to several inputs. Fan-in is not implicit aggregation. A list-valued input receives one
+list-typed value, not a variadic set of incoming edges. If a shape needs projection, packing,
+filtering, prompt assembly, list construction, record reshaping, or multi-consumer distribution,
+that shape is expressed as a `pure (...)` node or explicit structural adapter rather than as
+contextual interpretation by an executor or hidden edge semantics. Later Wire syntax may add sugar
+for common packing cases, but the admitted graph must still contain the explicit transformation
+vertex.
 
 ### LLM Executors
 
@@ -176,8 +179,9 @@ context capability with its own runtime contract and provenance obligations.
 
 ### Structural Work Belongs In Pure Nodes
 
-Projection, fan-in, fan-out, filtering, prompt-fragment construction, and record reshaping should be
-expressed as `pure (...)` work rather than hidden in LLM context concatenation.
+Projection, packing, filtering, prompt-fragment construction, record reshaping, and multi-output
+distribution should be expressed as `pure (...)` work rather than hidden in LLM context
+concatenation.
 
 For example, an LLM can produce one typed structured output, and a downstream pure node can expose
 fields as separate ports:
@@ -207,8 +211,9 @@ buried in a model prompt.
 
 ### Heterogeneous Models
 
-Heterogeneous model use is ordinary topology. A pure fan-out node can feed several typed LLM nodes,
-each with its own executor id, model policy, input contracts, and output contracts:
+Heterogeneous model use is ordinary topology. A pure distribution node can expose several distinct
+typed outputs for several typed LLM nodes, each with its own executor id, model policy, input
+contracts, and output contracts:
 
 ```wire
 node prepareReviews
@@ -238,7 +243,7 @@ For each representative downstream wire, audit every incoming edge to an LLM nod
 - move structural fan-in, projection, filtering, and prompt-fragment assembly into upstream
   `pure (...)` nodes;
 - define typed output contracts for the LLM result;
-- move fan-out and field projection into downstream `pure (...)` nodes;
+- move field projection and multi-consumer distribution into downstream `pure (...)` nodes;
 - simplify the LLM executor to typed inputs, prompt template, output schema, model policy, and
   validation.
 
@@ -303,7 +308,7 @@ workflows instead of a clean idealization where LLM nodes silently violate typed
   collectors.
 - Update grammar and reference docs to remove source/sink as semantic node categories. Empty input
   and output boundaries should be described as port-boundary arity only.
-- Add examples that show LLM structured output followed by pure fan-out.
+- Add examples that show LLM structured output followed by pure distribution.
 - Move topological memory wording into executor/downstream-context docs and keep it outside the
   proven CorePure and graph-wiring semantics.
 - Audit current downstream LLM wires and classify each incoming edge as model input or structural

--- a/docs/ADRs/0028-wire-topology-composition-and-boundary-labels.md
+++ b/docs/ADRs/0028-wire-topology-composition-and-boundary-labels.md
@@ -70,19 +70,24 @@ Pulse execution begins.
 - no new edges are added;
 - exposed boundaries are the union of both operands' unconnected boundaries;
 - node identity is preserved across references.
+- reject the composition if the operands contain the same node identity.
 
 Overlay is the way to express independent entry points, independent exits, and branches that should
-coexist before a later connect.
+coexist before a later connect. It is not a cloning operator. To make several nodes with the same
+shape, use node-body kinds, graph forms, or static generation; do not reference the same node twice
+in one graph expression.
 
 ### Connect
 
 `lhs => rhs` forms directional composition:
 
 - first overlay `lhs` and `rhs`;
-- then connect compatible exposed output ports from `lhs` to compatible exposed input ports on
-  `rhs`;
+- then connect each compatible exposed output/input pair only when both endpoint ports have exactly
+  one compatible counterpart across the boundary;
 - do not connect outputs from `rhs` back to inputs on `lhs`;
 - leave unmatched exposed ports on the composed boundary.
+- reject the composition if any output port on `lhs` has more than one compatible input on `rhs`;
+- reject the composition if any input port on `rhs` has more than one compatible output on `lhs`.
 
 Compatibility requires the same contract id and compatible payload kind. Labels are exact routing
 constraints:
@@ -91,10 +96,11 @@ constraints:
 - labeled ports match only ports with the identical label;
 - there is no wildcard label.
 
-One output port may feed several compatible input ports. One singular input port may receive at most
-one incoming edge. If a connect expression would send several outputs to the same singular input, it
-is a topology failure. Packing several values into one list value remains explicit `pure (...)`
-work; `=>` does not perform implicit aggregation.
+Every endpoint port is linear at the topology boundary. One output port may feed at most one input
+port, and one input port may receive at most one output port. Feeding the same output to multiple
+inputs or the same input from multiple outputs is a static topology failure. Packing several values
+into one aggregate remains explicit `pure (...)` work or an explicit structural adapter; `=>` does
+not perform implicit fan-out or aggregation.
 
 ### Associativity And Precedence
 
@@ -172,7 +178,8 @@ ports rather than to source variable names.
 ### Obligations
 
 - Add parser tests for overlay, connect, associativity, and required mixed-operator parentheses.
-- Add topology tests for label matching, unmatched boundaries, fan-out, and fan-in ambiguity.
+- Add topology tests for label matching, unmatched boundaries, repeated-node overlay rejection,
+  output fan-out rejection, and input fan-in rejection.
 - Add lowering tests that composition completes before runtime execution.
 - Update grammar docs to remove any implicit file-level output-label behavior.
 - Keep list construction and record packing as explicit pure nodes.

--- a/docs/ADRs/0028-wire-topology-composition-and-boundary-labels.md
+++ b/docs/ADRs/0028-wire-topology-composition-and-boundary-labels.md
@@ -20,6 +20,7 @@ related:
   - docs/ADRs/0022-wire-node-clause-grammar.md
   - docs/ADRs/0024-typed-executor-node-interface.md
   - docs/ADRs/0025-configured-executor-values.md
+  - docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
 ---
 
 # ADR 0028 - Wire Topology Composition and Boundary Labels
@@ -116,8 +117,9 @@ parses as:
 (a => b) => c
 ```
 
-The first implementation should require parentheses when `<>` and `=>` are mixed. This avoids
-encoding a precedence rule before examples prove which grouping authors expect.
+ADR 0047 amends this ADR's original caution around mixed operators. Current Wire gives `<>` / `,`
+tighter precedence than `=>` / `*`, so mixed expressions parse without mandatory parentheses.
+Endpoint linearity still decides whether the parsed expression is admitted.
 
 ### File-Level Values And Labels
 
@@ -155,8 +157,9 @@ ports rather than to source variable names.
   helper bindings create topology and gives binding names hidden port-label meaning.
 - **Let connect perform fan-in aggregation.** Rejected because aggregation is computation and should
   be expressed by an explicit pure node.
-- **Define precedence between `<>` and `=>` immediately.** Rejected because parentheses are cheaper
-  than committing a precedence rule before composition-heavy examples exist.
+- **Define precedence between `<>` and `=>` immediately.** Rejected in this first slice because
+  parentheses were cheaper than committing a precedence rule before composition-heavy examples
+  existed. ADR 0047 later amends this decision.
 
 ## Consequences
 
@@ -172,12 +175,13 @@ ports rather than to source variable names.
 
 - The parser and kind checker must distinguish ordinary pure-data, delayed CorePure helper,
   configured executor, and graph expression positions.
-- Mixed composition expressions require parentheses in the first slice.
+- Mixed composition expressions originally required parentheses in the first slice. ADR 0047 later
+  replaces that rule with a fixed precedence ladder.
 - Authors must write explicit constant nodes instead of relying on implicit literal circuits.
 
 ### Obligations
 
-- Add parser tests for overlay, connect, associativity, and required mixed-operator parentheses.
+- Add parser tests for overlay, connect, associativity, and ADR 0047 mixed-operator precedence.
 - Add topology tests for label matching, unmatched boundaries, repeated-node overlay rejection,
   output fan-out rejection, and input fan-in rejection.
 - Add lowering tests that composition completes before runtime execution.

--- a/docs/ADRs/0043-pulse-in-memory-runner.md
+++ b/docs/ADRs/0043-pulse-in-memory-runner.md
@@ -36,8 +36,9 @@ contract.
 
 ## Context
 
-Pulse is the durable runtime for Cortex. The production executor owns persistence, checkpoints,
-leases, retries, resume, cancellation, observability, and durable rewrite materialization.
+Durable Pulse is the production service profile for Cortex. The production executor owns
+persistence, checkpoints, leases, retries, resume, cancellation, observability, and durable rewrite
+materialization.
 
 That service boundary is necessary for long-lived workflows, but it is too heavy for every use case.
 Local Wire authoring, tutorials, unit tests, benchmark baselines, and small demos need a runner that

--- a/docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
+++ b/docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
@@ -1,0 +1,228 @@
+---
+title: "ADR 0047 - Wire Frontier Linearity and Topology Operator Precedence"
+description:
+  "Pins the linear endpoint rule, match determinism, repeated-reference rejection, and a committed
+  precedence ladder for Wire topology operators; formally amends ADR 0028."
+sidebar:
+  label: "0047. Frontier linearity and precedence"
+  order: 47
+status: proposed
+date: 2026-05-05
+superseded_by: null
+related:
+  - docs/Architecture/04-graph-and-circuit.md
+  - docs/Architecture/05-wire-language.md
+  - docs/Reference/Wire/grammar.md
+  - docs/Reference/Wire/contracts-ports-and-matching.md
+  - docs/ADRs/0024-typed-executor-node-interface.md
+  - docs/ADRs/0028-wire-topology-composition-and-boundary-labels.md
+---
+
+# ADR 0047 - Wire Frontier Linearity and Topology Operator Precedence
+
+## Status
+
+Proposed - this ADR formally amends ADR 0028 by:
+
+- pinning the **linear endpoint rule** on Wire's typed frontier (no implicit clone, no implicit
+  aggregation);
+- committing **match determinism** for `=>` (each endpoint has zero or one compatible counterpart);
+- retiring ADR 0028's "parens required when `<>` and `=>` are mixed" rule and replacing it with a
+  committed **precedence ladder**.
+
+It is the semantic foundation for ADR 0048 (`make`) and ADR 0049 (`*` fan operator); both depend on
+the rules pinned here.
+
+## Context
+
+ADR 0028 settled `=>` (connect, boundary product) and `<>` (overlay, graph union) but stops short of
+two commitments that subsequent design needs:
+
+1. **Endpoint linearity.** ADR 0028 allows one output port to feed several compatible inputs. That
+   is incompatible with the substructural reading of Wire's typed frontier - ports are resources,
+   not free variables - and it is what makes `make(N, K) => sink` quietly do the wrong thing if it
+   is not pinned.
+2. **Operator precedence.** The grammar reference rejects unparenthesized `a => b <> c` because ADR
+   0028 does not commit to a precedence between `<>` and `=>`. The result: every mixed expression
+   takes parens that are not needed by the algebra.
+
+Mokhov's `Algebra.Graph` law `connect distributes over overlay` makes mixed composition unambiguous
+_given_ a precedence rule. Pinning one is purely a parser/style choice; it does not change the
+algebra.
+
+ADR 0048 (bounded node generation via `make`) and ADR 0049 (record↔ports adapter via `*`) both need
+this foundation in place: `make` produces multi-port frontiers that must compose linearly under
+`=>`, and `*` adds a new operator whose precedence relative to `<>` and `=>` must be committed
+before it can land.
+
+### Algebraic foundation
+
+Wire's topology composition is a **linear refinement of Mokhov's algebra of graphs**. The syntactic
+skeleton (`empty`, vertex, overlay, connect) is Mokhov's; the semantic model is not the standard
+set-of-vertices reading. A graph value carries a typed **frontier** - a multiset of unmatched
+`(direction, label, contract)` ports - and ports are linear resources: each port is consumed exactly
+once during composition or remains exposed on the composed boundary; nothing implicitly duplicates
+or discards.
+
+Under this reading:
+
+- `<>` (overlay, also written `,` while that alias is admitted) is disjoint union of typed
+  frontiers. It is **not** a cloning operator: a repeated graph reference such as `a <> a` is a
+  static topology error.
+- `=>` (connect) is **boundary contraction**: it consumes matched ports from each side, adds the
+  matching edges, and leaves only the complementary unmatched ports exposed on the result. The
+  matched ports cease to exist as resources, not just cease to be visible.
+- Wire has no implicit duplication primitive. Authors who need N consumers of one value generate N
+  output ports (ADR 0048) and pair them through an explicit adapter (ADR 0049).
+
+This grounding makes admission decidable from typing alone: at each composition step the set of
+admissible frontier contractions is statically computable from the current signature, and every Wire
+operator is a linear transformation on the typed frontier multiset. Fuller treatment belongs in
+`docs/Architecture/04-graph-and-circuit.md` and the eventual paper; this ADR uses the
+linear-resource language where it sharpens the rules.
+
+## Decision
+
+Wire commits to four rules. They apply to every existing topology operator and to the operators
+introduced by ADRs 0048 and 0049.
+
+### 1. Linear endpoint rule
+
+Each output port and each input port in a typed frontier is consumed by at most one composition
+step. Repeated graph references (`a <> a`, `a => a`) are static topology errors, not implicit
+clones.
+
+This sharpens ADR 0028's allowance "one output port to feed several compatible inputs": an output
+port may participate in at most one matched edge per composition. Distinct inputs that need the same
+value are produced explicitly (multiple output ports on the same producer, or a fan adapter
+introduced by ADR 0049).
+
+### 2. Match determinism for `=>`
+
+`=>` (connect) is boundary contraction with a deterministic match relation:
+
+- Every output endpoint in `∂⁺G` and every input endpoint in `∂⁻H` has zero or one compatible
+  counterpart on the opposite side, where compatible means matching `(label, contract)`.
+- Zero counterparts: the endpoint remains exposed on the composed frontier.
+- One counterpart: the pair is consumed and the matching edge is added.
+- More than one counterpart on either side: static error.
+
+Static rejection in the multi-counterpart case is the deterministic rule. Authors disambiguate by
+naming their ports.
+
+### 3. Precedence ladder
+
+Wire commits to:
+
+| Tightness | Operators  | Associativity |
+| --------- | ---------- | ------------- |
+| Tighter   | `<>` / `,` | left          |
+| Looser    | `=>` / `*` | left          |
+
+Tighter binds first. `*` is defined by ADR 0049; this table reserves its precedence so the
+foundation is forward-compatible.
+
+This is **inverted from Mokhov's `Algebra.Graph` Haskell library**, where connect (the analog of
+`=>`) binds tighter than overlay. Wire chooses the inversion because Wire's authoring rhythm puts
+parallel branches at the end of a connect chain (`source => transform => a <> b <> c`), and the
+inverted ladder makes that natural without parens: the trailing overlay binds first as a single
+operand of the final `=>`. Connect's distributivity over overlay (Mokhov's law) does the rest. The
+connect still obeys the linear endpoint rule above; if `transform` exposes one output that would
+feed all three branches, the expression is rejected.
+
+### 4. Retire ADR 0028's parens-when-mixing rule
+
+ADR 0028's rule that `a => b <> c` and similar mixed expressions are syntactically rejected is
+retired. Parens are required only to override the natural precedence, never merely to disambiguate
+the grammar.
+
+Concretely:
+
+```wire
+time => flows => down => some <> things <> parallel
+```
+
+parses as `time => flows => down => (some <> things <> parallel)`. The trailing overlay is the right
+operand of the final `=>`; the connect succeeds iff `down` exposes three distinct compatible outputs
+(linear endpoint rule).
+
+The Wire grammar reference must be updated accordingly.
+
+### Comma overlay alias precedence
+
+While the comma overlay alias is admitted (its long-term survival is open), it inherits the
+precedence and semantics of `<>`. `a, b, c` parses identically to `a <> b <> c`. This ADR pins that
+contract; it does not decide whether `,` remains long-term.
+
+## Alternatives considered
+
+- **Standard Mokhov precedence (connect tighter than overlay).** Rejected because Wire's natural
+  authoring shape puts parallel branches at the end of a connect chain, and standard Mokhov
+  precedence would require parens around every such chain's tail. The inverted ladder is a one-time
+  documentation cost in exchange for cleaner source.
+- **Keep ADR 0028's parens-when-mixing rule.** Rejected because the algebra is unambiguous given a
+  precedence; the rule was conservative defensive programming that costs visual clarity in every
+  expression that mixes operators.
+- **Allow non-linear endpoints (one output to many inputs implicitly).** Rejected because it breaks
+  the substructural reading of the typed frontier and silently makes `make(N, K) => sink` do the
+  wrong thing. Authors who need multi-consumption produce multiple output ports explicitly.
+- **Defer the linearity rule to the construct ADRs (0048, 0049).** Rejected because both constructs
+  need linearity in place to define their semantics; pulling the rule into the foundation keeps each
+  construct ADR self-contained.
+- **Drop the comma overlay alias.** Deferred. The alias exists in current Wire; this ADR pins its
+  precedence rather than decide its survival.
+
+## Consequences
+
+### Positive
+
+- Mixed topology expressions read clean without parens.
+- Linear endpoints make `make(N, K) => sink` a static error rather than silently incorrect.
+- Match determinism is committed in one place; `*` (ADR 0049) inherits it without restating.
+- The frontier-as-multiset reading has a single canonical home.
+
+### Negative
+
+- Authors familiar with Mokhov's Haskell library face the inverted precedence and must learn it.
+- ADR 0028's mixing rule is retired; existing source that relied on parens for visual grouping
+  continues to work but reads differently to a reader fluent in the new ladder.
+- `=>` no longer permits one output to feed several compatible inputs. Existing source that depended
+  on that allowance is now a static error and must be rewritten with multiple output ports or an
+  explicit adapter (ADR 0049).
+
+### Obligations
+
+- Update `docs/Reference/Wire/grammar.md` to document the precedence ladder and remove the
+  parens-when-mixing rule.
+- Update `docs/Reference/Wire/contracts-ports-and-matching.md` to pin the linear endpoint rule and
+  reject one-output-to-many-inputs.
+- Update `docs/Architecture/04-graph-and-circuit.md` to reflect Wire as a linear refinement of
+  Mokhov's algebra (frontier as typed multiset, ports as linear resources).
+- Update the formatter to a conservative stance on parentheses: preserve authored parens until large
+  examples settle the idiom.
+- Update the tree-sitter grammar to recognize the new precedence and the comma alias as overlay.
+- Update the `wire-code-style` skill.
+- Add tests for: linear endpoint violations (`a <> a`, `a => a`, repeated reference inside form
+  bodies), match-determinism violations (multiple compatible counterparts), unparenthesized mixed
+  expressions parsing per the new ladder, distributivity-driven fan-out in connect chains.
+- Prove or document that admission preservation under the new rules is unchanged for existing
+  programs that did not rely on retired allowances.
+
+## Open questions
+
+- **Comma overlay alias longevity.** `,` currently aliases `<>` and inherits its precedence and
+  semantics under this ADR. Whether to deprecate `,` in a later cleanup is open; for now the alias
+  stays admitted under the rule above.
+- **Formatter strictness.** v1 preserves authored parentheses conservatively. The right idiom
+  emerges only with large real Wire examples; the formatter's stance can tighten once those exist.
+  This is formatter policy, not language semantics.
+
+## Related
+
+- [ADR 0024 - Typed Executor Node Interface](./0024-typed-executor-node-interface.md)
+- [ADR 0028 - Wire Topology Composition and Boundary Labels](./0028-wire-topology-composition-and-boundary-labels.md)
+- [ADR 0048 - Wire Compile-Time Make for Bounded Node Generation](./0048-wire-make-bounded-node-generation.md)
+- [ADR 0049 - Wire Phantom Record↔Ports Adapter for Topology Fans](./0049-wire-fan-phantom-adapter.md)
+- [Chapter 04 - Graph and Circuit](../Architecture/04-graph-and-circuit.md)
+- [Chapter 05 - Wire Language](../Architecture/05-wire-language.md)
+- [Wire Grammar Reference](../Reference/Wire/grammar.md)

--- a/docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
+++ b/docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
@@ -46,9 +46,11 @@ two commitments that subsequent design needs:
    0028 does not commit to a precedence between `<>` and `=>`. The result: every mixed expression
    takes parens that are not needed by the algebra.
 
-Mokhov's `Algebra.Graph` law `connect distributes over overlay` makes mixed composition unambiguous
-_given_ a precedence rule. Pinning one is purely a parser/style choice; it does not change the
-algebra.
+The source grammar can parse mixed composition unambiguously once a precedence rule is pinned.
+Whether the parsed expression is admitted is then decided by the linear endpoint rule below. This
+keeps parser grouping separate from Mokhov relation laws, which apply only after port identity is
+forgotten during lowering. Here, **lowering** means translating the accepted Wire/Circuit frontier
+object into the plain Graph relation used for topology algorithms.
 
 ADR 0048 (bounded node generation via `make`) and ADR 0049 (record↔ports adapter via `*`) both need
 this foundation in place: `make` produces multi-port frontiers that must compose linearly under
@@ -126,9 +128,9 @@ This is **inverted from Mokhov's `Algebra.Graph` Haskell library**, where connec
 `=>`) binds tighter than overlay. Wire chooses the inversion because Wire's authoring rhythm puts
 parallel branches at the end of a connect chain (`source => transform => a <> b <> c`), and the
 inverted ladder makes that natural without parens: the trailing overlay binds first as a single
-operand of the final `=>`. Connect's distributivity over overlay (Mokhov's law) does the rest. The
-connect still obeys the linear endpoint rule above; if `transform` exposes one output that would
-feed all three branches, the expression is rejected.
+operand of the final `=>`. The connect still obeys the linear endpoint rule above; if `transform`
+exposes one output that would feed all three branches, the expression is rejected rather than
+rewritten by source-level distributivity.
 
 ### 4. Retire ADR 0028's parens-when-mixing rule
 
@@ -204,7 +206,8 @@ contract; it does not decide whether `,` remains long-term.
 - Update the `wire-code-style` skill.
 - Add tests for: linear endpoint violations (`a <> a`, `a => a`, repeated reference inside form
   bodies), match-determinism violations (multiple compatible counterparts), unparenthesized mixed
-  expressions parsing per the new ladder, distributivity-driven fan-out in connect chains.
+  expressions parsing per the new ladder, and trailing-overlay connect chains that are admitted only
+  when each branch has a distinct compatible output.
 - Prove or document that admission preservation under the new rules is unchanged for existing
   programs that did not rely on retired allowances.
 

--- a/docs/ADRs/0048-wire-make-bounded-node-generation.md
+++ b/docs/ADRs/0048-wire-make-bounded-node-generation.md
@@ -1,0 +1,159 @@
+---
+title: "ADR 0048 - Wire Compile-Time Make for Bounded Node Generation"
+description:
+  "Adds make(N, K), a compile-time macro that elaborates to N fresh vertices from a kind reference
+  with deterministic source-stable identities."
+sidebar:
+  label: "0048. Make"
+  order: 48
+status: proposed
+date: 2026-05-05
+superseded_by: null
+related:
+  - docs/Architecture/04-graph-and-circuit.md
+  - docs/Architecture/05-wire-language.md
+  - docs/Reference/Wire/grammar.md
+  - docs/ADRs/0045-wire-compile-time-node-body-kinds.md
+  - docs/ADRs/0046-wire-compile-time-graph-forms.md
+  - docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
+  - docs/ADRs/0049-wire-fan-phantom-adapter.md
+---
+
+# ADR 0048 - Wire Compile-Time Make for Bounded Node Generation
+
+## Status
+
+Proposed - the iteration successor that ADR 0046 explicitly deferred. Forms (ADR 0046) and node-body
+kinds (ADR 0045) have landed; this ADR adds the bounded-N node generator that authors a fresh family
+of vertices from one kind reference. It depends on ADR 0047 for the frontier linearity rules that
+govern how generated families compose.
+
+## Context
+
+ADR 0046 added compile-time forms for fixed-shape multi-node fragments and explicitly deferred
+iteration ("Add static graph conditionals and loops at the same time. Rejected ... Forms should land
+first as finite non-recursive instantiation"). Forms have landed; the deferred shape - "I want N
+fresh nodes from this kind" - has no syntactic surface today.
+
+Authors who need bounded replication today write N `node` declarations by hand. Quantum sweeps,
+per-shot sampling, per-claim evidence gathering, and per-shard materialization all hit this shape.
+CorePure `map` is the wrong tool: it lifts a function over a list inside a single node body,
+producing list-shaped data on one output port. It cannot mint vertices.
+
+The constraint that anchors the design: **the count is static**. ADR 0046's rejection of dynamic
+graph shape stands; if an author needs a runtime-determined count, they rewrite the program.
+
+## Decision
+
+Wire adds a built-in `make(N, K)` node-generation macro.
+
+`make(N, K)` elaborates at compile time to N fresh vertices, each instantiated from the node-body
+kind `K` (ADR 0045) under a deterministic, source-stable identity. The result is a `Graph` value
+(ADR 0046's existing class) and composes with all topology operators under ADR 0047's rules.
+
+```wire
+let workers = make(10, sample);
+```
+
+### N is static
+
+`N` must be a non-negative integer literal or a closed compile-time-resolvable Value. Anything that
+requires runtime evaluation is a static error pointing at the argument. There is no fallback to
+runtime shape.
+
+### K is a kind reference
+
+`K` is a **kind reference**, not a kind application. It is resolved in the kind namespace and is
+valid only as the second argument of `make`; it is not a Wire value, graph value, or CorePure value.
+
+Kinds intended for `make` must expose a single generated port-label parameter that `make` supplies
+per index. Kinds that take additional `Value`/`Contract`/`ConfiguredExecutor` parameters are
+accommodated by binding a wrapping form (ADR 0046) that closes over those arguments and exposes the
+single generated-label kind to `make`.
+
+### Identity scheme
+
+Each generated vertex gets a deterministic name derived from the binding the `make` result is bound
+to: `<binding>_0`, `<binding>_1`, ... `<binding>_(N-1)`. With the example above, `workers` produces
+nodes named `workers_0` through `workers_9`. The identity scheme nests under ADR 0046's
+form-instantiation prefix when `make` appears inside a form body.
+
+For each generated child, `make` supplies the same `<binding>_<i>` token as the generated port
+label. This makes the children's exposed boundaries align naturally with record-form `*` (ADR 0049),
+which pairs by label.
+
+### Empty and singleton
+
+`make(0, K)` is legal and produces an empty graph. `make(1, K)` is legal and produces a single
+vertex named `<binding>_0`; the binding name still parameterizes identity.
+
+### Unbound inline use is rejected
+
+`make(...)` is rejected in graph position when not bound by `let` / `export let`, for the same
+reason ADR 0046 rejects unbound inline form applications: there is no source name to derive
+identities from.
+
+## Alternatives considered
+
+- **Dynamic N (runtime-shaped families).** Rejected. ADR 0046 rules out runtime topology; this ADR
+  keeps the rule.
+- **Allow inline `make(...)` in graph position with a synthetic prefix.** Rejected for the same
+  reason ADR 0046 rejected inline form applications: identity should come from source structure, not
+  synthetic counters.
+- **Multi-port generated label per child (kinds expose more than one parameterized label).**
+  Deferred. v1 supports one generated label per child; multi-label generation is a future extension
+  if real workloads need it.
+- **Variant naming schemes (`<binding>[i]`, `<binding>(i)`, etc.).** Rejected. `<binding>_<i>`
+  matches ADR 0046's prefix convention and is unambiguous in source text.
+
+## Consequences
+
+### Positive
+
+- Bounded replication becomes compact and readable.
+- Generated identities are deterministic and source-bisectable, matching ADR 0046's rules.
+- The static-topology invariant is preserved.
+
+### Negative
+
+- One new built-in identifier (`make`) enters the Wire surface.
+- **`make(N, K) => sink` is rejected for N > 1 unless every generated child exposes a distinct
+  output matching a distinct sink input.** Under ADR 0047's linear endpoint rule, several generated
+  children all exposing `out: T` cannot all feed one cardinality-one input port, and one output
+  cannot be implicitly copied. Authors hitting this surprise compose with `*` (ADR 0049) instead,
+  which inserts the phantom that aggregates the children's outputs into one nominal record port the
+  sink can consume. The language tour and `wire-code-style` skill must call this out prominently; it
+  is the first surprise authors will hit.
+
+### Obligations
+
+- Reserve `make` as a built-in topology form.
+- Reject dynamic-N arguments at the expander with a precise diagnostic.
+- Reject unbound inline `make(...)` in graph position; require a binding.
+- Document the identity scheme and the generated port-label convention in
+  `docs/Reference/Wire/grammar.md`.
+- Update the tree-sitter grammar to recognize `make` as a built-in form.
+- Update the `wire-code-style` skill: kinds intended for `make` should expose the generated port
+  label that `make` supplies, so record-form `*` (ADR 0049) pairs children's outputs by label.
+- Add expansion tests for: `make(0, K)`, `make(1, K)`, large-N, nested `make` inside form bodies,
+  `make` inside `make`, unbound-inline rejection, `make(N, K) => sink` rejection for N > 1 when
+  generated outputs collide with the sink's cardinality-one inputs.
+- Prove or document the preservation claim: after `make` expansion, the resulting Wire program
+  admits unchanged under all existing graph, port, authority, and runtime invariants.
+
+## Open questions
+
+- **`make(1, K)` identity.** Keep the uniform `<binding>_0` suffix, or special-case to `<binding>`?
+  Recommendation: keep `<binding>_0`. Uniform generation is better for proofs, diagnostics, and
+  nested expansion; the visual clutter for the single-instance case is the smaller cost.
+
+## Related
+
+- [ADR 0024 - Typed Executor Node Interface](./0024-typed-executor-node-interface.md)
+- [ADR 0028 - Wire Topology Composition and Boundary Labels](./0028-wire-topology-composition-and-boundary-labels.md)
+- [ADR 0045 - Wire Compile-Time Node-Body Kinds](./0045-wire-compile-time-node-body-kinds.md)
+- [ADR 0046 - Wire Compile-Time Graph Forms](./0046-wire-compile-time-graph-forms.md)
+- [ADR 0047 - Wire Frontier Linearity and Topology Operator Precedence](./0047-wire-frontier-linearity-and-precedence.md)
+- [ADR 0049 - Wire Phantom Record↔Ports Adapter for Topology Fans](./0049-wire-fan-phantom-adapter.md)
+- [Chapter 05 - Wire Language](../Architecture/05-wire-language.md)
+- [Wire Grammar Reference](../Reference/Wire/grammar.md)

--- a/docs/ADRs/0049-wire-fan-phantom-adapter.md
+++ b/docs/ADRs/0049-wire-fan-phantom-adapter.md
@@ -1,0 +1,221 @@
+---
+title: "ADR 0049 - Wire Phantom Record↔Ports Adapter for Topology Fans"
+description:
+  "Adds the * topology operator that elaborates to a phantom node from a parametric record↔ports
+  adapter family in Wire's closed alphabet."
+sidebar:
+  label: "0049. Fan phantom adapter"
+  order: 49
+status: proposed
+date: 2026-05-05
+superseded_by: null
+related:
+  - docs/Architecture/04-graph-and-circuit.md
+  - docs/Architecture/05-wire-language.md
+  - docs/Reference/Wire/grammar.md
+  - docs/Reference/Wire/contracts-ports-and-matching.md
+  - docs/ADRs/0024-typed-executor-node-interface.md
+  - docs/ADRs/0028-wire-topology-composition-and-boundary-labels.md
+  - docs/ADRs/0045-wire-compile-time-node-body-kinds.md
+  - docs/ADRs/0046-wire-compile-time-graph-forms.md
+  - docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
+  - docs/ADRs/0048-wire-make-bounded-node-generation.md
+---
+
+# ADR 0049 - Wire Phantom Record↔Ports Adapter for Topology Fans
+
+## Status
+
+Proposed - this ADR introduces the `*` topology operator. It depends on ADR 0047 for the linear
+endpoint rule, match determinism, and the precedence slot reserved for `*`. ADR 0048 supplies the
+typical multi-port frontier (`make(N, K)`) that `*` consumes.
+
+## Context
+
+ADR 0024 forbids implicit aggregation: authored inputs are cardinality-one, and aggregation belongs
+in an explicit node. ADR 0047 sharpens this with the linear endpoint rule: each output and each
+input is consumed at most once during composition.
+
+Together those rules make `make(N, K) => sink` a static error for N > 1 when several generated
+children expose the same `(label, contract)` and the sink's input is cardinality one. The correct
+authoring shape is an explicit adapter that converts the multi-port frontier into one
+aggregate-typed port (gather) or one aggregate-typed port into a multi-port frontier (scatter).
+
+This ADR adds that adapter and the operator that surfaces it.
+
+## Decision
+
+Wire adds a `*` topology operator that elaborates to a **phantom record↔ports adapter** inserted
+between its two operands; ordinary `=>` does all the wiring.
+
+The defining equivalence:
+
+```
+a * b   ≡   a => phantom => b
+```
+
+Both `=>` edges are ordinary boundary contractions under ADR 0047. The phantom node has two
+boundaries:
+
+- The **multi-side**, mirroring the multi-port frontier of whichever operand carries one. Each port
+  is a regular cardinality-one port; ordinary `=>` matches them against the multi-side operand's
+  ports under ADR 0047's match rule.
+- The **singular side**, a single port of nominal record contract.
+
+There is no `spoke_i` surface vocabulary at the topology layer. Pairing happens by record field and
+port label inside the phantom's CorePure body.
+
+The phantom belongs to a **parametric family of structural adapters** indexed by nominal record
+shape: the closed alphabet contains the family, and `*` selects the instance whose shape matches the
+call site. This is the same parametric move that makes `Option[T]` part of the language without
+admitting user-defined generics.
+
+### Record-form discriminator
+
+The phantom's body and multi-side shape are determined by the **singular side's expected nominal
+record contract**:
+
+- When the singular side's port contract is a nominal record contract with fields
+  `{label_1: T_1, ..., label_N: T_N}`, the phantom synthesizes multi-side ports `label_i: T_i` per
+  field.
+- The body pairs by **label**: `agg.label_i` ↔ multi-side port `label_i`.
+- The multi-side operand's exposed port set must match the record's fields exactly: same labels,
+  same contracts. A mismatch is a static error.
+- A singular side whose contract is not a nominal record is a static error.
+
+List-style aggregation (a homogeneous N-ary list contract) is not part of v1. Future work may
+introduce a bounded list contract, repurpose integer-keyed nominal records, or stay with record-form
+only; that decision is out of scope here.
+
+### No mixed forms
+
+There is no Wire contract that combines a nominal record with a positional list. Authors who want
+partially-uniform aggregates compose multiple `*` calls or write the adapter by hand. The exclusion
+of mixed forms is a corollary of the nominal-record discriminator.
+
+### Phantom synthesis
+
+The phantom is **always generated**, including for the degenerate cases:
+
+- **Empty fan** (multi-side has zero ports): the phantom is generated with empty multi-side and a
+  singular-side port of empty nominal record contract. The two `=>` edges connect normally; the
+  empty multi-side simply contributes no edges. The elaborator emits a lint warning at synthesis:
+  "`*` over an empty fan generates a degenerate phantom; consider whether the empty case was
+  intended." Firing at synthesis (not parse) catches non-literal-zero N too. The always-generate
+  stance keeps elaboration uniform and forward-compatible with conditional graph elaboration if that
+  lands.
+- **Singleton fan** (multi-side has one port): the phantom is generated. Authors who do not want the
+  phantom for N=1 use `=>` directly.
+
+### Port-clash diagnostic
+
+A port clash on the synthesized phantom is a static error: "phantom would have two outputs of the
+same (label, contract); rename or use a record contract." The diagnostic points at the `*` call site
+and at the phantom's synthesized boundary. Clashes only matter once the phantom is synthesized;
+multi-side operand label collisions are handled there, not at the operand site.
+
+### Match determinism
+
+Under phantom-insertion, all topology-level wiring is ordinary `=>` boundary contraction. Match
+determinism for `*` therefore reduces to ADR 0047's rule for `=>`: every endpoint has zero or one
+compatible counterpart; multiple is a static error. **No new tiebreak surface is introduced.**
+
+### Canonical rule
+
+Fan operators expand only to ordinary graph vertices and ordinary valid port edges. `*` inserts
+exactly one phantom vertex and emits two `=>` edges (one to each operand); the phantom's body
+performs the only aggregate-field projection in the entire elaboration, and that projection is
+confined to CorePure. There are no hidden adapters, no implicit aggregation, no changes to `=>`
+semantics, and no surface vocabulary for spokes.
+
+### Static errors
+
+- Singular side's contract is not a nominal record.
+- Multi-side operand's exposed port set does not exactly match the nominal record's fields (label or
+  contract mismatch).
+- Phantom synthesis would produce a port clash.
+- Both sides flat singleton: "`*` requires a multi-element frontier on at least one side; for 1:1
+  wiring use `=>`."
+- Both sides multi-element: "`*` requires exactly one singular side; both operands carry
+  multi-element frontiers."
+
+## Alternatives considered
+
+- **Separate `broadcast` and `gather` macros.** Rejected because the fan direction is unambiguously
+  determined by the boundary shape; one operator with shape-driven direction is honest about what is
+  happening, and it composes cleanly with the existing topology operators. Two macros would need
+  their own grammar, identity rules, and diagnostics.
+- **`<` and `>` as directional fan operators.** Considered briefly. Visually appealing
+  (`a < (b, c) > d` reads as a funnel) but bites on overlays (`a < b <> c > d` is ill-formed because
+  no operand is a tuple), and `<` shares tokens with CorePure comparison. Rejected for the simpler
+  `*` with shape-driven direction.
+- **`*` synthesizes adapters with no visible vertex.** Rejected because every Wire vertex is an
+  ordinary `node` declaration with a CorePure or executor body; hidden adapters would violate the
+  rule that the elaborated program is fully readable as Wire source.
+- **List-form aggregation in v1.** Rejected. A bounded homogeneous list adapter would need `[T; N]`
+  contracts and positional projection in CorePure before it can type-check. Record-form `*` is the
+  smaller first slice because it pairs existing labeled ports to nominal record fields by name.
+- **Unnamed ports for list-form aggregation.** Considered and rejected with list-form v1. List-form
+  `*` feels like it wants nameless homogeneous multi-side ports, since they are all the same
+  contract. That would introduce a second port flavor and weaken the label discipline. If bounded
+  lists land later, they should still preserve explicit field/index ownership rather than discard
+  authored labels silently.
+
+## Consequences
+
+### Positive
+
+- Bounded aggregation and scatter become compact and readable. The aggregation hub is an explicit,
+  visible node with a known body.
+- The static-topology invariant is preserved: every vertex is still introduced by a source-level
+  construct that the expander resolves before lowering.
+- `*`'s phantom is an ordinary pure node that obeys port matching, authority, and runtime invariants
+  without special-case handling.
+- Match determinism for `*` is inherited from ADR 0047; no new rule surface is introduced.
+
+### Negative
+
+- One new built-in identifier (`*`) and a closed-alphabet adapter family enter the Wire surface.
+- The closed alphabet now includes a parametric structural-adapter family (record↔ports adapters).
+  This is a real extension of the alphabet; it must be documented as such, and any formal claims
+  about Wire's alphabet (in the architecture chapter or papers) must reflect that the family is
+  parametric over aggregate shape but otherwise fixed.
+
+### Obligations
+
+- Reserve `*` as a built-in topology operator under ADR 0047's reserved precedence slot.
+- Reject `*` with two flat singletons (use `=>`) and `*` with two multi-element frontiers (ambiguous
+  fan).
+- Document the phantom-insertion equivalence in `docs/Reference/Wire/grammar.md`.
+- Update the tree-sitter grammar to recognize `*` as a topology operator.
+- Update the `wire-code-style` skill.
+- Amend `docs/Architecture/04-graph-and-circuit.md` in the same change set as this ADR's acceptance
+  to document the parametric record↔ports adapter family as part of Wire's closed alphabet.
+- Add expansion tests for: record-form `*`, empty-fan `*` lint warning, port-clash diagnostic at
+  phantom synthesis, record-form rejection on label-set mismatch, rejection of flat-singleton `*`
+  and double-multi `*`, `make(N, K) => sink` resolution via `*`.
+- Prove or document the preservation claim: after `*` expansion, the resulting Wire program admits
+  unchanged under all existing graph, port, authority, and runtime invariants.
+
+## Open questions
+
+- **Nominal-record contract surface.** This ADR commits to "the singular side's contract is a
+  nominal record." Implementation may reveal that ADR 0024's existing record contracts are not
+  nominal enough for `*` to read field labels off the contract itself. If so, the implementation
+  must stop and add a small contract-surface ADR before elaborating `*`.
+- **Future aggregate shape.** Whether list-style aggregation ever lands is genuinely open, with
+  three sub-options: a bounded list contract `[T; N]` (with positional projection `agg[i]` in
+  CorePure), integer-keyed nominal records (no new contract surface, heterogeneous-record typing
+  does more work), or no list-style topology aggregation at all.
+
+## Related
+
+- [ADR 0024 - Typed Executor Node Interface](./0024-typed-executor-node-interface.md)
+- [ADR 0028 - Wire Topology Composition and Boundary Labels](./0028-wire-topology-composition-and-boundary-labels.md)
+- [ADR 0045 - Wire Compile-Time Node-Body Kinds](./0045-wire-compile-time-node-body-kinds.md)
+- [ADR 0046 - Wire Compile-Time Graph Forms](./0046-wire-compile-time-graph-forms.md)
+- [ADR 0047 - Wire Frontier Linearity and Topology Operator Precedence](./0047-wire-frontier-linearity-and-precedence.md)
+- [ADR 0048 - Wire Compile-Time Make for Bounded Node Generation](./0048-wire-make-bounded-node-generation.md)
+- [Chapter 04 - Graph and Circuit](../Architecture/04-graph-and-circuit.md)
+- [Chapter 05 - Wire Language](../Architecture/05-wire-language.md)
+- [Wire Grammar Reference](../Reference/Wire/grammar.md)

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -63,6 +63,9 @@ values: `proposed`, `accepted`, `superseded`, `deprecated`.
 | [0044](0044-wire-namespace-use-imports.md)                      | Wire Namespace Use Imports                                          | proposed   |
 | [0045](0045-wire-compile-time-node-body-kinds.md)               | Wire Compile-Time Node-Body Kinds                                   | proposed   |
 | [0046](0046-wire-compile-time-graph-forms.md)                   | Wire Compile-Time Graph Forms                                       | proposed   |
+| [0047](0047-wire-frontier-linearity-and-precedence.md)          | Wire Frontier Linearity and Topology Operator Precedence            | proposed   |
+| [0048](0048-wire-make-bounded-node-generation.md)               | Wire Compile-Time Make for Bounded Node Generation                  | proposed   |
+| [0049](0049-wire-fan-phantom-adapter.md)                        | Wire Phantom Record↔Ports Adapter for Topology Fans                | proposed   |
 
 ## Writing a new ADR
 

--- a/docs/Architecture/01-overview.md
+++ b/docs/Architecture/01-overview.md
@@ -1,8 +1,8 @@
 ---
 title: "Chapter 01 — Overview"
 description:
-  "Overview of Cortex as a durable runtime and Wire language substrate. Sets the Graph/Circuit/Wire
-  model, the downstream integration boundary, and where detailed subsystem docs live."
+  "Overview of Cortex as a runtime and Wire language substrate. Sets the Graph/Circuit/Wire model,
+  the downstream integration boundary, and where detailed subsystem docs live."
 sidebar:
   label: "01. Overview"
   order: 1
@@ -11,10 +11,11 @@ status: active
 
 # Chapter 01 — Overview
 
-Cortex is a standalone durable runtime and Wire language substrate. This chapter sets the core
-architectural frame: Graph, Circuit, and Wire are separate layers; Cortex owns reusable runtime and
-language concerns; downstream products own domain semantics and the operator edge. Use this page to
-orient yourself. Use the later chapters for subsystem detail and the ADRs for settled decisions.
+Cortex is a standalone runtime and Wire language substrate. This chapter sets the core architectural
+frame: Graph, Circuit, and Wire are separate layers; Cortex owns reusable runtime and language
+concerns; downstream products own domain semantics and the operator edge. Pulse can run Circuits in
+an ephemeral local profile or a durable service profile. Use this page to orient yourself. Use the
+later chapters for subsystem detail and the ADRs for settled decisions.
 
 ## Three Layers
 
@@ -40,8 +41,8 @@ For Wire-specific detail:
 
 The core architectural split is:
 
-- Cortex owns reusable substrate concerns: authoring and typing, topology and compilation, durable
-  execution, and executor-registration capability abstractions.
+- Cortex owns reusable substrate concerns: authoring and typing, topology and compilation, runtime
+  execution profiles, and executor-registration capability abstractions.
 - A downstream product owns domain semantics, product policy, operator surfaces, transport, and
   persistence.
 
@@ -68,8 +69,8 @@ flowchart LR
 
 Ownership rules:
 
-- if a concern should be reusable across host applications as durable runtime or language
-  infrastructure, it belongs in Cortex
+- if a concern should be reusable across host applications as runtime or language infrastructure, it
+  belongs in Cortex
 - if a concern encodes domain policy, artifact meaning, approval rules, or product-specific tools,
   it stays downstream
 - if a concern owns transport, auth, delivery, storage, or API translation, it stays at the host
@@ -84,8 +85,8 @@ Cortex is not a thin provider wrapper. It owns the reusable substrate end to end
   [Wire Grammar](../Reference/Wire/grammar.md).
 - **Topology and compilation** — Graph and Circuit as the formal and executable layers below Wire;
   see [Chapter 04 — Graph and Circuit](04-graph-and-circuit.md).
-- **Durable execution** — Pulse as the runtime that executes compiled circuits; see
-  [Chapter 06 — Pulse runtime](06-pulse-runtime.md).
+- **Runtime execution** — Pulse as the runtime that executes compiled circuits in ephemeral or
+  durable profiles; see [Chapter 06 — Pulse runtime](06-pulse-runtime.md).
 - **Runtime evolution** — admitted rewrites, materialization, and graph-native execution; see
   [Chapter 07 — Rewrites and materialization](07-rewrites-and-materialization.md).
 - **Capability substrate** — executor registration and native pure-executor capability surfaces.
@@ -132,7 +133,7 @@ Read in order:
 4. [Chapter 04 — Graph and Circuit](04-graph-and-circuit.md) — the topology and executable layers
    below Wire.
 5. [Chapter 05 — Wire language](05-wire-language.md) — source-language and rewrite architecture.
-6. [Chapter 06 — Pulse runtime](06-pulse-runtime.md) — durable execution.
+6. [Chapter 06 — Pulse runtime](06-pulse-runtime.md) — runtime execution profiles.
 7. [Chapter 07 — Rewrites and materialization](07-rewrites-and-materialization.md) — admitted
    runtime graph evolution.
 8. [Chapter 08 — Artifacts and provenance](08-artifacts-and-provenance.md) — reusable artifact and

--- a/docs/Architecture/02-ownership-and-boundaries.md
+++ b/docs/Architecture/02-ownership-and-boundaries.md
@@ -11,8 +11,8 @@ status: active
 
 # Chapter 02 — Ownership and Boundaries
 
-Cortex is a generic durable runtime and Wire language substrate. A host application embeds Cortex
-and supplies domain semantics, transport, and persistence. The boundary described here is meant to
+Cortex is a generic runtime and Wire language substrate. A host application embeds Cortex and
+supplies domain semantics, transport, and persistence. The boundary described here is meant to
 survive any particular host.
 
 This chapter states which subsystems own which responsibilities, which direction dependencies run,
@@ -51,11 +51,10 @@ flowchart LR
     S --> D[Persistence<br/>schemas + storage]
 ```
 
-The placement rule: if a module would be reusable outside the host as durable runtime, Wire
-language, or executor-registration infrastructure, it belongs in the Cortex substrate, even when the
-product binding is currently the only caller. If it knows about host domain semantics, model
-providers, product-specific artifacts, truth policy, or host tool authority, it stays downstream or
-in Logos.
+The placement rule: if a module would be reusable outside the host as runtime, Wire language, or
+executor-registration infrastructure, it belongs in the Cortex substrate, even when the product
+binding is currently the only caller. If it knows about host domain semantics, model providers,
+product-specific artifacts, truth policy, or host tool authority, it stays downstream or in Logos.
 
 ## Public import boundary
 
@@ -86,9 +85,9 @@ layers:
   (`Empty | Vertex | Overlay | Connect`), DAG validation, the validated executable Circuit, and the
   Wire source language that authors circuits. Normative Wire grammar lives at
   [`../Reference/Wire/grammar.md`](../Reference/Wire/grammar.md).
-- **Runtime layer.** The Pulse runtime — durable stage execution, checkpointing, rewrite hydration,
-  and frontier scheduling — ships as its own service. Run lifecycle and stage events sit alongside
-  it.
+- **Runtime layer.** Pulse executes Circuits in an ephemeral local profile or a durable service
+  profile. Durable Pulse adds checkpointing, rewrite hydration, frontier scheduling, run lifecycle,
+  and stage events as service-owned state.
 - **Capability layer.** Executor registration and native pure-executor capability surfaces.
 
 ### Product binding

--- a/docs/Architecture/03-formalism-stack.md
+++ b/docs/Architecture/03-formalism-stack.md
@@ -25,15 +25,15 @@ coherent under that surface.
 
 Three layers, each defined over the previous:
 
-| Layer   | Object                                                | Algebra                                                             |
-| ------- | ----------------------------------------------------- | ------------------------------------------------------------------- |
-| Graph   | Pure topology: vertices and edges over a carrier set. | `Empty \| Vertex \| Overlay \| Connect`, per Mokhov.                |
-| Circuit | Validated executable topology: nodes plus wires.      | Graph plus DAG invariant plus port-contract compatibility.          |
-| Wire    | Source language that authors Circuits.                | `<>` (overlay) and `=>` (port-key-matched connect), plus value ops. |
+| Layer   | Object                                                | Algebra                                                               |
+| ------- | ----------------------------------------------------- | --------------------------------------------------------------------- |
+| Graph   | Pure topology: vertices and edges over a carrier set. | `Empty \| Vertex \| Overlay \| Connect`, per Mokhov.                  |
+| Circuit | Validated executable topology: nodes plus ports.      | Graph plus DAG invariant, port linearity, and contract compatibility. |
+| Wire    | Source language that authors Circuits.                | Linear-port `<>` and `=>`, plus value and structural authoring forms. |
 
-Pulse is the durable runtime that executes Circuits. It is not a new algebra; it interprets the
-Circuit object and applies admitted rewrites at runtime. The algebraic stack itself ends at Circuit
-— Pulse is the mechanical realization of its semantics.
+Pulse is the runtime that executes Circuits. It is not a new algebra; it interprets the Circuit
+object and applies admitted rewrites at runtime. The algebraic stack itself ends at Circuit — Pulse
+is the mechanical realization of its semantics in either an ephemeral or durable execution profile.
 
 The load-bearing property across these layers is **composition closure**. A wire value composed with
 another wire value under `<>` or `=>` is itself a wire value. The class is closed under its own
@@ -45,6 +45,18 @@ obligations**: the input/output contract boundary that an operation consumes, pr
 transforms. Boundary resources sit above Mokhov graph equality. They say whether a rewrite,
 conditional, or planner certificate has accounted for the exposed contract boundary it promises,
 while the graph algebra still says what topology denotes.
+
+This gives Cortex two equational theories, not one:
+
+- **Wire source equality** is linear-port equality. Node identity and endpoint ports are resources:
+  a graph reference is not implicitly cloned, one output port feeds at most one input port, and one
+  input port receives at most one producer.
+- **Graph relation equality** is Mokhov equality. After an admitted lowering forgets port identity
+  and boundary resources, the resulting relation satisfies the ordinary graph laws.
+
+The lowering from Wire/Circuit to Graph is therefore forgetful. It preserves the denoted topology,
+but it does not make every Mokhov equation a valid source-level rewrite. The load-bearing failure is
+distributivity; the `down` example in "Wire's linear-port refinement" below shows why.
 
 ## Detailed structure
 
@@ -62,28 +74,41 @@ that denotation. The laws hold by construction because the interpretation is the
 their algebraic statement and the proof obligations they carry into the staged-execution setting,
 see [`paper 2`](../Publications/Paper-2-algebraic-foundations/manuscript.md).
 
-### Wire's `<>` and `=>` as refinements
+### Wire's linear-port refinement
 
-Wire's two graph operators correspond directly to Mokhov's primitives, but refine them:
+Wire's two graph operators refine Mokhov's primitives through a typed port frontier:
 
-- **`<>` (overlay)** is exactly Mokhov's Overlay. Set-union of vertices and edges across two wires.
-  It inherits the Mokhov laws unchanged: commutative monoid with `Empty` as identity, idempotent
-  when the operands share vertices.
+- **`<>` (overlay)** places independent graph values side by side only when their node identities
+  are disjoint. Repeating the same node reference is a source error, not an idempotent graph law.
 
 - **`=>` (connect)** is a _refinement_ of Mokhov's Connect, not an instance of it. Mokhov's Connect
   takes the cross product of left outputs against right inputs and unions the resulting edges.
   Wire's `=>` is **port-key-matched**: an edge is added between a left-hand boundary output and a
   right-hand boundary input only when their port keys agree on `(direction, contract, label)`. An
-  absent label is itself a key, not a wildcard. The result is a deterministic cross-product with a
-  filter: fewer edges than Mokhov's Connect for the same endpoints, never more.
+  absent label is itself a key, not a wildcard. Each endpoint may have zero or one compatible
+  counterpart; multiple counterparts are a static error.
 
 This refinement is why `=>` lands usable edges instead of a combinatorial mesh of unchecked
-connections. It also preserves the Mokhov laws where they matter: overlay's associativity and
-commutativity hold on Wire values; connect remains associative under port-key matching;
-`Empty <> w = w` and `Empty => w = w`. The laws that involve the cross-product shape of Connect
-(full distributivity over Overlay) hold only on the port-matched projection, which is the only form
-Wire ever exposes. See [`terminology.md`](../Reference/terminology.md) for the normative definitions
-of port key and the composition algebra.
+connections. It also means Wire source expressions do not inherit every Mokhov equation. For
+example, distributing a source expression across an overlay can duplicate the left operand.
+**Rejected source form:**
+
+```text
+# rejected: repeats `down`
+(down => some) <> (down => things)
+```
+
+That repeats `down` and is not a valid Wire source expression. The related expression:
+
+```wire
+down
+  => some <> things
+```
+
+is valid only when `down` exposes distinct compatible outputs for `some` and `things`. Once the
+accepted Wire/Circuit object is lowered to the relation layer, the ordinary Mokhov laws apply to the
+forgotten topology. See [`terminology.md`](../Reference/terminology.md) for the normative
+definitions of port key and the composition algebra.
 
 ### DAG semantics as a Circuit-layer invariant
 
@@ -103,12 +128,12 @@ attach at the Circuit boundary.
 
 ### Rewrite algebra
 
-A rewrite is a structural edit: a function from a Circuit to a Circuit whose effect is expressible
-as a composition of Mokhov operators applied at an anchor. In Wire terms, a rewrite fragment is
-itself a wire value, and admitting a rewrite is overlaying that fragment into the live topology and
-re-connecting endpoints under `=>`. Because the fragment and the target belong to the same algebraic
-class, admission is law-preserving by construction: the post-rewrite object satisfies exactly the
-same overlay and connect laws as the pre-rewrite object.
+A rewrite is a structural edit: a function from a Circuit to a Circuit whose lowered topology is
+expressible as a composition of graph operators applied at an anchor. In Wire terms, a rewrite
+fragment is itself a wire value, and admitting a rewrite means checking the same linear-port
+obligations as ordinary source composition before lowering to the relation layer. Admission must
+preserve both sides of the stack: the source-level boundary resources and the relation-level graph
+denotation.
 
 The rewrite algebra is stated as vertex-anchored substitution: a fragment is spliced at a designated
 vertex through a typed interface, preserving causal structure outside the interface. This is the
@@ -132,19 +157,19 @@ branches are a sealed family of graph possibilities, not live topology and not a
 in the graph algebra. Every branch can be checked against its variant boundary, but each
 branch-local obligation is guarded and affine until the selected arm is actualized.
 
-After selection, the chosen branch lowers to ordinary Wire graph composition and the usual overlay
-and connect laws apply to the materialized result. Unselected branches do not become graph fragments
-for the run. This is how Wire can represent structured runtime choice without treating conditionals
-as ordinary fan-out or hiding the choice inside executor code.
+After selection, the chosen branch lowers to ordinary Wire linear-port composition and then to the
+relation layer. Unselected branches do not become graph fragments for the run. This is how Wire can
+represent structured runtime choice without treating conditionals as ordinary fan-out or hiding the
+choice inside executor code.
 
 ## Boundaries and invariants
 
 What this stack enforces:
 
-- **Composition closure.** Wire graph values are closed under `<>` and `=>`. Authored topology and
-  rewrites share the same object class as finished circuits.
-- **Law preservation through refinement.** `<>` inherits Mokhov overlay laws. `=>` preserves those
-  laws on the port-key-matched projection.
+- **Composition closure.** Wire graph values are closed under admitted `<>` and `=>`. Authored
+  topology and rewrites share the same object class as finished circuits.
+- **Two law surfaces.** Wire source composition preserves linear port resources. Graph relation
+  lowering preserves Mokhov topology laws after port identity is forgotten.
 - **Layered invariants.** Acyclicity and port-contract compatibility attach at the Circuit boundary,
   not at Graph. Fragments remain algebraically first-class below that line.
 - **Boundary-resource accounting.** Structural operations consume, preserve, or transform declared
@@ -152,8 +177,8 @@ What this stack enforces:
   but not the same resource.
 - **Latent control lowers after resolution.** A latent branch family is checked before runtime, but
   only the selected branch enters the live graph and inherits the graph laws.
-- **Rewrites as algebraic operations.** Structural edits are expressible in the same algebra that
-  authored the topology; admission preserves the laws.
+- **Rewrites as algebraic operations.** Structural edits are authored in the same linear-port
+  surface as ordinary topology and lower to the same graph relation algebra after admission.
 
 What the stack does not enforce: executor semantics, payload-kind validation, runtime scheduling,
 provenance — all delegated to Circuit, Pulse, or the contract registry.

--- a/docs/Architecture/04-graph-and-circuit.md
+++ b/docs/Architecture/04-graph-and-circuit.md
@@ -12,38 +12,41 @@ status: active
 # Chapter 04 — Graph and Circuit
 
 Chapter 03 establishes the algebraic basis. This chapter picks up one level later and defines the
-two artifacts that matter operationally: Graph as pure topology, and Circuit as validated executable
-topology. Graph keeps the formalism maximally reusable. Circuit is the point where a topology
-becomes an artifact that Pulse can execute, persist, and re-validate after admitted rewrites.
+artifacts that matter operationally: Graph as pure topology, the linear port graph as Wire's
+typed-frontier surface, and Circuit as validated executable topology. Graph keeps the formalism
+maximally reusable. Circuit is the point where a topology becomes an artifact that Pulse can execute
+in memory or through a durable runtime profile.
 
 ## Core Model
 
 The distinction is simple:
 
-| Layer       | Role                                                                                                | Excludes                                             |
-| ----------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| **Graph**   | Pure topology: vertices, edges, overlay, connect, traversal, decomposition.                         | Ports, contracts, executors, payloads, runtime state |
-| **Circuit** | Executable topology: stable nodes, compatible endpoints, boundary markers, runtime-facing metadata. | Scheduling, persistence policy, operator APIs        |
+| Layer                 | Role                                                                                                | Excludes                                             |
+| --------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| **Graph**             | Pure topology: vertices, edges, overlay, connect, traversal, decomposition.                         | Ports, contracts, executors, payloads, runtime state |
+| **Linear port graph** | Typed frontier: node identities, port instances, exposed boundaries, and one-use endpoint matching. | Executor behavior, payload meaning, scheduling       |
+| **Circuit**           | Executable topology: stable nodes, compatible endpoints, boundary markers, runtime-facing metadata. | Scheduling, persistence policy, operator APIs        |
 
-Wire authors topology using the Graph layer's composition laws. Pulse executes Circuits. The
-boundary looks like this:
+Wire authors topology through the linear port graph surface and lowers admitted topology to Graph
+relations. Pulse executes Circuits. The boundary looks like this:
 
 ```mermaid
 flowchart LR
-    W[Wire source] --> G[Graph]
-    G --> C[Circuit]
+    W[Wire source] --> L[Linear port graph]
+    L --> G[Graph relation]
+    L --> C[Circuit]
+    G --> C
     C --> P[Pulse]
-    P --> R[Run state]
 ```
 
 Each boundary narrows freedom:
 
 - Wire chooses names, composition, and endpoint intent.
+- The linear port graph checks one-use endpoint resources and exposes the frontier.
 - Graph carries only denotational topology.
 - Circuit checks that the topology is executable.
-- Pulse schedules and persists the resulting executable object over time.
-- Run state is the durable record of that execution, owned by Pulse and read by downstream artifact
-  and provenance surfaces.
+- Pulse executes the resulting object; the durable profile persists execution over time.
+- Durable run state is owned by Pulse and read by downstream artifact and provenance surfaces.
 
 ## Graph
 
@@ -73,6 +76,27 @@ In practice, topology algorithms often run over a lowered relation or adjacency 
 over the authoring expression itself. That does not add new semantics; it is just the executable
 denotation of the same topology.
 
+## Linear Port Graph
+
+The linear port graph is the typed source/Circuit seam. It records the information that pure Graph
+intentionally forgets:
+
+- node identities;
+- input and output port instances;
+- the exposed input and output frontier;
+- port-edge matches from one output instance to one input instance;
+- the `PortLinear` invariant: no endpoint port is consumed by more than one match.
+
+This layer is where Wire's "no implicit copy" rule lives. `a <> a` is rejected here because it
+repeats a node identity. `down => some <> things` is admitted only if `down` exposes distinct
+compatible outputs for both consumers. The forgetful lowering from this layer to Graph erases port
+identity and boundary resources, retaining the node relation that traversal, DAG checks, and rewrite
+topology operate on.
+
+At runtime, the same shape appears as an **actualized port graph**: the concrete port-instance view
+of the materialized Circuit or Pulse state. That projection is the natural place for the proof track
+to connect source frontier linearity to runtime well-formedness.
+
 ## Circuit
 
 Circuit is the executable topology artifact. It takes a graph-shaped structure and adds the facts
@@ -80,6 +104,7 @@ that execution needs but pure topology does not:
 
 - stable node identity
 - compatible endpoints between connected nodes
+- actualized port linearity
 - explicit boundaries such as signal, artifact, and rewrite boundaries
 - enough metadata for Pulse to lower and resume the topology safely
 - a compatibility witness that downstream durable state can key against
@@ -96,7 +121,8 @@ rewrites, or decide operator policy. It defines the object those mechanisms oper
 Wire contributes three things to the Circuit boundary:
 
 - a set of registered nodes and declared boundaries
-- a composed topology over those nodes
+- a linear port graph over those nodes
+- a lowered graph relation for topology algorithms
 - endpoint compatibility information already resolved at the authoring layer
 
 Circuit compilation does not re-interpret domain semantics. Its job is narrower and more mechanical:
@@ -105,10 +131,10 @@ artifact that Pulse can lower without re-parsing Wire.
 
 Stated as seam contracts:
 
-| Seam            | What comes in                                                        | What must come out                                                |
-| --------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| Wire → Circuit  | Registered nodes, composed topology, endpoint-compatible connections | Executable topology with stable identity and preserved boundaries |
-| Circuit → Pulse | Executable topology plus compatibility witness                       | Runtime plan that preserves topology up to runtime naming         |
+| Seam            | What comes in                                                             | What must come out                                                     |
+| --------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Wire → Circuit  | Registered nodes, linear port graph, lowered relation, endpoint witnesses | Executable topology with stable identity and preserved boundaries      |
+| Circuit → Pulse | Executable topology plus compatibility witness                            | Runtime plan that preserves topology and port use up to runtime naming |
 
 ## Boundaries and Invariants
 
@@ -116,9 +142,13 @@ Stated as seam contracts:
 views, adjacency, and decomposition must agree with the underlying edge set. Graph updates are
 purely structural.
 
+**Linear port graph guarantees upward.** Source composition consumes endpoint resources at most
+once, keeps unmatched endpoints exposed on the frontier, and lowers to a plain graph relation only
+after port identity has served its purpose.
+
 **Circuit guarantees upward.** A Circuit carries executable topology rather than merely possible
-topology: acyclic structure, stable node identity, preserved boundaries, and a compatibility witness
-suitable for durable consumers.
+topology: acyclic structure, stable node identity, port linearity, preserved boundaries, and a
+compatibility witness suitable for durable consumers.
 
 **Circuit guarantees downward.** Lowering preserves topology up to runtime renaming. Rewrite,
 signal, and artifact boundaries remain explicit; Circuit does not collapse them into opaque generic
@@ -149,8 +179,8 @@ place for product policy.
 
 - [./03-formalism-stack.md](./03-formalism-stack.md) — the algebra, Mokhov's laws, proofs.
 - [./05-wire-language.md](./05-wire-language.md) — Wire as source language; contract registry.
-- [./06-pulse-runtime.md](./06-pulse-runtime.md) — durable scheduling and execution over a compiled
-  Circuit.
+- [./06-pulse-runtime.md](./06-pulse-runtime.md) — runtime execution profiles over compiled
+  Circuits.
 - [./07-rewrites-and-materialization.md](./07-rewrites-and-materialization.md) — dynamic rewrites
   admitted during execution.
 - [./08-artifacts-and-provenance.md](./08-artifacts-and-provenance.md) — envelopes and payload kinds

--- a/docs/Architecture/05-wire-language.md
+++ b/docs/Architecture/05-wire-language.md
@@ -57,7 +57,7 @@ vocabulary into those artifacts.
 flowchart LR
     R[Registered authority<br/>executors, contracts, tools, constructors] --> W[Wire<br/>authoring and composition]
     W --> C[Circuit<br/>validated executable topology]
-    C --> P[Pulse<br/>durable execution]
+    C --> P[Pulse<br/>runtime execution]
     D[Downstream bindings<br/>domain policy and artifacts] --> R
 ```
 
@@ -99,6 +99,8 @@ its own domain vocabulary around Wire rather than by changing Wire semantics.
 
 Wire's graph vocabulary has three different objects that should not be collapsed into each other:
 
+- A **kind** is a reusable node-body shape. It is not live topology and does not have runtime
+  identity by itself.
 - A **node** is an addressable runtime and provenance object admitted into graph position.
 - A **port** is a labeled input or output slot on the node boundary, typed by a contract.
 - An **edge** connects one output port obligation to one compatible input port obligation.
@@ -139,9 +141,10 @@ analyze
   => summarize
 ```
 
-The node has identity and lifecycle. The ports carry the typed boundary obligations. The edge is
-only the structural connection that says a producer output port satisfies a consumer input port. It
-is not a place to hide computation, authority, projection, aggregation, or retry policy.
+The kind is the reusable shape. The node has identity and lifecycle. The ports carry the typed
+boundary obligations. The edge is only the structural connection that says a producer output port
+satisfies a consumer input port. It is not a place to hide computation, authority, projection,
+aggregation, or retry policy.
 
 This distinction matters for rewrites and recovery. A retained node can remain present for
 provenance while its exposed boundary obligation has been transformed or consumed. Conversely, a
@@ -172,6 +175,11 @@ an addressable runtime and provenance object, but the locally consumed resource 
 obligation it exposes. Rewrites, append continuations, and conditional actualization all have to
 state which boundary they consume and which boundary they return. Retaining a node for provenance is
 therefore not the same as keeping its original boundary obligation unspent.
+
+This distinction is also what makes bounded generation possible without copying. `make(N, K)`
+creates N fresh nodes from kind `K`; it does not clone one existing node or duplicate one output
+port. Similarly, the `*` topology operator is an explicit record↔ports adapter node, not a hidden
+fan-out rule on edges.
 
 ## Node boundary normal form
 
@@ -354,7 +362,7 @@ Cortex still owns the source language, composition rules, and substrate runtime.
 
 - [Chapter 01 — Overview](01-overview.md) — system overview and high-level boundary
 - [Chapter 04 — Graph and Circuit](04-graph-and-circuit.md) — the structural layers Wire authors
-- [Chapter 06 — Pulse runtime](06-pulse-runtime.md) — durable execution over Circuits
+- [Chapter 06 — Pulse runtime](06-pulse-runtime.md) — runtime execution over Circuits
 - [Chapter 07 — Rewrites and materialization](07-rewrites-and-materialization.md) — runtime
   admission and realized topology
 - [Chapter 08 — Artifacts and provenance](08-artifacts-and-provenance.md) — payload, artifact, and

--- a/docs/Architecture/06-pulse-runtime.md
+++ b/docs/Architecture/06-pulse-runtime.md
@@ -1,8 +1,8 @@
 ---
 title: "Chapter 06 — Pulse Runtime"
 description:
-  "The durable runtime that executes Circuits. Service boundary, runtime model, Pulse-owned state,
-  stage execution mechanics, and the host-action contract consumers use to extend Pulse."
+  "Runtime profiles for executing Circuits: ephemeral in-memory execution and durable execution with
+  checkpoints, provenance, observability, and recovery."
 sidebar:
   label: "06. Pulse runtime"
   order: 6
@@ -11,12 +11,16 @@ status: active
 
 # Chapter 06 — Pulse Runtime
 
-Pulse is the durable runtime that executes Circuits. It is the mechanical realization of the Circuit
-semantics laid out in chapters 03 and 04: a standalone service that owns scheduling, stage
-execution, checkpoint persistence, cancellation, lease recovery, and rewrite materialization for
-long-lived Cortex runs. This chapter covers the runtime model, Pulse-owned state, stage execution,
-the memory surface, and the contract Pulse presents to downstream consumers. The contract is
-generic; consumer-specific bindings live outside the substrate.
+Pulse is the runtime that executes Circuits. It is the mechanical realization of the Circuit
+semantics laid out in chapters 03 and 04. The same admitted Circuit can run in two profiles:
+
+- **Ephemeral Pulse** runs in process memory, like a script runner. It needs no database,
+  observability stack, durable checkpoint table, or provenance store.
+- **Durable Pulse** runs the same transition model with persisted events, checkpoints, provenance,
+  observability, lease recovery, and rewrite materialization for long-lived Cortex runs.
+
+This chapter covers both profiles, then spells out the durable service boundary and memory surface.
+The contract is generic; consumer-specific bindings live outside the substrate.
 
 If you are evaluating Cortex rather than implementing against Pulse directly, the core model and
 service boundary are the key sections. The later sections spell out the runtime mechanics in detail.
@@ -28,27 +32,51 @@ Wire source examples on this page use the canonical grammar. The normative gramm
 ## Core model
 
 Pulse is a runtime, not an algebra. It interprets a compiled Circuit as a sequence of stage
-transitions and records each transition durably. Every stage boundary has a persisted checkpoint;
-every resume is a pure function of persisted state. The service owns six concerns:
+transitions. Durability is an execution policy layered on top of those transitions, not part of Wire
+semantics.
 
-| Concern                 | Role                                                                          |
-| ----------------------- | ----------------------------------------------------------------------------- |
-| Scheduling              | Own due-task discovery, CAS claim, cron advancement, lease recovery.          |
-| Stage execution         | Drive a Circuit's stage plan forward, one admitted transition at a time.      |
-| Checkpoint persistence  | Write a versioned envelope at every stage boundary. Validate on resume.       |
-| Cancellation            | Propagate a cancel request to the executor and finalize at safe boundaries.   |
-| Rewrite materialization | Atomically admit, apply, and record structural rewrites during a run.         |
-| Observability           | Emit lifecycle and per-stage events; expose run detail through a service API. |
+| Profile       | Storage                  | Role                                                                   |
+| ------------- | ------------------------ | ---------------------------------------------------------------------- |
+| **Ephemeral** | Process memory           | Run an admitted Circuit locally with the same topology and port rules. |
+| **Durable**   | Persistent run substrate | Add checkpoints, resume, provenance, observability, and recovery.      |
+
+Both profiles own stage execution: drive a Circuit's stage plan forward, one admitted transition at
+a time. Durable Pulse additionally owns scheduling, checkpoint persistence, lease recovery,
+cancellation persistence, rewrite materialization lineage, and service-level observability.
 
 Pulse does not define task semantics. Consumers register task types and provide the stage actions;
 Pulse executes them. The generic contract is captured in
 [`../Reference/Pulse/`](../Reference/Pulse/). Consumer-specific bindings live under
 [`../Consumers/`](../Consumers/).
 
-## Service boundary
+## Execution profiles
 
-Pulse runs as its own service with its own DB schema. Consumers talk to Pulse through HTTP. When
-Pulse needs domain work, it calls the consumer back through a host-action API the consumer provides.
+### Ephemeral profile
+
+The ephemeral profile is the default mental model for local Wire execution: compile an admitted
+Wire/Circuit artifact and run it in one process. It is suitable for examples, tests, scripts,
+single-machine tools, and local development.
+
+Ephemeral execution still enforces the substrate semantics: topology validation, port linearity,
+executor authority, and rewrite admission where rewrites are enabled. It simply does not retain a
+durable event log or checkpoint lineage after the process exits.
+
+### Durable profile
+
+The durable profile is a refinement of the same transition system. It records each admitted
+transition as durable state, validates persisted versions on resume, and keeps provenance and
+observability available to operator and downstream surfaces.
+
+This split separates logical retention from physical residency. A node's identity, output envelope,
+and provenance may be retained durably, while its in-memory activation frame, input buffers, and
+temporary output buffers can be released after egress and materialization. Future computation reads
+through the runtime substrate, not through a live heap reference.
+
+## Durable service boundary
+
+Durable Pulse runs as its own service with its own DB schema. Consumers talk to Pulse through HTTP.
+When Pulse needs domain work, it calls the consumer back through a host-action API the consumer
+provides.
 
 ```mermaid
 flowchart LR
@@ -177,9 +205,9 @@ Per-stage `sdTimeoutSeconds` takes precedence over the task-level timeout when s
 
 ### Mandatory checkpoints
 
-The executor rejects a stage transition that does not include a checkpoint write. Every stage
-boundary has a persisted `CheckpointEnvelope`, even when the task completes successfully without
-needing resume. This enforces serialization discipline from day one.
+In the durable profile, the executor rejects a stage transition that does not include a checkpoint
+write. Every stage boundary has a persisted `CheckpointEnvelope`, even when the task completes
+successfully without needing resume. This enforces serialization discipline from day one.
 
 ### Resume
 
@@ -203,9 +231,10 @@ gas, admission policy, materialization, and structural provenance — belongs to
 
 ## Settled-State Queries
 
-Pulse owns the durable event/checkpoint substrate that makes settled-state queries deterministic.
+Durable Pulse owns the event/checkpoint substrate that makes settled-state queries deterministic.
 Logos and downstream libraries may shape that state into model or domain context, but Pulse itself
-remains the store of run events, frontier state, checkpoints, materialized outputs, and snapshots.
+remains the store of run events, frontier state, checkpoints, materialized outputs, and snapshots in
+durable mode.
 
 Memory is a query, not a store. A stage's view of upstream context is derived from the Pulse event
 substrate, scored by a composite of graph influence, wall-clock distance, and a pluggable semantic

--- a/docs/Reference/Wire/contracts-ports-and-matching.md
+++ b/docs/Reference/Wire/contracts-ports-and-matching.md
@@ -75,7 +75,8 @@ A port key is:
 (direction, contract, label)
 ```
 
-`=>` matches the contract and label, with direction reversed: output to input.
+`=>` matches the contract and label, with direction reversed: output to input. Each endpoint port
+may participate in at most one edge created by a connect expression.
 
 Boundary adaptation belongs to node ingress/egress adapters or to explicit pure nodes, not to the
 edge. `=>` only checks that an already-produced output port resource satisfies a consumer input
@@ -83,8 +84,10 @@ obligation.
 
 ## Cardinality
 
-All authored input ports are cardinality-one. A cardinality-one input may receive at most one edge.
-If `=>` would add two edges into the same input, the composition is rejected.
+All authored ports are cardinality-one at the graph boundary. An output may feed at most one input,
+and an input may receive at most one output. If `=>` would add two edges out of the same output or
+two edges into the same input, the composition is rejected. Implicit fan-out and implicit fan-in are
+never valid Wire topology.
 
 Wire no longer has `<- [Contract]` implicit list aggregation. To gather many values, author an
 explicit transformation node:

--- a/docs/Reference/Wire/contracts-ports-and-matching.md
+++ b/docs/Reference/Wire/contracts-ports-and-matching.md
@@ -87,7 +87,7 @@ obligation.
 All authored ports are cardinality-one at the graph boundary. An output may feed at most one input,
 and an input may receive at most one output. If `=>` would add two edges out of the same output or
 two edges into the same input, the composition is rejected. Implicit fan-out and implicit fan-in are
-never valid Wire topology.
+never valid Wire topology; use fresh generated nodes or an explicit record↔ports adapter instead.
 
 Wire no longer has `<- [Contract]` implicit list aggregation. To gather many values, author an
 explicit transformation node:

--- a/docs/Reference/Wire/grammar.md
+++ b/docs/Reference/Wire/grammar.md
@@ -408,11 +408,21 @@ wire_expr ::= atom
             | wire_expr "select" "(" arm ("," arm)* ","? ")"
 ```
 
-`<>` overlays graph values. It is set union on nodes and edges.
+`<>` overlays graph values. It is set union on nodes and edges when the operands have disjoint node
+identities. Repeating the same node identity in both operands is a static topology error; overlay
+does not clone nodes.
 
-`=>` connects every matching output boundary port on the left to every matching input boundary port
-on the right. Matching is by `(contract, label)`. It does not choose one edge; it adds all matching
-edges. Multiple edges into the same cardinality-one input are a compile error.
+`=>` matches left-side output boundary ports against right-side input boundary ports by
+`(contract, label)`. For each compatible output/input pair:
+
+- if both endpoint ports have exactly one compatible counterpart across the boundary, `=>` creates
+  one edge;
+- if an endpoint port has no compatible counterpart, it remains exposed on the composed boundary;
+- if an output has several compatible inputs, the composition is a static topology error;
+- if an input has several compatible outputs, the composition is a static topology error.
+
+Every endpoint port is linear in graph composition: one output feeds at most one input, and one
+input receives at most one output. `=>` does not perform implicit fan-out or aggregation.
 
 The implementation requires parentheses when `<>` and `=>` are mixed in one expression:
 

--- a/docs/Reference/Wire/grammar.md
+++ b/docs/Reference/Wire/grammar.md
@@ -133,8 +133,9 @@ captured constants. Graph values and configured executor values are not.
 
 Wire has three relevant value classes.
 
-**Graph values** are nodes, composed graph expressions, and `()`. Only graph values may appear in
-file-return position or on either side of graph operators.
+**Graph values** are nodes, bound form applications, bound `make(...)` expansions, composed graph
+expressions, and `()`. Only graph values may appear in file-return position or on either side of
+graph operators.
 
 **Configured executor values** have the form:
 
@@ -286,6 +287,16 @@ Rules:
 
 After expansion, a form instantiation is an ordinary graph value composed from ordinary nodes.
 
+### Bounded Node Generation
+
+`make(N, K)` is a compile-time graph form that expands to N fresh nodes from kind `K`. It is valid
+only when bound by `let` / `export let` or by a form-local `let`; inline `make(...)` in graph
+position is rejected because there is no source name to derive stable identities from.
+
+`N` must be a static non-negative count. `K` is a kind reference, not a kind application and not a
+CorePure value. Generated nodes get deterministic identities from the binding name and expose the
+generated port labels specified by the kind.
+
 ### 5.3 Pure Output Equations
 
 Pure nodes compute deterministic JSON-shaped values:
@@ -402,15 +413,18 @@ Record fields support Nix-style `inherit name;` sugar, which desugars to `name =
 ## 7. Graph Composition
 
 ```wire
-wire_expr ::= atom
-            | wire_expr "=>" wire_expr
-            | wire_expr "<>" wire_expr
-            | wire_expr "select" "(" arm ("," arm)* ","? ")"
+wire_expr    ::= connect_expr
+               | connect_expr "select" "(" arm ("," arm)* ","? ")"
+connect_expr ::= overlay_expr (("=>" | "*") overlay_expr)*
+overlay_expr ::= atom (("<>" | ",") atom)*
 ```
 
 `<>` overlays graph values. It is set union on nodes and edges when the operands have disjoint node
 identities. Repeating the same node identity in both operands is a static topology error; overlay
 does not clone nodes.
+
+`,` is admitted in graph position as an alias for `<>` and follows the same precedence while the
+alias remains part of the language.
 
 `=>` matches left-side output boundary ports against right-side input boundary ports by
 `(contract, label)`. For each compatible output/input pair:
@@ -424,16 +438,26 @@ does not clone nodes.
 Every endpoint port is linear in graph composition: one output feeds at most one input, and one
 input receives at most one output. `=>` does not perform implicit fan-out or aggregation.
 
-The implementation requires parentheses when `<>` and `=>` are mixed in one expression:
+`*` inserts an explicit record↔ports adapter node between its operands. It is not an exception to
+the `=>` rule: both sides of the adapter connect through ordinary linear endpoint matching.
+
+Topology operators have fixed precedence:
+
+| Tightness | Operators  | Associativity |
+| --------- | ---------- | ------------- |
+| Tighter   | `<>` / `,` | left          |
+| Looser    | `=>` / `*` | left          |
+
+Tighter binds first, so:
 
 ```wire
-(a <> b)
-  => c
 a
-  => (b <> c)
+  => b
+  => c <> d
 ```
 
-Unparenthesized `a => b <> c` is rejected.
+parses as `a => b => (c <> d)`. The expression is still admitted only if the final connect obeys the
+linear endpoint rule.
 
 `()` is the empty graph value and identity for overlay/connect.
 

--- a/docs/Research-notes/Foundation/2026-05-05-linear-port-graph-layer.md
+++ b/docs/Research-notes/Foundation/2026-05-05-linear-port-graph-layer.md
@@ -1,0 +1,356 @@
+---
+title: "Research Memo: Linear Port Graph Layer"
+description:
+  "Synthesis note on the two-layer Wire topology semantics: linear port graphs above Mokhov relation
+  graphs, with a forgetful lowering between them."
+date: 2026-05-05
+status: research
+related:
+  - docs/Architecture/03-formalism-stack.md
+  - docs/Architecture/04-graph-and-circuit.md
+  - docs/Architecture/05-wire-language.md
+  - docs/ADRs/0028-wire-topology-composition-and-boundary-labels.md
+  - docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
+  - docs/ADRs/0048-wire-make-bounded-node-generation.md
+  - docs/ADRs/0049-wire-fan-phantom-adapter.md
+---
+
+# Research Memo: Linear Port Graph Layer
+
+**Date:** 2026-05-05 **Scope:** Wire frontier linearity, Mokhov graph denotation, `make`, `*`, and
+the proposed runtime projection into actualized port graphs. **Branch / PR:**
+`wire-static-fanout-replicate` **Layers examined:** Haskell graph core, Lean Track 1 graph theory,
+Wire ADRs 0028/0047/0048/0049, Architecture chapters 03-05, Wire reference docs, and external
+port-graph / structured-cospan / string-diagram literature. **Layers skipped:** live GitHub issues
+and downstream repositories; the question is semantic and not tied to one issue. **Method:**
+Cross-source synthesis through the seven archetype lenses. **Confidence profile:** high on the
+two-layer correction; medium on the exact categorical presentation to use in papers.
+
+## Executive Summary
+
+Wire's source topology is not governed directly by Mokhov's graph laws. It is a finer **linear port
+graph** layer where node identity and endpoint ports are resources, so contraction and implicit
+copying are illegal. Mokhov's algebra remains the right relation-level substrate after a forgetful
+lowering erases port identity and boundary resources. The next proof move should be a typed
+`LinearPortGraph` / `ActualizedPortGraph` layer with `PortLinear`, a forgetful map to
+`Cortex.Graph.Relation`, and a Pulse-state projection that makes port linearity part of runtime
+well-formedness.
+
+The paper framing should give rhetorical weight to the upper layer: Cortex's contribution is not
+"Mokhov graphs for workflows" but a port-linear admission and rewrite layer that lowers into the
+Mokhov relation algebra.
+
+## Archetype Synthesis
+
+| Lens     | One-line read                                                                                  |
+| -------- | ---------------------------------------------------------------------------------------------- |
+| Episteme | Track 1 proves Mokhov relation laws; ADR 0047 asserts a stricter Wire frontier-resource model. |
+| Logos    | Source Wire has linear-port laws; Mokhov laws apply only after forgetful relation lowering.    |
+| Kritikos | Mokhov distributivity repeats operands and therefore violates Wire source linearity.           |
+| Themis   | Port identity belongs at Wire/Circuit/Pulse safety, not in pure Graph topology.                |
+| Techne   | Add `LinearPortGraph`, `forgetPorts`, `PortLinear`, and runtime projection lemmas.             |
+| Poiesis  | Best external vocabulary: port graphs/open graphs; SMC/string diagrams are paper framing.      |
+| Sophia   | Refine the base theory by adding a layer, not by replacing Mokhov.                             |
+
+## Key Findings
+
+### [P1] Wire source laws are linear-port laws, not Mokhov laws
+
+**Category:** Correctness Gap **Status:** Observed **Confidence:** High **Surfaced by:** Logos,
+Kritikos, Themis **Primary evidence:** ADR 0047 "Algebraic foundation" and "Linear endpoint rule";
+`theory/Cortex/Graph/Relation.lean`; `src/Cortex/Algebra/Graph/Core.hs`; Architecture chapter 03
+"Wire's `<>` and `=>` as refinements" **Cross-reference:** ADRs ↔ theory ↔ architecture.
+
+Track 1's graph theory is correctly Mokhov-shaped: `Graph` has `empty`, `vertex`, `overlay`, and
+`connect`, and the relation denotation interprets `connect` by adding every cross edge from the left
+vertex set to the right vertex set. ADR 0047 now commits Wire source to a stricter frontier model:
+typed endpoint ports are linear resources, repeated graph references are static errors, and `=>`
+creates an edge only when each endpoint has zero or one compatible counterpart.
+
+Those two theories cannot share all equations at the source layer. The diagnostic equation is Mokhov
+distributivity:
+
+```wire
+down => some <> things
+```
+
+versus:
+
+```wire
+(down => some) <> (down => things)
+```
+
+The second expression repeats `down`, so it is invalid Wire source. Mokhov distributivity is valid
+only after lowering to a relation where vertex identity is no longer a linear resource.
+
+**Why it matters:** Without this split, documentation and proofs can accidentally claim that Wire
+inherits a law that its own linearity rule rejects. That would undermine ADR 0047 and confuse the
+paper story.
+
+**Next step:** Amend Architecture chapter 03 to state two equational theories explicitly:
+linear-port source laws above Mokhov relation laws, connected by forgetful lowering.
+
+### [P2] The missing formal object is a linear port graph carrier
+
+**Category:** Missed Abstraction **Status:** Inferred **Confidence:** High **Surfaced by:** Techne,
+Themis **Primary evidence:** ADR 0047 typed frontier model; ADR 0049 phantom adapter; Track 2
+proposal for `actualizedPortGraphOf`; theory status table in `theory/README.md` **Cross-reference:**
+ADRs ↔ Lean proof track.
+
+ADR 0047 introduces the frontier-resource vocabulary, and ADR 0049 relies on it for `*`, but the
+Lean base currently has no carrier that makes this vocabulary a theorem object. The existing graph
+carrier is relational; it has vertices and edges, not port instances or exposed frontiers.
+
+The missing layer should contain:
+
+- node identities;
+- actualized input and output port instances;
+- a port-edge relation from output instance to input instance;
+- exposed input and output frontier sets;
+- `PortLinear`;
+- overlay with disjoint node identity;
+- connect with deterministic one-counterpart matching;
+- a forgetful map into `Cortex.Graph.Relation`.
+
+This layer should sit above pure Graph and below runtime Pulse state.
+
+**Why it matters:** This is what turns "no implicit fan-in/fan-out" from an ADR rule into a
+mechanized invariant. It also gives `make`, `*`, select actualization, and admitted rewrite
+materialization one shared target.
+
+**Next step:** Add a proof-track ADR or research-to-ADR follow-up for `LinearPortGraph`,
+`ActualizedPortGraph`, `forgetPorts`, and `PortLinear`.
+
+### [P3] `PortLinear` should be folded into runtime safe-state through projection
+
+**Category:** Correctness Gap **Status:** Inferred **Confidence:** High **Surfaced by:** Themis,
+Techne **Primary evidence:** Track 2 proposal; `SafePulseRunState` / `wellFormedGraphState` status
+in `theory/README.md`; ADR 0047 runtime-preservation obligations **Cross-reference:** Theory ↔
+ADRs.
+
+The proof track already has a closed middle around `SafePulseRunState` and finite admitted traces,
+but the current safe-state envelope is graph/rewrite/pulse shaped rather than port-resource shaped.
+ADR 0047 needs a bridge from runtime state to actualized port use:
+
+```lean
+actualizedPortGraphOf : PulseState ... -> ActualizedPortGraph ...
+```
+
+Then runtime safety can carry:
+
+```lean
+(actualizedPortGraphOf state).PortLinear
+```
+
+either inside `wellFormedGraphState` or as a field of `SafePulseRunState`.
+
+**Why it matters:** Parser/compiler checks are not enough once admitted runtime rewrites exist.
+Runtime materialization must preserve the same linear endpoint discipline that source Wire enforces.
+
+**Next step:** Prefer widening the safe-state predicate after the projection exists. Avoid a
+parallel sibling preservation chain; it would institutionalize drift between safety and linearity.
+
+### [P4] `*` is not an exception to linearity; it is the explicit linear adapter
+
+**Category:** Terminology Gap **Status:** Observed **Confidence:** High **Surfaced by:** Logos,
+Kritikos **Primary evidence:** ADR 0049 "defining equivalence" and "Canonical rule"; ADR 0047 linear
+endpoint rule **Cross-reference:** ADR 0047 ↔ ADR 0049.
+
+ADR 0049's `*` operator inserts an explicit phantom record↔ports adapter:
+
+```text
+a * b ≡ a => phantom => b
+```
+
+Both edges are ordinary `=>` boundary contractions. The multi-side ports are ordinary
+cardinality-one ports; the singular side is a nominal record port. Therefore `*` does not add
+copying, implicit aggregation, or hypergraph-style Frobenius structure. It preserves linearity by
+making the aggregation/scatter node explicit.
+
+**Why it matters:** This is the clean explanation for why Cortex can be strict about copying while
+still ergonomic. The language has no implicit contraction; it has explicit construction of fresh
+nodes and explicit structural adapters.
+
+**Next step:** In ADR 0049 and the language guide, keep saying "phantom adapter" rather than
+"fan-out" when precision matters. "Fan" is acceptable as authoring vocabulary, but proof prose
+should call it a record↔ports adapter.
+
+### [P5] SMC/string diagrams are useful framing, but port graphs/open graphs are the closer source model
+
+**Category:** Novel Idea **Status:** Inferred **Confidence:** Medium **Surfaced by:** Poiesis,
+Episteme **Primary evidence:** Joyal-Street string-diagram literature; port graph rewriting and
+PORGY; structured cospans for open systems **Cross-reference:** Architecture ↔ literature.
+
+Symmetric monoidal categories and string diagrams are useful paper language for parallel and
+sequential composition without copying. But Wire source has named ports, partial frontier exposure,
+static rejection, and runtime admission. That makes it closer to port graphs and open graph
+composition than to a plain SMC term calculus.
+
+Structured cospans supply a well-known framework for open networks with inputs and outputs.
+Port-graph rewriting supplies a graph-rewriting tradition that already treats ports as explicit
+connection sites. Both are closer to ADR 0047's frontier-resource model than unqualified "plain
+SMC."
+
+**Why it matters:** The literature framing determines whether reviewers see Cortex as inventing a
+bespoke graph language or refining known open-network and port-graph semantics for durable execution
+and admitted rewrites.
+
+**Next step:** For Paper A, use:
+
+```text
+linear port graphs / open graphs for the source layer
+Mokhov algebra for relation lowering
+SMC/string diagrams for intuition and coherence framing
+```
+
+Do not lead with "Wire is a plain SMC" without the port-layer qualification.
+
+### [P6] Chapter 03 currently risks overstating Wire's inheritance of Mokhov laws
+
+**Category:** ADR Drift **Status:** Observed **Confidence:** High **Surfaced by:** Kritikos, Themis
+**Primary evidence:** Architecture chapter 03 "Wire's `<>` and `=>` as refinements"; ADR 0047
+"linear endpoint rule" **Cross-reference:** Architecture ↔ ADRs.
+
+Chapter 03 says Wire's `<>` and `=>` correspond to Mokhov primitives and preserve laws "where they
+matter." After ADR 0047, that statement needs a sharper boundary: source Wire is port-linear, and
+Mokhov laws apply after admitted lowering. The architecture chapter should not suggest that Mokhov
+distributivity is a source-language equivalence.
+
+**Why it matters:** This is the exact place future contributors will read before changing the
+compiler, formatter, or proof track. If it remains ambiguous, the same fan-out/fan-in confusion will
+recur.
+
+**Next step:** Completed by the follow-up architecture patch: Chapter 03 now states:
+
+```text
+Wire source equality is not Mokhov equality.
+Wire source lowering preserves/forgets into Mokhov relation equality.
+```
+
+## Missed Abstractions
+
+| Multiple sites                                   | Shared shape                         | Proposed name         | Cost of unifying                    |
+| ------------------------------------------------ | ------------------------------------ | --------------------- | ----------------------------------- |
+| ADR 0047 frontier, ADR 0049 phantom, Track 2 WF  | port instances plus linear use       | `LinearPortGraph`     | medium Lean slice                   |
+| Runtime materialization, selected actualization  | concrete runtime port graph          | `ActualizedPortGraph` | medium-high projection proof        |
+| Compiler rejection and runtime preservation      | no duplicated endpoint consumption   | `PortLinear`          | medium per-constructor preservation |
+| Relation topology and port-resource source layer | erase ports and retain node relation | `forgetPorts`         | small definition, harder laws       |
+
+## Claim-to-Evidence Matrix
+
+| Claim                                        | Artifact that supports it                                               | Artifact that weakens it                         | Verdict                                      |
+| -------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------------- |
+| Graph layer is Mokhov relation algebra       | `theory/Cortex/Graph/Relation.lean`, `src/Cortex/Algebra/Graph/Core.hs` | none                                             | established                                  |
+| Wire source is linear in endpoints           | ADR 0047, Wire reference cardinality text                               | older ADR 0028 wording prior to amendment        | active proposed correction                   |
+| Wire directly inherits Mokhov distributivity | older Chapter 03 phrasing                                               | `down` counterexample under ADR 0047             | reject at source layer                       |
+| `*` introduces a copying/fan-out primitive   | informal word "fan"                                                     | ADR 0049 phantom-insertion and ordinary `=>` use | reject; `*` is explicit adapter construction |
+| Runtime states preserve port linearity       | desired Track 2 proposal                                                | no current projection theorem                    | target, not yet proved                       |
+
+## Design Tensions
+
+### Source ergonomics vs. linear resource discipline
+
+Authors want compact expressions such as:
+
+```wire
+make(8, worker) * summarize
+```
+
+The system wants no implicit copying. The resolution is explicit construction: `make` creates fresh
+node identities; `*` creates an explicit adapter node. Ergonomics should come from visible
+constructors, not hidden graph contraction.
+
+### Mokhov algebra elegance vs. Wire source correctness
+
+Mokhov's laws are elegant and mechanically useful. But Wire source has more structure than a vertex
+relation. Treat Mokhov as the lowered relation layer, not as the source equality theory. This keeps
+both benefits: source linearity and relation-level algebraic reasoning.
+
+### Paper simplicity vs. accurate categorical placement
+
+"Wire is a symmetric monoidal category" is memorable but incomplete. "Wire source is a port-linear
+open graph calculus that forgets to a Mokhov relation algebra" is longer but accurate. The paper can
+use SMC/string-diagram language for intuition while keeping port graphs/open graphs as the formal
+source model.
+
+## Novel Ideas & Hypotheses
+
+- **Forgetful lowering as a theorem boundary** - Treat source-to-relation lowering as a named
+  forgetful map between equational theories. **Validation path:** define `forgetPorts` in Lean and
+  prove that admitted overlay/connect steps commute with relation denotation.
+- **Runtime actualization as port-graph projection** - Make `actualizedPortGraphOf` the bridge from
+  Pulse state to the source-layer invariant. **Validation path:** start with fixed topology, then
+  extend to constructed rewrites and selected actualization.
+- **Paper contribution statement** - Frame Cortex as "linear port-graph admission with durable
+  rewrite preservation, lowering to Mokhov relation topology." **Validation path:** draft Paper A
+  section and compare reviewer-legibility against port-graph / open-systems literature.
+
+## Dead Ends / Rejected Directions
+
+- **Replace Mokhov with plain SMC.** Rejected. It loses the existing relation-level theorem base and
+  does not account for named frontiers, partial exposure, static rejection, or runtime projection.
+- **Let Mokhov distributivity be a Wire source rewrite.** Rejected. It duplicates operands and
+  violates ADR 0047 linearity.
+- **Model `*` as hidden fan-out.** Rejected. ADR 0049 deliberately inserts a visible adapter node;
+  hidden copying would undermine the whole frontier-resource story.
+
+## Recommended Actions
+
+### Act now
+
+- [x] Patch Chapter 03 to state the two-layer theory explicitly. Owner: architecture/docs. Cost: S.
+- [x] Adjust ADR 0047 wording that says Mokhov distributivity "does the rest"; precedence parses the
+      expression, endpoint linearity admits or rejects it. Owner: architecture/docs. Cost: S.
+
+### Design next
+
+- [ ] Draft the proof/runtime ADR for `LinearPortGraph`, `ActualizedPortGraph`, `PortLinear`,
+      `forgetPorts`, and `actualizedPortGraphOf`. Owner: architecture + lean-theorem-attack. Cost:
+      M.
+- [ ] Plan the Lean slice that first defines the carrier and forgetful map, before widening
+      `SafePulseRunState`. Owner: lean-code-style / theorem track. Cost: M.
+
+### Write up
+
+- [ ] Add a Paper A subsection: "Two Equational Theories: Linear Port Graphs and Relation Graphs."
+- [ ] Cite port-graph rewriting / PORGY for port-based graph rewriting, structured cospans for open
+      networks, Joyal-Street for string-diagram intuition, and Mokhov for relation-level algebra.
+
+### Parked
+
+- Bounded homogeneous list contracts for `*`. Defer until record-form adapter proves insufficient.
+- Full categorical completeness theorem. Defer until the Lean port-graph layer exists.
+
+## Known Unknowns
+
+| Unknown                                                            | Why it matters                                         | Validation path                                     |
+| ------------------------------------------------------------------ | ------------------------------------------------------ | --------------------------------------------------- |
+| Whether existing record contracts are nominal enough for ADR 0049  | `*` depends on field labels from nominal record shapes | implement small contract-surface prototype          |
+| Whether runtime exposes total executor-port projection             | `actualizedPortGraphOf` needs port instances per node  | inspect compiler/runtime projection data structures |
+| Whether `PortLinear` belongs in `wellFormedGraphState` or wrapper  | affects proof churn and paper alignment                | draft both theorem signatures before implementation |
+| How much structured-cospan machinery is worth importing into prose | avoids overclaiming categorical novelty                | focused literature pass before Paper A              |
+
+## External Anchors
+
+- Andrey Mokhov, [_Algebraic Graphs with Class_](https://eprints.ncl.ac.uk/239461), Haskell
+  Symposium 2017. Algebraic graph construction and equational reasoning over relation-like
+  denotations.
+- PORGY, [_Strategic Port Graph Rewriting_](https://porgy.labri.fr/), and related work by Fernández,
+  Kirchner, Pinaud, Andrei, and collaborators. Explicit ports and rewriting strategies over graph
+  states.
+- John C. Baez and Kenny Courser, [_Structured Cospans_](https://arxiv.org/abs/1911.04630), Theory
+  and Applications of Categories 2020. Open systems with input/output boundaries and symmetric
+  monoidal structure.
+- André Joyal and Ross Street,
+  [_The Geometry of Tensor Calculus, I_](https://researchers.mq.edu.au/en/publications/the-geometry-of-tensor-calculus-i/),
+  Advances in Mathematics 1991. String diagrams and monoidal-categorical graphical reasoning.
+
+## Related
+
+- [Formalism stack synthesis](2026-04-11-formalism-stack-synthesis.md)
+- [../../Architecture/03-formalism-stack.md](../../Architecture/03-formalism-stack.md)
+- [../../Architecture/04-graph-and-circuit.md](../../Architecture/04-graph-and-circuit.md)
+- [../../Architecture/05-wire-language.md](../../Architecture/05-wire-language.md)
+- [../../ADRs/0047-wire-frontier-linearity-and-precedence.md](../../ADRs/0047-wire-frontier-linearity-and-precedence.md)
+- [../../ADRs/0048-wire-make-bounded-node-generation.md](../../ADRs/0048-wire-make-bounded-node-generation.md)
+- [../../ADRs/0049-wire-fan-phantom-adapter.md](../../ADRs/0049-wire-fan-phantom-adapter.md)

--- a/docs/Research-notes/Foundation/index.md
+++ b/docs/Research-notes/Foundation/index.md
@@ -16,6 +16,7 @@ Substrate-layer research synthesis: formalism, algebraic structure, and coordina
 | ---------- | -------------------------------------------------------------------------------------------------------------------- |
 | 2026-04-11 | [Formalism stack synthesis](2026-04-11-formalism-stack-synthesis.md)                                                 |
 | 2026-04-24 | [CALM and coordination boundaries on evolving graphs](2026-04-24-calm-coordination-boundaries-on-evolving-graphs.md) |
+| 2026-05-05 | [Linear port graph layer](2026-05-05-linear-port-graph-layer.md)                                                     |
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Splits the previously-combined fan-topology design into three ADRs: **0047** (frontier linearity, match determinism, precedence ladder), **0048** (`make(N, K)` bounded node generation), and **0049** (`*` operator as a phantom record↔ports adapter).
- Formally amends **ADR 0028** by retiring its parens-when-mixing rule and pinning the linear endpoint rule (one output → at most one input, one input ← at most one output, no implicit clone).
- Documents the two-equational-theory split between Wire's linear-port source layer and the lowered Mokhov relation layer across architecture chapters 01–06, the Wire reference (`grammar.md`, `contracts-ports-and-matching.md`), and a new research memo (`2026-05-05-linear-port-graph-layer`). ADRs 0024 and 0043 are amended to track the linear-port framing and the ephemeral/durable Pulse profile split.

## Test plan

- [x] \`just docs-check\` passes
- [x] \`just docs-lint\` passes (141 docs/Markdown artifacts)
- [x] \`just check-commit-provenance origin/main..HEAD\` passes
- [ ] Reviewer pass on ADR cross-references and amendment language (0024/0028/0043/0047 ↔ 0048/0049)
- [ ] Reviewer pass on architecture ch. 03/04 for the linear-port-graph framing and the rejected-example exposition
- [ ] Reviewer pass on the research memo for paper-shape suitability