### PR TITLE
feat(wire): expand admission validator core checks

### DIFF
--- a/docs/Reference/proof-status.md
+++ b/docs/Reference/proof-status.md
@@ -108,10 +108,13 @@ rows.
   Haskell validator clause with a Lean checker plus theorem, not yet a full executable
   `ValidatorReady` checker.
 - `AdmissionArtifact.validatorReadyCoreCheck_sound` now measures the next strategy: a Lean-owned
-  executable checker can establish a representative `ValidatorReadyCore` covering schema version,
-  summary-key uniqueness, summary-row validity, component-row uniqueness, primitive row validity,
-  and primitive stack replay. The remaining full-validator work is now a field-by-field checker
-  conversion, not an undefined aggregate proof assumption.
+  executable checker can establish a representative `ValidatorReadyCore` covering twelve fields:
+  schema version, summary-key uniqueness, summary-row validity, summary domain closure, summary
+  identities matching primitive rows, summary frontiers backed by primitive rows, exact summary
+  residual-frontier matching, raw connections matching primitive rows, local select-row validity,
+  component-row uniqueness, primitive row validity, and primitive stack replay. The helper
+  combinators are Lean-side soundness tools (`check = true → predicate`); full Haskell-validator
+  equivalence remains a separate field-by-field correspondence obligation.
 - The remaining end-to-end compiler theorem is stronger than `Sound`: it must show that every
   accepted Wire program causes the Haskell compiler to emit an artifact satisfying the validator,
   and that decoded rows can be replayed into the concrete Lean witnesses consumed by graph

--- a/theory/Cortex.lean
+++ b/theory/Cortex.lean
@@ -35,6 +35,7 @@ import Cortex.Wire.Make
 import Cortex.Wire.PhantomAdapter
 import Cortex.Wire.GeneratedForms
 import Cortex.Wire.AdmissionArtifact
+import Cortex.Wire.AdmissionArtifact.Check
 import Cortex.Wire.AdmissionArtifact.Boundary
 import Cortex.Wire.AdmissionArtifact.Generated
 import Cortex.Wire.AdmissionArtifact.Phantom

--- a/theory/Cortex/Wire/AdmissionArtifact.lean
+++ b/theory/Cortex/Wire/AdmissionArtifact.lean
@@ -1,3 +1,4 @@
+import Cortex.Wire.AdmissionArtifact.Check
 import Cortex.Wire.AdmissionArtifact.PrimitiveTraceCheck
 import Cortex.Wire.AdmissionArtifact.Sound
 import Cortex.Wire.AdmissionArtifact.ValidatorCoreCheck
@@ -8,10 +9,10 @@ import Cortex.Wire.AdmissionArtifact.ValidatorCoreCheck
 Umbrella module for the decoded Wire admission artifact proof surface.
 
 The implementation is split into rendered subpages under
-`Cortex.Wire.AdmissionArtifact.*`: boundary rows, primitive traces, static
-values, generated forms, phantom adapters, select rows, and the top-level
-validator-ready and proof-facing soundness contracts. The primitive trace and a
-representative validator-ready core now have Lean-owned executable checkers with
-soundness theorems. Importing this module preserves the public import path for
-downstream theory code.
+`Cortex.Wire.AdmissionArtifact.*`: checker helpers, boundary rows, primitive
+traces, static values, generated forms, phantom adapters, select rows, and the
+top-level validator-ready and proof-facing soundness contracts. The primitive
+trace and a representative validator-ready core now have Lean-owned executable
+checkers with soundness theorems. Importing this module preserves the public
+import path for downstream theory code.
 -/

--- a/theory/Cortex/Wire/AdmissionArtifact/Check.lean
+++ b/theory/Cortex/Wire/AdmissionArtifact/Check.lean
@@ -6,10 +6,10 @@ import Mathlib.Data.List.Perm.Basic
 Reusable boolean checker combinators for decoded Wire admission artifacts.
 
 Each helper is intentionally small: a checker returns `Bool`, and its paired
-soundness theorem converts `check = true` into the proof-facing predicate. The
-artifact-specific modules keep the semantic predicates; this page only removes
-the recurring list, membership, permutation, uniqueness, and gated-pair
-boilerplate.
+soundness theorem converts `check = true` into the proof-facing predicate. These
+are Lean-side soundness combinators, not standalone proofs that the Haskell
+validator uses the same algorithm. Artifact-specific modules keep the semantic
+predicates and any Haskell-correspondence obligations.
 -/
 
 namespace Cortex.Wire
@@ -149,6 +149,27 @@ theorem memCheck_sound
     (hCheck : memCheck item items = true) :
     item ∈ items :=
   propCheck_sound hCheck
+
+/-- Boolean set-style equality for lists, ignoring multiplicity and order. -/
+def sameMembersCheck {α : Type} [DecidableEq α] (left right : List α) : Bool :=
+  allDecide left (fun item => item ∈ right) &&
+    allDecide right (fun item => item ∈ left)
+
+/-- Successful set-style equality checking proves membership equivalence. -/
+theorem sameMembersCheck_sound
+    {α : Type}
+    [DecidableEq α]
+    {left right : List α}
+    (hCheck : sameMembersCheck left right = true) :
+    ∀ item, item ∈ left ↔ item ∈ right := by
+  unfold sameMembersCheck at hCheck
+  rw [Bool.and_eq_true] at hCheck
+  intro item
+  constructor
+  · intro hItem
+    exact allDecide_sound hCheck.left item hItem
+  · intro hItem
+    exact allDecide_sound hCheck.right item hItem
 
 /-! ## Gated Pair Checks -/
 

--- a/theory/Cortex/Wire/AdmissionArtifact/Check.lean
+++ b/theory/Cortex/Wire/AdmissionArtifact/Check.lean
@@ -1,0 +1,201 @@
+import Mathlib.Data.List.Perm.Basic
+
+/-!
+## Overview
+
+Reusable boolean checker combinators for decoded Wire admission artifacts.
+
+Each helper is intentionally small: a checker returns `Bool`, and its paired
+soundness theorem converts `check = true` into the proof-facing predicate. The
+artifact-specific modules keep the semantic predicates; this page only removes
+the recurring list, membership, permutation, uniqueness, and gated-pair
+boilerplate.
+-/
+
+namespace Cortex.Wire
+namespace AdmissionArtifact
+namespace Check
+
+/-! ## Decidable Propositions -/
+
+/-- Boolean form of a decidable proposition. -/
+def propCheck (predicate : Prop) [Decidable predicate] : Bool :=
+  decide predicate
+
+/-- Successful proposition checking returns the proposition. -/
+theorem propCheck_sound
+    {predicate : Prop}
+    [Decidable predicate]
+    (hCheck : propCheck predicate = true) :
+    predicate :=
+  of_decide_eq_true hCheck
+
+/-! ## List Quantifiers -/
+
+/-- Boolean universal quantification over a decoded finite row list. -/
+def allDecide {α : Type}
+    (items : List α)
+    (predicate : α → Prop)
+    [DecidablePred predicate] :
+    Bool :=
+  items.all fun item => decide (predicate item)
+
+/-- A successful finite boolean universal check supplies the corresponding predicate. -/
+theorem allDecide_sound
+    {α : Type}
+    {items : List α}
+    {predicate : α → Prop}
+    [DecidablePred predicate]
+    (hCheck : allDecide items predicate = true) :
+    ∀ item, item ∈ items → predicate item := by
+  intro item hItem
+  have hItemCheck :
+      decide (predicate item) = true :=
+    (List.all_eq_true.mp hCheck) item hItem
+  exact of_decide_eq_true hItemCheck
+
+/-- Boolean universal quantification for row checkers that already return `Bool`. -/
+def allBool {α : Type} (items : List α) (check : α → Bool) : Bool :=
+  items.all check
+
+/-- A successful finite boolean universal check transports through local soundness. -/
+theorem allBool_sound
+    {α : Type}
+    {items : List α}
+    {check : α → Bool}
+    {predicate : α → Prop}
+    (hCheck : allBool items check = true)
+    (hSound :
+      ∀ item, item ∈ items → check item = true → predicate item) :
+    ∀ item, item ∈ items → predicate item := by
+  intro item hItem
+  exact hSound item hItem ((List.all_eq_true.mp hCheck) item hItem)
+
+/-- Boolean existential search over a decoded finite row list. -/
+def anyDecide {α : Type}
+    (items : List α)
+    (predicate : α → Prop)
+    [DecidablePred predicate] :
+    Bool :=
+  items.any fun item => decide (predicate item)
+
+/-- A successful finite boolean existential check supplies a matching row. -/
+theorem anyDecide_sound
+    {α : Type}
+    {items : List α}
+    {predicate : α → Prop}
+    [DecidablePred predicate]
+    (hCheck : anyDecide items predicate = true) :
+    ∃ item, item ∈ items ∧ predicate item := by
+  rcases List.any_eq_true.mp hCheck with ⟨item, hItem, hPredicate⟩
+  exact ⟨item, hItem, of_decide_eq_true hPredicate⟩
+
+/-! ## Standard Row Properties -/
+
+/-- Boolean duplicate-freedom check for a decoded list. -/
+def nodupCheck {α : Type} [DecidableEq α] (items : List α) : Bool :=
+  propCheck items.Nodup
+
+/-- Successful duplicate-freedom checking proves `List.Nodup`. -/
+theorem nodupCheck_sound
+    {α : Type}
+    [DecidableEq α]
+    {items : List α}
+    (hCheck : nodupCheck items = true) :
+    items.Nodup :=
+  propCheck_sound hCheck
+
+/-- Boolean duplicate-freedom check for a projected key list. -/
+def nodupMapCheck {α β : Type}
+    [DecidableEq β]
+    (items : List α)
+    (key : α → β) :
+    Bool :=
+  nodupCheck (items.map key)
+
+/-- Successful projected duplicate-freedom checking proves `List.Nodup` for the keys. -/
+theorem nodupMapCheck_sound
+    {α β : Type}
+    [DecidableEq β]
+    {items : List α}
+    {key : α → β}
+    (hCheck : nodupMapCheck items key = true) :
+    (items.map key).Nodup :=
+  nodupCheck_sound hCheck
+
+/-- Boolean permutation check for two decoded lists. -/
+def permCheck {α : Type} [DecidableEq α] (left right : List α) : Bool :=
+  propCheck (left.Perm right)
+
+/-- Successful permutation checking proves `List.Perm`. -/
+theorem permCheck_sound
+    {α : Type}
+    [DecidableEq α]
+    {left right : List α}
+    (hCheck : permCheck left right = true) :
+    left.Perm right :=
+  propCheck_sound hCheck
+
+/-- Boolean membership check for a decoded finite list. -/
+def memCheck {α : Type} [DecidableEq α] (item : α) (items : List α) : Bool :=
+  propCheck (item ∈ items)
+
+/-- Successful membership checking proves list membership. -/
+theorem memCheck_sound
+    {α : Type}
+    [DecidableEq α]
+    {item : α}
+    {items : List α}
+    (hCheck : memCheck item items = true) :
+    item ∈ items :=
+  propCheck_sound hCheck
+
+/-! ## Gated Pair Checks -/
+
+/-- Check all pairs that satisfy a decidable gate. Ungated pairs are ignored. -/
+def allPairsWhenCheck
+    {α β : Type}
+    (left : List α)
+    (right : List β)
+    (condition : α → β → Prop)
+    [DecidableRel condition]
+    (check : α → β → Bool) :
+    Bool :=
+  left.all fun leftItem =>
+    right.all fun rightItem =>
+      if condition leftItem rightItem then
+        check leftItem rightItem
+      else
+        true
+
+/-- Successful gated-pair checking proves the target predicate for every gated pair. -/
+theorem allPairsWhenCheck_sound
+    {α β : Type}
+    {left : List α}
+    {right : List β}
+    {condition : α → β → Prop}
+    [DecidableRel condition]
+    {check : α → β → Bool}
+    {predicate : α → β → Prop}
+    (hCheck : allPairsWhenCheck left right condition check = true)
+    (hSound :
+      ∀ leftItem, leftItem ∈ left →
+        ∀ rightItem, rightItem ∈ right →
+          check leftItem rightItem = true → predicate leftItem rightItem) :
+    ∀ leftItem, leftItem ∈ left →
+      ∀ rightItem, rightItem ∈ right →
+        condition leftItem rightItem → predicate leftItem rightItem := by
+  intro leftItem hLeft rightItem hRight hCondition
+  unfold allPairsWhenCheck at hCheck
+  have hLeftCheck :=
+    (List.all_eq_true.mp hCheck) leftItem hLeft
+  have hRightCheck :=
+    (List.all_eq_true.mp hLeftCheck) rightItem hRight
+  by_cases hConditionCheck : condition leftItem rightItem
+  · simp [hConditionCheck] at hRightCheck
+    exact hSound leftItem hLeft rightItem hRight hRightCheck
+  · exact False.elim (hConditionCheck hCondition)
+
+end Check
+end AdmissionArtifact
+end Cortex.Wire

