### PR TITLE
feat(wire): reconstruct select-admission artifacts

### DIFF
--- a/docs/Reference/proof-status.md
+++ b/docs/Reference/proof-status.md
@@ -142,6 +142,13 @@ rows.
   bulk rows, direction-specific multi/singular endpoint coverage, and record or bounded-indexed
   product-shape evidence. This is intentionally not yet `PhantomAdapterWitness`: the serialized row
   does not contain the left/right operand objects or certified `BulkContract` traces.
+- Select-admission artifacts now reconstruct at the artifact boundary:
+  `AdmissionArtifact.SelectReconstruction`. `AdmissionArtifact.Sound.toSelectReconstruction` proves
+  that every persisted `select(...)` row has projected latent-admission key coverage, source arm
+  provenance, label-first or unique-contract-fallback resolution evidence, latent body freshness and
+  pairwise body disjointness, condition-bridge/body-boundary shape evidence, and selected-variant
+  bridge entry consumption. This is intentionally not selected-branch durable recovery: replaying
+  the chosen latent body remains a separate recovery witness.
 - The remaining end-to-end compiler theorem is stronger than `Sound`: it must show that every
   accepted Wire program causes the Haskell compiler to emit an artifact satisfying the validator,
   and that decoded rows can be replayed into the concrete Lean witnesses consumed by graph

--- a/theory/Cortex.lean
+++ b/theory/Cortex.lean
@@ -54,6 +54,7 @@ import Cortex.Wire.AdmissionArtifact.ReadySelect
 import Cortex.Wire.AdmissionArtifact.ReadySelectBridge
 import Cortex.Wire.AdmissionArtifact.ReadySummary
 import Cortex.Wire.AdmissionArtifact.Select
+import Cortex.Wire.AdmissionArtifact.SelectReconstruction
 import Cortex.Wire.AdmissionArtifact.Sound
 import Cortex.Wire.AdmissionArtifact.StaticValue
 import Cortex.Wire.AdmissionArtifact.Validator

--- a/theory/Cortex/Wire/AdmissionArtifact.lean
+++ b/theory/Cortex/Wire/AdmissionArtifact.lean
@@ -3,6 +3,7 @@ import Cortex.Wire.AdmissionArtifact.GeneratedReconstruction
 import Cortex.Wire.AdmissionArtifact.PhantomReconstruction
 import Cortex.Wire.AdmissionArtifact.PrimitiveReconstruction
 import Cortex.Wire.AdmissionArtifact.PrimitiveTraceCheck
+import Cortex.Wire.AdmissionArtifact.SelectReconstruction
 import Cortex.Wire.AdmissionArtifact.Sound
 import Cortex.Wire.AdmissionArtifact.ValidatorCoreCheck
 
@@ -21,6 +22,8 @@ artifact-level graph witness with explicit frontier-key accounting. Generated
 artifact rows reconstruct source item provenance and primitive-backed child
 frontier evidence, and phantom rows reconstruct primitive-backed adapter-node
 and bulk-replay evidence without yet claiming full `PhantomAdapterWitness`
-construction. Importing this module preserves the public import path for
-downstream theory code.
+construction. Select rows reconstruct projected latent admissions, arm
+provenance, resolution, condition-bridge, and body-domain evidence without yet
+claiming durable selected-branch replay. Importing this module preserves the
+public import path for downstream theory code.
 -/

