### PR TITLE
feat(wire): reconstruct primitive admission artifacts

### DIFF
--- a/docs/Reference/proof-status.md
+++ b/docs/Reference/proof-status.md
@@ -120,6 +120,14 @@ rows.
   `AdmissionArtifact.validatorReady_sound` to produce `AdmissionArtifact.Sound`. Haskell integration
   still needs to run this checker on decoded artifacts; the Lean checker is now the intended
   artifact-validation authority.
+- Primitive artifact replay now has an explicit reconstruction target:
+  `AdmissionArtifact.PrimitiveGraphReconstruction`. From `AdmissionArtifact.Sound`,
+  `AdmissionArtifact.Sound.toPrimitiveGraphReconstruction` recovers the final primitive replay
+  frame, proves it matches the top-level summary, proves source-visible primitive rows are
+  duplicate-free, classifies every primitive frontier key as exposed, consumed, or select-internal,
+  and keeps raw-connection projection tied to replayed primitive contractions. This is intentionally
+  not yet `GraphElaboration.CertifiedGraph`: accepted-node declarations and binding expansion are
+  still separate correspondence evidence.
 - The remaining end-to-end compiler theorem is stronger than `Sound`: it must show that every
   accepted Wire program causes the Haskell compiler to emit an artifact satisfying the validator,
   and that decoded rows can be replayed into the concrete Lean witnesses consumed by graph

--- a/theory/Cortex.lean
+++ b/theory/Cortex.lean
@@ -40,6 +40,7 @@ import Cortex.Wire.AdmissionArtifact.Boundary
 import Cortex.Wire.AdmissionArtifact.Generated
 import Cortex.Wire.AdmissionArtifact.Phantom
 import Cortex.Wire.AdmissionArtifact.Primitive
+import Cortex.Wire.AdmissionArtifact.PrimitiveReconstruction
 import Cortex.Wire.AdmissionArtifact.PrimitiveTraceCheck
 import Cortex.Wire.AdmissionArtifact.ReadyGeneral
 import Cortex.Wire.AdmissionArtifact.ReadyGenerated

--- a/theory/Cortex/Wire/AdmissionArtifact.lean
+++ b/theory/Cortex/Wire/AdmissionArtifact.lean
@@ -1,4 +1,5 @@
 import Cortex.Wire.AdmissionArtifact.Check
+import Cortex.Wire.AdmissionArtifact.PrimitiveReconstruction
 import Cortex.Wire.AdmissionArtifact.PrimitiveTraceCheck
 import Cortex.Wire.AdmissionArtifact.Sound
 import Cortex.Wire.AdmissionArtifact.ValidatorCoreCheck
@@ -13,6 +14,7 @@ The implementation is split into rendered subpages under
 traces, static values, generated forms, phantom adapters, select rows, and the
 top-level validator-ready and proof-facing soundness contracts. The primitive
 trace and full validator-ready contract now have Lean-owned executable checkers
-with soundness theorems. Importing this module preserves the public import path
-for downstream theory code.
+with soundness theorems, and the primitive replay contract reconstructs an
+artifact-level graph witness with explicit frontier-key accounting. Importing
+this module preserves the public import path for downstream theory code.
 -/