--- a/theory/Cortex/Wire/AdmissionArtifact/ValidatorCoreCheck.lean
+++ b/theory/Cortex/Wire/AdmissionArtifact/ValidatorCoreCheck.lean
@@ -8,9 +8,9 @@ Executable core checks for decoded Wire admission artifacts.
 
 This module is a measurement slice for the Lean-owned validator strategy. It
 does not decide the full `ValidatorReady` predicate. Instead, it groups a
-representative core: schema version, summary uniqueness, summary row validity,
-component-row uniqueness, primitive row validity, and executable primitive
-stack replay.
+representative core: schema version, summary invariants, local select-row
+validity, component-row uniqueness, primitive row validity, and executable
+primitive stack replay.
 
 Each checker has a theorem of the form `check = true → predicate`, so this file
 tests whether replacing mirrored Haskell validator clauses with Lean-owned
@@ -618,6 +618,721 @@ theorem summaryRowsValidCheck_sound
     , connectionsValid := Check.allDecide_sound hConnections
     }
 
+/-- Executable checker for boundary rows being closed over a node summary. -/
+def boundaryPortClosedCheck
+    (nodes : List NodeId)
+    (port : AdmissionBoundaryPort) :
+    Bool :=
+  Check.memCheck port.node nodes &&
+    match port.exclusiveGroup with
+    | none => true
+    | some (owner, _index) => Check.memCheck owner nodes
+
+/-- Successful boundary-row closure checking proves `AdmissionBoundaryPort.ClosedOver`. -/
+theorem boundaryPortClosedCheck_sound
+    {nodes : List NodeId}
+    {port : AdmissionBoundaryPort}
+    (hCheck : boundaryPortClosedCheck nodes port = true) :
+    port.ClosedOver nodes := by
+  unfold boundaryPortClosedCheck at hCheck
+  rw [Bool.and_eq_true] at hCheck
+  constructor
+  · exact Check.memCheck_sound hCheck.left
+  · cases hGroup : port.exclusiveGroup with
+    | none =>
+        trivial
+    | some group =>
+        cases group with
+        | mk owner index =>
+            have hOwnerCheck : Check.memCheck owner nodes = true := by
+              simpa [hGroup] using hCheck.right
+            exact Check.memCheck_sound hOwnerCheck
+
+/-- Executable checker for boundary lists being closed over a node summary. -/
+def boundaryPortsClosedCheck
+    (nodes : List NodeId)
+    (ports : List AdmissionBoundaryPort) :
+    Bool :=
+  Check.allBool ports (boundaryPortClosedCheck nodes)
+
+/-- Successful boundary-closure checking proves `BoundaryPortsClosed`. -/
+theorem boundaryPortsClosedCheck_sound
+    {nodes : List NodeId}
+    {ports : List AdmissionBoundaryPort}
+    (hCheck : boundaryPortsClosedCheck nodes ports = true) :
+    BoundaryPortsClosed nodes ports :=
+  Check.allBool_sound hCheck
+    (fun _port _ hPortCheck => boundaryPortClosedCheck_sound hPortCheck)
+
+/-- Executable checker for raw connection endpoints being closed over a node summary. -/
+def rawConnectionsClosedCheck
+    (nodes : List NodeId)
+    (connections : List AdmissionRawConnection) :
+    Bool :=
+  Check.allDecide connections fun connection =>
+    connection.fromEndpoint.node ∈ nodes ∧ connection.toEndpoint.node ∈ nodes
+
+/-- Successful raw-connection closure checking proves endpoint-node closure. -/
+theorem rawConnectionsClosedCheck_sound
+    {nodes : List NodeId}
+    {connections : List AdmissionRawConnection}
+    (hCheck : rawConnectionsClosedCheck nodes connections = true) :
+    ∀ connection, connection ∈ connections →
+      connection.fromEndpoint.node ∈ nodes ∧ connection.toEndpoint.node ∈ nodes :=
+  Check.allDecide_sound hCheck
+
+/-- Executable checker for top-level summary closure over serialized nodes. -/
+def summaryDomainClosedCheck (artifact : WireAdmissionArtifact) : Bool :=
+  boundaryPortsClosedCheck artifact.nodes artifact.entries &&
+    boundaryPortsClosedCheck artifact.nodes artifact.exits &&
+      rawConnectionsClosedCheck artifact.nodes artifact.connections
+
+/-- Successful summary-domain checking proves `SummaryDomainClosed`. -/
+theorem summaryDomainClosedCheck_sound
+    {artifact : WireAdmissionArtifact}
+    (hCheck : artifact.summaryDomainClosedCheck = true) :
+    artifact.SummaryDomainClosed := by
+  unfold summaryDomainClosedCheck at hCheck
+  simp only [Bool.and_eq_true] at hCheck
+  rcases hCheck with ⟨⟨hEntries, hExits⟩, hConnections⟩
+  exact
+    { entriesClosed := boundaryPortsClosedCheck_sound hEntries
+    , exitsClosed := boundaryPortsClosedCheck_sound hExits
+    , connectionsClosed := rawConnectionsClosedCheck_sound hConnections
+    }
+
+/-- Executable checker that summary identities match primitive identity rows. -/
+def summaryIdentitiesMatchPrimitiveCheck
+    (artifact : WireAdmissionArtifact) :
+    Bool :=
+  Check.permCheck artifact.nodes
+      (PrimitiveGraphStep.nodeRowsList artifact.primitiveSteps) &&
+    Check.permCheck artifact.bindingRefs
+      (PrimitiveGraphStep.bindingRowsList artifact.primitiveSteps)
+
+/-- Successful identity matching proves `SummaryIdentitiesMatchPrimitive`. -/
+theorem summaryIdentitiesMatchPrimitiveCheck_sound
+    {artifact : WireAdmissionArtifact}
+    (hCheck : artifact.summaryIdentitiesMatchPrimitiveCheck = true) :
+    artifact.SummaryIdentitiesMatchPrimitive := by
+  unfold summaryIdentitiesMatchPrimitiveCheck at hCheck
+  rw [Bool.and_eq_true] at hCheck
+  exact
+    ⟨ Check.permCheck_sound hCheck.left
+    , Check.permCheck_sound hCheck.right
+    ⟩
+
+/-- Executable checker that summary frontiers are backed by primitive residual frontiers. -/
+def summaryFrontiersBackedByPrimitiveCheck
+    (artifact : WireAdmissionArtifact) :
+    Bool :=
+  (Check.allDecide artifact.entries fun entry =>
+    entry.key ∈ PrimitiveGraphStep.nodeEntryKeysList artifact.primitiveSteps ∧
+      entry.key ∉ PrimitiveGraphStep.consumedEntryKeysList artifact.primitiveSteps) &&
+  (Check.allDecide artifact.exits fun exit =>
+    exit.key ∈ PrimitiveGraphStep.nodeExitKeysList artifact.primitiveSteps ∧
+      exit.key ∉ PrimitiveGraphStep.consumedExitKeysList artifact.primitiveSteps)
+
+/-- Successful frontier-backing checking proves `SummaryFrontiersBackedByPrimitive`. -/
+theorem summaryFrontiersBackedByPrimitiveCheck_sound
+    {artifact : WireAdmissionArtifact}
+    (hCheck : artifact.summaryFrontiersBackedByPrimitiveCheck = true) :
+    artifact.SummaryFrontiersBackedByPrimitive := by
+  unfold summaryFrontiersBackedByPrimitiveCheck at hCheck
+  rw [Bool.and_eq_true] at hCheck
+  exact
+    ⟨ Check.allDecide_sound hCheck.left
+    , Check.allDecide_sound hCheck.right
+    ⟩
+
+/-- Primitive entry keys that remain source-visible after primitive connection replay. -/
+def residualPrimitiveEntryKeys (artifact : WireAdmissionArtifact) :
+    List (NodeId × FieldLabel × ContractId) :=
+  (PrimitiveGraphStep.nodeEntryKeysList artifact.primitiveSteps).filter fun key =>
+    decide (key ∉ PrimitiveGraphStep.consumedEntryKeysList artifact.primitiveSteps)
+
+/-- Boolean check that one exit row witnesses a select-internal key. -/
+def selectInternalExitRowKeyCheck
+    (selectAdmission : SelectAdmissionArtifact)
+    (key : NodeId × FieldLabel × ContractId)
+    (exit : AdmissionBoundaryPort) :
+    Bool :=
+  decide (exit.key = key) &&
+    match exit.exclusiveGroup with
+    | none => false
+    | some (owner, _index) =>
+        decide (owner = selectAdmission.conditionNode) &&
+          selectAdmission.variants.any fun variant =>
+            decide (variant.port.CompatibleWith exit)
+
+/-- Successful row-level select-internal checking returns the matched exit and variant facts. -/
+theorem selectInternalExitRowKeyCheck_sound
+    {selectAdmission : SelectAdmissionArtifact}
+    {key : NodeId × FieldLabel × ContractId}
+    {exit : AdmissionBoundaryPort}
+    (hCheck : selectInternalExitRowKeyCheck selectAdmission key exit = true) :
+    exit.key = key ∧
+      (∃ index, exit.exclusiveGroup = some (selectAdmission.conditionNode, index)) ∧
+        ∃ variant, variant ∈ selectAdmission.variants ∧
+          variant.port.CompatibleWith exit := by
+  unfold selectInternalExitRowKeyCheck at hCheck
+  rw [Bool.and_eq_true] at hCheck
+  have hKey : exit.key = key := of_decide_eq_true hCheck.left
+  cases hGroup : exit.exclusiveGroup with
+  | none =>
+      simp [hGroup] at hCheck
+  | some group =>
+      cases group with
+      | mk owner index =>
+          have hTail :
+              (decide (owner = selectAdmission.conditionNode) &&
+                selectAdmission.variants.any
+                  (fun variant => decide (variant.port.CompatibleWith exit))) = true := by
+            simpa [hGroup] using hCheck.right
+          rw [Bool.and_eq_true] at hTail
+          have hOwner : owner = selectAdmission.conditionNode :=
+            of_decide_eq_true hTail.left
+          rcases List.any_eq_true.mp hTail.right with
+            ⟨variant, hVariant, hCompatibleBool⟩
+          have hCompatible : variant.port.CompatibleWith exit :=
+            of_decide_eq_true hCompatibleBool
+          exact
+            ⟨ hKey
+            , ⟨index, by simp [hOwner]⟩
+            , variant
+            , hVariant
+            , hCompatible
+            ⟩
+
+/-- Row-level select-internal key witnesses are accepted by the boolean checker. -/
+theorem selectInternalExitRowKeyCheck_complete
+    {selectAdmission : SelectAdmissionArtifact}
+    {key : NodeId × FieldLabel × ContractId}
+    {exit : AdmissionBoundaryPort}
+    (hKey : exit.key = key)
+    (hGroup :
+      ∃ index, exit.exclusiveGroup = some (selectAdmission.conditionNode, index))
+    (hVariant :
+      ∃ variant, variant ∈ selectAdmission.variants ∧
+        variant.port.CompatibleWith exit) :
+    selectInternalExitRowKeyCheck selectAdmission key exit = true := by
+  obtain ⟨index, hGroupEq⟩ := hGroup
+  obtain ⟨variant, hVariant, hCompatible⟩ := hVariant
+  unfold selectInternalExitRowKeyCheck
+  rw [Bool.and_eq_true]
+  constructor
+  · exact decide_eq_true hKey
+  · rw [hGroupEq]
+    rw [Bool.and_eq_true]
+    constructor
+    · simp
+    · exact List.any_eq_true.mpr
+        ⟨variant, hVariant, decide_eq_true hCompatible⟩
+
+/-- Boolean check that a primitive node row witnesses a select-internal key. -/
+def selectInternalNodeKeyCheck
+    (selectAdmission : SelectAdmissionArtifact)
+    (key : NodeId × FieldLabel × ContractId) :
+    PrimitiveGraphStep → Bool
+  | PrimitiveGraphStep.node node _entries exits =>
+      decide (node = selectAdmission.conditionNode) &&
+        exits.any fun exit =>
+          selectInternalExitRowKeyCheck selectAdmission key exit
+  | PrimitiveGraphStep.empty => false
+  | PrimitiveGraphStep.bindingRef _binding => false
+  | PrimitiveGraphStep.overlay _leftNodes _rightNodes _leftBindings _rightBindings =>
+      false
+  | PrimitiveGraphStep.connect _leftExits _rightEntries _matchedPairs
+      _unmatchedLeftExits _unmatchedRightEntries =>
+      false
+
+/-- Successful primitive-node key checking returns the primitive row and exit witness. -/
+theorem selectInternalNodeKeyCheck_sound
+    {selectAdmission : SelectAdmissionArtifact}
+    {key : NodeId × FieldLabel × ContractId}
+    {primitiveStep : PrimitiveGraphStep}
+    (hCheck : selectInternalNodeKeyCheck selectAdmission key primitiveStep = true) :
+    ∃ entries exits,
+      primitiveStep = PrimitiveGraphStep.node selectAdmission.conditionNode entries exits ∧
+        ∃ exit, exit ∈ exits ∧
+          exit.key = key ∧
+            (∃ index,
+              exit.exclusiveGroup = some (selectAdmission.conditionNode, index)) ∧
+              ∃ variant, variant ∈ selectAdmission.variants ∧
+                variant.port.CompatibleWith exit := by
+  cases primitiveStep with
+  | empty =>
+      simp [selectInternalNodeKeyCheck] at hCheck
+  | bindingRef binding =>
+      simp [selectInternalNodeKeyCheck] at hCheck
+  | overlay leftNodes rightNodes leftBindings rightBindings =>
+      simp [selectInternalNodeKeyCheck] at hCheck
+  | connect leftExits rightEntries matchedPairs unmatchedLeftExits unmatchedRightEntries =>
+      simp [selectInternalNodeKeyCheck] at hCheck
+  | node node entries exits =>
+      unfold selectInternalNodeKeyCheck at hCheck
+      rw [Bool.and_eq_true] at hCheck
+      have hNode : node = selectAdmission.conditionNode :=
+        of_decide_eq_true hCheck.left
+      rcases List.any_eq_true.mp hCheck.right with
+        ⟨exit, hExit, hExitCheck⟩
+      rcases selectInternalExitRowKeyCheck_sound hExitCheck with
+        ⟨hKey, hGroup, hVariant⟩
+      exact
+        ⟨ entries
+        , exits
+        , by simp [hNode]
+        , exit
+        , hExit
+        , hKey
+        , hGroup
+        , hVariant
+        ⟩
+
+/-- Primitive-node key witnesses are accepted by the boolean checker. -/
+theorem selectInternalNodeKeyCheck_complete
+    {selectAdmission : SelectAdmissionArtifact}
+    {key : NodeId × FieldLabel × ContractId}
+    {entries exits : List AdmissionBoundaryPort}
+    (hExit :
+      ∃ exit, exit ∈ exits ∧
+        exit.key = key ∧
+          (∃ index,
+            exit.exclusiveGroup = some (selectAdmission.conditionNode, index)) ∧
+            ∃ variant, variant ∈ selectAdmission.variants ∧
+              variant.port.CompatibleWith exit) :
+    selectInternalNodeKeyCheck selectAdmission key
+      (PrimitiveGraphStep.node selectAdmission.conditionNode entries exits) = true := by
+  obtain ⟨exit, hExitMem, hKey, hGroup, hVariant⟩ := hExit
+  unfold selectInternalNodeKeyCheck
+  rw [Bool.and_eq_true]
+  constructor
+  · simp
+  · exact List.any_eq_true.mpr
+      ⟨ exit
+      , hExitMem
+      , selectInternalExitRowKeyCheck_complete hKey hGroup hVariant
+      ⟩
+
+/-- Boolean form of key-level select-internal exit detection. -/
+def selectInternalExitKeyCheck
+    (artifact : WireAdmissionArtifact)
+    (key : NodeId × FieldLabel × ContractId) :
+    Bool :=
+  artifact.selects.any fun selectAdmission =>
+    artifact.primitiveSteps.any fun primitiveStep =>
+      selectInternalNodeKeyCheck selectAdmission key primitiveStep
+
+/-- The key-level select-internal checker is exact for `SelectInternalExitKey`. -/
+theorem selectInternalExitKeyCheck_eq_true_iff
+    {artifact : WireAdmissionArtifact}
+    {key : NodeId × FieldLabel × ContractId} :
+    artifact.selectInternalExitKeyCheck key = true ↔
+      artifact.SelectInternalExitKey key := by
+  unfold selectInternalExitKeyCheck SelectInternalExitKey
+  constructor
+  · intro hCheck
+    rcases List.any_eq_true.mp hCheck with
+      ⟨selectAdmission, hSelect, hPrimitiveCheck⟩
+    rcases List.any_eq_true.mp hPrimitiveCheck with
+      ⟨primitiveStep, hPrimitive, hNodeCheck⟩
+    rcases selectInternalNodeKeyCheck_sound hNodeCheck with
+      ⟨entries, exits, hStep, exit, hExit, hKey, hGroup, variant,
+        hVariant, hCompatible⟩
+    subst primitiveStep
+    exact
+      ⟨ selectAdmission
+      , hSelect
+      , entries
+      , exits
+      , hPrimitive
+      , exit
+      , hExit
+      , hKey
+      , hGroup
+      , variant
+      , hVariant
+      , hCompatible
+      ⟩
+  · rintro
+      ⟨ selectAdmission, hSelect, entries, exits, hPrimitive, exit, hExit,
+        hKey, hGroup, variant, hVariant, hCompatible ⟩
+    exact
+      List.any_eq_true.mpr
+        ⟨ selectAdmission
+        , hSelect
+        , List.any_eq_true.mpr
+          ⟨ PrimitiveGraphStep.node selectAdmission.conditionNode entries exits
+          , hPrimitive
+          , selectInternalNodeKeyCheck_complete
+            ⟨ exit
+            , hExit
+            , hKey
+            , hGroup
+            , variant
+            , hVariant
+            , hCompatible
+            ⟩
+          ⟩
+        ⟩
+
+/-- Primitive exit keys that remain source-visible after replay and select erasure. -/
+def residualPrimitiveExitKeys (artifact : WireAdmissionArtifact) :
+    List (NodeId × FieldLabel × ContractId) :=
+  (PrimitiveGraphStep.nodeExitKeysList artifact.primitiveSteps).filter fun key =>
+    decide (key ∉ PrimitiveGraphStep.consumedExitKeysList artifact.primitiveSteps) &&
+      !(artifact.selectInternalExitKeyCheck key)
+
+/-- Executable checker that summary frontiers exactly match residual primitive frontiers. -/
+def summaryFrontiersMatchPrimitiveCheck
+    (artifact : WireAdmissionArtifact) :
+    Bool :=
+  Check.sameMembersCheck
+      (artifact.entries.map AdmissionBoundaryPort.key)
+      artifact.residualPrimitiveEntryKeys &&
+    Check.sameMembersCheck
+      (artifact.exits.map AdmissionBoundaryPort.key)
+      artifact.residualPrimitiveExitKeys
+
+/-- Successful frontier-exactness checking proves `SummaryFrontiersMatchPrimitive`. -/
+theorem summaryFrontiersMatchPrimitiveCheck_sound
+    {artifact : WireAdmissionArtifact}
+    (hCheck : artifact.summaryFrontiersMatchPrimitiveCheck = true) :
+    artifact.SummaryFrontiersMatchPrimitive := by
+  unfold summaryFrontiersMatchPrimitiveCheck at hCheck
+  rw [Bool.and_eq_true] at hCheck
+  have hEntriesMembers := Check.sameMembersCheck_sound hCheck.left
+  have hExitsMembers := Check.sameMembersCheck_sound hCheck.right
+  constructor
+  · intro key
+    constructor
+    · intro hSummary
+      have hResidual : key ∈ artifact.residualPrimitiveEntryKeys :=
+        (hEntriesMembers key).mp hSummary
+      unfold residualPrimitiveEntryKeys at hResidual
+      rw [List.mem_filter] at hResidual
+      exact ⟨hResidual.left, of_decide_eq_true hResidual.right⟩
+    · intro hPrimitive
+      have hResidual : key ∈ artifact.residualPrimitiveEntryKeys := by
+        unfold residualPrimitiveEntryKeys
+        rw [List.mem_filter]
+        exact ⟨hPrimitive.left, by simpa using decide_eq_true hPrimitive.right⟩
+      exact (hEntriesMembers key).mpr hResidual
+  · intro key
+    constructor
+    · intro hSummary
+      have hResidual : key ∈ artifact.residualPrimitiveExitKeys :=
+        (hExitsMembers key).mp hSummary
+      unfold residualPrimitiveExitKeys at hResidual
+      rw [List.mem_filter] at hResidual
+      rw [Bool.and_eq_true] at hResidual
+      have hNotConsumed :
+          key ∉ PrimitiveGraphStep.consumedExitKeysList artifact.primitiveSteps :=
+        of_decide_eq_true hResidual.right.left
+      have hNotInternal : ¬ artifact.SelectInternalExitKey key := by
+        intro hInternal
+        have hInternalCheck : artifact.selectInternalExitKeyCheck key = true :=
+          selectInternalExitKeyCheck_eq_true_iff.mpr hInternal
+        rw [hInternalCheck] at hResidual
+        simp at hResidual
+      exact ⟨hResidual.left, hNotConsumed, hNotInternal⟩
+    · intro hPrimitive
+      have hResidual : key ∈ artifact.residualPrimitiveExitKeys := by
+        unfold residualPrimitiveExitKeys
+        rw [List.mem_filter]
+        refine ⟨hPrimitive.left, ?_⟩
+        rw [Bool.and_eq_true]
+        constructor
+        · exact decide_eq_true hPrimitive.right.left
+        · cases hInternalCheck : artifact.selectInternalExitKeyCheck key with
+          | false =>
+              rfl
+          | true =>
+              have hInternal : artifact.SelectInternalExitKey key :=
+                selectInternalExitKeyCheck_eq_true_iff.mp hInternalCheck
+              exact False.elim (hPrimitive.right.right hInternal)
+      exact (hExitsMembers key).mpr hResidual
+
+/-- Executable checker that top-level raw connections match primitive connect projections. -/
+def rawConnectionsMatchPrimitiveCheck
+    (artifact : WireAdmissionArtifact) :
+    Bool :=
+  Check.permCheck artifact.connections
+    (PrimitiveGraphStep.rawConnectionsList artifact.primitiveSteps)
+
+/-- Successful raw-connection matching proves `RawConnectionsMatchPrimitive`. -/
+theorem rawConnectionsMatchPrimitiveCheck_sound
+    {artifact : WireAdmissionArtifact}
+    (hCheck : artifact.rawConnectionsMatchPrimitiveCheck = true) :
+    artifact.RawConnectionsMatchPrimitive :=
+  Check.permCheck_sound hCheck
+
+/-! ## Select Row Checks -/
+
+/-- Executable checker for one select variant row. -/
+def selectVariantValidCheck (variant : SelectVariantArtifact) : Bool :=
+  decide variant.key.Valid &&
+    decide variant.port.Valid &&
+      decide (variant.key = variant.port.selectKey)
+
+/-- Successful select-variant checking proves `SelectVariantArtifact.Valid`. -/
+theorem selectVariantValidCheck_sound
+    {variant : SelectVariantArtifact}
+    (hCheck : selectVariantValidCheck variant = true) :
+    variant.Valid := by
+  unfold selectVariantValidCheck at hCheck
+  simp only [Bool.and_eq_true] at hCheck
+  rcases hCheck with ⟨⟨hKey, hPort⟩, hCanonical⟩
+  exact
+    { keyValid := of_decide_eq_true hKey
+    , portValid := of_decide_eq_true hPort
+    , keyCanonical := by
+        unfold SelectVariantArtifact.KeyCanonical
+        exact of_decide_eq_true hCanonical
+    }
+
+/-- Executable checker for one select arm row. -/
+def selectArmValidCheck (arm : SelectArmAdmissionArtifact) : Bool :=
+  decide arm.sourceKey.Valid &&
+    decide arm.canonicalKey.Valid &&
+      boundaryPortsClosedCheck arm.bodyNodes arm.bodyEntries &&
+        boundaryPortsClosedCheck arm.bodyNodes arm.bodyExits &&
+          Check.nodupCheck arm.bodyNodes &&
+            Check.nodupCheck arm.bodyEntryKeys &&
+              Check.nodupCheck arm.bodyExitKeys &&
+                Check.allDecide arm.bodyNodes NodeId.Valid &&
+                  AdmissionArtifactCheck.boundaryPortsValidCheck arm.bodyEntries &&
+                    AdmissionArtifactCheck.boundaryPortsValidCheck arm.bodyExits
+
+/-- Successful select-arm checking proves `SelectArmAdmissionArtifact.Valid`. -/
+theorem selectArmValidCheck_sound
+    {arm : SelectArmAdmissionArtifact}
+    (hCheck : selectArmValidCheck arm = true) :
+    arm.Valid := by
+  unfold selectArmValidCheck at hCheck
+  simp only [Bool.and_eq_true] at hCheck
+  rcases hCheck with
+    ⟨⟨⟨⟨⟨⟨⟨⟨⟨hSourceKey, hCanonicalKey⟩, hBodyEntriesClosed⟩,
+      hBodyExitsClosed⟩, hBodyNodesUnique⟩, hBodyEntriesUnique⟩, hBodyExitsUnique⟩,
+      hBodyNodesValid⟩, hBodyEntriesValid⟩, hBodyExitsValid⟩
+  exact
+    { sourceKeyValid := of_decide_eq_true hSourceKey
+    , canonicalKeyValid := of_decide_eq_true hCanonicalKey
+    , bodyBoundariesClosed :=
+        ⟨ boundaryPortsClosedCheck_sound hBodyEntriesClosed
+        , boundaryPortsClosedCheck_sound hBodyExitsClosed
+        ⟩
+    , bodyRowsUnique :=
+        ⟨ Check.nodupCheck_sound hBodyNodesUnique
+        , Check.nodupCheck_sound hBodyEntriesUnique
+        , Check.nodupCheck_sound hBodyExitsUnique
+        ⟩
+    , bodyNodesValid := Check.allDecide_sound hBodyNodesValid
+    , bodyEntriesValid :=
+        AdmissionArtifactCheck.boundaryPortsValidCheck_sound hBodyEntriesValid
+    , bodyExitsValid :=
+        AdmissionArtifactCheck.boundaryPortsValidCheck_sound hBodyExitsValid
+    }
+
+/-- Executable checker that all variant ports share one exclusive output group. -/
+def selectVariantsShareExclusiveGroupCheck :
+    List SelectVariantArtifact → Bool
+  | [] => false
+  | variant :: variants =>
+      match variant.port.exclusiveGroup with
+      | none => false
+      | some group =>
+          Check.allDecide variants fun other =>
+            other.port.exclusiveGroup = some group
+
+/-- Successful exclusive-group checking proves `VariantsShareExclusiveGroup`. -/
+theorem selectVariantsShareExclusiveGroupCheck_sound
+    {variants : List SelectVariantArtifact}
+    (hCheck : selectVariantsShareExclusiveGroupCheck variants = true) :
+    ∃ owner index,
+      ∀ variant, variant ∈ variants →
+        variant.port.exclusiveGroup = some (owner, index) := by
+  cases variants with
+  | nil =>
+      simp [selectVariantsShareExclusiveGroupCheck] at hCheck
+  | cons variant variants =>
+      cases hGroup : variant.port.exclusiveGroup with
+      | none =>
+          simp [selectVariantsShareExclusiveGroupCheck, hGroup] at hCheck
+      | some group =>
+          cases group with
+          | mk owner index =>
+              have hTail :
+                  Check.allDecide variants
+                    (fun other =>
+                      other.port.exclusiveGroup = some (owner, index)) = true := by
+                simpa [selectVariantsShareExclusiveGroupCheck, hGroup] using hCheck
+              refine ⟨owner, index, ?_⟩
+              intro candidate hCandidate
+              simp at hCandidate
+              rcases hCandidate with hHead | hTailMem
+              ·
+                  cases hHead
+                  exact hGroup
+              ·
+                  exact Check.allDecide_sound hTail candidate hTailMem
+
+/-- Executable checker for one select arm's persisted resolution mode. -/
+def selectArmResolutionSoundCheck
+    (variants : List SelectVariantArtifact)
+    (arm : SelectArmAdmissionArtifact) :
+    Bool :=
+  match arm.mode with
+  | SelectResolutionMode.resolvedByLabel =>
+      decide (arm.sourceKey = arm.canonicalKey) &&
+        Check.anyDecide variants (fun variant =>
+          variant.key = arm.canonicalKey ∧
+            variant.port.label = AdmissionPortLabel.label arm.sourceKey)
+  | SelectResolutionMode.resolvedByContract =>
+      Check.allDecide variants (fun variant =>
+          variant.port.label ≠ AdmissionPortLabel.label arm.sourceKey) &&
+        Check.allDecide variants (fun variant =>
+          (variant.port.contract.name = arm.sourceKey.name ↔
+            variant.key = arm.canonicalKey))
+
+/-- Successful resolution-mode checking proves the relational resolution contract. -/
+theorem selectArmResolutionSoundCheck_sound
+    {variants : List SelectVariantArtifact}
+    {arm : SelectArmAdmissionArtifact}
+    (hCheck : selectArmResolutionSoundCheck variants arm = true) :
+    match arm.mode with
+    | SelectResolutionMode.resolvedByLabel =>
+        arm.sourceKey = arm.canonicalKey ∧
+          ∃ variant, variant ∈ variants ∧
+            variant.key = arm.canonicalKey ∧
+            variant.port.label = AdmissionPortLabel.label arm.sourceKey
+    | SelectResolutionMode.resolvedByContract =>
+        (∀ variant, variant ∈ variants →
+          variant.port.label ≠ AdmissionPortLabel.label arm.sourceKey) ∧
+          (∀ variant, variant ∈ variants →
+            (variant.port.contract.name = arm.sourceKey.name ↔
+              variant.key = arm.canonicalKey)) := by
+  cases hMode : arm.mode with
+  | resolvedByLabel =>
+      unfold selectArmResolutionSoundCheck at hCheck
+      rw [hMode] at hCheck
+      rw [Bool.and_eq_true] at hCheck
+      have hResult :
+          arm.sourceKey = arm.canonicalKey ∧
+            ∃ variant, variant ∈ variants ∧
+              variant.key = arm.canonicalKey ∧
+                variant.port.label = AdmissionPortLabel.label arm.sourceKey :=
+        ⟨of_decide_eq_true hCheck.left, Check.anyDecide_sound hCheck.right⟩
+      simpa [hMode] using hResult
+  | resolvedByContract =>
+      unfold selectArmResolutionSoundCheck at hCheck
+      rw [hMode] at hCheck
+      rw [Bool.and_eq_true] at hCheck
+      have hResult :
+          (∀ variant, variant ∈ variants →
+            variant.port.label ≠ AdmissionPortLabel.label arm.sourceKey) ∧
+            (∀ variant, variant ∈ variants →
+              (variant.port.contract.name = arm.sourceKey.name ↔
+                variant.key = arm.canonicalKey)) :=
+        ⟨Check.allDecide_sound hCheck.left, Check.allDecide_sound hCheck.right⟩
+      simpa [hMode] using hResult
+
+/-- Executable checker for select-admission row-local facts. -/
+def selectAdmissionRowsValidCheck
+    (selectAdmission : SelectAdmissionArtifact) :
+    Bool :=
+  decide selectAdmission.owner.Valid &&
+    decide selectAdmission.conditionNode.Valid &&
+      Check.allBool selectAdmission.variants selectVariantValidCheck &&
+        Check.allBool selectAdmission.arms selectArmValidCheck
+
+/-- Successful row-local checking proves `SelectAdmissionArtifact.RowsValid`. -/
+theorem selectAdmissionRowsValidCheck_sound
+    {selectAdmission : SelectAdmissionArtifact}
+    (hCheck : selectAdmissionRowsValidCheck selectAdmission = true) :
+    selectAdmission.RowsValid := by
+  unfold selectAdmissionRowsValidCheck at hCheck
+  simp only [Bool.and_eq_true] at hCheck
+  rcases hCheck with ⟨⟨⟨hOwner, hCondition⟩, hVariants⟩, hArms⟩
+  exact
+    { ownerValid := of_decide_eq_true hOwner
+    , conditionNodeValid := of_decide_eq_true hCondition
+    , variantsValid :=
+        Check.allBool_sound hVariants
+          (fun _variant _ hVariant =>
+            selectVariantValidCheck_sound hVariant)
+    , armsValid :=
+        Check.allBool_sound hArms
+          (fun _arm _ hArm =>
+            selectArmValidCheck_sound hArm)
+    }
+
+/-- Executable checker for one select-admission artifact. -/
+def selectAdmissionValidCheck
+    (selectAdmission : SelectAdmissionArtifact) :
+    Bool :=
+  decide (selectAdmission.owner = selectAdmission.conditionNode) &&
+    Check.permCheck selectAdmission.armCanonicalKeys
+      selectAdmission.variantKeys &&
+      Check.nodupCheck selectAdmission.variantKeys &&
+        decide (2 ≤ selectAdmission.variants.length) &&
+          selectVariantsShareExclusiveGroupCheck selectAdmission.variants &&
+            Check.nodupCheck selectAdmission.armCanonicalKeys &&
+              Check.nodupCheck selectAdmission.armSourceIndexes &&
+                decide
+                  (selectAdmission.armSourceIndexes =
+                    List.range selectAdmission.arms.length) &&
+                  selectAdmissionRowsValidCheck selectAdmission &&
+                    Check.allBool selectAdmission.arms
+                      (selectArmResolutionSoundCheck selectAdmission.variants)
+
+/-- Successful select-admission checking proves `SelectAdmissionArtifact.Valid`. -/
+theorem selectAdmissionValidCheck_sound
+    {selectAdmission : SelectAdmissionArtifact}
+    (hCheck : selectAdmissionValidCheck selectAdmission = true) :
+    selectAdmission.Valid := by
+  unfold selectAdmissionValidCheck at hCheck
+  simp only [Bool.and_eq_true] at hCheck
+  rcases hCheck with
+    ⟨⟨⟨⟨⟨⟨⟨⟨⟨hOwner, hCovered⟩, hVariantKeys⟩, hAtLeastTwo⟩,
+      hExclusiveGroup⟩, hArmKeys⟩, hArmIndexes⟩, hArmIndexesCanonical⟩,
+      hRows⟩, hResolution⟩
+  exact
+    { ownerMatchesCondition := by
+        unfold SelectAdmissionArtifact.OwnerMatchesCondition
+        exact of_decide_eq_true hOwner
+    , keysCovered := Check.permCheck_sound hCovered
+    , variantKeysUnique := Check.nodupCheck_sound hVariantKeys
+    , variantsAtLeastTwo := by
+        unfold SelectAdmissionArtifact.VariantsAtLeastTwo
+        exact of_decide_eq_true hAtLeastTwo
+    , variantsShareExclusiveGroup :=
+        selectVariantsShareExclusiveGroupCheck_sound hExclusiveGroup
+    , armCanonicalKeysUnique := Check.nodupCheck_sound hArmKeys
+    , armSourceIndexesUnique := Check.nodupCheck_sound hArmIndexes
+    , armSourceIndexesCanonical := by
+        unfold SelectAdmissionArtifact.ArmSourceIndexesCanonical
+        exact of_decide_eq_true hArmIndexesCanonical
+    , rowsValid := selectAdmissionRowsValidCheck_sound hRows
+    , armResolutionSound :=
+        Check.allBool_sound hResolution
+          (fun _arm _ hArm =>
+            selectArmResolutionSoundCheck_sound hArm)
+    }
+
+/-- Executable checker that all select-admission artifacts are locally valid. -/
+def selectsValidCheck (artifact : WireAdmissionArtifact) : Bool :=
+  Check.allBool artifact.selects selectAdmissionValidCheck
+
+/-- Successful select-list checking proves `SelectsValid`. -/
+theorem selectsValidCheck_sound
+    {artifact : WireAdmissionArtifact}
+    (hCheck : artifact.selectsValidCheck = true) :
+    artifact.SelectsValid :=
+  Check.allBool_sound hCheck
+    (fun _selectAdmission _ hSelect =>
+      selectAdmissionValidCheck_sound hSelect)
+
 /-- Executable checker for component-row identity uniqueness. -/
 def componentRowsUniqueCheck (artifact : WireAdmissionArtifact) : Bool :=
   Check.nodupMapCheck artifact.generatedForms GeneratedFormArtifact.binding &&
