### PR TITLE
refactor(wire): share bridge witnesses in reconstruction records

### DIFF
--- a/theory/Cortex/Wire/AdmissionArtifact/PhantomReconstruction.lean
+++ b/theory/Cortex/Wire/AdmissionArtifact/PhantomReconstruction.lean
@@ -93,12 +93,20 @@ structure PhantomBridgeObjectReconstruction
     PrimitiveGraphStep.node phantom.node entries exits ∈ artifact.primitiveSteps
   entriesOwned : ∀ entry, entry ∈ entries → entry.node = phantom.node
   exitsOwned : ∀ exit, exit ∈ exits → exit.node = phantom.node
+  /-- No two entries share a boundary key. Load-bearing against silent collapse
+  in `openBoundaryNodeObject`'s `.toFinset` dedup, which projects on the
+  `(node, port, contract)` key only (see `AdmissionBoundaryPort.key`). -/
   entriesUnique : (entries.map AdmissionBoundaryPort.key).Nodup
+  /-- No two exits share a boundary key. Same role as `entriesUnique`. -/
   exitsUnique : (exits.map AdmissionBoundaryPort.key).Nodup
   leftBulkTargetsMatchPrimitive :
     phantom.leftBulkTargetKeys.Perm (entries.map AdmissionBoundaryPort.key)
   rightBulkSourcesMatchPrimitive :
     phantom.rightBulkSourceKeys.Perm (exits.map AdmissionBoundaryPort.key)
+  /-- The open phantom-node object is source-linear. The proof is the smart
+  constructor's built-in `openNodePorts_portLinear` invariant; it does not
+  depend on artifact-specific data. The no-silent-collapse fields downstream
+  consumers should read are `entriesUnique` / `exitsUnique`. -/
   openObjectLinear :
     (AdmissionBoundaryPort.openBoundaryNodeObject
       phantom.node entries exits entriesOwned exitsOwned).graph.PortLinear
@@ -190,14 +198,23 @@ inductive PhantomDirectionReconstruction
                   artifact.primitiveSteps) :
         PhantomDirectionReconstruction artifact phantom
 
-/-- Artifact-boundary reconstruction evidence for one phantom adapter row. -/
-structure PhantomAdapterReconstruction
+/-- Artifact-boundary reconstruction evidence for one phantom adapter row
+indexed by a shared primitive bridge witness.
+
+The `bridgeEntries` / `bridgeExits` parameters name the single primitive node
+row that backs the adapter node. Sharing them at this layer pins the bridge
+frontier witness to one concrete primitive row, removing the ambiguity that
+would otherwise arise from `bridge` carrying its own existential `(entries,
+exits)`. The bulk-replay fields don't quantify over any primitive frontier
+row — they only assert membership in `matchedConnectionsList`, so they're
+unaffected by this parameterization. -/
+structure PhantomAdapterReconstructionRecord
     (artifact : WireAdmissionArtifact)
-    (phantom : PhantomAdapterArtifact) : Prop where
+    (phantom : PhantomAdapterArtifact)
+    (bridgeEntries bridgeExits : List AdmissionBoundaryPort) : Prop where
   valid : phantom.Valid
   bridge :
-    ∃ entries exits,
-      PhantomBridgeObjectReconstruction artifact phantom entries exits
+    PhantomBridgeObjectReconstruction artifact phantom bridgeEntries bridgeExits
   product : PhantomProductReconstruction artifact phantom
   direction : PhantomDirectionReconstruction artifact phantom
   leftBulkReplayed :
@@ -208,6 +225,13 @@ structure PhantomAdapterReconstruction
     ∀ {pair : AdmissionConnection},
       pair ∈ phantom.rightBulk →
         pair ∈ PrimitiveGraphStep.matchedConnectionsList artifact.primitiveSteps
+
+/-- Artifact-boundary reconstruction evidence for one phantom adapter row. -/
+def PhantomAdapterReconstruction
+    (artifact : WireAdmissionArtifact)
+    (phantom : PhantomAdapterArtifact) : Prop :=
+  ∃ bridgeEntries bridgeExits,
+    PhantomAdapterReconstructionRecord artifact phantom bridgeEntries bridgeExits
 
 /-- Artifact-boundary phantom reconstruction for every phantom adapter row. -/
 def PhantomReconstruction (artifact : WireAdmissionArtifact) : Prop :=
