### PR TITLE
fix(nix): improve macOS flake compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,9 +45,11 @@
     ...
   }:
     flake-parts.lib.mkFlake {inherit inputs;} {
-      # Initial scaffold targets only x86_64-linux. Additional systems can
-      # be added once the Haskell layer is exercised there too.
-      systems = ["x86_64-linux"];
+      systems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
 
       imports = [
         inputs.treefmt-nix.flakeModule

--- a/nix/quantum.nix
+++ b/nix/quantum.nix
@@ -1,14 +1,17 @@
-{...}: {
+{lib, ...}: {
   perSystem = {
     config,
     pkgs,
     ...
   }: let
+    qiskitAer = pkgs.python313Packages.qiskit-aer;
+    qiskitSupported = !(qiskitAer.meta.broken or false);
+
     qiskitPython =
       pkgs.python313.withPackages
       (ps: [
         ps.qiskit
-        ps.qiskit-aer
+        qiskitAer
       ]);
 
     wire-quantum-qiskit = pkgs.writeShellApplication {
@@ -57,34 +60,40 @@
       '';
     };
   in {
-    packages = {
-      wire-quantum-qiskit = wire-quantum-qiskit;
-      wire-quantum-ibm-rest = wire-quantum-ibm-rest;
-      wire-quantum-ipea = wire-quantum-ipea;
-      wire-quantum-eraser = wire-quantum-eraser;
-    };
+    packages =
+      {
+        wire-quantum-ibm-rest = wire-quantum-ibm-rest;
+        wire-quantum-eraser = wire-quantum-eraser;
+      }
+      // lib.optionalAttrs qiskitSupported {
+        wire-quantum-qiskit = wire-quantum-qiskit;
+        wire-quantum-ipea = wire-quantum-ipea;
+      };
 
-    apps = {
-      wire-quantum-qiskit = {
-        type = "app";
-        program = "${wire-quantum-qiskit}/bin/wire-quantum-qiskit";
-        meta.description = "Run Wire quantum examples through a local Qiskit Aer simulator";
+    apps =
+      {
+        wire-quantum-ibm-rest = {
+          type = "app";
+          program = "${wire-quantum-ibm-rest}/bin/wire-quantum-ibm-rest";
+          meta.description = "Submit Wire quantum examples to IBM Quantum Runtime REST";
+        };
+        wire-quantum-eraser = {
+          type = "app";
+          program = "${wire-quantum-eraser}/bin/wire-quantum-eraser";
+          meta.description = "Run the delayed-choice quantum eraser Wire sweep on IBM Runtime REST hardware";
+        };
+      }
+      // lib.optionalAttrs qiskitSupported {
+        wire-quantum-qiskit = {
+          type = "app";
+          program = "${wire-quantum-qiskit}/bin/wire-quantum-qiskit";
+          meta.description = "Run Wire quantum examples through a local Qiskit Aer simulator";
+        };
+        wire-quantum-ipea = {
+          type = "app";
+          program = "${wire-quantum-ipea}/bin/wire-quantum-ipea";
+          meta.description = "Run iterative phase estimation as composed Wire quantum rounds";
+        };
       };
-      wire-quantum-ibm-rest = {
-        type = "app";
-        program = "${wire-quantum-ibm-rest}/bin/wire-quantum-ibm-rest";
-        meta.description = "Submit Wire quantum examples to IBM Quantum Runtime REST";
-      };
-      wire-quantum-ipea = {
-        type = "app";
-        program = "${wire-quantum-ipea}/bin/wire-quantum-ipea";
-        meta.description = "Run iterative phase estimation as composed Wire quantum rounds";
-      };
-      wire-quantum-eraser = {
-        type = "app";
-        program = "${wire-quantum-eraser}/bin/wire-quantum-eraser";
-        meta.description = "Run the delayed-choice quantum eraser Wire sweep on IBM Runtime REST hardware";
-      };
-    };
   };
 }


### PR DESCRIPTION
## Summary

This PR improves macOS flake compatibility by exposing Darwin systems in the flake and avoiding evaluation of Qiskit Aer-backed outputs on platforms where nixpkgs marks `python313Packages.qiskit-aer` as broken.

## Why

Adding Darwin systems caused `nix flake check` on macOS to enumerate `packages.aarch64-darwin.wire-quantum-qiskit`. That package pulled in `python3.13-qiskit-aer-0.17.2`, which nixpkgs currently marks as broken on Darwin, so evaluation stopped before the rest of the flake could be checked.

## Changes

- Adds `aarch64-darwin` and `x86_64-darwin` to the flake systems list.
- Checks `pkgs.python313Packages.qiskit-aer.meta.broken` before exporting Aer-backed quantum packages and apps.
- Keeps IBM REST/hardware quantum apps available on Darwin because they do not depend on Qiskit Aer.

## Validation

- `nix fmt nix/quantum.nix`
- `nix flake check --no-build`
- Commit hook `treefmt` passed during commit

A full `nix flake check` was started locally and moved past the original Qiskit Aer evaluator failure, but it was stopped after several minutes while compiling large unrelated Lean/Haskell checks.