@@ -663,6 +1378,12 @@ structure ValidatorReadyCore (artifact : WireAdmissionArtifact) : Prop where
   schemaCurrent : artifact.SchemaCurrent
   summaryKeysUnique : artifact.SummaryKeysUnique
   summaryRowsValid : artifact.SummaryRowsValid
+  summaryDomainClosed : artifact.SummaryDomainClosed
+  summaryIdentitiesMatchPrimitive : artifact.SummaryIdentitiesMatchPrimitive
+  summaryFrontiersBackedByPrimitive : artifact.SummaryFrontiersBackedByPrimitive
+  summaryFrontiersMatchPrimitive : artifact.SummaryFrontiersMatchPrimitive
+  rawConnectionsMatchPrimitive : artifact.RawConnectionsMatchPrimitive
+  selectsValid : artifact.SelectsValid
   componentRowsUnique : artifact.ComponentRowsUnique
   primitiveStepsValid : artifact.PrimitiveStepsValid
   primitiveTraceStackValid : artifact.PrimitiveTraceStackValid
@@ -675,6 +1396,12 @@ theorem validatorReady_core
   schemaCurrent := hReady.schemaCurrent
   summaryKeysUnique := hReady.summaryKeysUnique
   summaryRowsValid := hReady.summaryRowsValid