@@ -411,9 +435,12 @@ theorem Sound.toPhantomReconstruction
     (hSound : artifact.Sound) :
     artifact.PhantomReconstruction := by
   intro phantom hPhantom
+  obtain ⟨bridgeEntries, bridgeExits, hBridge⟩ :=
+    hSound.phantomBridgeObjectReconstruction hPhantom
+  refine ⟨bridgeEntries, bridgeExits, ?_⟩
   exact
     { valid := hSound.phantom.phantomAdaptersValid phantom hPhantom
-      bridge := hSound.phantomBridgeObjectReconstruction hPhantom
+      bridge := hBridge
       product := hSound.phantomProductReconstruction hPhantom
       direction := hSound.phantomDirectionReconstruction hPhantom
       leftBulkReplayed := by

--- a/theory/Cortex/Wire/AdmissionArtifact/PrimitiveReconstruction.lean
+++ b/theory/Cortex/Wire/AdmissionArtifact/PrimitiveReconstruction.lean
@@ -197,6 +197,48 @@ theorem sourceVisibleRowsUnique_of_matchesSummary
 
 end PrimitiveTraceFrame
 
+/-! ## Primitive Node Row Uniqueness -/
+
+/-- Sound artifacts have duplicate-free primitive node identity rows.
+
+`Sound.primitive` carries `summaryIdentitiesMatchPrimitive` and
+`summaryKeysUnique.nodesUnique`; together they force the primitive node-row
+ledger to inherit the top-level summary's Nodup. Reconstruction proofs use this
+to identify the unique primitive node row for a given `NodeId`. -/
+theorem PrimitiveSound.primitiveNodeRowsUnique
+    {artifact : WireAdmissionArtifact}
+    (hPrimitive : artifact.PrimitiveSound) :
+    (PrimitiveGraphStep.nodeRowsList artifact.primitiveSteps).Nodup :=
+  hPrimitive.summaryIdentitiesMatchPrimitive.left.nodup_iff.mp
+    hPrimitive.summaryKeysUnique.nodesUnique
+
+/-- Sound artifacts have at most one primitive node row per `NodeId`. -/
+theorem PrimitiveSound.primitiveNode_frontiers_unique
+    {artifact : WireAdmissionArtifact}
+    (hPrimitive : artifact.PrimitiveSound)
+    {node : NodeId}
+    {entries₁ exits₁ entries₂ exits₂ : List AdmissionBoundaryPort}
+    (hLeft :
+      PrimitiveGraphStep.node node entries₁ exits₁ ∈ artifact.primitiveSteps)
+    (hRight :
+      PrimitiveGraphStep.node node entries₂ exits₂ ∈ artifact.primitiveSteps) :
+    entries₁ = entries₂ ∧ exits₁ = exits₂ :=
+  PrimitiveGraphStep.node_frontiers_eq_of_nodeRowsList_nodup
+    hPrimitive.primitiveNodeRowsUnique hLeft hRight
+
+/-- Sound artifacts have at most one primitive node row per `NodeId`. -/
+theorem Sound.primitiveNode_frontiers_unique
+    {artifact : WireAdmissionArtifact}
+    (hSound : artifact.Sound)
+    {node : NodeId}
+    {entries₁ exits₁ entries₂ exits₂ : List AdmissionBoundaryPort}
+    (hLeft :
+      PrimitiveGraphStep.node node entries₁ exits₁ ∈ artifact.primitiveSteps)
+    (hRight :
+      PrimitiveGraphStep.node node entries₂ exits₂ ∈ artifact.primitiveSteps) :
+    entries₁ = entries₂ ∧ exits₁ = exits₂ :=
+  hSound.primitive.primitiveNode_frontiers_unique hLeft hRight
+
 /-! ## Primitive Frontier Accounting -/
 
 /-- A primitive input key is accounted for either as a source-visible entry or

--- a/theory/Cortex/Wire/AdmissionArtifact/SelectReconstruction.lean
+++ b/theory/Cortex/Wire/AdmissionArtifact/SelectReconstruction.lean
@@ -17,6 +17,10 @@ should consume:
 - arm body boundary rows match the condition bridge; and
 - selected-variant bridge entries are consumed by primitive replay.
 
+The reconstruction record exposes one shared `(conditionEntries, conditionExits)`
+primitive node row at the top level so that all per-arm and per-variant bridge
+facts witness the same primitive backing for the condition node.
+
 This is still source-side admission. Replaying a chosen latent body into durable
 selected-branch recovery remains a separate proof surface.
 -/
@@ -53,69 +57,58 @@ inductive SelectArmResolutionReconstruction
             variant.key = arm.canonicalKey)) :
         SelectArmResolutionReconstruction selectAdmission arm
 