--- a/theory/Cortex/Wire/AdmissionArtifact/PrimitiveReconstruction.lean
+++ b/theory/Cortex/Wire/AdmissionArtifact/PrimitiveReconstruction.lean
@@ -1,0 +1,226 @@
+import Cortex.Wire.AdmissionArtifact.Sound
+
+/-!
+## Overview
+
+Primitive graph reconstruction from a validator-sound admission artifact.
+
+The decoded admission artifact is lower-level than `GraphElaboration.CertifiedGraph`:
+it carries primitive boundary rows and a replay stack, not accepted node declarations
+inside an `AdmittedModuleShell`. This module therefore names the strongest honest
+primitive reconstruction target at the artifact boundary.
+
+A `PrimitiveGraphReconstruction` says:
+
+- primitive rows replay to one final frame;
+- the final frame is exactly the top-level serialized summary, up to permutation;
+- source-visible frontier rows are duplicate-free;
+- every primitive node-frontier key is accounted for as exposed, consumed, or
+  select-internal; and
+- top-level raw connections are exactly the raw projection of replayed primitive
+  contractions.
+
+The later `CertifiedGraph` reconstruction step must add the accepted-node/module
+evidence that is intentionally absent from the serialized artifact rows.
+-/
+
+namespace Cortex.Wire
+namespace AdmissionArtifact
+
+open Cortex.Wire.ElaborationIR
+
+namespace WireAdmissionArtifact
+
+namespace PrimitiveTraceFrame
+
+/-! ## Frame-Level Linearity Facts -/
+
+/-- Duplicate-free primitive replay rows after summary matching.
+
+This is the artifact-level frontier-linearity fact: source-visible entry and
+exit endpoints have unique boundary keys, and the raw connection summary has no
+duplicate serialized connection rows. It is deliberately phrased over the
+primitive replay frame rather than over `LinearPortObject`, because artifact rows
+do not carry accepted node declarations. -/
+structure SourceVisibleRowsUnique (frame : PrimitiveTraceFrame) : Prop where
+  nodesUnique : frame.nodes.Nodup
+  bindingRefsUnique : frame.bindingRefs.Nodup
+  entriesUnique : (frame.entries.map AdmissionBoundaryPort.key).Nodup
+  exitsUnique : (frame.exits.map AdmissionBoundaryPort.key).Nodup
+  connectionsUnique : frame.connections.Nodup
+
+/-- A summary-matching frame inherits the artifact's duplicate-free summary rows. -/
+theorem sourceVisibleRowsUnique_of_matchesSummary
+    {frame : PrimitiveTraceFrame}
+    {artifact : WireAdmissionArtifact}
+    (hMatch : frame.MatchesSummary artifact)
+    (hUnique : artifact.SummaryKeysUnique) :
+    frame.SourceVisibleRowsUnique where
+  nodesUnique := by
+    exact
+      (matchesSummary_nodes_perm hMatch).nodup_iff.mpr
+        hUnique.nodesUnique
+  bindingRefsUnique := by
+    exact
+      (matchesSummary_bindingRefs_perm hMatch).nodup_iff.mpr
+        hUnique.bindingRefsUnique
+  entriesUnique := by
+    have hPerm :
+        (frame.entries.map AdmissionBoundaryPort.key).Perm
+          (artifact.entries.map AdmissionBoundaryPort.key) :=
+      (matchesSummary_entries_perm hMatch).map AdmissionBoundaryPort.key
+    exact hPerm.nodup_iff.mpr hUnique.entriesUnique
+  exitsUnique := by
+    have hPerm :
+        (frame.exits.map AdmissionBoundaryPort.key).Perm
+          (artifact.exits.map AdmissionBoundaryPort.key) :=
+      (matchesSummary_exits_perm hMatch).map AdmissionBoundaryPort.key
+    exact hPerm.nodup_iff.mpr hUnique.exitsUnique
+  connectionsUnique := by
+    exact
+      (matchesSummary_connections_perm hMatch).nodup_iff.mpr
+        hUnique.connectionsUnique
+
+end PrimitiveTraceFrame
+
+/-! ## Primitive Frontier Accounting -/
+
+/-- A primitive input key is accounted for either as a source-visible entry or
+as an input consumed by a primitive contraction. -/
+inductive PrimitiveInputKeyAccounted
+    (artifact : WireAdmissionArtifact)
+    (key : NodeId × FieldLabel × ContractId) : Prop where
+  | exposed :
+      key ∈ artifact.entries.map AdmissionBoundaryPort.key →
+        PrimitiveInputKeyAccounted artifact key
+  | consumed :
+      key ∈ PrimitiveGraphStep.consumedEntryKeysList artifact.primitiveSteps →
+        PrimitiveInputKeyAccounted artifact key
+
+/-- A primitive output key is accounted for as a source-visible exit, as an
+output consumed by a primitive contraction, or as a select-condition internal
+choice exit hidden from the source-visible summary. -/
+inductive PrimitiveOutputKeyAccounted
+    (artifact : WireAdmissionArtifact)
+    (key : NodeId × FieldLabel × ContractId) : Prop where
+  | exposed :
+      key ∈ artifact.exits.map AdmissionBoundaryPort.key →
+        PrimitiveOutputKeyAccounted artifact key
+  | consumed :
+      key ∈ PrimitiveGraphStep.consumedExitKeysList artifact.primitiveSteps →
+        PrimitiveOutputKeyAccounted artifact key
+  | selectInternal :
+      artifact.SelectInternalExitKey key →
+        PrimitiveOutputKeyAccounted artifact key
+
+/-- Every primitive node frontier key has a linear accounting classification. -/
+structure PrimitiveFrontierKeysAccounted
+    (artifact : WireAdmissionArtifact) : Prop where
+  inputs :
+    ∀ {key : NodeId × FieldLabel × ContractId},
+      key ∈ PrimitiveGraphStep.nodeEntryKeysList artifact.primitiveSteps →
+        PrimitiveInputKeyAccounted artifact key
+  outputs :
+    ∀ {key : NodeId × FieldLabel × ContractId},
+      key ∈ PrimitiveGraphStep.nodeExitKeysList artifact.primitiveSteps →
+        PrimitiveOutputKeyAccounted artifact key
+
+/-- Exact residual-frontier coverage classifies every primitive input key. -/
+theorem primitiveInputKey_accounted
+    {artifact : WireAdmissionArtifact}
+    (hFrontiers : artifact.SummaryFrontiersMatchPrimitive)
+    {key : NodeId × FieldLabel × ContractId}
+    (hPrimitiveKey :
+      key ∈ PrimitiveGraphStep.nodeEntryKeysList artifact.primitiveSteps) :
+    PrimitiveInputKeyAccounted artifact key := by
+  by_cases hConsumed :
+      key ∈ PrimitiveGraphStep.consumedEntryKeysList artifact.primitiveSteps
+  · exact PrimitiveInputKeyAccounted.consumed hConsumed
+  · exact
+      PrimitiveInputKeyAccounted.exposed
+        ((hFrontiers.left key).mpr ⟨hPrimitiveKey, hConsumed⟩)
+
+/-- Exact residual-frontier coverage classifies every primitive output key. -/
+theorem primitiveOutputKey_accounted
+    {artifact : WireAdmissionArtifact}
+    (hFrontiers : artifact.SummaryFrontiersMatchPrimitive)
+    {key : NodeId × FieldLabel × ContractId}
+    (hPrimitiveKey :
+      key ∈ PrimitiveGraphStep.nodeExitKeysList artifact.primitiveSteps) :
+    PrimitiveOutputKeyAccounted artifact key := by
+  by_cases hConsumed :
+      key ∈ PrimitiveGraphStep.consumedExitKeysList artifact.primitiveSteps
+  · exact PrimitiveOutputKeyAccounted.consumed hConsumed
+  · by_cases hInternal : artifact.SelectInternalExitKey key
+    · exact PrimitiveOutputKeyAccounted.selectInternal hInternal
+    · exact
+        PrimitiveOutputKeyAccounted.exposed
+          ((hFrontiers.right key).mpr
+            ⟨hPrimitiveKey, hConsumed, hInternal⟩)
+
+/-- Exact residual-frontier coverage gives the primitive frontier accounting
+needed by reconstruction. -/
+theorem primitiveFrontierKeysAccounted
+    {artifact : WireAdmissionArtifact}
+    (hFrontiers : artifact.SummaryFrontiersMatchPrimitive) :
+    artifact.PrimitiveFrontierKeysAccounted where
+  inputs hPrimitiveKey :=
+    primitiveInputKey_accounted hFrontiers hPrimitiveKey
+  outputs hPrimitiveKey :=
+    primitiveOutputKey_accounted hFrontiers hPrimitiveKey
+
+/-! ## Reconstruction Contract -/
+
+/-- Primitive graph evidence reconstructed for one final replay frame.
+
+This is the current artifact-boundary target, not the final
+`GraphElaboration.CertifiedGraph` target. The latter additionally needs
+accepted-node declarations and module binding expansion that are not serialized
+in primitive artifact rows. -/
+structure PrimitiveGraphReconstructionFrame
+    (artifact : WireAdmissionArtifact)
+    (finalFrame : PrimitiveTraceFrame) : Prop where
+  replay :
+    PrimitiveTraceReplays artifact.SelectInternalTraceExit
+      artifact.primitiveSteps [] [finalFrame]
+  matchesSummary : finalFrame.MatchesSummary artifact
+  sourceVisibleRowsUnique : finalFrame.SourceVisibleRowsUnique
+  frontierKeysAccounted : artifact.PrimitiveFrontierKeysAccounted
+  rawConnectionsMatchPrimitive : artifact.RawConnectionsMatchPrimitive
+
+/-- Primitive graph evidence reconstructed from a sound admission artifact. -/
+def PrimitiveGraphReconstruction
+    (artifact : WireAdmissionArtifact) : Prop :=
+  ∃ finalFrame, PrimitiveGraphReconstructionFrame artifact finalFrame
+
+/-- Primitive soundness reconstructs the artifact-level primitive graph witness. -/
+theorem PrimitiveSound.toPrimitiveGraphReconstruction
+    {artifact : WireAdmissionArtifact}
+    (hPrimitive : artifact.PrimitiveSound) :
+    artifact.PrimitiveGraphReconstruction := by
+  obtain ⟨finalFrame, hReplay, hMatch⟩ :=
+    hPrimitive.primitiveTraceStackValid
+  exact
+    ⟨ finalFrame
+    , { replay := hReplay
+        matchesSummary := hMatch
+        sourceVisibleRowsUnique :=
+          PrimitiveTraceFrame.sourceVisibleRowsUnique_of_matchesSummary
+            hMatch hPrimitive.summaryKeysUnique
+        frontierKeysAccounted :=
+          primitiveFrontierKeysAccounted hPrimitive.summaryFrontiersMatchPrimitive
+        rawConnectionsMatchPrimitive :=
+          hPrimitive.rawConnectionsMatchPrimitive }
+    ⟩
+
+/-- Validator soundness reconstructs the artifact-level primitive graph witness. -/
+theorem Sound.toPrimitiveGraphReconstruction
+    {artifact : WireAdmissionArtifact}
+    (hSound : artifact.Sound) :
+    artifact.PrimitiveGraphReconstruction :=
+  hSound.primitive.toPrimitiveGraphReconstruction
+
+end WireAdmissionArtifact
+
+end AdmissionArtifact
+end Cortex.Wire