+  summaryDomainClosed := hReady.summaryDomainClosed
+  summaryIdentitiesMatchPrimitive := hReady.summaryIdentitiesMatchPrimitive
+  summaryFrontiersBackedByPrimitive := hReady.summaryFrontiersBackedByPrimitive
+  summaryFrontiersMatchPrimitive := hReady.summaryFrontiersMatchPrimitive
+  rawConnectionsMatchPrimitive := hReady.rawConnectionsMatchPrimitive
+  selectsValid := hReady.selectsValid
   componentRowsUnique := hReady.componentRowsUnique
   primitiveStepsValid := hReady.primitiveStepsValid
   primitiveTraceStackValid := hReady.primitiveTraceStackValid
@@ -684,9 +1411,15 @@ def validatorReadyCoreCheck (artifact : WireAdmissionArtifact) : Bool :=
   decide artifact.SchemaCurrent &&
     artifact.summaryKeysUniqueCheck &&
       artifact.summaryRowsValidCheck &&
-        artifact.componentRowsUniqueCheck &&
-          artifact.primitiveStepsValidCheck &&
-            artifact.primitiveTraceStackValidCheck
+        artifact.summaryDomainClosedCheck &&
+          artifact.summaryIdentitiesMatchPrimitiveCheck &&
+            artifact.summaryFrontiersBackedByPrimitiveCheck &&
+              artifact.summaryFrontiersMatchPrimitiveCheck &&
+                artifact.rawConnectionsMatchPrimitiveCheck &&
+                  artifact.selectsValidCheck &&
+                    artifact.componentRowsUniqueCheck &&
+                      artifact.primitiveStepsValidCheck &&
+                        artifact.primitiveTraceStackValidCheck
 
 /-- Successful core checking proves the representative validator-ready core. -/
 theorem validatorReadyCoreCheck_sound
