### PR TITLE
docs: add executable diagrams submission

### DIFF
--- a/docs/Publications/Paper-6-executable-diagrams/Figures/dashboard-topology-module.typ
+++ b/docs/Publications/Paper-6-executable-diagrams/Figures/dashboard-topology-module.typ
@@ -1,0 +1,80 @@
+#let diagram-ink = rgb("#172033")
+#let diagram-muted = rgb("#596577")
+#let diagram-rule = rgb("#b8c2d0")
+#let diagram-fill = rgb("#f8fafc")
+#let diagram-pure-fill = rgb("#eef5f0")
+#let diagram-edge = rgb("#596577")
+#let diagram-profile-edge = rgb("#304f8f")
+#let diagram-label-bg = rgb("#ffffff")
+
+#let dashboard-topology() = {
+  let diagram-node(body, width: 19mm, fill: diagram-fill) = box(
+    width: width,
+    height: 8.8mm,
+    inset: 2pt,
+    fill: fill,
+    stroke: 0.45pt + diagram-rule,
+    radius: 1.4pt,
+    align(center + horizon, text(size: 6.15pt, fill: diagram-ink, body)),
+  )
+
+  let node(x, y, body, width: 19mm, fill: diagram-fill) = place(
+    top + left,
+    dx: x,
+    dy: y,
+  )[#diagram-node(body, width: width, fill: fill)]
+
+  let edge(x1, y1, x2, y2, angle: 0deg, ink: diagram-edge, width: 0.55pt) = {
+    place(top + left, dx: x1, dy: y1)[
+      #line(start: (0mm, 0mm), end: (x2 - x1, y2 - y1), stroke: width + ink)
+    ]
+    place(top + left, dx: x2, dy: y2)[
+      #rotate(angle)[#polygon(
+        (0pt, 0pt),
+        (-3.3pt, -1.7pt),
+        (-3.3pt, 1.7pt),
+        fill: ink,
+      )]
+    ]
+  }
+
+  let label(x, y, body, fill: diagram-label-bg) = place(
+    top + left,
+    dx: x,
+    dy: y,
+  )[
+    #box(
+      inset: (x: 1.4pt, y: 0.4pt),
+      fill: fill,
+      align(center, text(size: 5.75pt, fill: diagram-muted, body)),
+    )
+  ]
+
+  align(center)[
+    #box(width: 148mm, height: 45mm)[
+      #node(0mm, 18mm)[receive\ request]
+      #node(23mm, 18mm)[fetch\ user]
+      #node(46mm, 18mm, width: 23mm, fill: diagram-pure-fill)[prepare\ dashboard]
+      #node(78mm, 3mm, width: 20mm)[fetch\ posts]
+      #node(78mm, 33mm, width: 20mm)[fetch\ friends]
+      #node(108mm, 18mm)[assemble]
+      #node(131mm, 18mm, width: 17mm)[respond]
+
+      #edge(19mm, 22.4mm, 23mm, 22.4mm)
+      #edge(42mm, 22.4mm, 46mm, 22.4mm)
+      #edge(69mm, 19.7mm, 78mm, 7.4mm, angle: -35deg)
+      #edge(69mm, 25.1mm, 78mm, 37.4mm, angle: 35deg)
+      #edge(69mm, 22.4mm, 108mm, 22.4mm, ink: diagram-profile-edge, width: 0.7pt)
+      #edge(98mm, 7.4mm, 108mm, 20.1mm, angle: 35deg)
+      #edge(98mm, 37.4mm, 108mm, 24.7mm, angle: -35deg)
+      #edge(127mm, 22.4mm, 131mm, 22.4mm)
+
+      #label(31mm, 14.4mm)[user]
+      #label(70mm, 8.9mm)[posts_req]
+      #label(68.4mm, 31.1mm)[friends_req]
+      #label(85.6mm, 18.9mm, [profile], fill: rgb("#f6f8ff"))
+      #label(100.5mm, 10.9mm)[posts]
+      #label(99.2mm, 30.8mm)[friends]
+    ]
+  ]
+}

--- a/docs/Publications/Paper-6-executable-diagrams/Figures/dashboard-topology.mmd
+++ b/docs/Publications/Paper-6-executable-diagrams/Figures/dashboard-topology.mmd
@@ -1,0 +1,9 @@
+flowchart LR
+    receive_request["receive_request"] --> fetch_user["fetch_user"]
+    fetch_user --> prepare_dashboard["prepare_dashboard"]
+    prepare_dashboard -- "posts_req" --> fetch_posts["fetch_posts"]
+    prepare_dashboard -- "friends_req" --> fetch_friends["fetch_friends"]
+    prepare_dashboard -- "profile" --> assemble["assemble"]
+    fetch_posts -- "posts" --> assemble
+    fetch_friends -- "friends" --> assemble
+    assemble --> respond["respond"]

--- a/docs/Publications/Paper-6-executable-diagrams/Figures/dashboard-topology.typ
+++ b/docs/Publications/Paper-6-executable-diagrams/Figures/dashboard-topology.typ
@@ -1,0 +1,13 @@
+#import "dashboard-topology-module.typ": dashboard-topology
+
+#set page(width: 170mm, height: 62mm, margin: 5mm)
+#set text(font: "Libertinus Serif", size: 8pt)
+
+#dashboard-topology()
+
+#align(center)[
+  #text(size: 7.3pt)[
+    #emph[Figure 1:] Dashboard topology after admission. The `profile` endpoint is carried directly
+    from `prepare_dashboard` to `assemble`.
+  ]
+]

--- a/docs/Publications/Paper-6-executable-diagrams/Figures/executable-diagram-layers-module.typ
+++ b/docs/Publications/Paper-6-executable-diagrams/Figures/executable-diagram-layers-module.typ
@@ -1,0 +1,73 @@
+#let diagram-ink = rgb("#172033")
+#let diagram-muted = rgb("#596577")
+#let diagram-rule = rgb("#b8c2d0")
+#let diagram-fill = rgb("#f8fafc")
+#let diagram-proof-fill = rgb("#eef5f0")
+
+#let executable-diagram-layers() = {
+  let diagram-node(body, fill: diagram-fill) = box(
+    width: 25mm,
+    height: 11.5mm,
+    inset: 3pt,
+    fill: fill,
+    stroke: 0.45pt + diagram-rule,
+    radius: 1.4pt,
+    align(center + horizon, text(size: 7.3pt, fill: diagram-ink, body)),
+  )
+
+  let node(x, y, body, fill: diagram-fill) = place(
+    top + left,
+    dx: x,
+    dy: y,
+  )[#diagram-node(body, fill: fill)]
+
+  let arrow(x, y) = place(
+    top + left,
+    dx: x,
+    dy: y,
+  )[#box(width: 6mm, align(center)[#text(size: 7.4pt, fill: diagram-muted)[->]])]
+
+  let dotted(x, y, width, label) = place(
+    top + left,
+    dx: x,
+    dy: y,
+  )[
+    #box(
+      width: width,
+      align(center)[#text(size: 6.6pt, fill: diagram-muted)[#label]],
+    )
+  ]
+
+  let y-top = 0mm
+  let y-arrow = 4.6mm
+  let y-proof = 20mm
+
+  let x-source = 0mm
+  let x-linear = 31mm
+  let x-relation = 62mm
+  let x-circuit = 93mm
+  let x-runtime = 124mm
+  let x-arrow-a = 25mm
+  let x-arrow-b = 56mm
+  let x-arrow-c = 87mm
+  let x-arrow-d = 118mm
+  let x-proof = 31mm
+
+  align(center)[
+    #box(width: 150mm, height: 34mm)[
+      #node(x-source, y-top)[Source diagram\ causal expression]
+      #arrow(x-arrow-a, y-arrow)
+      #node(x-linear, y-top)[Admitted frontier\ typed resources]
+      #arrow(x-arrow-b, y-arrow)
+      #node(x-relation, y-top)[Causal topology\ port-erased graph]
+      #arrow(x-arrow-c, y-arrow)
+      #node(x-circuit, y-top)[Circuit\ executable artifact]
+      #arrow(x-arrow-d, y-arrow)
+      #node(x-runtime, y-top)[Runtime trace\ schedule, replay]
+
+      #node(x-proof, y-proof, fill: diagram-proof-fill)[Proof IR\ accepted objects]
+      #dotted(5mm, 16mm, 51mm, [correspondence obligations])
+      #dotted(55mm, 16mm, 55mm, [names post-elaboration objects])
+    ]
+  ]
+}

--- a/docs/Publications/Paper-6-executable-diagrams/Figures/executable-diagram-layers.mmd
+++ b/docs/Publications/Paper-6-executable-diagrams/Figures/executable-diagram-layers.mmd
@@ -1,0 +1,8 @@
+flowchart LR
+    S["Source diagram<br/>causal expression"] --> L["Admitted frontier<br/>typed resources"]
+    L --> G["Causal topology<br/>port-erased graph"]
+    L --> C["Circuit<br/>executable artifact"]
+    G --> C
+    C --> R["Runtime trace<br/>schedule, replay"]
+    P["Proof IR<br/>accepted objects"] -. "names post-elaboration objects" .- L
+    P -. "correspondence obligations" .- S

--- a/docs/Publications/Paper-6-executable-diagrams/Figures/executable-diagram-layers.typ
+++ b/docs/Publications/Paper-6-executable-diagrams/Figures/executable-diagram-layers.typ
@@ -1,0 +1,13 @@
+#import "executable-diagram-layers-module.typ": executable-diagram-layers
+
+#set page(width: 170mm, height: 52mm, margin: 5mm)
+#set text(font: "Libertinus Serif", size: 8pt)
+
+#executable-diagram-layers()
+
+#align(center)[
+  #text(size: 7.3pt)[
+    #emph[Figure 2:] Wire's causal diagram layers and the proof-facing IR's relation to the
+    admitted frontier.
+  ]
+]

--- a/docs/Publications/Paper-6-executable-diagrams/Figures/index.md
+++ b/docs/Publications/Paper-6-executable-diagrams/Figures/index.md
@@ -1,0 +1,38 @@
+---
+title: "Paper 6 Figures"
+description:
+  Figure inventory and export status for the Executable Causal Diagrams with Typed Linear Frontiers
+  draft.
+sidebar:
+  label: Figures
+  order: 2
+status: draft
+date: 2026-05-08
+updated: 2026-05-13
+related:
+  - docs/Publications/Paper-6-executable-diagrams/manuscript.md
+  - docs/Publications/Paper-6-executable-diagrams/index.md
+---
+
+# Paper 6 Figures
+
+## Sources
+
+- [dashboard-topology.mmd](dashboard-topology.mmd) - admitted dashboard topology with the carried
+  `profile` dependency and the two branch-local fetch paths.
+- [dashboard-topology-module.typ](dashboard-topology-module.typ) - reusable Typst figure body
+  imported by the manuscript and standalone figure export.
+- [dashboard-topology.typ](dashboard-topology.typ) - PDF-oriented Typst source for the dashboard
+  topology figure.
+- [executable-diagram-layers.mmd](executable-diagram-layers.mmd) - source diagram, admitted
+  frontier, causal topology, circuit, runtime trace, and proof-facing IR as one layered view.
+- [executable-diagram-layers-module.typ](executable-diagram-layers-module.typ) - reusable Typst
+  figure body imported by the manuscript and standalone figure export.
+- [executable-diagram-layers.typ](executable-diagram-layers.typ) - PDF-oriented Typst source for the
+  same figure.
+
+## Export Status
+
+- Mermaid source is checked in.
+- Typst source is checked in for standalone figures and manuscript figures.
+- Publication renderings are produced through the Typst manuscript's Nix output.