-/-- Condition-bridge/body-boundary evidence for one select arm. -/
-structure SelectArmBridgeReconstruction
-    (artifact : WireAdmissionArtifact)
+/-- Body-shape evidence for one source select arm against its chosen variant
+and the shared condition-bridge exits. -/
+inductive SelectArmBodyShapeReconstruction
     (selectAdmission : SelectAdmissionArtifact)
     (arm : SelectArmAdmissionArtifact)
-    (entries exits : List AdmissionBoundaryPort)
+    (conditionExits : List AdmissionBoundaryPort)
     (variant : SelectVariantArtifact) : Prop where
-  primitiveConditionNode :
-    PrimitiveGraphStep.node selectAdmission.conditionNode entries exits ∈
-      artifact.primitiveSteps
+  | emptyBody
+      (bodyNodesEmpty : arm.bodyNodes = [])
+      (bodyEntriesEmpty : arm.bodyEntries = [])
+      (bodyExitsEmpty : arm.bodyExits = [])
+      (conditionOutputShapesIdentity :
+        SelectConditionBridgeOutputShapes selectAdmission conditionExits =
+          [variant.port.identityOutputShape]) :
+        SelectArmBodyShapeReconstruction
+          selectAdmission arm conditionExits variant
+  | nonEmptyBody
+      (bodyEntriesMatch :
+        arm.bodyEntries.map AdmissionBoundaryPort.compatibilityShape =
+          [variant.port.compatibilityShape])
+      (bodyExitsPerm :
+        (arm.bodyExits.map AdmissionBoundaryPort.outputShape).Perm
+          (SelectConditionBridgeOutputShapes selectAdmission conditionExits)) :
+        SelectArmBodyShapeReconstruction
+          selectAdmission arm conditionExits variant
+
+/-- Condition-bridge variant evidence for one source select arm, indexed by
+the shared condition-node exits and the resolved variant. -/
+structure SelectArmBridgeReconstruction
+    (selectAdmission : SelectAdmissionArtifact)
+    (arm : SelectArmAdmissionArtifact)
+    (conditionExits : List AdmissionBoundaryPort)
+    (variant : SelectVariantArtifact) : Prop where
   variantMem : variant ∈ selectAdmission.variants
   variantKey : variant.key = arm.canonicalKey
   bodyShape :
-    (((arm.bodyNodes = [] ∧ arm.bodyEntries = [] ∧ arm.bodyExits = []) ∧
-        SelectConditionBridgeOutputShapes selectAdmission exits =
-          [variant.port.identityOutputShape]) ∨
-      (arm.bodyEntries.map AdmissionBoundaryPort.compatibilityShape =
-          [variant.port.compatibilityShape] ∧
-        (arm.bodyExits.map AdmissionBoundaryPort.outputShape).Perm
-          (SelectConditionBridgeOutputShapes selectAdmission exits)))
-  conditionInputKeysAccounted :
-    ∀ {key : NodeId × FieldLabel × ContractId},
-      key ∈ entries.map AdmissionBoundaryPort.key →
-        PrimitiveInputKeyAccounted artifact key
-  conditionOutputKeysAccounted :
-    ∀ {key : NodeId × FieldLabel × ContractId},
-      key ∈ exits.map AdmissionBoundaryPort.key →
-        PrimitiveOutputKeyAccounted artifact key
+    SelectArmBodyShapeReconstruction selectAdmission arm conditionExits variant
 