@@ -696,12 +1429,23 @@ theorem validatorReadyCoreCheck_sound
   unfold validatorReadyCoreCheck at hCheck
   simp only [Bool.and_eq_true] at hCheck
   rcases hCheck with
-    ⟨⟨⟨⟨⟨hSchema, hSummaryKeys⟩, hSummaryRows⟩, hComponentRows⟩,
-      hPrimitiveSteps⟩, hPrimitiveTrace⟩
+    ⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨⟨hSchema, hSummaryKeys⟩, hSummaryRows⟩,
+      hSummaryDomain⟩, hSummaryIdentities⟩, hSummaryBacked⟩, hSummaryFrontiers⟩,
+      hRawConnections⟩, hSelects⟩, hComponentRows⟩, hPrimitiveSteps⟩, hPrimitiveTrace⟩
   exact
     { schemaCurrent := of_decide_eq_true hSchema
     , summaryKeysUnique := summaryKeysUniqueCheck_sound hSummaryKeys
     , summaryRowsValid := summaryRowsValidCheck_sound hSummaryRows
+    , summaryDomainClosed := summaryDomainClosedCheck_sound hSummaryDomain
+    , summaryIdentitiesMatchPrimitive :=
+        summaryIdentitiesMatchPrimitiveCheck_sound hSummaryIdentities
+    , summaryFrontiersBackedByPrimitive :=
+        summaryFrontiersBackedByPrimitiveCheck_sound hSummaryBacked
+    , summaryFrontiersMatchPrimitive :=
+        summaryFrontiersMatchPrimitiveCheck_sound hSummaryFrontiers
+    , rawConnectionsMatchPrimitive :=
+        rawConnectionsMatchPrimitiveCheck_sound hRawConnections
+    , selectsValid := selectsValidCheck_sound hSelects
     , componentRowsUnique := componentRowsUniqueCheck_sound hComponentRows
     , primitiveStepsValid := primitiveStepsValidCheck_sound hPrimitiveSteps
     , primitiveTraceStackValid := primitiveTraceStackValidCheck_sound hPrimitiveTrace

--- a/theory/Cortex/Wire/AdmissionArtifact/ValidatorCoreCheck.lean
+++ b/theory/Cortex/Wire/AdmissionArtifact/ValidatorCoreCheck.lean
@@ -1,3 +1,4 @@
+import Cortex.Wire.AdmissionArtifact.Check
 import Cortex.Wire.AdmissionArtifact.PrimitiveTraceCheck
 
 /-!
@@ -94,53 +95,6 @@ instance validDecidable (connection : AdmissionRawConnection) :
 
 end AdmissionRawConnection
 
-/-! ## List Helpers -/
-
-namespace Check
-
-/-- Boolean universal quantification over a decoded finite row list. -/
-def allDecide {α : Type}
-    (items : List α)
-    (predicate : α → Prop)
-    [DecidablePred predicate] :
-    Bool :=
-  items.all fun item => decide (predicate item)
-
-/-- A successful finite boolean universal check supplies the corresponding predicate. -/
-theorem allDecide_sound
-    {α : Type}
-    {items : List α}
-    {predicate : α → Prop}
-    [DecidablePred predicate]
-    (hCheck : allDecide items predicate = true) :
-    ∀ item, item ∈ items → predicate item := by
-  intro item hItem
-  have hItemCheck :
-      decide (predicate item) = true :=
-    (List.all_eq_true.mp hCheck) item hItem
-  exact of_decide_eq_true hItemCheck
-
-/-- Boolean existential search over a decoded finite row list. -/
-def anyDecide {α : Type}
-    (items : List α)
-    (predicate : α → Prop)
-    [DecidablePred predicate] :
-    Bool :=
-  items.any fun item => decide (predicate item)
-
-/-- A successful finite boolean existential check supplies a matching row. -/
-theorem anyDecide_sound
-    {α : Type}
-    {items : List α}
-    {predicate : α → Prop}
-    [DecidablePred predicate]
-    (hCheck : anyDecide items predicate = true) :
-    ∃ item, item ∈ items ∧ predicate item := by
-  rcases List.any_eq_true.mp hCheck with ⟨item, hItem, hPredicate⟩
-  exact ⟨item, hItem, of_decide_eq_true hPredicate⟩
-
-end Check
-
 /-! ## Boundary Checks -/
 
 namespace AdmissionArtifactCheck
@@ -198,8 +152,8 @@ theorem nodeFrontiersOwnedCheck_sound
 def nodeFrontiersLinearCheck
     (entries exits : List AdmissionBoundaryPort) :
     Bool :=
-  decide ((entries.map AdmissionBoundaryPort.key).Nodup) &&
-    decide ((exits.map AdmissionBoundaryPort.key).Nodup)
+  Check.nodupMapCheck entries AdmissionBoundaryPort.key &&
+    Check.nodupMapCheck exits AdmissionBoundaryPort.key
 
 /-- Successful frontier-linearity checking proves `NodeFrontiersLinear`. -/
 theorem nodeFrontiersLinearCheck_sound
@@ -208,7 +162,10 @@ theorem nodeFrontiersLinearCheck_sound
     NodeFrontiersLinear entries exits := by
   unfold nodeFrontiersLinearCheck at hCheck
   rw [Bool.and_eq_true] at hCheck
-  exact ⟨of_decide_eq_true hCheck.left, of_decide_eq_true hCheck.right⟩
+  exact
+    ⟨ Check.nodupMapCheck_sound hCheck.left
+    , Check.nodupMapCheck_sound hCheck.right
+    ⟩
 
 /-- Executable checker for primitive node-row validity. -/
 def nodeValidCheck
@@ -243,10 +200,10 @@ def overlayLedgersUniqueCheck
     (leftNodeIds rightNodeIds : List NodeId)
     (leftBindings rightBindings : List BindingName) :
     Bool :=
-  decide leftNodeIds.Nodup &&
-    decide rightNodeIds.Nodup &&
-      decide leftBindings.Nodup &&
-        decide rightBindings.Nodup
+  Check.nodupCheck leftNodeIds &&
+    Check.nodupCheck rightNodeIds &&
+      Check.nodupCheck leftBindings &&
+        Check.nodupCheck rightBindings
 
 /-- Successful overlay-uniqueness checking proves `OverlayLedgersUnique`. -/
 theorem overlayLedgersUniqueCheck_sound
@@ -260,10 +217,10 @@ theorem overlayLedgersUniqueCheck_sound
   simp only [Bool.and_eq_true] at hCheck
   rcases hCheck with ⟨⟨⟨hLeftNodes, hRightNodes⟩, hLeftBindings⟩, hRightBindings⟩
   exact
-    ⟨ of_decide_eq_true hLeftNodes
-    , of_decide_eq_true hRightNodes
-    , of_decide_eq_true hLeftBindings
-    , of_decide_eq_true hRightBindings
+    ⟨ Check.nodupCheck_sound hLeftNodes
+    , Check.nodupCheck_sound hRightNodes
+    , Check.nodupCheck_sound hLeftBindings
+    , Check.nodupCheck_sound hRightBindings
     ⟩
 
 /-- Primitive overlay side ledgers are disjoint before merge. -/
@@ -328,8 +285,8 @@ theorem overlayValidCheck_sound
 
 /-- Matched primitive connect pairs do not reuse outputs or inputs. -/
 def connectPairsLinearCheck (matchedPairs : List AdmissionConnection) : Bool :=
-  decide ((matchedPairs.map AdmissionConnection.fromKey).Nodup) &&
-    decide ((matchedPairs.map AdmissionConnection.toKey).Nodup)
+  Check.nodupMapCheck matchedPairs AdmissionConnection.fromKey &&
+    Check.nodupMapCheck matchedPairs AdmissionConnection.toKey
 
 /-- Successful connect-pair linearity checking proves `ConnectPairsLinear`. -/
 theorem connectPairsLinearCheck_sound
@@ -338,14 +295,17 @@ theorem connectPairsLinearCheck_sound
     ConnectPairsLinear matchedPairs := by
   unfold connectPairsLinearCheck at hCheck
   rw [Bool.and_eq_true] at hCheck
-  exact ⟨of_decide_eq_true hCheck.left, of_decide_eq_true hCheck.right⟩
+  exact
+    ⟨ Check.nodupMapCheck_sound hCheck.left
+    , Check.nodupMapCheck_sound hCheck.right
+    ⟩
 
 /-- Serialized primitive connect frontiers are duplicate-free per side. -/
 def connectFrontiersLinearCheck
     (leftExits rightEntries : List AdmissionBoundaryPort) :
     Bool :=
-  decide ((leftExits.map AdmissionBoundaryPort.key).Nodup) &&
-    decide ((rightEntries.map AdmissionBoundaryPort.key).Nodup)
+  Check.nodupMapCheck leftExits AdmissionBoundaryPort.key &&
+    Check.nodupMapCheck rightEntries AdmissionBoundaryPort.key
 
 /-- Successful connect-frontier linearity checking proves `ConnectFrontiersLinear`. -/
 theorem connectFrontiersLinearCheck_sound
@@ -354,7 +314,10 @@ theorem connectFrontiersLinearCheck_sound
     ConnectFrontiersLinear leftExits rightEntries := by
   unfold connectFrontiersLinearCheck at hCheck
   rw [Bool.and_eq_true] at hCheck
-  exact ⟨of_decide_eq_true hCheck.left, of_decide_eq_true hCheck.right⟩
+  exact
+    ⟨ Check.nodupMapCheck_sound hCheck.left
+    , Check.nodupMapCheck_sound hCheck.right
+    ⟩
 
 /-- Matched and residual connect rows partition the serialized frontiers. -/
 def connectFrontierPartitionCheck
@@ -362,14 +325,14 @@ def connectFrontierPartitionCheck
     (matchedPairs : List AdmissionConnection)
     (unmatchedLeftExits unmatchedRightEntries : List AdmissionBoundaryPort) :
     Bool :=
-  decide
-      (((matchedPairs.map AdmissionConnection.fromKey) ++
-          (unmatchedLeftExits.map AdmissionBoundaryPort.key)).Perm
-        (leftExits.map AdmissionBoundaryPort.key)) &&
-    decide
-      (((matchedPairs.map AdmissionConnection.toKey) ++
-          (unmatchedRightEntries.map AdmissionBoundaryPort.key)).Perm
-        (rightEntries.map AdmissionBoundaryPort.key))
+  Check.permCheck
+      ((matchedPairs.map AdmissionConnection.fromKey) ++
+        (unmatchedLeftExits.map AdmissionBoundaryPort.key))
+      (leftExits.map AdmissionBoundaryPort.key) &&
+    Check.permCheck
+      ((matchedPairs.map AdmissionConnection.toKey) ++
+        (unmatchedRightEntries.map AdmissionBoundaryPort.key))
+      (rightEntries.map AdmissionBoundaryPort.key)
 
 /-- Successful partition checking proves `ConnectFrontierPartition`. -/
 theorem connectFrontierPartitionCheck_sound
@@ -385,7 +348,10 @@ theorem connectFrontierPartitionCheck_sound
         unmatchedLeftExits unmatchedRightEntries := by
   unfold connectFrontierPartitionCheck at hCheck
   rw [Bool.and_eq_true] at hCheck
-  exact ⟨of_decide_eq_true hCheck.left, of_decide_eq_true hCheck.right⟩
+  exact
+    ⟨ Check.permCheck_sound hCheck.left
+    , Check.permCheck_sound hCheck.right
+    ⟩
 
 /-- Matched pairs are drawn from the frontiers serialized in the same connect row. -/
 def connectPairsDrawnFromFrontiersCheck
@@ -459,12 +425,10 @@ def connectMatchesAllCompatibleCheck
     (leftExits rightEntries : List AdmissionBoundaryPort)
     (matchedPairs : List AdmissionConnection) :
     Bool :=
-  leftExits.all fun leftExit =>
-    rightEntries.all fun rightEntry =>
-      if leftExit.CompatibleWith rightEntry then
-        exactMatchedPairCheck matchedPairs leftExit rightEntry
-      else
-        true
+  Check.allPairsWhenCheck
+    leftExits rightEntries
+    AdmissionBoundaryPort.CompatibleWith
+    (exactMatchedPairCheck matchedPairs)
 
 /-- Successful compatibility matching proves `ConnectMatchesAllCompatible`. -/
 theorem connectMatchesAllCompatibleCheck_sound
@@ -474,16 +438,11 @@ theorem connectMatchesAllCompatibleCheck_sound
       connectMatchesAllCompatibleCheck leftExits rightEntries matchedPairs =
         true) :
     ConnectMatchesAllCompatible leftExits rightEntries matchedPairs := by