--- a/docs/Publications/Paper-6-executable-diagrams/index.md
+++ b/docs/Publications/Paper-6-executable-diagrams/index.md
@@ -1,0 +1,95 @@
+---
+title: "Paper 6 - Executable Causal Diagrams with Typed Linear Frontiers"
+description:
+  Landing page for the Executable Causal Diagrams with Typed Linear Frontiers draft. Abstract,
+  status, figures, and related material for the frontier-transformer causal pipeline framing.
+sidebar:
+  label: Paper 6
+  order: 6
+status: draft
+date: 2026-05-08
+updated: 2026-05-13
+related:
+  - docs/Publications/Paper-2-algebraic-foundations/
+  - docs/Publications/Paper-3-graph-substitution-semantics/
+  - docs/Publications/Paper-4-wire-language/
+  - docs/Architecture/04-graph-and-circuit.md
+  - docs/Architecture/05-wire-language.md
+  - docs/Reference/proof-status.md
+  - docs/Reference/Wire/style.md
+  - docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
+  - docs/ADRs/0049-wire-fan-phantom-adapter.md
+  - docs/ADRs/0052-wire-bounded-indexed-boundary-products.md
+  - examples/wire/dashboard-request.wire
+  - theory/Cortex/Wire/ElaborationIR.lean
+---
+
+# Paper 6 - Executable Causal Diagrams with Typed Linear Frontiers
+
+This draft frames Wire as executable causal diagram syntax: `<>` forms incomparable frontiers, `=>`
+consumes compatible endpoint pairs while carrying unmatched endpoints forward, and named typed ports
+determine which observations may cross the composed boundary. Typed linear frontiers provide the
+accounting discipline for that diagram.
+
+## Status
+
+Draft manuscript. See [manuscript.md](manuscript.md) for the Markdown text and
+[typst/manuscript.typ](typst/manuscript.typ) for the submission-ready PDF source registered as a Nix
+docs output. The PDF uses the shared profile-driven Cortex submission template under
+`docs/Publications/_typst/`.
+
+Public artifact context is available through the
+[Cortex documentation](https://digimuoto.github.io/cortex/) and the
+[proof-status dashboard](https://digimuoto.github.io/cortex/Reference/proof-status/), the live
+source of truth for current Lean mechanization and Haskell correspondence.
+
+## Abstract
+
+Wire is a source language for executable causal diagrams. Its surface is a typed
+frontier-transformer calculus: `<>` forms incomparable frontier union, `=>` consumes compatible
+endpoint pairs and carries unmatched endpoints forward, and typed ports decide which observations
+may cross the composed boundary. The draft uses an async dashboard diamond as its canonical example:
+fetch a user, derive distinct branch facts in CorePure (Wire's deterministic expression layer),
+fetch posts and friends independently, carry the profile fact directly to the join, then assemble
+the response. In host languages the diamond is a property of execution; in Wire the admitted diagram
+is the shared object. The Cortex artifact aligns algebraic graph syntax, source elaboration, circuit
+lowering to Pulse, Cortex's durable runtime, proof-track admission slices, and a Lean-facing
+post-elaboration IR. The public proof-status dashboard links the relevant Lean declarations and
+distinguishes proven claims, runtime hooks, tests, witnesses, and remaining correspondence
+obligations.
+
+## Figures
+
+- [Figures/index.md](Figures/index.md) - figure inventory and export status.
+- [dashboard-topology.mmd](Figures/dashboard-topology.mmd) - admitted dashboard topology with the
+  carried `profile` dependency.
+- [dashboard-topology-module.typ](Figures/dashboard-topology-module.typ) - reusable Typst figure
+  body used by the manuscript.
+- [executable-diagram-layers.mmd](Figures/executable-diagram-layers.mmd) - source diagram, admitted
+  frontier, causal topology, circuit, runtime trace, and proof-facing IR as one layered view.
+- [executable-diagram-layers-module.typ](Figures/executable-diagram-layers-module.typ) - reusable
+  Typst figure body used by the manuscript.
+- [executable-diagram-layers.typ](Figures/executable-diagram-layers.typ) - standalone Typst export
+  for the same figure.
+
+## Related
+
+- [manuscript.md](manuscript.md) - full draft.
+- [typst/manuscript.typ](typst/manuscript.typ) - submission-ready Typst manuscript.
+- [../../../examples/wire/dashboard-request.wire](../../../examples/wire/dashboard-request.wire) -
+  build-backed canonical Wire example.
+- [../../Reference/proof-status.md](../../Reference/proof-status.md) - Lean proof and Haskell
+  correspondence status dashboard.
+- [../Paper-2-algebraic-foundations/](../Paper-2-algebraic-foundations/) - algebraic substrate.
+- [../Paper-3-graph-substitution-semantics/](../Paper-3-graph-substitution-semantics/) - dynamic
+  substitution and materialization semantics.
+- [../Paper-4-wire-language/](../Paper-4-wire-language/) - Wire as an authoring language.
+- [../../Architecture/04-graph-and-circuit.md](../../Architecture/04-graph-and-circuit.md) -
+  topology layers below Wire.
+- [../../Reference/Wire/style.md](../../Reference/Wire/style.md) - topology-first formatting rules.
+- [../../ADRs/0047-wire-frontier-linearity-and-precedence.md](../../ADRs/0047-wire-frontier-linearity-and-precedence.md)
+  - linear frontier semantics.
+- [../../ADRs/0049-wire-fan-phantom-adapter.md](../../ADRs/0049-wire-fan-phantom-adapter.md) - `*`
+  as an explicit phantom adapter.
+- [../../ADRs/0052-wire-bounded-indexed-boundary-products.md](../../ADRs/0052-wire-bounded-indexed-boundary-products.md)
+  - bounded indexed products and finite-product adapters.

--- a/docs/Publications/Paper-6-executable-diagrams/manuscript.md
+++ b/docs/Publications/Paper-6-executable-diagrams/manuscript.md
@@ -1,0 +1,307 @@
+---
+title: "Executable Causal Diagrams with Typed Linear Frontiers"
+description:
+  Draft abstract on Wire as a frontier-transformer language where authored topology, durable runtime
+  replay, and proof-facing admission obligations refer to the same diagrammatic object.
+kind: publication
+status: draft
+authors:
+  - Julius Koskela
+date: 2026-05-08
+updated: 2026-05-13
+related:
+  - docs/Publications/Paper-2-algebraic-foundations/
+  - docs/Publications/Paper-3-graph-substitution-semantics/
+  - docs/Publications/Paper-4-wire-language/
+  - docs/Publications/Paper-5-Causal-Programming/
+  - docs/Architecture/04-graph-and-circuit.md
+  - docs/Architecture/05-wire-language.md
+  - docs/Architecture/06-pulse-runtime.md
+  - docs/Reference/proof-status.md
+  - docs/Reference/Wire/grammar.md
+  - docs/Reference/Wire/style.md
+  - docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
+  - docs/ADRs/0049-wire-fan-phantom-adapter.md
+  - docs/ADRs/0051-wire-source-includes-and-item-generation.md
+  - docs/ADRs/0052-wire-bounded-indexed-boundary-products.md
+  - examples/wire/dashboard-request.wire
+  - theory/Cortex/Wire/ElaborationIR.lean
+  - theory/Cortex/Wire/GeneratedForms.lean
+  - theory/Cortex/Wire/PhantomAdapter.lean
+  - theory/Cortex/Wire/PortLinearity.lean
+documentation: https://digimuoto.github.io/cortex/
+---
+
+# Executable Causal Diagrams with Typed Linear Frontiers
+
+Wire makes a source program elaborate to the causal diagram scheduled, replayed, and explained by
+the runtime. The admitted diagram records which events depend on prior observations, which events
+are incomparable, and which typed values cross between them. Wire turns Lamport's partial-order view
+of distributed execution [\[1\]](#ref-1) into an authoring discipline for executable artifacts.
+
+Conventional source forms tend to hide that structure. Imperative programs are ordered vectors of
+effects: a later read is meaningful only because the program counter supplies an ordered prefix.
+Pure functional `let` expressions move closer to named records of dependencies, but effectful
+programs usually regain a linear spine unless the author adds a separate parallel or applicative
+structure. Wire makes the next step explicit. A graph expression is read as a typed frontier
+transformer: `<>` unions incomparable boundary fragments, and `=>` matches compatible output-input
+endpoints while carrying unmatched endpoints forward. A written pipeline is therefore not a sequence
+of barriers; it is a compact description of a partial order.
+
+A dashboard request illustrates the gap:
+
+```python
+async def dashboard(uid):
+    user = await fetch_user(uid)
+    posts, friends = await asyncio.gather(
+        fetch_posts(user.id),
+        fetch_friends(user.id),
+    )
+    return assemble(user, posts, friends)
+```
+
+A human reads this as a causal diamond: fetch the user, fetch posts and friends independently, then
+assemble. `asyncio.gather` exposes part of that structure, but the source language's primary object
+is still the executing coroutine rather than an admitted typed topology. Distributed tracing
+reconstructs a DAG from spans after the fact. Durable workflow runtimes can journal and replay
+`await` points, but they recover topology from runtime behavior because the host language did not
+expose the causal object directly.
+
+In Wire, the diamond is authored directly rather than inferred from spans, continuations, or runtime
+heuristics. Durable replay and provenance refer to the admitted diagram: recovery resumes from a
+recorded causal prefix, and audit trails can point to named nodes and typed edges instead of
+reconstructed traces outside the language.
+
+## The Dashboard Diamond in Wire
+
+The same request can be authored as a typed causal diagram. Contracts are nominal boundary
+interfaces, not first-class CorePure values. Wire's pure expression sublanguage, CorePure, computes
+JSON-shaped payloads; contracts classify the ports through which those payloads enter and leave the
+diagram. The `@` form is Wire's effect boundary: network calls, storage, model calls, tools, and
+other host effects stay behind registered executors, while deterministic payload shaping can stay in
+Wire. Pulse, Cortex's durable runtime, journals outcomes for those executor nodes over the admitted
+topology; CorePure expressions remain deterministic boundary equations rather than hidden host
+effects.
+
+```wire
+# Registered facts that may cross node boundaries.
+contract UserId;
+contract UserProfile;
+contract ProfileSummary;
+contract PostsRequest;
+contract FriendsRequest;
+contract PostsFeed;
+contract FriendGraph;
+contract Dashboard;
+
+# Executable events and their typed input/output frontiers.
+node receive_request
+  -> uid: UserId = @http.receive_dashboard_request ({});
+
+node fetch_user
+  <- uid: UserId;
+  -> user: UserProfile = @http.fetch_user (uid);
+
+node prepare_dashboard
+  <- user: UserProfile;
+  -> profile: ProfileSummary = {
+    id = user.id;
+    name = user.name;
+  };
+  -> posts_req: PostsRequest = {
+    user_id = user.id;
+    limit = 20;
+  };
+  -> friends_req: FriendsRequest = {
+    user_id = user.id;
+    include_mutual = true;
+  };
+
+node fetch_posts
+  <- posts_req: PostsRequest;
+  -> posts: PostsFeed = @http.fetch_posts (posts_req);
+
+node fetch_friends
+  <- friends_req: FriendsRequest;
+  -> friends: FriendGraph = @http.fetch_friends (friends_req);
+
+node assemble
+  <- profile: ProfileSummary;
+  <- posts: PostsFeed;
+  <- friends: FriendGraph;
+  -> dashboard: Dashboard = @dashboard.assemble ({
+    inherit profile posts friends;
+  });
+
+node respond
+  <- dashboard: Dashboard;
+  = @http.respond_dashboard (dashboard);
+
+# The file's graph expression: the returned executable topology.
+receive_request
+  => fetch_user
+  => prepare_dashboard
+  => fetch_posts <> fetch_friends
+  => assemble
+  => respond
+```
+
+Wire deliberately binds `<>` tighter than `=>`. The final expression therefore parses as a pipeline
+whose middle stage is `fetch_posts <> fetch_friends`, an incomparable frontier. This differs from
+the `Algebra.Graph` Haskell library convention to make the dashboard diamond readable without
+parentheses.
+
+The key node is `prepare_dashboard`. It has no `@` executor: its three output equations are CorePure
+expressions evaluated when `user` is available. The node consumes the fetched `UserProfile` once and
+produces three distinct typed facts: a profile summary for the join, a posts request for one branch,
+and a friends request for the other. CorePure is deterministic and effect-free; output wrapping then
+records the nominal contracts `ProfileSummary`, `PostsRequest`, and `FriendsRequest` at the ports.
+The parallelism is graph structure: `fetch_posts` and `fetch_friends` are incomparable after
+`prepare_dashboard`, while `assemble` is the join where their histories become comparable again.
+
+The carried `profile` endpoint is where the frontier view does real work. The branch overlay exposes
+only the inputs its operands need; it does not absorb outputs that are irrelevant to the branch. In
+`prepare_dashboard => fetch_posts <> fetch_friends`, connect consumes `posts_req` and `friends_req`,
+while `profile` remains a typed resource on the composed frontier. The later `=> assemble` consumes
+that carried endpoint together with `posts` and `friends`. At runtime this is a direct
+`prepare_dashboard -> assemble` dependency plus the two branch dependencies.
+
+```mermaid
+flowchart LR
+    receive_request["receive_request"] --> fetch_user["fetch_user"]
+    fetch_user --> prepare_dashboard["prepare_dashboard"]
+    prepare_dashboard -- "posts_req" --> fetch_posts["fetch_posts"]
+    prepare_dashboard -- "friends_req" --> fetch_friends["fetch_friends"]
+    prepare_dashboard -- "profile" --> assemble["assemble"]
+    fetch_posts -- "posts" --> assemble
+    fetch_friends -- "friends" --> assemble
+    assemble --> respond["respond"]
+```
+
+_Figure 1: Dashboard topology after admission. `profile` is carried directly from
+`prepare_dashboard` to `assemble`; branch-local requests are consumed by `fetch_posts` and
+`fetch_friends`._
+
+The direct `profile` edge does not make `assemble` ready early, because readiness is still
+conjunctive over all predecessors. It records that `profile` has no causal reason to flow through
+either branch.
+
+If the dashboard tried to wire `fetch_user` directly into two branches that both declared
+`<- user: UserProfile`, admission would reject the graph: one produced endpoint would have two
+consumers. This is a semantic rejection. A silent copy of `user` would remove the event that
+explains why two downstream observations are legitimate. The fix is to name the causal event that
+derives branch facts from one prior observation.
+
+## Linear Frontiers and Algebraic Graphs
+
+Linearity supplies the accounting discipline behind the causal reading. It is the bridge from
+Lamport's partial-order view to source authoring: fan-out without a named event destroys the causal
+explanation for why two downstream observations share a prior source. Wire refines Mokhov's algebra
+of graphs [\[2\]](#ref-2): the source skeleton still has empty diagrams, vertices, overlay, and
+connect, but vertices carry named input and output ports, and each port endpoint is a resource. The
+same boundary admits graph expressions, determines executable topology, and exposes proof
+obligations.
+
+At the node boundary, the intended invariant is small enough to state directly:
+
+$$
+\forall e \in \operatorname{OwnedPorts}(n),\quad
+\operatorname{internal}(e) + \operatorname{frontier}(e) = 1
+$$
+
+An owned endpoint is either used by exactly one internal edge or remains exposed on the frontier.
+The closed-circuit check is the final admission step requiring a top-level circuit to have no
+exposed endpoints. Overlay forms disjoint incomparable frontier union; connect matches and consumes
+compatible output-input endpoint pairs; unmatched endpoints remain open obligations on the composed
+boundary. Operationally, a carried endpoint plays the role of an identity wire for an open frontier:
+it crosses a composition unchanged until a later compatible input consumes it. The frontier is
+treated as a multiset of labelled ports, so exchange holds definitionally while source order is
+retained for diagnostics. Weakening is not an operation that discards resources. Contraction is not
+ambient either: reusing information requires a node that consumes one endpoint and produces fresh
+endpoints with their own labels and contracts.
+
+Finite-product adapters support the same law. The artifact supports a `*` operator that elaborates
+to a generated phantom adapter for named records and bounded indexed products such as `[T; 4]`. The
+adapter crosses one product constructor, creates distinct leaf endpoints, and then ordinary connect
+consumes each leaf once. Static scatter/gather uses this mechanism, but it adds no copying rule and
+does not drive the paper's argument. The structural-rule vocabulary is inherited from linear logic
+and proof-net work [\[5\]](#ref-5), [\[6\]](#ref-6), while the interface shape places Wire near
+cospan, open-graph, and string-diagram accounts of composition [\[3\]](#ref-3), [\[4\]](#ref-4),
+[\[7\]](#ref-7).
+
+## One Object, Five Views
+
+The implementation separates five views of the admitted diagram. Source is the authored causal
+expression. The admitted frontier records typed endpoint resources and remaining obligations. The
+port-erased graph relation exposes topology for graph algorithms. The circuit is the executable
+artifact consumed by Pulse. The runtime trace records schedule, replay, and provenance events over
+that circuit. Source elaboration expands compile-time includes, bounded generation, static family
+projections, and product adapters before the effectful runtime boundary.
+
+```mermaid
+flowchart LR
+    S["Source diagram<br/>causal expression"] --> L["Admitted frontier<br/>typed resources"]
+    L --> G["Causal topology<br/>port-erased graph"]
+    L --> C["Circuit<br/>executable artifact"]
+    G --> C
+    C --> R["Runtime trace<br/>schedule, replay"]
+    P["Proof IR<br/>accepted objects"] -. "names post-elaboration objects" .- L
+    P -. "correspondence obligations" .- S
+```
+
+_Figure 2: Wire's executable causal-diagram layers and the proof-facing IR's relation to the
+admitted frontier._
+
+The split mirrors the distinction between source, admission, topology, executable artifact, and
+trace. Concrete node instances are invoked, completed, recovered, or observed under the partial
+order implied by the topology. That separation gives Wire both roles: diagram language and
+executable artifact boundary.
+
+The proof-facing layer is narrower than a verified compiler, but it already has a live mechanized
+proof surface. The public
+[proof-status dashboard](https://digimuoto.github.io/cortex/Reference/proof-status/) is the source
+of truth for current Lean mechanization and Haskell correspondence: it separates Lean-proven or
+integrated claims from witness-backed, hooked, tested, proof-only, and still-open executable
+correspondence. The generated [Lean docs](https://digimuoto.github.io/cortex/Theory/) expose the
+declarations themselves. For this paper's slice, the Lean elaboration IR names accepted declarations
+inside an admitted module shell after source inclusion and local admission.
+`GraphExpr.AcceptedRefsClosed` states that every accepted graph expression references only accepted
+nodes, kinds, and graph bindings in the surrounding admitted shell. Accepted node and kind
+declarations carry label-unique frontiers whose contracts reference the accepted contract
+declarations modeled in the current IR; the projection
+`RawNodeDecl.toAccepted_toLinearPortObject_portLinear` records the corresponding `PortLinear`
+obligation for accepted node declarations. Here `PortLinear` requires each owned output endpoint to
+be either exposed or consumed by exactly one internal edge, and each owned input endpoint to be
+either exposed or produced by exactly one internal edge.
+
+Generated node provenance is explicit through `NodeOrigin`. Generated-form theorems
+(`Make.accept_portLinear`, `MakeEach.accept_portLinear`, and `Star.accept_portLinear`) state
+source-linearity preservation for certified bounded generation and product adapters. The
+source-to-actualized bridge proves port-domain exactness for aligned witnesses. Edge-side exactness,
+runtime-witness production, and correspondence to compiled Haskell artifacts remain open obligations
+in the verification story.
+
+The submitted artifact exposes this boundary through a build-backed dashboard example, parser and
+compiler path, source includes, bounded graph generation, indexed family projection, finite-product
+phantom adapters, topology-first formatter, Tree-sitter editor grammar, generated Lean docs, and
+proof-status dashboard. The current verification boundary is staged rather than end-to-end: the
+compiler and executor are not fully verified, while the proof surfaces keep authored topology
+inspectable and tie diagram syntax, linear boundary checking, runtime topology, and proof-facing
+closure conditions to the admitted object.
+
+## References
+
+1. <a id="ref-1"></a>Leslie Lamport. _Time, Clocks, and the Ordering of Events in a Distributed
+   System_. Communications of the ACM 21(7), 1978: 558–565. <https://doi.org/10.1145/359545.359563>
+2. <a id="ref-2"></a>Andrey Mokhov. _Algebraic Graphs with Class (Functional Pearl)_. Haskell 2017:
+   2–13. <https://doi.org/10.1145/3122955.3122956>
+3. <a id="ref-3"></a>Brendan Fong. _Decorated Cospans_. Theory and Applications of Categories,
+   30(33), 2015. <https://arxiv.org/abs/1502.00872>
+4. <a id="ref-4"></a>Peter Selinger. _A Survey of Graphical Languages for Monoidal Categories_.
+   Lecture Notes in Physics 813, 2011. <https://arxiv.org/abs/0908.3347>
+5. <a id="ref-5"></a>Jean-Yves Girard. _Linear Logic_. Theoretical Computer Science 50(1), 1987.
+   <https://doi.org/10.1016/0304-3975(87)90045-4>
+6. <a id="ref-6"></a>Vincent Danos and Laurent Regnier. _The Structure of Multiplicatives_. Archive
+   for Mathematical Logic 28(3), 1989. <https://doi.org/10.1007/BF01622878>
+7. <a id="ref-7"></a>Lucas Dixon, Ross Duncan, and Aleks Kissinger. _Open Graphs and Computational
+   Reasoning_. EPTCS 26, 2010. <https://doi.org/10.4204/EPTCS.26.16>

--- a/docs/Publications/Paper-6-executable-diagrams/typst/manuscript.typ
+++ b/docs/Publications/Paper-6-executable-diagrams/typst/manuscript.typ
@@ -1,0 +1,286 @@
+#import "../../_typst/cortex-submission.typ": cortex-submission
+#import "../Figures/dashboard-topology-module.typ": dashboard-topology
+#import "../Figures/executable-diagram-layers-module.typ": executable-diagram-layers
+
+#show: doc => cortex-submission(
+  profile: "workshop-abstract",
+  title: [Executable Causal Diagrams with Typed Linear Frontiers],
+  short-title: [Executable Causal Diagrams],
+  category: [Workshop abstract],
+  authors: (
+    (
+      name: [Julius Koskela],
+      affiliation: [Digimuoto Oy, Helsinki, Finland],
+      email: "julius.koskela@digimuoto.com",
+    ),
+  ),
+  author-running: [J. Koskela],
+  pdf-title: "Executable Causal Diagrams with Typed Linear Frontiers",
+  pdf-author: "Julius Koskela",
+  abstract: [
+    Wire is a source language for executable causal diagrams. Its surface is a typed
+    frontier-transformer calculus: `<>` unions incomparable boundary fragments, `=>` consumes
+    compatible endpoint pairs while carrying unmatched endpoints forward, and typed ports decide
+    which observations may cross the composed boundary. We illustrate the design with an async
+    dashboard diamond: fetch a user, derive branch facts in CorePure (Wire's deterministic
+    expression layer), fetch posts and friends independently, carry the profile fact directly to the
+    join, then assemble a response. In a host language, the diamond is a property of execution,
+    traces, and replay logs; in Wire, the admitted diagram is the shared object. The Cortex artifact
+    refines algebraic graphs with named typed ports, source elaboration, linear frontier checking,
+    circuit lowering to Pulse, Cortex's durable runtime, and a Lean-side accepted-object IR. The
+    contribution is an interface where authored topology, runtime replay and provenance, and
+    proof-facing closure obligations all refer to the admitted diagram.
+  ],
+  keywords: (
+    "diagrammatic programming",
+    "causal diagrams",
+    "algebraic graphs",
+    "durable execution",
+    "linear frontiers",
+  ),
+  ccs: (
+    [Theory of computation $->$ Program semantics],
+    [Software and its engineering $->$ Domain specific languages],
+  ),
+  repository: [#link("https://github.com/Digimuoto/cortex")[github.com/Digimuoto/cortex]],
+  documentation: [#link("https://digimuoto.github.io/cortex/")[digimuoto.github.io/cortex]],
+  supplement: [#link("https://digimuoto.github.io/cortex/Reference/proof-status/")[Cortex proof-status dashboard]],
+  artifact: [Haskell implementation, Wire reference, generated Lean docs, proof-status dashboard, Tree-sitter grammar, and ADRs],
+  doc,
+)
+
+= Causal Pipelines as Frontier Transformers
+
+Wire makes a source program elaborate to the causal diagram scheduled, replayed, and explained by
+the runtime. The admitted diagram records which events depend on prior observations, which events
+are incomparable, and which typed values cross between them. Wire turns Lamport's partial-order view
+of distributed execution @lamport1978 into an authoring discipline for executable artifacts.
+
+Conventional source forms tend to hide that structure. Imperative programs are ordered vectors of
+effects: a later read is meaningful only because the program counter supplies an ordered prefix.
+Pure functional `let` expressions move closer to named records of dependencies, but effectful
+programs usually regain a linear spine unless the author adds a separate parallel or applicative
+structure. Wire makes the next step explicit. A graph expression is read as a typed frontier
+transformer: `<>` unions incomparable boundary fragments, and `=>` matches compatible output-input
+endpoints while carrying unmatched endpoints forward. A written pipeline is therefore not a sequence
+of barriers; it is a compact description of a partial order.
+
+A dashboard request illustrates the gap:
+
+```python
+async def dashboard(uid):
+    user = await fetch_user(uid)
+    posts, friends = await asyncio.gather(
+        fetch_posts(user.id),
+        fetch_friends(user.id),
+    )
+    return assemble(user, posts, friends)
+```
+
+A human reads this as a causal diamond: fetch the user, fetch posts and friends independently, then
+assemble. `asyncio.gather` exposes part of that structure, but the source language's primary object
+is still the executing coroutine rather than an admitted typed topology. Distributed tracing
+reconstructs a DAG from spans after the fact. Durable workflow runtimes can journal and replay
+`await` points, but they recover topology from runtime behavior because the host language did not
+expose the causal object directly.
+
+In Wire, the diamond is authored directly rather than inferred from spans, continuations, or runtime
+heuristics. Durable replay and provenance refer to the admitted diagram: recovery resumes from a
+recorded causal prefix, and audit trails can point to named nodes and typed edges instead of
+reconstructed traces outside the language.
+
+= The Dashboard Diamond in Wire
+
+The same request can be authored as a typed causal diagram. Contracts are nominal boundary
+interfaces, not first-class CorePure values. Wire's pure expression sublanguage, CorePure, computes
+JSON-shaped payloads; contracts classify the ports through which those payloads enter and leave the
+diagram. The `@` form is Wire's effect boundary: network calls, storage, model calls, tools, and
+other host effects stay behind registered executors, while deterministic payload shaping can stay in
+Wire. Pulse, Cortex's durable runtime, journals outcomes for those executor nodes over the admitted topology; CorePure
+expressions remain deterministic boundary equations rather than hidden host effects.
+
+```wire
+# Registered facts that may cross node boundaries.
+contract UserId;
+contract UserProfile;
+contract ProfileSummary;
+contract PostsRequest;
+contract FriendsRequest;
+contract PostsFeed;
+contract FriendGraph;
+contract Dashboard;
+
+# Executable events and their typed input/output frontiers.
+node receive_request
+  -> uid: UserId = @http.receive_dashboard_request ({});
+
+node fetch_user
+  <- uid: UserId;
+  -> user: UserProfile = @http.fetch_user (uid);
+
+node prepare_dashboard
+  <- user: UserProfile;
+  -> profile: ProfileSummary = {
+    id = user.id;
+    name = user.name;
+  };
+  -> posts_req: PostsRequest = {
+    user_id = user.id;
+    limit = 20;
+  };
+  -> friends_req: FriendsRequest = {
+    user_id = user.id;
+    include_mutual = true;
+  };
+
+node fetch_posts
+  <- posts_req: PostsRequest;
+  -> posts: PostsFeed = @http.fetch_posts (posts_req);
+
+node fetch_friends
+  <- friends_req: FriendsRequest;
+  -> friends: FriendGraph = @http.fetch_friends (friends_req);
+
+node assemble
+  <- profile: ProfileSummary;
+  <- posts: PostsFeed;
+  <- friends: FriendGraph;
+  -> dashboard: Dashboard = @dashboard.assemble ({
+    inherit profile posts friends;
+  });
+
+node respond
+  <- dashboard: Dashboard;
+  = @http.respond_dashboard (dashboard);
+
+# The file's graph expression: the returned executable topology.
+receive_request
+  => fetch_user
+  => prepare_dashboard
+  => fetch_posts <> fetch_friends
+  => assemble
+  => respond
+```
+
+Wire deliberately binds `<>` tighter than `=>`. The final expression therefore parses as a
+pipeline whose middle stage is `fetch_posts <> fetch_friends`, an incomparable frontier. This
+differs from the `Algebra.Graph` Haskell library convention to make the dashboard diamond readable
+without parentheses.
+
+The key node is `prepare_dashboard`. It has no `@` executor: its three output equations are CorePure
+expressions evaluated when `user` is available. The node consumes the fetched `UserProfile` once and
+produces three distinct typed facts: a profile summary for the join, a posts request for one branch,
+and a friends request for the other. CorePure is deterministic and effect-free; output wrapping
+then records the nominal contracts `ProfileSummary`, `PostsRequest`, and `FriendsRequest` at the
+ports. The parallelism is graph structure: `fetch_posts` and `fetch_friends` are incomparable after
+`prepare_dashboard`, while `assemble` is the join where their histories become comparable again.
+
+The carried `profile` endpoint is where the frontier view does real work. The branch overlay exposes
+only the inputs its operands need; it does not absorb outputs that are irrelevant to the branch. In
+`prepare_dashboard => fetch_posts <> fetch_friends`, connect consumes `posts_req` and `friends_req`,
+while `profile` remains a typed resource on the composed frontier. The later `=> assemble` consumes
+that carried endpoint together with `posts` and `friends`. At runtime this is a direct
+`prepare_dashboard -> assemble` dependency plus the two branch dependencies.
+
+#figure(
+  dashboard-topology(),
+  caption: [Dashboard topology after admission. `profile` is carried directly from `prepare_dashboard` to `assemble`; branch-local requests are consumed by `fetch_posts` and `fetch_friends`.],
+) <fig:dashboard-topology>
+
+The direct `profile` edge does not make `assemble` ready early, because readiness is still
+conjunctive over all predecessors. It records that `profile` has no causal reason to flow through
+either branch.
+
+If the dashboard tried to wire `fetch_user` directly into two branches that both declared
+`<- user: UserProfile`, admission would reject the graph: one produced endpoint would have two
+consumers. This is a semantic rejection. A silent copy of `user` would remove the event that
+explains why two downstream observations are legitimate. The fix is to name the causal event that
+derives branch facts from one prior observation.
+
+= Linear Frontiers and Algebraic Graphs
+
+Linearity supplies the accounting discipline behind the causal reading. It is the bridge from
+Lamport's partial-order view to source authoring: fan-out without a named event destroys the causal
+explanation for why two downstream observations share a prior source. Wire refines Mokhov's algebra
+of graphs @mokhov2017: the source skeleton still has empty diagrams, vertices, overlay, and connect,
+but vertices carry named input and output ports, and each port endpoint is a resource. The same
+boundary admits graph expressions, determines executable topology, and exposes proof obligations.
+
+At the node boundary, the intended invariant is small enough to state directly:
+
+$
+forall e in "OwnedPorts"(n), "internal"(e) + "frontier"(e) = 1
+$
+
+An owned endpoint is either used by exactly one internal edge or remains exposed on the frontier.
+The closed-circuit check is the final admission step requiring a top-level circuit to have no
+exposed endpoints. Overlay forms disjoint incomparable frontier union; connect matches and consumes
+compatible output-input endpoint pairs; unmatched endpoints remain open obligations on the composed
+boundary. Operationally, a carried endpoint plays the role of an identity wire for an open frontier:
+it crosses a composition unchanged until a later compatible input consumes it. The frontier is treated
+as a multiset of labelled ports, so exchange holds definitionally while source order is retained for
+diagnostics. Weakening is not an operation that discards resources. Contraction is not ambient
+either: reusing information requires a node that consumes one endpoint and produces fresh endpoints
+with their own labels and contracts.
+
+Finite-product adapters support the same law. The artifact supports a `*` operator that elaborates
+to a generated phantom adapter for named records and bounded indexed
+products such as `[T; 4]`. The adapter crosses one product constructor, creates distinct leaf
+endpoints, and then ordinary connect consumes each leaf once. Static scatter/gather uses this
+mechanism, but it adds no copying rule and does not drive the paper's argument. The
+structural-rule vocabulary is inherited from linear logic and proof-net work @girard1987 @danos1989,
+while the interface shape places Wire near cospan, open-graph, and string-diagram accounts of
+composition @fong2015 @dixon2010 @selinger2011.
+
+= One Object, Five Views
+
+The implementation separates five views of the admitted diagram. Source is the authored causal
+expression. The admitted frontier records typed endpoint resources and remaining obligations. The
+port-erased graph relation exposes topology for graph algorithms. The circuit is the executable
+artifact consumed by Pulse. The runtime trace records schedule, replay, and provenance events over
+that circuit. Source elaboration expands compile-time includes, bounded generation, static family
+projections, and product adapters before the effectful runtime boundary.
+
+#figure(
+  executable-diagram-layers(),
+  caption: [Wire's executable causal-diagram layers and the proof-facing IR's relation to the admitted frontier.],
+) <fig:wire-layers>
+
+The split mirrors the distinction between source, admission, topology, executable artifact, and
+trace. Concrete node instances are invoked, completed, recovered, or observed under the partial
+order implied by the topology. That separation gives Wire both roles: diagram language and
+executable artifact boundary.
+
+The proof-facing layer is narrower than a verified compiler, but it already has a live mechanized
+proof surface. The public
+#link("https://digimuoto.github.io/cortex/Reference/proof-status/")[proof-status dashboard]
+is the source of truth for current Lean mechanization and Haskell correspondence: it separates
+Lean-proven or integrated claims from witness-backed, hooked, tested, proof-only, and still-open
+executable correspondence. The generated
+#link("https://digimuoto.github.io/cortex/Theory/")[Lean docs] expose the declarations themselves.
+For this paper's slice, the Lean elaboration IR names accepted declarations inside an admitted
+module shell after source inclusion and local admission. `GraphExpr.AcceptedRefsClosed` states that
+every accepted graph expression references only accepted nodes, kinds, and graph bindings in the
+surrounding admitted shell. Accepted node and kind declarations carry label-unique frontiers whose
+contracts reference the accepted contract declarations modeled in the current IR; the projection
+`RawNodeDecl.toAccepted_toLinearPortObject_portLinear` records the corresponding `PortLinear`
+obligation for accepted node declarations. Here `PortLinear` requires each owned output endpoint to
+be either exposed or consumed by exactly one internal edge, and each owned input endpoint to be
+either exposed or produced by exactly one internal edge.
+
+Generated node provenance is explicit through `NodeOrigin`. Generated-form theorems
+(`Make.accept_portLinear`, `MakeEach.accept_portLinear`, and `Star.accept_portLinear`) state
+source-linearity preservation for certified bounded generation and product adapters. The
+source-to-actualized bridge proves port-domain exactness for aligned witnesses. Edge-side exactness,
+runtime-witness production, and correspondence to compiled Haskell artifacts remain open
+obligations in the verification story.
+
+The submitted artifact exposes this boundary through a build-backed dashboard example, parser and
+compiler path, source includes, bounded graph generation, indexed family projection, finite-product
+phantom adapters, topology-first formatter, Tree-sitter editor grammar, generated Lean docs, and
+proof-status dashboard. The current verification boundary is staged rather than end-to-end: the
+compiler and executor are not fully verified, while the proof surfaces keep authored topology
+inspectable and tie diagram syntax, linear boundary checking, runtime topology, and proof-facing
+closure conditions to the admitted object.
+
+#bibliography("references.bib", title: [References], style: "association-for-computing-machinery")

--- a/docs/Publications/Paper-6-executable-diagrams/typst/references.bib
+++ b/docs/Publications/Paper-6-executable-diagrams/typst/references.bib
@@ -1,0 +1,78 @@
+@article{lamport1978,
+  author = {Lamport, Leslie},
+  title = {Time, Clocks, and the Ordering of Events in a Distributed System},
+  journal = {Communications of the ACM},
+  volume = {21},
+  number = {7},
+  pages = {558--565},
+  year = {1978},
+  doi = {10.1145/359545.359563}
+}
+
+@inproceedings{mokhov2017,
+  author = {Mokhov, Andrey},
+  title = {Algebraic Graphs with Class (Functional Pearl)},
+  booktitle = {Proceedings of the 10th ACM SIGPLAN International Symposium on Haskell},
+  pages = {2--13},
+  year = {2017},
+  doi = {10.1145/3122955.3122956}
+}
+
+@article{fong2015,
+  author = {Fong, Brendan},
+  title = {Decorated Cospans},
+  journal = {Theory and Applications of Categories},
+  volume = {30},
+  number = {33},
+  pages = {1096--1120},
+  year = {2015},
+  url = {https://arxiv.org/abs/1502.00872}
+}
+
+@incollection{selinger2011,
+  author = {Selinger, Peter},
+  title = {A Survey of Graphical Languages for Monoidal Categories},
+  booktitle = {New Structures for Physics},
+  series = {Lecture Notes in Physics},
+  volume = {813},
+  pages = {289--355},
+  publisher = {Springer},
+  year = {2011},
+  eprint = {0908.3347},
+  archivePrefix = {arXiv},
+  primaryClass = {math.CT},
+  url = {https://arxiv.org/abs/0908.3347}
+}
+
+@article{girard1987,
+  author = {Girard, Jean-Yves},
+  title = {Linear Logic},
+  journal = {Theoretical Computer Science},
+  volume = {50},
+  number = {1},
+  pages = {1--101},
+  year = {1987},
+  doi = {10.1016/0304-3975(87)90045-4}
+}
+
+@article{danos1989,
+  author = {Danos, Vincent and Regnier, Laurent},
+  title = {The Structure of Multiplicatives},
+  journal = {Archive for Mathematical Logic},
+  volume = {28},
+  number = {3},
+  pages = {181--203},
+  year = {1989},
+  doi = {10.1007/BF01622878}
+}
+
+@inproceedings{dixon2010,
+  author = {Dixon, Lucas and Duncan, Ross and Kissinger, Aleks},
+  title = {Open Graphs and Computational Reasoning},
+  booktitle = {Proceedings of the Workshop on Graphical Languages for Quantum Computation},
+  series = {Electronic Proceedings in Theoretical Computer Science},
+  volume = {26},
+  pages = {169--180},
+  year = {2010},
+  doi = {10.4204/EPTCS.26.16}
+}

--- a/docs/Publications/Paper-6-executable-diagrams/typst/repo-docs-typst.json
+++ b/docs/Publications/Paper-6-executable-diagrams/typst/repo-docs-typst.json
@@ -1,0 +1,11 @@
+{
+  "entry": "manuscript.typ",
+  "output": "manuscript.pdf",
+  "route": "Publications/Paper-6-executable-diagrams/typeset-manuscript",
+  "title": "Paper 6 - Executable Causal Diagrams with Typed Linear Frontiers",
+  "description": "Submission-ready Typst rendering of the executable causal diagrams manuscript.",
+  "sidebar": {
+    "label": "Typeset PDF",
+    "order": 3
+  }
+}

--- a/docs/Publications/_typst/cortex-submission.typ
+++ b/docs/Publications/_typst/cortex-submission.typ
@@ -1,0 +1,546 @@
+// Cortex publication layout for submission-ready PDF manuscripts.
+// Wire colours mirror editors/tree-sitter-wire/queries/highlights.scm capture classes.
+// Profiles: workshop-abstract, preprint, camera-ready, anonymous.
+// Authors are dictionaries with name, affiliation/affiliations, email, website, and orcid fields.
+
+#let ink = rgb("#161a22")
+#let muted = rgb("#5c6575")
+#let rule = rgb("#cfd5df")
+#let pale = rgb("#f7f8fb")
+#let accent = rgb("#1e4f8a")
+#let accent-soft = rgb("#edf3fa")
+
+#let code-bg = rgb("#f8fafc")
+#let code-rule = rgb("#d9e0ea")
+#let code-keyword = rgb("#7a3e9d")
+#let code-topology = rgb("#9a3412")
+#let code-operator = rgb("#286a78")
+#let code-type = rgb("#1f6f4a")
+#let code-ident = rgb("#173f77")
+#let code-property = rgb("#74531f")
+#let code-string = rgb("#7c4a03")
+#let code-comment = rgb("#697386")
+#let code-number = rgb("#6b4fa3")
+
+#let wire-keywords = (
+  "contract",
+  "form",
+  "kind",
+  "make",
+  "node",
+  "export",
+  "let",
+  "in",
+  "import",
+  "from",
+  "use",
+  "as",
+  "inherit",
+  "select",
+  "if",
+  "then",
+  "else",
+  "where",
+)
+
+#let wire-builtins = ("true", "false", "null")
+#let wire-topology-ops = ("=>", "<>", "*")
+#let wire-two-ops = ("=>", "<>", "//", "++", "|>", "<-", "->", "==", "!=", "<=", ">=", "&&", "||")
+#let wire-one-ops = ("=", "@", "+", "-", "*", "/", "<", ">", "!", "|")
+#let wire-delims = (":", ";", ",", ".")
+#let wire-brackets = ("{", "}", "[", "]", "(", ")")
+
+#let alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+#let digits = "0123456789"
+#let ident-chars = alpha + digits + "_"
+#let upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+#let tok(fill, value, strong: false, italic: false) = text(
+  fill: fill,
+  weight: if strong { "bold" } else { "regular" },
+  style: if italic { "italic" } else { "normal" },
+  value,
+)
+
+#let starts-ident(ch) = alpha.contains(ch) or ch == "_"
+#let continues-ident(ch) = ident-chars.contains(ch)
+#let is-digit(ch) = digits.contains(ch)
+
+#let take-while(line, start, pred) = {
+  let i = start
+  while i < line.len() and pred(line.at(i)) {
+    i += 1
+  }
+  i
+}
+
+#let take-string(line, start, delimiter) = {
+  let i = start + delimiter.len()
+  let escaped = false
+  while i < line.len() {
+    let rest = line.slice(i)
+    let ch = line.at(i)
+    if delimiter == "\"" and escaped {
+      escaped = false
+      i += 1
+    } else if delimiter == "\"" and ch == "\\" {
+      escaped = true
+      i += 1
+    } else if rest.starts-with(delimiter) {
+      i += delimiter.len()
+      break
+    } else {
+      i += 1
+    }
+  }
+  i
+}
+
+#let wire-word(value) = {
+  if value in wire-keywords {
+    tok(code-keyword, value, strong: true)
+  } else if value in wire-builtins {
+    tok(code-number, value, strong: true)
+  } else if value.len() > 0 and upper.contains(value.at(0)) {
+    tok(code-type, value)
+  } else {
+    tok(code-ident, value)
+  }
+}
+
+#let wire-highlight-line(line) = {
+  let pieces = ()
+  let i = 0
+
+  while i < line.len() {
+    let rest = line.slice(i)
+    let ch = line.at(i)
+
+    if rest.starts-with("#") {
+      pieces.push(tok(code-comment, rest, italic: true))
+      i = line.len()
+    } else if rest.starts-with("/*") {
+      let end = if rest.contains("*/") {
+        i + rest.position("*/") + 2
+      } else {
+        line.len()
+      }
+      pieces.push(tok(code-comment, line.slice(i, end), italic: true))
+      i = end
+    } else if rest.starts-with("\"") {
+      let end = take-string(line, i, "\"")
+      pieces.push(tok(code-string, line.slice(i, end)))
+      i = end
+    } else if rest.starts-with("''") {
+      let end = take-string(line, i, "''")
+      pieces.push(tok(code-string, line.slice(i, end)))
+      i = end
+    } else if i + 2 <= line.len() and line.slice(i, i + 2) in wire-two-ops {
+      let op = line.slice(i, i + 2)
+      pieces.push(tok(if op in wire-topology-ops { code-topology } else { code-operator }, op, strong: op in wire-topology-ops))
+      i += 2
+    } else if ch in wire-one-ops {
+      pieces.push(tok(if ch in wire-topology-ops { code-topology } else { code-operator }, ch, strong: ch in wire-topology-ops))
+      i += 1
+    } else if ch in wire-delims or ch in wire-brackets {
+      pieces.push(tok(muted, ch))
+      i += 1
+    } else if is-digit(ch) {
+      let end = take-while(line, i, c => is-digit(c) or c == ".")
+      pieces.push(tok(code-number, line.slice(i, end)))
+      i = end
+    } else if starts-ident(ch) {
+      let end = take-while(line, i, continues-ident)
+      pieces.push(wire-word(line.slice(i, end)))
+      i = end
+    } else {
+      pieces.push(tok(ink, ch))
+      i += 1
+    }
+  }
+
+  pieces.join()
+}
+
+#let mermaid-keywords = ("flowchart", "graph", "subgraph", "end", "classDef", "style", "linkStyle")
+#let mermaid-highlight-line(line) = {
+  let pieces = ()
+  let i = 0
+
+  while i < line.len() {
+    let rest = line.slice(i)
+    let ch = line.at(i)
+
+    if rest.starts-with("%%") {
+      pieces.push(tok(code-comment, rest, italic: true))
+      i = line.len()
+    } else if rest.starts-with("\"") {
+      let end = take-string(line, i, "\"")
+      pieces.push(tok(code-string, line.slice(i, end)))
+      i = end
+    } else if rest.starts-with("-->") or rest.starts-with("-.") or rest.starts-with(".-") {
+      let end = if rest.starts-with("-->") { i + 3 } else { i + 2 }
+      pieces.push(tok(code-topology, line.slice(i, end), strong: true))
+      i = end
+    } else if starts-ident(ch) {
+      let end = take-while(line, i, continues-ident)
+      let value = line.slice(i, end)
+      pieces.push(if value in mermaid-keywords { tok(code-keyword, value, strong: true) } else { tok(code-ident, value) })
+      i = end
+    } else if ch in wire-brackets or ch in wire-delims {
+      pieces.push(tok(muted, ch))
+      i += 1
+    } else {
+      pieces.push(tok(ink, ch))
+      i += 1
+    }
+  }
+
+  pieces.join()
+}
+
+#let plain-highlight-line(line) = text(fill: ink, line)
+
+#let code-lines(source, highlighter) = {
+  let rows = ()
+  for line in source.split("\n") {
+    rows.push(box(width: 100%, highlighter(line)))
+  }
+  stack(dir: ttb, spacing: 1.15pt, ..rows)
+}
+
+#let code-frame-body(body, label: none) = block(
+  width: 100%,
+  breakable: false,
+  fill: code-bg,
+  stroke: 0.45pt + code-rule,
+  radius: 2pt,
+  inset: (x: 7pt, y: 5pt),
+)[
+  #set text(font: "DejaVu Sans Mono", size: 8.1pt, hyphenate: false)
+  #if label != none [
+    #text(font: "Libertinus Serif", size: 6.7pt, fill: muted, weight: "bold")[#label]
+    #v(2pt)
+  ]
+  #body
+]
+
+#let code-frame(source, highlighter: plain-highlight-line, label: none) = code-frame-body(
+  code-lines(source, highlighter),
+  label: label,
+)
+
+#let code-lang-label(lang) = {
+  if lang == none {
+    none
+  } else if lang == "python" {
+    "Python"
+  } else if lang == "typst" {
+    "Typst"
+  } else {
+    lang
+  }
+}
+
+#let metadata-row(label, value) = [
+  #text(size: 8.4pt, weight: "bold", fill: muted)[#label]
+  #h(0.45em)
+  #text(size: 8.4pt)[#value]
+]
+
+#let profile-settings(profile) = {
+  if profile == "anonymous" {
+    (
+      anonymous: true,
+      abstract-box: false,
+      show-contact: false,
+      show-artifact: false,
+      show-links: false,
+      show-header: true,
+    )
+  } else if profile == "preprint" {
+    (
+      anonymous: false,
+      abstract-box: true,
+      show-contact: true,
+      show-artifact: true,
+      show-links: true,
+      show-header: true,
+    )
+  } else if profile == "camera-ready" {
+    (
+      anonymous: false,
+      abstract-box: false,
+      show-contact: true,
+      show-artifact: true,
+      show-links: true,
+      show-header: true,
+    )
+  } else {
+    // Default profile: PDF-only workshop abstract / conference submission.
+    (
+      anonymous: false,
+      abstract-box: false,
+      show-contact: true,
+      show-artifact: true,
+      show-links: true,
+      show-header: true,
+    )
+  }
+}
+
+#let content-list(value, separator: [; ]) = {
+  if value == none {
+    none
+  } else if type(value) == array {
+    value.join(separator)
+  } else {
+    value
+  }
+}
+
+#let author-field(author, field, default: none) = {
+  if type(author) == dictionary {
+    author.at(field, default: default)
+  } else {
+    if field == "name" { author } else { default }
+  }
+}
+
+#let render-author(author, show-contact: true) = {
+  let name = author-field(author, "name")
+  let affiliation = content-list(author-field(author, "affiliations", default: author-field(author, "affiliation")))
+  let email = author-field(author, "email")
+  let website = author-field(author, "website")
+  let orcid = author-field(author, "orcid")
+  [
+    #text(size: 10.2pt, weight: "bold")[#name]
+    #if orcid != none [
+      #h(0.35em)
+      #link("https://orcid.org/" + orcid)[#text(size: 7.4pt, fill: muted)[ORCID]]
+    ]
+    #if affiliation != none [
+      #linebreak()
+      #text(size: 8.6pt, fill: muted)[#affiliation]
+    ]
+    #if show-contact and (email != none or website != none) [
+      #linebreak()
+      #if email != none [
+        #text(size: 7.9pt, fill: muted)[#link("mailto:" + email)[#email]]
+      ]
+      #if email != none and website != none [
+        #text(size: 7.9pt, fill: muted)[ #sym.bullet ]
+      ]
+      #if website != none [
+        #text(size: 7.9pt, fill: muted)[#link(website)[#website]]
+      ]
+    ]
+  ]
+}
+
+#let render-authors(authors, settings) = {
+  if settings.anonymous {
+    [#text(size: 10.2pt, weight: "bold")[Anonymous submission]]
+  } else {
+    let rows = ()
+    for author in authors {
+      rows.push(render-author(author, show-contact: settings.show-contact))
+    }
+    stack(dir: ttb, spacing: 5pt, ..rows)
+  }
+}
+
+#let abstract-block(abstract, boxed: false) = {
+  if boxed {
+    block(
+      width: 100%,
+      fill: pale,
+      stroke: (left: 1.2pt + accent, rest: 0.45pt + rule),
+      inset: (left: 8pt, right: 8pt, y: 6pt),
+      radius: 1pt,
+    )[
+      #text(size: 9.6pt, weight: "bold", fill: accent)[Abstract.]
+      #h(0.35em)
+      #text(size: 9.6pt)[#abstract]
+    ]
+  } else {
+    block(width: 100%)[
+      #text(size: 9.6pt, weight: "bold")[Abstract.]
+      #h(0.35em)
+      #text(size: 9.6pt)[#abstract]
+    ]
+  }
+}
+
+#let optional-metadata(label, value) = {
+  if value != none [
+    #linebreak()
+    #metadata-row(label, value)
+  ]
+}
+
+#let frontmatter(
+  title: none,
+  subtitle: none,
+  category: none,
+  authors: (),
+  settings: profile-settings("workshop-abstract"),
+  abstract: none,
+  keywords: (),
+  ccs: (),
+  repository: none,
+  documentation: none,
+  related-version: none,
+  supplement: none,
+  artifact: none,
+  funding: none,
+  acknowledgements: none,
+  submission-id: none,
+) = [
+  #v(4pt)
+  #align(left)[
+    #set par(justify: false)
+    #text(size: 18pt, weight: "bold", tracking: 0pt, hyphenate: false)[#title]
+    #if subtitle != none [
+      #linebreak()
+      #v(2pt)
+      #text(size: 10.2pt, fill: muted)[#subtitle]
+    ]
+    #if category != none [
+      #linebreak()
+      #v(2pt)
+      #text(size: 8.2pt, fill: muted, weight: "bold")[#category]
+    ]
+    #v(8pt)
+    #render-authors(authors, settings)
+  ]
+
+  #v(10pt)
+  #abstract-block(abstract, boxed: settings.abstract-box)
+
+  #v(5pt)
+  #if ccs.len() > 0 [
+    #metadata-row[2012 ACM Subject Classification][#ccs.join("; ")]
+    #linebreak()
+  ]
+  #metadata-row[Keywords and phrases][#keywords.join(", ")]
+  #if settings.show-links [
+    #optional-metadata([Repository], repository)
+    #optional-metadata([Documentation], documentation)
+    #optional-metadata([Related version], related-version)
+    #optional-metadata([Supplementary material], supplement)
+  ]
+  #if settings.show-artifact [
+    #optional-metadata([Artifact], artifact)
+  ]
+  #optional-metadata([Funding], funding)
+  #optional-metadata([Acknowledgements], acknowledgements)
+  #optional-metadata([Submission ID], submission-id)
+  #v(10pt)
+]
+
+#let cortex-submission(
+  profile: "workshop-abstract",
+  title: none,
+  short-title: none,
+  subtitle: none,
+  category: none,
+  authors: (),
+  author-running: none,
+  pdf-title: none,
+  pdf-author: none,
+  pdf-keywords: none,
+  abstract: none,
+  keywords: (),
+  ccs: (),
+  repository: none,
+  documentation: none,
+  related-version: none,
+  supplement: none,
+  artifact: none,
+  funding: none,
+  acknowledgements: none,
+  submission-id: none,
+  body,
+) = [
+  #let settings = profile-settings(profile)
+  #let running-title = if short-title == none { title } else { short-title }
+  #let running-authors = if author-running == none {
+    if settings.anonymous { [Anonymous] } else { none }
+  } else {
+    author-running
+  }
+  #let document-title = if pdf-title == none { title } else { pdf-title }
+  #let document-author = if settings.anonymous {
+    "Anonymous"
+  } else if pdf-author == none {
+    ""
+  } else {
+    pdf-author
+  }
+  #let document-keywords = if pdf-keywords == none { keywords } else { pdf-keywords }
+
+  #set document(title: document-title, author: document-author, keywords: document-keywords)
+  #set page(
+    paper: "a4",
+    margin: (left: 25mm, right: 25mm, top: 22mm, bottom: 24mm),
+    numbering: "1",
+    header: if settings.show-header {
+      context if counter(page).get().first() == 1 {
+        none
+      } else [
+          #if running-authors != none [
+            #text(size: 7.3pt, fill: muted)[#running-authors]
+            #h(0.65em)
+            #text(size: 7.3pt, fill: rule)[|]
+            #h(0.65em)
+          ]
+          #text(size: 7.3pt, fill: muted)[#running-title]
+        ]
+    } else { none },
+  )
+  #set text(font: "Libertinus Serif", size: 9.6pt, lang: "en", fill: ink)
+  #set par(justify: true, leading: 0.57em)
+  #set heading(numbering: "1.1")
+  #set figure(numbering: "1")
+  #set math.equation(numbering: "(1)")
+  #set list(indent: 1.25em, body-indent: 0.5em)
+  #show heading.where(level: 1): set text(size: 12pt, weight: "bold", fill: ink)
+  #show heading.where(level: 2): set text(size: 10.4pt, weight: "bold", fill: ink)
+  #show raw.where(block: true): it => {
+    if it.lang == "wire" {
+      code-frame(it.text, highlighter: wire-highlight-line, label: "Wire")
+    } else if it.lang == "mermaid" {
+      code-frame(it.text, highlighter: mermaid-highlight-line, label: "Mermaid")
+    } else {
+      code-frame-body(it, label: code-lang-label(it.lang))
+    }
+  }
+  #show quote.where(block: true): it => block(
+    width: 100%,
+    fill: accent-soft,
+    stroke: (left: 1pt + accent),
+    inset: (left: 8pt, right: 7pt, y: 5pt),
+  )[#it.body]
+
+  #frontmatter(
+    title: title,
+    subtitle: subtitle,
+    category: category,
+    authors: authors,
+    settings: settings,
+    abstract: abstract,
+    keywords: keywords,
+    ccs: ccs,
+    repository: repository,
+    documentation: documentation,
+    related-version: related-version,
+    supplement: supplement,
+    artifact: artifact,
+    funding: funding,
+    acknowledgements: acknowledgements,
+    submission-id: submission-id,
+  )
+
+  #body
+]