-/-- Artifact-boundary bridge evidence exists for one select arm. -/
-def SelectArmBridge
-    (artifact : WireAdmissionArtifact)
-    (selectAdmission : SelectAdmissionArtifact)
-    (arm : SelectArmAdmissionArtifact) : Prop :=
-  ∃ entries exits variant,
-    SelectArmBridgeReconstruction artifact selectAdmission arm entries exits variant
-
-/-- Primitive replay evidence for one selected variant's bridge entry. -/
+/-- Primitive replay evidence for one selected variant's bridge entry, indexed
+by the shared condition-node entries and the chosen entry. -/
 structure SelectVariantBridgeReconstruction
     (artifact : WireAdmissionArtifact)
-    (selectAdmission : SelectAdmissionArtifact)
     (variant : SelectVariantArtifact)
-    (entries exits : List AdmissionBoundaryPort)
+    (conditionEntries : List AdmissionBoundaryPort)
     (entry : AdmissionBoundaryPort) : Prop where
-  primitiveConditionNode :
-    PrimitiveGraphStep.node selectAdmission.conditionNode entries exits ∈
-      artifact.primitiveSteps
-  entryMem : entry ∈ entries
+  entryMem : entry ∈ conditionEntries
   compatible : variant.port.CompatibleWith entry
   replayed :
     { fromPort := variant.port, toPort := entry } ∈
       PrimitiveGraphStep.matchedConnectionsList artifact.primitiveSteps
   entryConsumed :
     entry.key ∈ PrimitiveGraphStep.consumedEntryKeysList artifact.primitiveSteps
-
-/-- Artifact-boundary variant bridge evidence exists for one base variant. -/
-def SelectVariantBridge
-    (artifact : WireAdmissionArtifact)
-    (selectAdmission : SelectAdmissionArtifact)
-    (variant : SelectVariantArtifact) : Prop :=
-  ∃ entries exits entry,
-    SelectVariantBridgeReconstruction
-      artifact selectAdmission variant entries exits entry
 
 /-- Reconstruction evidence for one projected latent select entry. -/
 structure SelectLatentEntryReconstruction
@@ -136,16 +129,34 @@ structure SelectLatentEntryReconstruction
           ∀ {node : NodeId},
             node ∈ entry.snd.bodyNodes → node ∉ other.snd.bodyNodes
 
-/-- Artifact-boundary reconstruction evidence for one select-admission row. -/
-structure SelectAdmissionReconstruction
+/-- Artifact-boundary reconstruction evidence for one select-admission row,
+indexed by a shared condition-node primitive row.
+
+Sharing `conditionEntries` / `conditionExits` at this layer rules out the
+formal countermodel where `armBridge` and `variantBridge` could pick different
+primitive node rows for the same `selectAdmission.conditionNode`. -/
+structure SelectAdmissionReconstructionRecord
     (artifact : WireAdmissionArtifact)
-    (selectAdmission : SelectAdmissionArtifact) : Prop where
+    (selectAdmission : SelectAdmissionArtifact)
+    (conditionEntries conditionExits : List AdmissionBoundaryPort) : Prop where
   valid : selectAdmission.Valid
   ownerMatchesCondition : selectAdmission.owner = selectAdmission.conditionNode
   armsAtLeastTwo : 2 ≤ selectAdmission.arms.length
   latentKeyCoverage :
     ((selectAdmission.toLatentSelectAdmission valid).entries.map Prod.fst).Perm
       (selectAdmission.toLatentSelectAdmission valid).shape.armKeys
+  primitiveConditionNode :
+    PrimitiveGraphStep.node selectAdmission.conditionNode
+        conditionEntries conditionExits ∈
+      artifact.primitiveSteps
+  conditionInputKeysAccounted :
+    ∀ {key : NodeId × FieldLabel × ContractId},
+      key ∈ conditionEntries.map AdmissionBoundaryPort.key →
+        PrimitiveInputKeyAccounted artifact key
+  conditionOutputKeysAccounted :
+    ∀ {key : NodeId × FieldLabel × ContractId},
+      key ∈ conditionExits.map AdmissionBoundaryPort.key →
+        PrimitiveOutputKeyAccounted artifact key
   latentEntries :
     ∀ {entry : SelectArmKey × SelectArmAdmissionArtifact},
       entry ∈ (selectAdmission.toLatentSelectAdmission valid).entries →