--- a/theory/Cortex/Wire/AdmissionArtifact/SelectReconstruction.lean
+++ b/theory/Cortex/Wire/AdmissionArtifact/SelectReconstruction.lean
@@ -1,0 +1,319 @@
+import Cortex.Wire.AdmissionArtifact.PrimitiveReconstruction
+
+/-!
+## Overview
+
+Select-admission reconstruction from validator-sound admission artifacts.
+
+The select artifact rows already project to the generic
+`SelectAdmission.LatentSelectAdmission` carrier. This module names the
+artifact-boundary reconstruction theorem that downstream correspondence proofs
+should consume:
+
+- every select row carries the projected latent admission and key coverage;
+- latent entries come from decoded source arm rows;
+- label-first and unique-contract-fallback resolution facts are preserved;
+- latent body nodes are fresh from the top-level summary and pairwise disjoint;
+- arm body boundary rows match the condition bridge; and
+- selected-variant bridge entries are consumed by primitive replay.
+
+This is still source-side admission. Replaying a chosen latent body into durable
+selected-branch recovery remains a separate proof surface.
+-/
+
+namespace Cortex.Wire
+namespace AdmissionArtifact
+
+open Cortex.Wire.ElaborationIR
+
+namespace WireAdmissionArtifact
+
+/-! ## Select Reconstruction Contract -/
+
+/-- Resolution evidence for one persisted source select arm. -/
+inductive SelectArmResolutionReconstruction
+    (selectAdmission : SelectAdmissionArtifact)
+    (arm : SelectArmAdmissionArtifact) : Prop where
+  | byLabel
+      (mode_eq : arm.mode = SelectResolutionMode.resolvedByLabel)
+      (sourceKey_eq : arm.sourceKey = arm.canonicalKey)
+      (variant :
+        ∃ variant, variant ∈ selectAdmission.variants ∧
+          variant.key = arm.canonicalKey ∧
+          variant.port.label = AdmissionPortLabel.label arm.sourceKey) :
+        SelectArmResolutionReconstruction selectAdmission arm
+  | byContract
+      (mode_eq : arm.mode = SelectResolutionMode.resolvedByContract)
+      (noLabelShadow :
+        ∀ variant, variant ∈ selectAdmission.variants →
+          variant.port.label ≠ AdmissionPortLabel.label arm.sourceKey)
+      (contractFallbackUnique :
+        ∀ variant, variant ∈ selectAdmission.variants →
+          (variant.port.contract.name = arm.sourceKey.name ↔
+            variant.key = arm.canonicalKey)) :
+        SelectArmResolutionReconstruction selectAdmission arm
+
+/-- Condition-bridge/body-boundary evidence for one select arm. -/
+structure SelectArmBridgeReconstruction
+    (artifact : WireAdmissionArtifact)
+    (selectAdmission : SelectAdmissionArtifact)
+    (arm : SelectArmAdmissionArtifact)
+    (entries exits : List AdmissionBoundaryPort)
+    (variant : SelectVariantArtifact) : Prop where
+  primitiveConditionNode :
+    PrimitiveGraphStep.node selectAdmission.conditionNode entries exits ∈
+      artifact.primitiveSteps
+  variantMem : variant ∈ selectAdmission.variants
+  variantKey : variant.key = arm.canonicalKey
+  bodyShape :
+    (((arm.bodyNodes = [] ∧ arm.bodyEntries = [] ∧ arm.bodyExits = []) ∧
+        SelectConditionBridgeOutputShapes selectAdmission exits =
+          [variant.port.identityOutputShape]) ∨
+      (arm.bodyEntries.map AdmissionBoundaryPort.compatibilityShape =
+          [variant.port.compatibilityShape] ∧
+        (arm.bodyExits.map AdmissionBoundaryPort.outputShape).Perm
+          (SelectConditionBridgeOutputShapes selectAdmission exits)))
+  conditionInputKeysAccounted :
+    ∀ {key : NodeId × FieldLabel × ContractId},
+      key ∈ entries.map AdmissionBoundaryPort.key →
+        PrimitiveInputKeyAccounted artifact key
+  conditionOutputKeysAccounted :
+    ∀ {key : NodeId × FieldLabel × ContractId},
+      key ∈ exits.map AdmissionBoundaryPort.key →
+        PrimitiveOutputKeyAccounted artifact key
+
+/-- Artifact-boundary bridge evidence exists for one select arm. -/
+def SelectArmBridge
+    (artifact : WireAdmissionArtifact)
+    (selectAdmission : SelectAdmissionArtifact)
+    (arm : SelectArmAdmissionArtifact) : Prop :=
+  ∃ entries exits variant,
+    SelectArmBridgeReconstruction artifact selectAdmission arm entries exits variant
+
+/-- Primitive replay evidence for one selected variant's bridge entry. -/
+structure SelectVariantBridgeReconstruction
+    (artifact : WireAdmissionArtifact)
+    (selectAdmission : SelectAdmissionArtifact)
+    (variant : SelectVariantArtifact)
+    (entries exits : List AdmissionBoundaryPort)
+    (entry : AdmissionBoundaryPort) : Prop where
+  primitiveConditionNode :
+    PrimitiveGraphStep.node selectAdmission.conditionNode entries exits ∈
+      artifact.primitiveSteps
+  entryMem : entry ∈ entries
+  compatible : variant.port.CompatibleWith entry
+  replayed :
+    { fromPort := variant.port, toPort := entry } ∈
+      PrimitiveGraphStep.matchedConnectionsList artifact.primitiveSteps
+  entryConsumed :
+    entry.key ∈ PrimitiveGraphStep.consumedEntryKeysList artifact.primitiveSteps
+
+/-- Artifact-boundary variant bridge evidence exists for one base variant. -/
+def SelectVariantBridge
+    (artifact : WireAdmissionArtifact)
+    (selectAdmission : SelectAdmissionArtifact)
+    (variant : SelectVariantArtifact) : Prop :=
+  ∃ entries exits entry,
+    SelectVariantBridgeReconstruction
+      artifact selectAdmission variant entries exits entry
+
+/-- Reconstruction evidence for one projected latent select entry. -/
+structure SelectLatentEntryReconstruction
+    (artifact : WireAdmissionArtifact)
+    (selectAdmission : SelectAdmissionArtifact)
+    (hValid : selectAdmission.Valid)
+    (entry : SelectArmKey × SelectArmAdmissionArtifact) : Prop where
+  sourceArm :
+    ∃ arm, arm ∈ selectAdmission.arms ∧
+      entry = (arm.canonicalSelectArmKey, arm)
+  bodyValid : entry.snd.Valid
+  bodyNodeFresh :
+    ∀ {node : NodeId}, node ∈ entry.snd.bodyNodes → node ∉ artifact.nodes
+  bodyNodesDisjoint :
+    ∀ {other : SelectArmKey × SelectArmAdmissionArtifact},
+      other ∈ (selectAdmission.toLatentSelectAdmission hValid).entries →
+        entry.fst ≠ other.fst →
+          ∀ {node : NodeId},
+            node ∈ entry.snd.bodyNodes → node ∉ other.snd.bodyNodes
+
+/-- Artifact-boundary reconstruction evidence for one select-admission row. -/
+structure SelectAdmissionReconstruction
+    (artifact : WireAdmissionArtifact)
+    (selectAdmission : SelectAdmissionArtifact) : Prop where
+  valid : selectAdmission.Valid
+  ownerMatchesCondition : selectAdmission.owner = selectAdmission.conditionNode
+  armsAtLeastTwo : 2 ≤ selectAdmission.arms.length
+  latentKeyCoverage :
+    ((selectAdmission.toLatentSelectAdmission valid).entries.map Prod.fst).Perm
+      (selectAdmission.toLatentSelectAdmission valid).shape.armKeys
+  latentEntries :
+    ∀ {entry : SelectArmKey × SelectArmAdmissionArtifact},
+      entry ∈ (selectAdmission.toLatentSelectAdmission valid).entries →
+        SelectLatentEntryReconstruction artifact selectAdmission valid entry
+  armResolution :
+    ∀ {arm : SelectArmAdmissionArtifact},
+      arm ∈ selectAdmission.arms →
+        SelectArmResolutionReconstruction selectAdmission arm
+  armBridge :
+    ∀ {arm : SelectArmAdmissionArtifact},
+      arm ∈ selectAdmission.arms →
+        SelectArmBridge artifact selectAdmission arm
+  variantBridge :
+    ∀ {variant : SelectVariantArtifact},
+      variant ∈ selectAdmission.variants →
+        SelectVariantBridge artifact selectAdmission variant
+
+/-- Artifact-boundary select reconstruction for every select row. -/
+def SelectReconstruction (artifact : WireAdmissionArtifact) : Prop :=
+  ∀ selectAdmission, selectAdmission ∈ artifact.selects →
+    SelectAdmissionReconstruction artifact selectAdmission
+
+/-! ## Reconstruction Theorems -/
+
+/-- Select soundness reconstructs source-arm resolution evidence for one arm. -/
+theorem Sound.selectArmResolutionReconstruction
+    {artifact : WireAdmissionArtifact}
+    (hSound : artifact.Sound)
+    {selectAdmission : SelectAdmissionArtifact}
+    (hSelect : selectAdmission ∈ artifact.selects)
+    {arm : SelectArmAdmissionArtifact}
+    (hArm : arm ∈ selectAdmission.arms) :
+    SelectArmResolutionReconstruction selectAdmission arm := by
+  have hValid := hSound.select.selectsValid selectAdmission hSelect
+  have hResolution := hValid.armResolutionSound arm hArm
+  cases hMode : arm.mode with
+  | resolvedByLabel =>
+      rw [hMode] at hResolution
+      exact
+        SelectArmResolutionReconstruction.byLabel
+          hMode hResolution.left hResolution.right
+  | resolvedByContract =>
+      rw [hMode] at hResolution
+      exact
+        SelectArmResolutionReconstruction.byContract
+          hMode hResolution.left hResolution.right
+
+/-- Select soundness reconstructs condition-bridge evidence for one arm. -/
+theorem Sound.selectArmBridge
+    {artifact : WireAdmissionArtifact}
+    (hSound : artifact.Sound)
+    {selectAdmission : SelectAdmissionArtifact}
+    (hSelect : selectAdmission ∈ artifact.selects)
+    {arm : SelectArmAdmissionArtifact}
+    (hArm : arm ∈ selectAdmission.arms) :
+    SelectArmBridge artifact selectAdmission arm := by
+  obtain ⟨entries, exits, hPrimitiveNode, hArms⟩ :=
+    hSound.select.selectArmBodyBoundariesMatchCondition
+      selectAdmission hSelect
+  obtain ⟨variant, hVariant, hVariantKey, hBodyShape⟩ :=
+    hArms arm hArm
+  have hAccounted :
+      artifact.PrimitiveFrontierKeysAccounted :=
+    primitiveFrontierKeysAccounted
+      hSound.primitive.summaryFrontiersMatchPrimitive
+  refine ⟨entries, exits, variant, ?_⟩
+  exact
+    { primitiveConditionNode := hPrimitiveNode
+      variantMem := hVariant
+      variantKey := hVariantKey
+      bodyShape := hBodyShape
+      conditionInputKeysAccounted := by
+        intro key hKey
+        have hPrimitiveKey :
+            key ∈ PrimitiveGraphStep.nodeEntryKeysList
+              artifact.primitiveSteps :=
+          PrimitiveGraphStep.nodeEntryKeysList_mem_of_node_mem
+            hPrimitiveNode hKey
+        exact hAccounted.inputs hPrimitiveKey
+      conditionOutputKeysAccounted := by
+        intro key hKey
+        have hPrimitiveKey :
+            key ∈ PrimitiveGraphStep.nodeExitKeysList
+              artifact.primitiveSteps :=
+          PrimitiveGraphStep.nodeExitKeysList_mem_of_node_mem
+            hPrimitiveNode hKey
+        exact hAccounted.outputs hPrimitiveKey }
+
+/-- Select soundness reconstructs primitive bridge evidence for one base variant. -/
+theorem Sound.selectVariantBridge
+    {artifact : WireAdmissionArtifact}
+    (hSound : artifact.Sound)
+    {selectAdmission : SelectAdmissionArtifact}
+    (hSelect : selectAdmission ∈ artifact.selects)
+    {variant : SelectVariantArtifact}
+    (hVariant : variant ∈ selectAdmission.variants) :
+    SelectVariantBridge artifact selectAdmission variant := by
+  obtain ⟨entries, exits, entry, hPrimitiveNode, hEntry, hCompat,
+    hReplayed, hConsumed⟩ :=
+      hSound.select.variantBridgeEntryConsumed hSelect hVariant
+  exact
+    ⟨ entries
+    , exits
+    , entry
+    , { primitiveConditionNode := hPrimitiveNode
+        entryMem := hEntry
+        compatible := hCompat
+        replayed := hReplayed
+        entryConsumed := hConsumed }
+    ⟩
+
+/-- Select soundness reconstructs provenance and freshness for one latent entry. -/
+theorem Sound.selectLatentEntryReconstruction
+    {artifact : WireAdmissionArtifact}
+    (hSound : artifact.Sound)
+    {selectAdmission : SelectAdmissionArtifact}
+    (hSelect : selectAdmission ∈ artifact.selects)
+    (hValid : selectAdmission.Valid)
+    {entry : SelectArmKey × SelectArmAdmissionArtifact}
+    (hEntry :
+      entry ∈ (selectAdmission.toLatentSelectAdmission hValid).entries) :
+    SelectLatentEntryReconstruction artifact selectAdmission hValid entry := by
+  exact
+    { sourceArm :=
+        hSound.select.latentEntrySourceArm hSelect hValid hEntry
+      bodyValid :=
+        SelectAdmissionArtifact.toLatentSelectAdmission_entry_body_valid
+          hEntry
+      bodyNodeFresh := by
+        intro node hNode
+        exact
+          hSound.select.latentEntryBodyNodeFresh
+            hSelect hValid hEntry hNode
+      bodyNodesDisjoint := by
+        intro other hOther hKeys node hNode
+        exact
+          hSound.select.latentEntriesBodyNodesDisjoint
+            hSelect hValid hEntry hOther hKeys hNode }
+
+/-- Validator soundness reconstructs select-admission artifact-boundary witnesses. -/
+theorem Sound.toSelectReconstruction
+    {artifact : WireAdmissionArtifact}
+    (hSound : artifact.Sound) :
+    artifact.SelectReconstruction := by
+  intro selectAdmission hSelect
+  let hValid := hSound.select.selectsValid selectAdmission hSelect
+  exact
+    { valid := hValid
+      ownerMatchesCondition := hValid.ownerMatchesCondition
+      armsAtLeastTwo := hSound.select.armsAtLeastTwo hSelect
+      latentKeyCoverage :=
+        (selectAdmission.toLatentSelectAdmission hValid).entries_keys_perm
+      latentEntries := by
+        intro entry hEntry
+        exact
+          hSound.selectLatentEntryReconstruction
+            hSelect hValid hEntry
+      armResolution := by
+        intro arm hArm
+        exact hSound.selectArmResolutionReconstruction hSelect hArm
+      armBridge := by
+        intro arm hArm
+        exact hSound.selectArmBridge hSelect hArm
+      variantBridge := by
+        intro variant hVariant
+        exact hSound.selectVariantBridge hSelect hVariant }
+
+end WireAdmissionArtifact
+
+end AdmissionArtifact
+end Cortex.Wire