--- a/docs/Publications/index.md
+++ b/docs/Publications/index.md
@@ -24,6 +24,8 @@ now holds the active paper candidates. Companion theory and proof plans live und
   artifacts, graph substitution, and dynamic-topology semantics.
 - **[Paper-4-wire-language/](Paper-4-wire-language/)** — authoring language for typed topology,
   registered authority, and bounded structural proposals.
+- **[Paper-6-executable-diagrams/](Paper-6-executable-diagrams/)** — executable causal diagrams,
+  tying Wire source, durable replay, and proof-facing admission together.
 
 ## Supporting material
 
@@ -40,6 +42,7 @@ Each `paper-N-*/` folder contains:
 
 - `index.md` — landing page with status, abstract, figures, and related material.
 - `manuscript.md` — the manuscript itself.
+- `typst/` — Nix-rendered PDF source when a paper has a typeset manuscript.
 - `Figures/` — figure sources and export notes.
 
 ## Template

--- a/docs/Publications/roadmap.md
+++ b/docs/Publications/roadmap.md
@@ -20,6 +20,7 @@ Plan and state of the current Cortex publication portfolio.
 | 2   | [Algebraic foundations](Paper-2-algebraic-foundations/)               | Draft  | Core fixed-topology theory                         |
 | 3   | [Graph substitution semantics](Paper-3-graph-substitution-semantics/) | Draft  | Dynamic substitution theory                        |
 | 4   | [Wire language](Paper-4-wire-language/)                               | Draft  | Authoring language and authority-composition paper |