@@ -157,11 +168,23 @@ structure SelectAdmissionReconstruction
   armBridge :
     ∀ {arm : SelectArmAdmissionArtifact},
       arm ∈ selectAdmission.arms →
-        SelectArmBridge artifact selectAdmission arm
+        ∃ variant,
+          SelectArmBridgeReconstruction
+            selectAdmission arm conditionExits variant
   variantBridge :
     ∀ {variant : SelectVariantArtifact},
       variant ∈ selectAdmission.variants →
-        SelectVariantBridge artifact selectAdmission variant
+        ∃ entry,
+          SelectVariantBridgeReconstruction
+            artifact variant conditionEntries entry
+
+/-- Artifact-boundary reconstruction evidence for one select-admission row. -/
+def SelectAdmissionReconstruction
+    (artifact : WireAdmissionArtifact)
+    (selectAdmission : SelectAdmissionArtifact) : Prop :=
+  ∃ conditionEntries conditionExits,
+    SelectAdmissionReconstructionRecord
+      artifact selectAdmission conditionEntries conditionExits
 
 /-- Artifact-boundary select reconstruction for every select row. -/
 def SelectReconstruction (artifact : WireAdmissionArtifact) : Prop :=
@@ -193,70 +216,6 @@ theorem Sound.selectArmResolutionReconstruction
         SelectArmResolutionReconstruction.byContract
           hMode hResolution.left hResolution.right
 
-/-- Select soundness reconstructs condition-bridge evidence for one arm. -/
-theorem Sound.selectArmBridge
-    {artifact : WireAdmissionArtifact}
-    (hSound : artifact.Sound)
-    {selectAdmission : SelectAdmissionArtifact}
-    (hSelect : selectAdmission ∈ artifact.selects)
-    {arm : SelectArmAdmissionArtifact}
-    (hArm : arm ∈ selectAdmission.arms) :
-    SelectArmBridge artifact selectAdmission arm := by
-  obtain ⟨entries, exits, hPrimitiveNode, hArms⟩ :=
-    hSound.select.selectArmBodyBoundariesMatchCondition
-      selectAdmission hSelect
-  obtain ⟨variant, hVariant, hVariantKey, hBodyShape⟩ :=
-    hArms arm hArm
-  have hAccounted :
-      artifact.PrimitiveFrontierKeysAccounted :=
-    primitiveFrontierKeysAccounted
-      hSound.primitive.summaryFrontiersMatchPrimitive
-  refine ⟨entries, exits, variant, ?_⟩
-  exact
-    { primitiveConditionNode := hPrimitiveNode
-      variantMem := hVariant
-      variantKey := hVariantKey
-      bodyShape := hBodyShape
-      conditionInputKeysAccounted := by
-        intro key hKey
-        have hPrimitiveKey :
-            key ∈ PrimitiveGraphStep.nodeEntryKeysList
-              artifact.primitiveSteps :=
-          PrimitiveGraphStep.nodeEntryKeysList_mem_of_node_mem
-            hPrimitiveNode hKey
-        exact hAccounted.inputs hPrimitiveKey
-      conditionOutputKeysAccounted := by
-        intro key hKey
-        have hPrimitiveKey :
-            key ∈ PrimitiveGraphStep.nodeExitKeysList
-              artifact.primitiveSteps :=
-          PrimitiveGraphStep.nodeExitKeysList_mem_of_node_mem
-            hPrimitiveNode hKey
-        exact hAccounted.outputs hPrimitiveKey }
-
-/-- Select soundness reconstructs primitive bridge evidence for one base variant. -/
-theorem Sound.selectVariantBridge
-    {artifact : WireAdmissionArtifact}
-    (hSound : artifact.Sound)
-    {selectAdmission : SelectAdmissionArtifact}
-    (hSelect : selectAdmission ∈ artifact.selects)
-    {variant : SelectVariantArtifact}
-    (hVariant : variant ∈ selectAdmission.variants) :
-    SelectVariantBridge artifact selectAdmission variant := by
-  obtain ⟨entries, exits, entry, hPrimitiveNode, hEntry, hCompat,
-    hReplayed, hConsumed⟩ :=
-      hSound.select.variantBridgeEntryConsumed hSelect hVariant
-  exact
-    ⟨ entries
-    , exits
-    , entry
-    , { primitiveConditionNode := hPrimitiveNode
-        entryMem := hEntry
-        compatible := hCompat
-        replayed := hReplayed
-        entryConsumed := hConsumed }
-    ⟩
-
 /-- Select soundness reconstructs provenance and freshness for one latent entry. -/
 theorem Sound.selectLatentEntryReconstruction
     {artifact : WireAdmissionArtifact}