--- a/theory/README.md
+++ b/theory/README.md
@@ -458,6 +458,12 @@ Mechanized results now include:
   without downstream proofs depending on checker-internal field layout. This is still not a
   completeness proof that the Haskell compiler emits such an artifact for every accepted Wire
   program; it is the reusable target that such a proof must hit.
+  `AdmissionArtifact.PrimitiveGraphReconstruction` is the first replay witness reconstructed from
+  that cutline: `AdmissionArtifact.Sound.toPrimitiveGraphReconstruction` recovers the final
+  primitive frame, summary matching, source-visible duplicate-freedom, frontier-key accounting
+  (exposed, consumed, or select-internal), and raw-connection projection. It deliberately stops at
+  the artifact boundary rather than claiming a `GraphElaboration.CertifiedGraph`, because accepted
+  node declarations and binding expansion are not serialized in primitive artifact rows.
 - `LinearPortGraph.FrontierFinished`, `LinearPortGraph.OutputReclaimable`,
   `LinearPortGraph.InputReclaimable`, `frontierFinished_noRemainingConsumerObligations`,
   `frontierFinished_noRemainingProducerObligations`, and `frontierFinished_reclaimable`: finished

--- a/theory/lakefile.lean
+++ b/theory/lakefile.lean
@@ -64,6 +64,7 @@ lean_lib «Cortex» where
     `Cortex.Wire.AdmissionArtifact.Generated,
     `Cortex.Wire.AdmissionArtifact.Phantom,
     `Cortex.Wire.AdmissionArtifact.Primitive,
+    `Cortex.Wire.AdmissionArtifact.PrimitiveReconstruction,
     `Cortex.Wire.AdmissionArtifact.PrimitiveTraceCheck,
     `Cortex.Wire.AdmissionArtifact.ReadyGeneral,
     `Cortex.Wire.AdmissionArtifact.ReadyGenerated,


### PR DESCRIPTION
## Summary

- add `Cortex.Wire.AdmissionArtifact.PrimitiveReconstruction`
- define the artifact-boundary primitive reconstruction target from `AdmissionArtifact.Sound`
- recover the final primitive replay frame, summary matching, source-visible row uniqueness, frontier-key accounting, and raw-connection replay projection
- document why this stops at the artifact boundary instead of claiming `GraphElaboration.CertifiedGraph` reconstruction from JSON rows

## Validation

- `cd theory && lake build Cortex.Wire.AdmissionArtifact.PrimitiveReconstruction Cortex.Wire.AdmissionArtifact Cortex`
- `just lean-lint`
- `just lean-check`
- `just docs-check`
- `just fmt-check`
- `git diff --check`
- `just check-commit-provenance 197-lean-full-wire-admission-artifact-validator..HEAD`

Closes #198