+| 6   | [Executable causal diagrams](Paper-6-executable-diagrams/)            | Draft  | Short artifact paper on executable causal diagrams |
 
 ## Supporting research plans
 
@@ -40,6 +41,8 @@ Paper 2 is the keystone paper.
   lineage-plus-materialization semantics.
 - Paper 4 explains the authoring layer above that substrate: closed authority registration,
   endpoint-typed composition, partial reuse, and bounded proposal authoring.
+- Paper 6 extracts the diagrammatic-computation story from Wire: source causal diagrams, typed
+  linear frontiers, circuit lowering, durable replay, and proof-facing accepted objects.
 - The rewrite materialization and recovery plan connects Paper 3's substitution theory back to
   runtime recovery and admission policy.
 

--- a/docs/Reference/Wire/grammar.md
+++ b/docs/Reference/Wire/grammar.md
@@ -232,7 +232,7 @@ node_body ::=
   | executor_output_clause* "=" executor_call ";"
   | "->" output_variant "=" executor_call ";"
 
-pure_output_equation ::= "->" output_variant "=" "pure" "(" corepure_expr ")" ";"
+pure_output_equation ::= "->" output_variant "=" corepure_expr ";"
 executor_output_clause ::= "->" output_body ";"
 output_body ::= output_variant ("|" output_variant)*
 output_variant ::= ident ":" contract_ref