-  intro leftExit hLeftExit rightEntry hRightEntry hCompatible
   unfold connectMatchesAllCompatibleCheck at hCheck
-  have hLeftCheck :=
-    (List.all_eq_true.mp hCheck) leftExit hLeftExit
-  have hRightCheck :=
-    (List.all_eq_true.mp hLeftCheck) rightEntry hRightEntry
-  by_cases hCompatibleCheck : leftExit.CompatibleWith rightEntry
-  · simp [hCompatibleCheck] at hRightCheck
-    exact exactMatchedPairCheck_sound hRightCheck
-  · exact False.elim (hCompatibleCheck hCompatible)
+  exact
+    Check.allPairsWhenCheck_sound hCheck
+      (fun leftExit _ rightEntry _ hExact =>
+        exactMatchedPairCheck_sound hExact)
 
 /-- Boundary rows inside a primitive connect row are structurally valid. -/
 def connectRowsValidCheck
@@ -613,11 +572,11 @@ namespace WireAdmissionArtifact
 
 /-- Executable checker for top-level summary-key uniqueness. -/
 def summaryKeysUniqueCheck (artifact : WireAdmissionArtifact) : Bool :=
-  decide artifact.nodes.Nodup &&
-    decide artifact.bindingRefs.Nodup &&
-      decide ((artifact.entries.map AdmissionBoundaryPort.key).Nodup) &&
-        decide ((artifact.exits.map AdmissionBoundaryPort.key).Nodup) &&
-          decide artifact.connections.Nodup
+  Check.nodupCheck artifact.nodes &&
+    Check.nodupCheck artifact.bindingRefs &&
+      Check.nodupMapCheck artifact.entries AdmissionBoundaryPort.key &&
+        Check.nodupMapCheck artifact.exits AdmissionBoundaryPort.key &&
+          Check.nodupCheck artifact.connections
 
 /-- Successful summary-key checking proves `SummaryKeysUnique`. -/
 theorem summaryKeysUniqueCheck_sound