@@ -285,33 +244,94 @@ theorem Sound.selectLatentEntryReconstruction
           hSound.select.latentEntriesBodyNodesDisjoint
             hSelect hValid hEntry hOther hKeys hNode }
 
-/-- Validator soundness reconstructs select-admission artifact-boundary witnesses. -/
+/-- Validator soundness reconstructs select-admission artifact-boundary witnesses
+indexed by a single shared condition-node primitive row.
+
+Primitive node-row uniqueness (`Sound.primitiveNode_frontiers_unique`) collapses
+the per-variant existential in `variantBridgeEntryConsumed` onto the same
+`(conditionEntries, conditionExits)` chosen by
+`selectArmBodyBoundariesMatchCondition`. -/
 theorem Sound.toSelectReconstruction
     {artifact : WireAdmissionArtifact}
     (hSound : artifact.Sound) :
     artifact.SelectReconstruction := by
   intro selectAdmission hSelect
-  let hValid := hSound.select.selectsValid selectAdmission hSelect
-  exact
+  obtain ⟨conditionEntries, conditionExits, hPrimitiveNode, hArms⟩ :=
+    hSound.select.selectArmBodyBoundariesMatchCondition
+      selectAdmission hSelect
+  have hValid := hSound.select.selectsValid selectAdmission hSelect
+  have hAccounted :
+      artifact.PrimitiveFrontierKeysAccounted :=
+    primitiveFrontierKeysAccounted
+      hSound.primitive.summaryFrontiersMatchPrimitive
+  refine ⟨conditionEntries, conditionExits, ?_⟩
+  refine
     { valid := hValid
       ownerMatchesCondition := hValid.ownerMatchesCondition
       armsAtLeastTwo := hSound.select.armsAtLeastTwo hSelect
       latentKeyCoverage :=
         (selectAdmission.toLatentSelectAdmission hValid).entries_keys_perm
-      latentEntries := by
-        intro entry hEntry
+      primitiveConditionNode := hPrimitiveNode
+      conditionInputKeysAccounted := ?inputs
+      conditionOutputKeysAccounted := ?outputs
+      latentEntries := ?latent
+      armResolution := ?resolution
+      armBridge := ?bridge
+      variantBridge := ?variantBridge }
+  case inputs =>
+    intro key hKey
+    exact
+      hAccounted.inputs
+        (PrimitiveGraphStep.nodeEntryKeysList_mem_of_node_mem
+          hPrimitiveNode hKey)
+  case outputs =>
+    intro key hKey
+    exact
+      hAccounted.outputs
+        (PrimitiveGraphStep.nodeExitKeysList_mem_of_node_mem
+          hPrimitiveNode hKey)
+  case latent =>
+    intro entry hEntry
+    exact hSound.selectLatentEntryReconstruction hSelect hValid hEntry
+  case resolution =>
+    intro arm hArm
+    exact hSound.selectArmResolutionReconstruction hSelect hArm
+  case bridge =>
+    intro arm hArm
+    obtain ⟨variant, hVariantMem, hVariantKey, hBodyShape⟩ := hArms arm hArm
+    refine
+      ⟨ variant
+      , { variantMem := hVariantMem
+          variantKey := hVariantKey
+          bodyShape := ?_ }⟩
+    cases hBodyShape with
+    | inl hEmpty =>
+        obtain ⟨⟨hBodyNodes, hBodyEntries, hBodyExits⟩, hOutputShapes⟩ :=
+          hEmpty
         exact