--- a/docs/Research-notes/Foundation/2026-05-09-stage-structured-causal-pipelines.md
+++ b/docs/Research-notes/Foundation/2026-05-09-stage-structured-causal-pipelines.md
@@ -1,0 +1,647 @@
+---
+title: "Research Memo: Stage-Structured Causal Pipelines"
+description:
+  "Synthesis note on Wire as a stage-structured causal pipeline language: from ordered vectors and
+  lexical records to typed frontier graphs, with implications for examples, runtime loops, and child
+  runs."
+date: 2026-05-09
+status: research
+related:
+  - docs/Publications/Paper-5-Causal-Programming/
+  - docs/Publications/Paper-6-executable-diagrams/
+  - docs/Architecture/05-wire-language.md
+  - docs/Architecture/06-pulse-runtime.md
+  - docs/Architecture/07-rewrites-and-materialization.md
+  - docs/Reference/Wire/grammar.md
+  - docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
+  - docs/ADRs/0052-wire-bounded-indexed-boundary-products.md
+  - examples/wire/dashboard-request.wire
+  - examples/wire/bounded-shard-analysis.wire
+---
+
+# Research Memo: Stage-Structured Causal Pipelines
+
+**Date:** 2026-05-09 **Scope:** the current Paper 6 example, the `<>`/`=>` precedence discovery, the
+vector/record/graph explanation of ordinary programs, finite-product adapters, bounded loops,
+runtime-owned process loops, and aspirational child-run composition. **Branch / PR:**
+`docs/executable-diagrams-submission` **Layers examined:** Wire parser and grammar, Wire/Pulse
+architecture chapters, ADRs 0047 and 0052, Paper 5 and Paper 6 drafts, current Wire examples, Theory
+README proof-status surface, and selected external context on graph algebra, arrows, dataflow,
+traces, and durable execution. **Layers skipped:** live GitHub issues and PRs; `gh` returned 401
+after token removal, so issue state was not authoritative in this pass. Downstream repositories were
+skipped because the question is substrate-level. **Method:** cross-source synthesis through the
+seven archetype lenses. **Confidence profile:** high on the local Wire/Pulse semantics and Paper 6
+example; medium on the broader programming-language framing; speculative on new child-run syntax.
+
+External context checked:
+
+- Andrey Mokhov, _Algebraic Graphs with Class_: <https://eprints.ncl.ac.uk/239461>
+- John Hughes / Haskell arrows overview: <https://www.haskell.org/arrows/>
+- Gilles Kahn, _The Semantics of a Simple Language for Parallel Programming_:
+  <https://www.cs.columbia.edu/~sedwards/papers/kahn1974semantics.pdf>
+- OpenTelemetry traces: <https://opentelemetry.io/docs/concepts/signals/traces/>
+- Restate durable execution: <https://docs.restate.dev/foundations/key-concepts#durable-execution>
+- AWS Durable Execution SDK determinism guidance:
+  <https://docs.aws.amazon.com/durable-execution/patterns/best-practices/determinism/>
+
+## Executive Summary
+
+The best synthesis is that Wire is not mainly a "graph DSL" and not mainly a language about `*`. It
+is a **stage-structured causal pipeline** language: `<>` forms a same-stage frontier, `=>` advances
+the frontier, and typed ports decide which causal observations may cross between stages. That phrase
+connects Paper 6 back to Paper 5's stronger thesis: ordinary code overuses ordered vectors and
+lexical call/return records for computations whose true structure is an asymmetric causal DAG.
+
+The current dashboard example is close to canonical because `prepare_dashboard` is a causal
+derivation node, not a fan adapter: it consumes `UserProfile` once and emits the distinct branch
+facts required by later work. `*` remains important, but only as the finite-product boundary adapter
+for product-shaped frontiers such as records and `[T; N]`. Unbounded or dynamically bounded looping
+should stay outside pure Wire topology for now: the process loop belongs to Pulse, while child runs,
+bounded generated families, and runtime-admitted rewrites are the controlled ways to express
+repetition and hierarchy.
+
+## Coherent Narrative
+
+### 1. From ordered vectors to named records to causal frontier graphs
+
+Imperative code is structurally close to an ordered vector of effects. The reader cannot interpret a
+later variable use by name alone; the ordered prefix decides what the name currently denotes:
+
+```python
+x = 1
+x = x + 1
+y = x * 2
+```
+
+An SSA transform makes the dependency structure more record-like:
+
+```text
+x0 = 1
+x1 = x0 + 1
+y0 = x1 * 2
+```
+
+Functional programming moves part of that record structure into source. In a pure `let`, a binding
+can be understood by recursively following names:
+
+```haskell
+let
+  user = fetchUser uid
+  posts = fetchPosts (userId user)
+  friends = fetchFriends (userId user)
+in assemble user posts friends
+```
+
+But effects pull the program back toward a linear spine unless the language or library adds a second
+structure:
+
+```haskell
+do
+  user <- fetchUser uid
+  posts <- fetchPosts (userId user)
+  friends <- fetchFriends (userId user)
+  pure (assemble user posts friends)
+```
+
+Paper 5 names the general problem as temporal dishonesty: mainstream syntax presents a single-stack
+or sequence-shaped story even when the real execution is partially ordered. Wire's move is to make
+the partial-order frontier explicit in the source:
+
+```wire
+receive_request
+  => fetch_user
+  => prepare_dashboard
+  => fetch_posts <> fetch_friends
+  => assemble
+  => respond
+```
+
+Here the graph is not a record of expressions and not an ordered vector. It is a source-level
+frontier transformer. `receive_request => fetch_user` advances a causal stage;
+`fetch_posts <> fetch_friends` forms a same-stage frontier; `assemble` consumes the branch facts and
+makes their histories comparable again.
+
+Useful progression:
+
+```text
+imperative: order first, names are mutable slots
+functional: names first, dependency can be recovered for pure code
+Wire: dependency/frontier first, execution order is derived
+```
+
+### 2. The precedence choice is semantic ergonomics, not parser trivia
+
+ADR 0047 and the current parser deliberately bind `<>` tighter than `=>`. This is inverted from the
+usual Algebra.Graph/Haskell operator convention, where connect-like composition binds tighter. For
+Wire, the inversion is load-bearing:
+
+```wire
+source
+  => prepare
+  => left <> right
+  => join
+```
+
+parses as:
+
+```wire
+source => prepare => (left <> right) => join
+```
+
+That makes the common source shape a pipeline whose stages can be whole graph frontiers. The author
+does not write a parenthesized graph calculus term at every diamond. They write a causal pipeline
+where overlay is same-stage formation and connect is stage advancement.
+
+This does not weaken the algebraic story. Wire still refines Mokhov's empty/vertex/overlay/connect
+skeleton. The point is that the source syntax is tuned for executable causal diagrams rather than
+for a generic graph library. The authoring contribution is: _pipeline ergonomics over a typed linear
+graph algebra_.
+
+### 3. The dashboard diamond is the right example when written as causal derivation
+
+The canonical implemented example is
+[examples/wire/dashboard-request.wire](../../../examples/wire/dashboard-request.wire):
+
+```wire
+node prepare_dashboard
+  <- user: UserProfile;
+  -> profile: ProfileSummary;
+  -> posts_req: PostsRequest;
+  -> friends_req: FriendsRequest;
+  = @dashboard.prepare (user);
+
+receive_request
+  => fetch_user
+  => prepare_dashboard
+  => fetch_posts <> fetch_friends
+  => assemble
+  => respond
+```
+
+The load-bearing point is not that Wire can run two HTTP calls. Many languages can do that. The
+point is that the causal act is named: `prepare_dashboard` consumes the observed user exactly once
+and derives three distinct facts. That derivation is what authorizes parallel branches and the later
+join. A shorter graph that silently lets both branches consume the same `user` endpoint is rejected,
+because it hides the event that explains why two downstream observations are legitimate.
+
+This is also why `*` should not dominate the paper. `*` is the right mechanism when the boundary
+itself is a finite product. The dashboard example is stronger because it shows the ordinary causal
+case: facts are derived by a real domain node, then consumed linearly downstream.
+
+### 4. Finite products solve bounded topology, not unbounded control
+
+ADR 0052 makes a separate point. When the topology really is a finite product, Wire now has a
+bounded indexed idiom:
+
+```wire
+let workers[] = make(4, analyze_shard);
+
+slice_corpus
+  => plan_shards
+  * workers
+  * reduce_findings
+```
+
+The implemented example is
+[examples/wire/bounded-shard-analysis.wire](../../../examples/wire/bounded-shard-analysis.wire).
+Here `plan_shards` emits `[ShardPlan; 4]`, `workers[]` denotes four generated workers, and `*`
+crosses the product boundary explicitly. Each leaf remains linear after the adapter elaborates.
+
+This answers the bounded fan question without making `=>` magical. It does not answer the unbounded
+loop question, and it should not. A runtime-length list such as `[T]` must not decide graph shape.
+If a value produced by a node is used to choose a loop bound, that is runtime policy or a
+runtime-admitted rewrite/child-run boundary, not ordinary static Wire topology.
+
+### 5. Process loops belong to Pulse; Wire describes one admitted causal object
+
+The earlier observation was:
+
+> Computation is a set of bounded loops inside a bigger possibly unbounded process loop. The only
+> thing that really has to be unbounded in a program is the process loop itself.
+
+The Cortex architecture already points this way. Wire composes registered authority; Circuit
+validates executable topology; Pulse owns scheduling, replay, child-run lifecycle, and runtime
+policy. General loops, host scripts, dynamic languages, IO, tools, and model calls belong behind
+explicit executors, while Pulse owns the process loop that repeatedly claims work, advances
+frontiers, persists checkpoints, resumes, and materializes admitted rewrites.
+
+That suggests a clean rule:
+
+```text
+Wire describes a finite admitted causal object.
+Pulse owns the possibly unbounded process loop.
+Executors may implement bounded or host-domain loops behind typed authority.
+Runtime rewrites and child runs are admitted structural extensions, not ambient recursion.
+```
+
+This keeps Wire compatible with efficient compilation. A finite admitted graph can lower to a stage
+plan, bytecode, or native code without also becoming the global scheduler. The scheduler can remain
+Pulse's responsibility.
+
+### 6. Child-run composition is the promising hierarchy, but not native runtime syntax
+
+The clean version of the nested-Pulse idea is not "Pulse executors are native to Wire." That phrase
+collapses layers. The better framing is:
+
+```text
+Wire authors a parent graph where one node invokes another admitted Circuit as a durable child run.
+```
+
+Aspirational Wire-shaped sketch, not current syntax:
+
+```wire
+contract IndexPlan;
+contract IndexRun;
+contract IndexArtifact;
+contract PublishedIndex;
+
+node plan_index
+  -> plan: IndexPlan = @search.plan_index ({});
+
+node spawn_index_run
+  <- plan: IndexPlan;
+  -> run: IndexRun = @pulse.spawn_index_run (plan);
+
+node await_index_run
+  <- run: IndexRun;
+  -> artifact: IndexArtifact = @pulse.await_index_run (run);
+
+node publish_index
+  <- artifact: IndexArtifact;
+  -> published: PublishedIndex = @search.publish_index (artifact);
+
+plan_index
+  => spawn_index_run
+  => await_index_run
+  => publish_index
+```
+
+The child run is a typed executor boundary. The parent observes a run reference, result artifact,
+failure state, signal, or cancellation outcome. The parent does not inspect child memory, and the
+child does not make Wire itself recursive. This aligns with current Pulse docs that list child
+workflows as a deferred extension and with rewrite docs that reserve hierarchical subgraphs for a
+later composition slice.
+
+### 7. A listener or web server is a runtime pattern, not a Wire `while true`
+
+A web server should not be explained as one Wire graph that loops forever internally. A cleaner
+model is: the service or Pulse process loop accepts work, and each request becomes an admitted run
+of a finite causal graph.
+
+Aspirational service shape:
+
+```text
+Pulse service loop:
+  accept request
+  choose admitted Circuit
+  start run with request envelope
+  drive frontier until terminal state
+  persist trace / result / failure
+```
+
+Wire-shaped request graph:
+
+```wire
+receive_request
+  => fetch_user
+  => prepare_dashboard
+  => fetch_posts <> fetch_friends
+  => assemble
+  => respond
+```
+
+This is not less expressive than async host code; it is a different assignment of responsibility.
+The unbounded listener is runtime infrastructure. The per-request computation is a typed causal
+artifact. Host executors may still run blocking code internally; Wire/Pulse is the durable,
+observable scheduler around those authorities.
+
+## Archetype Synthesis
+
+| Lens     | One-line read                                                                                          |
+| -------- | ------------------------------------------------------------------------------------------------------ |
+| Episteme | ADR 0047, the parser, grammar docs, and examples agree: `<>` forms frontiers; `=>` advances them.      |
+| Logos    | The load-bearing claim is frontier-first causality, not the existence of graph syntax or `*`.          |
+| Kritikos | If the example centers `*`, the paper looks like a fan-adapter paper and loses Paper 5's stronger arc. |
+| Themis   | Wire owns candidate topology; Circuit owns admission; Pulse owns loops, scheduling, and child runs.    |
+| Techne   | Patch Paper 6 around stage-structured pipelines and keep `*` as a secondary finite-product section.    |
+| Poiesis  | Useful phrase: "pipeline ergonomics over a typed linear graph algebra."                                |
+| Sophia   | Make dashboard the canonical causal example; use bounded shard only when explaining product adapters.  |
+
+## Key Findings
+
+### [P1] Wire's main argument is stage-structured causal pipelines
+
+**Category:** Novel Idea **Status:** Inferred **Confidence:** High **Surfaced by:** poiesis, logos,
+sophia **Primary evidence:** ADR 0047 precedence ladder; `src/Cortex/Wire/Parser.hs` comment
+"Overlay binds tighter than connect/star"; Wire grammar section 7; Paper 6 dashboard example;
+`EPHEMERAL_NOTES.md` stage-pipeline note **Cross-reference:** implementation <-> ADRs <->
+publication draft.
+
+The best name for the source contribution is **stage-structured causal pipeline**. `<>` forms a
+same-stage frontier; `=>` advances the causal frontier; ports/contracts determine which facts may
+cross the stage boundary. The unusual precedence choice makes this readable in ordinary source:
+
+```wire
+a => b => c <> d => e
+```
+
+is read as a pipeline with `c <> d` as one stage. That is not a minor syntactic preference. It is
+how Wire becomes pleasant to author without giving up the algebra.
+
+**Why it matters:** This is the paper-grade answer to "why Wire syntax?" It avoids reducing the work
+to either "graph DSL" or "`*` adapter," and it ties the implementation to Paper 5's causal
+programming thesis.
+
+**Next step:** Update Paper 6's opening and example section to name stage-structured causal
+pipelines directly, and add the one sentence about `<>` binding tighter than `=>`.
+
+### [P2] The vector/record/graph ladder is the clearest explanation of what Wire improves
+
+**Category:** Terminology Gap **Status:** Inferred **Confidence:** Medium **Surfaced by:** episteme,
+poiesis **Primary evidence:** Paper 5 single-stack diagnosis and async/await critique; Paper 6
+dashboard example; `EPHEMERAL_NOTES.md` vector/record/graph notes **Cross-reference:** publication
+draft <-> conversation notes <-> grammar.
+
+The strongest explanatory ladder is:
+
+```text
+imperative: order first, names are mutable slots
+functional: names first, dependency can be recovered for pure code
+Wire: dependency/frontier first, execution order is derived
+```
+
+The "stack program as nested record" intuition is useful but incomplete. Imperative code is more
+like a nested ordered vector, because order is semantic. Functional code moves toward named records,
+but effectful code regains a linear spine. Wire makes the frontier graph itself the authored object.
+
+**Why it matters:** This gives Cortex a general explanation that is bigger than any single Wire
+operator. It also makes the relationship to async, futures, traces, and durable workflows easier to
+explain without sounding like a workflow-tool comparison.
+
+**Next step:** Add a compact version of this ladder to Paper 6 or Paper 5. Keep the note short in
+the paper; the research memo can carry the full explanation.
+
+### [P3] `prepare_dashboard` is the causal derivation pattern the examples should teach
+
+**Category:** Correctness Gap **Status:** Observed **Confidence:** High **Surfaced by:** logos,
+kritikos **Primary evidence:** `examples/wire/dashboard-request.wire`; Paper 6 lines around the
+dashboard example; Wire grammar linear endpoint rule; ADR 0047 multi-counterpart rejection
+**Cross-reference:** examples <-> grammar <-> publication draft.
+
+The dashboard example only lands if `prepare_dashboard` is shown as a node with multiple typed
+outputs:
+
+```wire
+node prepare_dashboard
+  <- user: UserProfile;
+  -> profile: ProfileSummary;
+  -> posts_req: PostsRequest;
+  -> friends_req: FriendsRequest;
+  = @dashboard.prepare (user);
+```
+
+This is not a select, not a hidden copy, and not a `*` operation. It is a domain derivation event:
+one observation is consumed, and several new facts are produced for distinct downstream uses.
+
+**Why it matters:** If the example is written as a call-site fan or implicit projection, the paper
+teaches the opposite of the intended discipline. The example must show that linearity is causal
+accounting, not a nuisance solved by syntax.
+
+**Next step:** Keep the dashboard example as the first canonical example. Mention the rejected
+implicit-copy graph once. Move product adapters to a later paragraph or footnote.
+
+### [P4] Bounded indexed products are correct but should remain a secondary idiom
+
+**Category:** Design Tension **Status:** Observed **Confidence:** High **Surfaced by:** themis,
+sophia **Primary evidence:** ADR 0052; `examples/wire/bounded-shard-analysis.wire`; Wire grammar
+section 7 **Cross-reference:** ADRs <-> examples <-> publication framing.
+
+ADR 0052 resolves an important design problem: homogeneous generated frontiers need a first-class
+finite product shape, not invented record labels and not implicit fan from `=>`. The result is good:
+`[T; N]`, `let workers[] = make(N, kind)`, and `*` give bounded scatter/gather without weakening
+endpoint linearity.
+
+But the feature is not the center of Wire's research story. It is a supporting idiom for static
+product-shaped topology. The core story is still typed causal stage composition.
+
+**Why it matters:** Over-centering `*` makes the work look like a clever fan-in/fan-out surface. The
+stronger claim is that ordinary programs can be authored as typed causal diagrams, with product
+adapters only when product boundaries are actually present.
+
+**Next step:** In Paper 6, keep bounded shard as a secondary "when topology is a finite product"
+example. Do not use it as the opening example.
+
+### [P5] Runtime loops and dynamic bounds need a named boundary before syntax
+
+**Category:** Design Tension **Status:** Inferred **Confidence:** Medium **Surfaced by:** themis,
+kritikos **Primary evidence:** Architecture chapter 05 on general loops behind executors and Wire
+runtime handoff; chapter 06 on Pulse as runtime; chapter 07 on bounded rewrites; ADR 0052 rejection
+of unbounded `[T]` shaping topology **Cross-reference:** architecture <-> ADRs <-> examples.
+
+Wire should not grow an unbounded `loop` just because web servers, listeners, streams, and retry
+loops matter. The architecture already assigns the process loop to Pulse. Static bounded topology
+belongs in Wire (`make(N, K)`, `[T; N]`, product adapters). Runtime-discovered topology belongs in
+admitted rewrites or explicit executor/child-run boundaries.
+
+The hard unresolved case is a node result used as a loop bound:
+
+```text
+count = @planner.count(...)
+repeat graph count
+```
+
+That is not ordinary static Wire. It may be a runtime-admitted expansion with a budget, a child run
+that owns its own finite trace, or an executor that implements the loop behind a typed contract.
+
+**Why it matters:** This boundary determines whether Wire stays compile-friendly and proof-friendly
+or becomes a general recursive host language with graph syntax.
+
+**Next step:** Draft an ADR or issue for "runtime dynamic bounds" before adding syntax. The ADR
+should classify static bounded generation, executor-local loops, runtime-admitted expansions, and
+child-run loops separately.
+
+### [P6] Child-run composition is the right hierarchy if it stays at the Circuit/Pulse boundary
+
+**Category:** Novel Idea **Status:** Speculative **Confidence:** Medium **Surfaced by:** poiesis,
+themis **Primary evidence:** Architecture chapter 06 deferred child workflows; chapter 07
+hierarchical subgraphs as planned extension; `EPHEMERAL_NOTES.md` aspirational child-run note
+**Cross-reference:** architecture <-> ephemeral design notes.
+
+The promising hierarchy is not native recursive Wire execution. It is a registered executor that
+spawns or observes another admitted Circuit as a durable child run. This keeps the parent graph
+finite and typed while allowing a subsystem to have its own replay, checkpointing, failures,
+signals, and rewrite budget.
+
+**Why it matters:** This is how Wire can model long-lived systems without importing unbounded loops
+into the language. It also gives a concrete path for complex systems: parent circuits supervise
+child circuits through typed run references and artifacts.
+
+**Next step:** Create a design note or ADR sketch for durable child-run composition. Required
+questions: child identity, parent/child contract mapping, spawn replay, await semantics, failure
+propagation, cancellation, nested budgets, and proof envelope composition.
+
+### [P7] Prior art suggests the novelty is synthesis and layer assignment
+
+**Category:** Evidence Gap **Status:** Inferred **Confidence:** Medium **Surfaced by:** episteme,
+poiesis **Primary evidence:** Mokhov graph algebra, Kahn process networks, Hughes arrows,
+OpenTelemetry traces, durable-execution replay docs, Paper 5 related-work section
+**Cross-reference:** literature <-> Cortex architecture.
+
+Several neighboring ideas are established:
+
+- graph algebra gives equational graph construction;
+- process networks and dataflow models expose networks of communicating computations;
+- arrows model composable computations with input/output structure;
+- tracing systems reconstruct request paths from spans and propagated context;
+- durable execution systems use journals/checkpoints and deterministic replay constraints.
+
+Cortex's plausible contribution is not any one ingredient. It is the layer assignment:
+
+```text
+Wire: authored typed causal frontier graph
+Circuit: admitted executable artifact
+Pulse: process loop, replay, scheduling, rewrite admission
+Theory: closure and safety obligations over admitted objects
+```
+
+**Why it matters:** This keeps the research claim defensible. The right posture is "we synthesize
+known ingredients into an executable, typed, durable, proof-facing language substrate," not "we
+invented dataflow, arrows, or graph algebra."
+
+**Next step:** Add a related-work paragraph to the paper that compares on layer assignment, not just
+topic names.
+
+## Missed Abstractions
+
+| Multiple sites                                       | Shared shape                                           | Proposed name                    | Cost of unifying                         |
+| ---------------------------------------------------- | ------------------------------------------------------ | -------------------------------- | ---------------------------------------- |
+| `<>` precedence, frontier execution, Paper 6 diamond | same-stage graph frontier inside a source pipeline     | stage-structured causal pipeline | Mostly prose and example discipline      |
+| `make`, `[T; N]`, `*`, bounded shard example         | static finite product topology with linear leaves      | bounded product frontier         | Already partly implemented by ADR 0052   |
+| Pulse process loop, child workflows, executor loops  | runtime-owned repetition outside static graph topology | runtime loop boundary            | Needs ADR and proof/runtime design       |
+| Parent graph spawning admitted child circuit         | circuit treated as typed executor authority            | durable child-run composition    | Medium; identity/replay/budget semantics |
+| Traces, replay journals, Wire source causal topology | runtime explanation graph                              | source-owned trace skeleton      | Needs observability/provenance write-up  |
+
+## Evidence Gaps
+
+| Claim                                                   | Current evidence                             | Missing evidence                                      | Recommended validation                         |
+| ------------------------------------------------------- | -------------------------------------------- | ----------------------------------------------------- | ---------------------------------------------- |
+| Stage-structured pipeline phrasing improves Paper 6     | ADR/parser/docs agree; example reads well    | Fresh-reader review after paper patch                 | Run doc-review against the revised manuscript  |
+| Child-run composition preserves Wire/Pulse layering     | Architecture says child workflows deferred   | Concrete spawn/await contract and replay semantics    | ADR sketch plus one small executable prototype |
+| Dynamic node-emitted bounds can stay outside pure Wire  | ADR 0052 rejects unbounded topology shaping  | Classification of all loop/bound use cases            | Design note with counterexamples               |
+| Vector/record/graph ladder is academically robust       | Strong local intuition and Paper 5 alignment | Literature pass through arrows/dataflow/FRP/workflows | Focused related-work note                      |
+| Source-owned trace skeleton helps observability tooling | Paper 5 and OTel context align conceptually  | Mapping from Wire node/edge IDs to emitted spans      | Prototype span exporter from admitted Circuit  |
+
+## Design Tensions
+
+### Ergonomics versus algebraic expectation
+
+Wire's precedence inverts the common Algebra.Graph convention. That is surprising to graph-library
+readers but makes pipeline-shaped source dramatically cleaner. The paper should name the inversion
+once and then lean into it: overlay is stage formation; connect is stage advancement.
+
+### Bounded topology versus dynamic control
+
+Static products (`[T; N]`) and static `make(N, K)` are compatible with compile-time graph shape.
+Runtime-discovered bounds are not. The design tension is not whether dynamic loops are useful; they
+are. The question is which boundary owns them: executor, runtime rewrite, child run, or future
+admitted dynamic expansion.
+
+### Causal derivation versus convenient copying
+
+Developers want to reuse values freely. Wire refuses ambient copying because reuse must be a causal
+event with a name, contract, and provenance. The dashboard example is the friendly version of that
+law: deriving branch facts is ordinary programming, but the derivation is explicit.
+
+## Novel Ideas & Hypotheses
+
+- **Source-owned trace skeleton** - A Wire graph can be understood as the trace skeleton before
+  execution: runtime spans, checkpoints, and provenance events attach to source nodes and typed
+  edges rather than reconstructing an unrelated graph afterward. **Validation path:** add a
+  prototype exporter from compiled Circuit nodes/edges to OpenTelemetry span names/links and check
+  whether the dashboard trace is readable without bespoke instrumentation.
+
+- **Circuit-as-executor boundary** - A child Circuit can be registered as executor authority so a
+  parent Wire graph can spawn, await, cancel, or observe it through ordinary typed ports.
+  **Validation path:** design ADR first; then prototype one `spawn`/`await` pair without adding
+  syntax.
+
+- **Frontier transformer type** - A Wire graph expression can be explained informally as a typed
+  frontier transformer rather than as a value expression or function call. `<>` combines
+  transformers at one stage; `=>` composes stage transitions. **Validation path:** write a small
+  formal note mapping graph expressions to input/output frontier sets and compare to the current
+  compiler boundary model.
+
+- **Pipeline ergonomics as a research contribution** - The authoring surface is not just notation;
+  it changes which causal structures are natural to write. **Validation path:** collect three
+  examples that are awkward in async/await but direct in Wire: dashboard diamond, bounded shard
+  scatter/gather, and runtime cache insertion.
+
+## Dead Ends / Rejected Directions
+
+- **Make `=>` infer bounded fan from adjacent topology** - Rejected by ADR 0052. It makes edge
+  semantics nonlocal and order-sensitive. Product unfolding must be visible through `*` or an
+  explicit adapter node.
+
+- **Treat nested Pulse as native Wire recursion** - Too early and layer-confusing. The child-run
+  idea should go through Circuit/Pulse executor authority, not through unbounded Wire syntax.
+
+- **Lead the paper with `*`** - It is accurate for finite products but too narrow. It makes the
+  paper look like it is about fan adapters rather than executable causal diagrams.
+
+## Recommended Actions
+
+### Act now
+
+- [ ] Patch Paper 6 to say "stage-structured causal pipeline" and explicitly state that `<>` binds
+      tighter than `=>`. Owner: doc-review-and-fix; cost: S.
+- [ ] Keep the dashboard diamond as the first example and ensure `prepare_dashboard` remains a
+      multi-output causal derivation node. Owner: doc-review; cost: S.
+- [ ] Demote `*` to a finite-product-adapter paragraph backed by the bounded shard example. Owner:
+      doc-review-and-fix; cost: S.
+
+### Design next
+
+- [ ] Draft a runtime-loop-boundary ADR that separates static bounded generation, executor-local
+      loops, runtime-admitted dynamic expansion, and child-run loops. Owner: architecture; cost: M.
+- [ ] Draft a durable child-run composition note with spawn/await replay semantics, failure
+      propagation, and nested budget questions. Owner: architecture; cost: M.
+- [ ] Prototype source-owned trace skeleton export from admitted Circuit to spans/links. Owner:
+      implementation; cost: M.
+
+### Write up
+
+- [ ] Turn the vector/record/graph ladder into a compact explanatory sidebar for Paper 5 or Paper 6.
+- [ ] Add a related-work paragraph that compares layer assignments across graph algebra, arrows,
+      dataflow, tracing, and durable workflows.
+- [ ] Preserve "pipeline ergonomics over a typed linear graph algebra" as the paper-grade phrasing.
+
+### Parked
+
+- Native unbounded loops in Wire - deferred until runtime dynamic bounds and child-run semantics are
+  classified.
+- Recursive nested Pulse syntax - deferred; use child-run executor framing first.
+- Dependent/generic child-run contracts - deferred until ordinary typed child run references exist.
+- Automatic recursive flattening of nested products - rejected for now by ADR 0052's shallow-product
+  decision.
+
+## Known Unknowns
+
+- The issue tracker was not available in this pass because GitHub authentication returned 401. The
+  memo relies on canonical docs, ADRs, examples, and local proof-status notes rather than live issue
+  state.
+- The external literature pass was selective. A dedicated related-work pass should still check
+  synchronous dataflow, FRP, workflow calculi, build systems, and open-graph semantics before the
+  larger causal-programming paper makes broad novelty claims.
+- The child-run example is intentionally aspirational. It should not be copied into reference docs
+  until the executor boundary and replay semantics are designed.
+
+## Claim-to-Evidence Matrix
+
+| Claim                                     | Artifact that supports it                             | Artifact that weakens it               | Verdict                 |
+| ----------------------------------------- | ----------------------------------------------------- | -------------------------------------- | ----------------------- |
+| Wire source is stage-structured           | ADR 0047, parser precedence, grammar section 7        | Reader expectation from Algebra.Graph  | Strong, needs prose     |
+| Dashboard is a canonical causal example   | `examples/wire/dashboard-request.wire`, Paper 6 draft | Initial drafts overemphasized `*`      | Strong                  |
+| `*` is secondary                          | ADR 0052, bounded shard example                       | Product adapter is recently prominent  | Strong for Paper 6      |
+| Process loop belongs to Pulse             | Architecture chapters 05 and 06                       | Need for servers/listeners/streams     | Strong layer decision   |
+| Child runs are the right hierarchy        | Architecture 06/07 deferred-extension notes           | No concrete syntax or theorem yet      | Plausible, speculative  |
+| Vector/record/graph ladder is paper-grade | Paper 5 diagnosis and Wire example                    | Literature comparison still incomplete | Promising, needs review |