--- a/theory/README.md
+++ b/theory/README.md
@@ -475,6 +475,11 @@ Mechanized results now include:
   left/right bulk replay, direction-specific multi/singular endpoint coverage, and record or
   bounded-indexed product facts. It deliberately stops short of `PhantomAdapterWitness` until full
   graph reconstruction supplies operand objects and certified `BulkContract` traces.
+  `AdmissionArtifact.SelectReconstruction` reconstructs select-admission artifact evidence:
+  projected latent admissions, source arm provenance, label-first or unique-contract-fallback
+  resolution, body freshness and pairwise body disjointness, condition-bridge/body-boundary shape,
+  and selected-variant bridge consumption. It deliberately stops short of selected-branch durable
+  recovery, which still belongs to the recovery witness layer.
 - `LinearPortGraph.FrontierFinished`, `LinearPortGraph.OutputReclaimable`,
   `LinearPortGraph.InputReclaimable`, `frontierFinished_noRemainingConsumerObligations`,
   `frontierFinished_noRemainingProducerObligations`, and `frontierFinished_reclaimable`: finished

--- a/theory/lakefile.lean
+++ b/theory/lakefile.lean
@@ -78,6 +78,7 @@ lean_lib «Cortex» where
     `Cortex.Wire.AdmissionArtifact.ReadySelectBridge,
     `Cortex.Wire.AdmissionArtifact.ReadySummary,
     `Cortex.Wire.AdmissionArtifact.Select,
+    `Cortex.Wire.AdmissionArtifact.SelectReconstruction,
     `Cortex.Wire.AdmissionArtifact.Sound,
     `Cortex.Wire.AdmissionArtifact.StaticValue,
     `Cortex.Wire.AdmissionArtifact.Validator,


### PR DESCRIPTION
## Summary

Adds the artifact-boundary select-admission reconstruction layer. From a `WireAdmissionArtifact.Sound` certificate, every persisted `select(...)` row now reconstructs a named Lean evidence record without overclaiming durable selected-branch recovery.

## What lands

- New module `Cortex.Wire.AdmissionArtifact.SelectReconstruction` with:
  - `SelectArmResolutionReconstruction` — label-first vs. unique-contract-fallback per arm
  - `SelectArmBridgeReconstruction` / `SelectArmBridge` — condition-node primitive backing, variant linkage, body-boundary shape, condition-frontier key accounting
  - `SelectVariantBridgeReconstruction` / `SelectVariantBridge` — primitive replay of the selected-variant bridge entry plus consumption
  - `SelectLatentEntryReconstruction` — source-arm provenance, body validity, freshness, pairwise body-domain disjointness
  - `SelectAdmissionReconstruction` — composes the per-row evidence, plus latent-admission key coverage
- `Sound.toSelectReconstruction` proves every Sound artifact satisfies `SelectReconstruction`
- Module wired into `theory/Cortex.lean`, `theory/Cortex/Wire/AdmissionArtifact.lean`, and `theory/lakefile.lean`
- Proof inventory updated in `theory/README.md` and `docs/Reference/proof-status.md`

## What is deliberately not claimed

Selected-branch durable recovery — replaying the chosen latent body into a concrete recovered branch — remains a separate recovery witness layer. This slice only reconstructs source-side admission evidence projected by the validator.

## Stack

Stacked on #215; depends on #200. Base branch: `200-lean-reconstruct-phantom-adapter-witnesses`.

## Verification

- `just fmt-check && just docs-check && just lean-check` — exit 0
- focused `lake build Cortex.Wire.AdmissionArtifact.SelectReconstruction Cortex.Wire.AdmissionArtifact Cortex` — green
- `git verify-commit HEAD` — good ED25519 signature
- `just check-commit-provenance 200-lean-reconstruct-phantom-adapter-witnesses..HEAD` — OK