-          hSound.selectLatentEntryReconstruction
-            hSelect hValid hEntry
-      armResolution := by
-        intro arm hArm
-        exact hSound.selectArmResolutionReconstruction hSelect hArm
-      armBridge := by
-        intro arm hArm
-        exact hSound.selectArmBridge hSelect hArm
-      variantBridge := by
-        intro variant hVariant
-        exact hSound.selectVariantBridge hSelect hVariant }
+          SelectArmBodyShapeReconstruction.emptyBody
+            hBodyNodes hBodyEntries hBodyExits hOutputShapes
+    | inr hNonEmpty =>
+        exact
+          SelectArmBodyShapeReconstruction.nonEmptyBody
+            hNonEmpty.left hNonEmpty.right
+  case variantBridge =>
+    intro variant hVariant
+    obtain
+      ⟨variantEntries, _variantExits, variantEntry,
+        hVariantPrimitiveNode, hVariantEntryMem, hVariantCompat,
+        hVariantReplayed, hVariantConsumed⟩ :=
+      hSound.select.variantBridgeEntryConsumed hSelect hVariant
+    obtain ⟨hEntriesEq, _hExitsEq⟩ :=
+      hSound.primitiveNode_frontiers_unique
+        hVariantPrimitiveNode hPrimitiveNode
+    subst hEntriesEq
+    exact
+      ⟨ variantEntry
+      , { entryMem := hVariantEntryMem
+          compatible := hVariantCompat
+          replayed := hVariantReplayed
+          entryConsumed := hVariantConsumed }⟩
 
 end WireAdmissionArtifact
 


### PR DESCRIPTION
## Summary

Addresses the three top-priority interface findings from the theorem attack on the reconstruction stack (PRs #213/#214/#215/#216): the bare `(entries, exits)` existentials in select / phantom bridge claims, and the load-bearing role of the Nodup fields against silent `.toFinset` collapse in `openObjectLinear`.

## What lands

- **Shared select bridge witness.** `SelectAdmissionReconstruction` is now `∃ conditionEntries conditionExits, SelectAdmissionReconstructionRecord ...`. `armBridge` and `variantBridge` both index off the same shared condition-node primitive row; the per-variant `variantBridgeEntryConsumed` existential collapses via primitive node-row uniqueness onto the row chosen by `selectArmBodyBoundariesMatchCondition`.
- **Shared phantom bridge witness.** `PhantomAdapterReconstruction` is now `∃ bridgeEntries bridgeExits, PhantomAdapterReconstructionRecord ...`. `bridge`, `leftBulkReplayed`, and `rightBulkReplayed` all reference the same primitive row.
- **`SelectArmBodyShapeReconstruction` inductive.** Extracted from the inline disjunction inside `SelectArmBridgeReconstruction.bodyShape`. Constructors `emptyBody` / `nonEmptyBody` mirror the style of `PhantomProductReconstruction` (`record` / `indexed`) and `PhantomDirectionReconstruction` (`gather` / `scatter`).
- **`openObjectLinear` documentation.** Inline docstrings on `entriesUnique`, `exitsUnique`, and `openObjectLinear` clarify that linearity is from the `LinearPortObject.nodePorts` smart constructor and the no-silent-collapse fields downstream consumers should read are the Nodup pair.
- **`Sound.primitiveNode_frontiers_unique`.** New helper in `PrimitiveReconstruction.lean` that derives "at most one primitive node row per `NodeId`" from `Sound.primitive.summaryIdentitiesMatchPrimitive` + `summaryKeysUnique.nodesUnique`. Used to collapse the variant-bridge witness onto the shared condition-node row.

## Stack

Stacked on #216; depends on #213/#214/#215. Base branch: `205-lean-reconstruct-select-admission-witnesses`.

## Verification

- `just fmt-check && just docs-check && just lean-check` — exit 0
- `lake build Cortex.Wire.AdmissionArtifact.{PrimitiveReconstruction,PhantomReconstruction,SelectReconstruction} Cortex.Wire.AdmissionArtifact Cortex` — green
- `git verify-commit HEAD` — good ED25519 signature
- `just check-commit-provenance 205-lean-reconstruct-select-admission-witnesses..HEAD` — OK