--- a/docs/Research-notes/Foundation/index.md
+++ b/docs/Research-notes/Foundation/index.md
@@ -17,6 +17,7 @@ Substrate-layer research synthesis: formalism, algebraic structure, and coordina
 | 2026-04-11 | [Formalism stack synthesis](2026-04-11-formalism-stack-synthesis.md)                                                 |
 | 2026-04-24 | [CALM and coordination boundaries on evolving graphs](2026-04-24-calm-coordination-boundaries-on-evolving-graphs.md) |
 | 2026-05-05 | [Linear port graph layer](2026-05-05-linear-port-graph-layer.md)                                                     |
+| 2026-05-09 | [Stage-structured causal pipelines](2026-05-09-stage-structured-causal-pipelines.md)                                 |
 
 ## Related
 

--- a/examples/wire/dashboard-request.wire
+++ b/examples/wire/dashboard-request.wire
@@ -1,0 +1,63 @@
+# Canonical executable causal diagram example for the Paper 6 dashboard diamond.
+# The `prepare_dashboard` node is effect-free CorePure: it consumes the
+# fetched user once and emits distinct typed facts for the parallel branches
+# and join. The `profile` endpoint remains exposed across the branch connect
+# and is consumed by `assemble`; it does not pass through either branch.
+
+contract UserId;
+contract UserProfile;
+contract ProfileSummary;
+contract PostsRequest;
+contract FriendsRequest;
+contract PostsFeed;
+contract FriendGraph;
+contract Dashboard;
+
+node receive_request
+  -> uid: UserId = @http.receive_dashboard_request ({});
+
+node fetch_user
+  <- uid: UserId;
+  -> user: UserProfile = @http.fetch_user (uid);
+
+node prepare_dashboard
+  <- user: UserProfile;
+  -> profile: ProfileSummary = {
+    id = user.id;
+    name = user.name;
+  };
+  -> posts_req: PostsRequest = {
+    user_id = user.id;
+    limit = 20;
+  };
+  -> friends_req: FriendsRequest = {
+    user_id = user.id;
+    include_mutual = true;
+  };
+
+node fetch_posts
+  <- posts_req: PostsRequest;
+  -> posts: PostsFeed = @http.fetch_posts (posts_req);
+
+node fetch_friends
+  <- friends_req: FriendsRequest;
+  -> friends: FriendGraph = @http.fetch_friends (friends_req);
+
+node assemble
+  <- profile: ProfileSummary;
+  <- posts: PostsFeed;
+  <- friends: FriendGraph;
+  -> dashboard: Dashboard = @dashboard.assemble ({
+    inherit profile posts friends;
+  });
+
+node respond
+  <- dashboard: Dashboard;
+  = @http.respond_dashboard (dashboard);
+
+receive_request
+  => fetch_user
+  => prepare_dashboard
+  => fetch_posts <> fetch_friends
+  => assemble
+  => respond