@@ -628,11 +587,11 @@ theorem summaryKeysUniqueCheck_sound
   simp only [Bool.and_eq_true] at hCheck
   rcases hCheck with ⟨⟨⟨⟨hNodes, hBindings⟩, hEntries⟩, hExits⟩, hConnections⟩
   exact
-    { nodesUnique := of_decide_eq_true hNodes
-    , bindingRefsUnique := of_decide_eq_true hBindings
-    , entriesUnique := of_decide_eq_true hEntries
-    , exitsUnique := of_decide_eq_true hExits
-    , connectionsUnique := of_decide_eq_true hConnections
+    { nodesUnique := Check.nodupCheck_sound hNodes
+    , bindingRefsUnique := Check.nodupCheck_sound hBindings
+    , entriesUnique := Check.nodupMapCheck_sound hEntries
+    , exitsUnique := Check.nodupMapCheck_sound hExits
+    , connectionsUnique := Check.nodupCheck_sound hConnections
     }
 
 /-- Executable checker for top-level summary row validity. -/
@@ -661,10 +620,10 @@ theorem summaryRowsValidCheck_sound
 
 /-- Executable checker for component-row identity uniqueness. -/
 def componentRowsUniqueCheck (artifact : WireAdmissionArtifact) : Bool :=
-  decide ((artifact.generatedForms.map GeneratedFormArtifact.binding).Nodup) &&
-    decide ((artifact.phantomAdapters.map PhantomAdapterArtifact.node).Nodup) &&
-      decide ((artifact.selects.map SelectAdmissionArtifact.conditionNode).Nodup) &&
-        decide artifact.componentRoleNodes.Nodup
+  Check.nodupMapCheck artifact.generatedForms GeneratedFormArtifact.binding &&
+    Check.nodupMapCheck artifact.phantomAdapters PhantomAdapterArtifact.node &&
+      Check.nodupMapCheck artifact.selects SelectAdmissionArtifact.conditionNode &&
+        Check.nodupCheck artifact.componentRoleNodes
 
 /-- Successful component-row checking proves `ComponentRowsUnique`. -/
 theorem componentRowsUniqueCheck_sound
@@ -675,23 +634,25 @@ theorem componentRowsUniqueCheck_sound
   simp only [Bool.and_eq_true] at hCheck
   rcases hCheck with ⟨⟨⟨hGenerated, hPhantom⟩, hSelect⟩, hRoles⟩
   exact
-    { generatedFormBindingsUnique := of_decide_eq_true hGenerated
-    , phantomAdapterNodesUnique := of_decide_eq_true hPhantom
-    , selectConditionNodesUnique := of_decide_eq_true hSelect
-    , componentRoleNodesUnique := of_decide_eq_true hRoles
+    { generatedFormBindingsUnique := Check.nodupMapCheck_sound hGenerated
+    , phantomAdapterNodesUnique := Check.nodupMapCheck_sound hPhantom
+    , selectConditionNodesUnique := Check.nodupMapCheck_sound hSelect
+    , componentRoleNodesUnique := Check.nodupCheck_sound hRoles
     }
 
 /-- Executable checker for primitive graph-step row-local validity. -/
 def primitiveStepsValidCheck (artifact : WireAdmissionArtifact) : Bool :=
-  artifact.primitiveSteps.all PrimitiveGraphStep.validCheck
+  Check.allBool artifact.primitiveSteps PrimitiveGraphStep.validCheck
 
 /-- Successful primitive-step checking proves `PrimitiveStepsValid`. -/
 theorem primitiveStepsValidCheck_sound
     {artifact : WireAdmissionArtifact}
     (hCheck : artifact.primitiveStepsValidCheck = true) :
     artifact.PrimitiveStepsValid := by
-  intro primitiveStep hStep
-  exact PrimitiveGraphStep.validCheck_sound ((List.all_eq_true.mp hCheck) _ hStep)
+  exact
+    Check.allBool_sound hCheck
+      (fun primitiveStep _ hStepCheck =>
+        PrimitiveGraphStep.validCheck_sound hStepCheck)
 
 /-- Representative executable subset of `ValidatorReady`.
 

--- a/theory/README.md
+++ b/theory/README.md
@@ -396,8 +396,9 @@ Mechanized results now include:
   relational `PrimitiveTraceStackValid` field required by `ValidatorReady`.
   `AdmissionArtifact.ValidatorReadyCore`, `AdmissionArtifact.validatorReadyCoreCheck`, and
   `AdmissionArtifact.validatorReadyCoreCheck_sound` extend that strategy to a representative
-  executable validator core: schema version, summary-key uniqueness, summary-row validity,
-  component-row uniqueness, primitive row validity, and primitive stack replay.
+  executable validator core: schema version, summary-key uniqueness, summary-row validity, summary
+  domain closure, summary identity/frontier/raw-connection matching against primitive rows, local
+  select-row validity, component-row uniqueness, primitive row validity, and primitive stack replay.
   `AdmissionArtifact.validatorReady_generated_usedChild_sourceChild` and
   `AdmissionArtifact.validatorReady_emptyGeneratedForm_bindingRow` recover the concrete source
   generated-child or empty-family row for each generated artifact, rather than only a label

--- a/theory/lakefile.lean
+++ b/theory/lakefile.lean
@@ -59,6 +59,7 @@ lean_lib «Cortex» where
     `Cortex.Wire.PhantomAdapter,
     `Cortex.Wire.GeneratedForms,
     `Cortex.Wire.AdmissionArtifact,
+    `Cortex.Wire.AdmissionArtifact.Check,
     `Cortex.Wire.AdmissionArtifact.Boundary,
     `Cortex.Wire.AdmissionArtifact.Generated,
     `Cortex.Wire.AdmissionArtifact.Phantom,


### PR DESCRIPTION
## Summary

Refactor the Lean Wire admission-artifact checker helpers and overlay the first summary-invariant checker slice. The executable `ValidatorReadyCore` checker now covers the #191 helper strategy plus #192 summary/domain/primitive matching fields, with local select-row validity included before select-internal exit erasure is trusted.

## Plan

- [x] Inspect `ValidatorCoreCheck.lean` for repeated list, membership, `Nodup`, `Perm`, and gated-pair proof patterns.
- [x] Extract theorem-facing helper combinators without changing checker semantics.
- [x] Rewrite existing core checker proofs to use the helpers.
- [x] Add executable checks and soundness theorems for summary domain closure.
- [x] Add executable checks and soundness theorems for summary identity/frontier/raw-connection matching against primitive rows.
- [x] Add executable checks and soundness theorems for local select-row validity.
- [x] Align residual-frontier checking with set-style membership equality rather than list-order/multiplicity.
- [x] Update proof-status documentation for the expanded validator-core coverage.
- [x] Verify the focused Lean module and repo Lean/docs checks.

## Validation

- [x] `nix develop -c bash -lc 'cd theory && lake build Cortex.Wire.AdmissionArtifact.ValidatorCoreCheck'`\n- [x] `just lean-lint`\n- [x] `just lean-check`\n- [x] `just docs-check`\n- [x] `just check-commit-provenance origin/main..HEAD`\n\n## Checklist\n\n- [x] Implementation complete\n- [x] Lean checks pass locally\n- [x] Docs check passes locally\n- [ ] Ready for review\n\n## Issues\n\nCloses #191\nCloses #192\n