--- a/justfile
+++ b/justfile
@@ -107,6 +107,55 @@ docs-preview:
     nix run .#docs-preview
 
 # ============================================================================
+# PAPERS
+# ============================================================================
+
+# Build all Nix-rendered paper PDFs
+papers-build:
+    @echo "📄 Building paper PDFs..."
+    nix build .#papers-renderings --out-link result-papers
+
+# Build the main paper PDF and copy it into the directory where just was invoked
+paper-generate PDF="paper6-executable-diagrams.pdf":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    out="$(nix build .#papers-renderings --no-link --print-out-paths)"
+    pdf="$out/{{ PDF }}"
+    dest="{{ invocation_directory() }}"
+
+    if [[ ! -e "$pdf" ]]; then
+      echo "paper PDF not found: {{ PDF }}" >&2
+      echo "available PDFs:" >&2
+      find "$out" -maxdepth 1 -name '*.pdf' | sort | while IFS= read -r candidate; do
+        printf '  %s\n' "$(basename "$candidate")" >&2
+      done
+      exit 1
+    fi
+
+    cp -f "$pdf" "$dest/"
+    printf 'generated %s\n' "$dest/$(basename "$pdf")"
+
+# Build paper PDFs and open one with zathura from the Nix dev shell
+papers-open PDF="paper6-executable-diagrams.pdf":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    out="$(nix build .#papers-renderings --no-link --print-out-paths)"
+    pdf="$out/{{ PDF }}"
+
+    if [[ ! -e "$pdf" ]]; then
+      echo "paper PDF not found: {{ PDF }}" >&2
+      echo "available PDFs:" >&2
+      find "$out" -maxdepth 1 -name '*.pdf' | sort | while IFS= read -r candidate; do
+        printf '  %s\n' "$(basename "$candidate")" >&2
+      done
+      exit 1
+    fi
+
+    exec nix develop -c zathura "$pdf"
+
+# ============================================================================
 # LEAN 4 THEORY (theory/)
 # ============================================================================
 

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -58,7 +58,10 @@
           # `elan` resolves the toolchain version pinned in
           # `theory/lean-toolchain` and provides `lake`, `lean`, `leanc`.
           elan
-        ]);
+        ])
+        ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+          pkgs.zathura
+        ];
 
       shellHook = ''
         ${config.pre-commit.installationScript or ""}
@@ -81,6 +84,8 @@
           just test        # Run test suite
           just fmt         # Format code
           just docs-dev    # Docs dev server
+          just paper-generate # Build paper PDF into current dir
+          just papers-open # Build and view paper PDFs
 
         Wire DSL:
           hl-wire <path.wire>   # Terminal-highlight a .wire file

--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -2,7 +2,11 @@
 #
 # Outputs: packages.docs-site, apps.docs-{dev,preview}.
 {
-  perSystem = {config, ...}: {
+  perSystem = {
+    config,
+    pkgs,
+    ...
+  }: {
     docsSite = {
       enable = true;
 
@@ -74,8 +78,42 @@
           paper2.dir = "Publications/Paper-2-algebraic-foundations/typst";
           paper3.dir = "Publications/Paper-3-graph-substitution-semantics/typst";
           paper4.dir = "Publications/Paper-4-wire-language/typst";
+          paper6.dir = "Publications/Paper-6-executable-diagrams/typst";
         };
       };
+    };
+
+    packages.paper6-executable-diagrams-renderings = pkgs.stdenvNoCC.mkDerivation {
+      pname = "paper6-executable-diagrams-renderings";
+      version = "2026-05-08";
+      src = ../.;
+      nativeBuildInputs = [pkgs.typst];
+      dontConfigure = true;
+      dontFixup = true;
+      buildPhase = ''
+        runHook preBuild
+        typst compile --root "$PWD" \
+          docs/Publications/Paper-6-executable-diagrams/typst/manuscript.typ \
+          paper6-executable-diagrams.pdf
+        typst compile --root "$PWD" \
+          docs/Publications/Paper-6-executable-diagrams/Figures/executable-diagram-layers.typ \
+          executable-diagram-layers.pdf
+        runHook postBuild
+      '';
+      installPhase = ''
+        runHook preInstall
+        mkdir -p "$out"
+        cp paper6-executable-diagrams.pdf "$out/"
+        cp executable-diagram-layers.pdf "$out/"
+        runHook postInstall
+      '';
+    };
+
+    packages.papers-renderings = pkgs.symlinkJoin {
+      name = "cortex-paper-renderings";
+      paths = [
+        config.packages.paper6-executable-diagrams-renderings
+      ];
     };
 
     packages.docs-site = config.packages.default-site;


### PR DESCRIPTION
## Summary

- add the Paper 6 executable diagrams submission draft
- add Typst submission layout, references, and figure sources
- wire the publication Typst build into the docs Nix outputs

## Checks

- `just fmt-check`
- `just docs-check`
- `just check-commit-provenance origin/main..HEAD`