### PR TITLE
chore: harden runtime ADR and Wire shell example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,12 @@ docs/.astro/
 docs/node_modules/
 docs/package-lock.json
 
+# Generated artifacts from runnable examples
+examples/wire/c-build/build
+examples/wire/c-build/build/
+examples/wire/c-build/dist
+examples/wire/c-build/dist/
+
 # Cabal / GHC
 dist-newstyle/
 dist/

--- a/docs/ADRs/0055-pulse-runtime-bounded-iteration.md
+++ b/docs/ADRs/0055-pulse-runtime-bounded-iteration.md
@@ -1,0 +1,430 @@
+---
+title: "ADR 0055 - Pulse Runtime-Bounded Iteration"
+description:
+  "Classifies runtime-dynamic repetition as Pulse-admitted bounded execution of finite kernels, not
+  Wire graph expansion or CorePure looping."
+sidebar:
+  label: "0055. Runtime-bounded iteration"
+  order: 55
+status: proposed
+date: 2026-05-08
+superseded_by: null
+related:
+  - docs/Architecture/04-graph-and-circuit.md
+  - docs/Architecture/05-wire-language.md
+  - docs/Architecture/06-pulse-runtime.md
+  - docs/Reference/Wire/grammar.md
+  - docs/Reference/Wire/pure-execution.md
+  - docs/Reference/Pulse/schema.md
+  - docs/ADRs/0003-pulse-service-and-host-action-boundary.md
+  - docs/ADRs/0005-budgeted-rewrite-admission-and-materialization.md
+  - docs/ADRs/0037-wire-latent-structural-control.md
+  - docs/ADRs/0043-pulse-in-memory-runner.md
+  - docs/ADRs/0046-wire-compile-time-graph-forms.md
+  - docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
+  - docs/ADRs/0048-wire-make-bounded-node-generation.md
+  - docs/ADRs/0050-wire-corepure-output-residue.md
+  - "GitHub #181"
+  - "GitHub #182"
+---
+
+# ADR 0055 - Pulse Runtime-Bounded Iteration
+
+## Status
+
+Proposed - this ADR names the runtime boundary and required model for data-dependent iteration. It
+does not add Wire syntax by itself.
+
+## Context
+
+Wire has two deliberately separate repetition pressures:
+
+1. **Source repetition**, where a statically known count expands graph shape before lowering.
+2. **Runtime repetition**, where a finite kernel should execute several times because runtime data
+   says there is more work.
+
+ADR 0046 and ADR 0048 keep source graph construction static: forms expand before Pulse execution,
+and `make(N, K)` requires a compile-time-resolvable `N`. ADR 0050 keeps CorePure non-recursive and
+authority-free; input-dependent CorePure may compute values at runtime, but it may not introduce
+loops, inspect Pulse state, call executors, or create topology.
+
+At the same time, ordinary programs need runtime-sized finite work:
+
+- read chunks until EOF, subject to a maximum item count;
+- drain a queue until it is empty, subject to a maximum batch size;
+- retry or refine a bounded analysis while a runtime score remains below a threshold;
+- let an upstream node propose a count, then clamp or validate that count before executing a kernel.
+
+The tempting spelling is to let an executor output drive a source-level form:
+
+```text
+# not admitted by this ADR
+decide_bound -> repeat(kernel, bound)
+```
+
+That cannot work as Wire graph expansion. By the time `decide_bound` produces a value, the source
+graph has already elaborated, port matching has already been checked, and topology witnesses have
+already been built. Feeding runtime values back into source graph shape would make source
+elaboration depend on execution.
+
+The other tempting spelling is a sealed executor that internally loops until it decides to stop and
+then emits one downstream value. That is acceptable only as executor-local implementation detail,
+not as the substrate's graph-level iteration model, unless Pulse can still observe and enforce a
+finite runtime budget. A truly unbounded sealed loop does not fit the downstream dataflow model:
+downstream nodes can advance only after a completed output exists.
+
+## Decision
+
+Pulse should classify **runtime-bounded iteration** as a runtime-admitted execution feature: a
+finite Wire/Circuit kernel may be repeated under a runtime-dynamic bound only when Pulse can
+enforce, checkpoint, and record a finite per-run budget.
+
+Runtime-bounded iteration is not source graph expansion, not CorePure recursion, and not an
+unbounded background process hidden inside an ordinary executor. The source graph remains finite and
+its node identities remain source-elaborated. The repeated body is a finite admitted kernel. Pulse
+owns the iteration policy, budget enforcement, checkpoint/resume behavior, cancellation boundary,
+lineage, and failure semantics.
+
+This ADR does not choose final surface syntax. Any future syntax or executor-like spelling must
+lower to the same runtime concept:
+
+```text
+upstream value -> CorePure clamp/validate -> Pulse runtime-bounded kernel execution
+```
+
+The upstream value may be executor output. CorePure may derive or clamp the bound as ordinary
+authority-free value adaptation. Pulse then admits or rejects the requested iteration against
+policy. The value never feeds Wire source elaboration.
+
+The required runtime object is:
+
+```text
+RuntimeIteration =
+  finite admitted kernel
+  + loop policy
+  + requested runtime bound or guard
+  + continuation state
+  + durable iteration trace
+```
+
+If any of those fields is missing, the mechanism is not this ADR's feature. It is either static
+source elaboration, CorePure value computation, an ordinary executor-local algorithm, a child-run
+design, or an unbounded service loop at the Pulse/host process boundary.
+
+## Mental Model
+
+The safe model is **bounded kernel repetition inside the runtime process loop, not dynamic graph
+construction**.
+
+| Layer                      | Repetition shape                                      | Owner              | Rule                                                                 |
+| -------------------------- | ----------------------------------------------------- | ------------------ | -------------------------------------------------------------------- |
+| Pulse/host process         | scheduler, poller, service, or daemon loop            | Pulse or host      | May be long-lived; not an ordinary downstream-producing graph node   |
+| Wire source elaboration    | `make(N, K)`, forms, future static repeat             | Wire compiler      | Count and graph shape are static before Pulse execution              |
+| CorePure                   | value derivation, filtering, clamping, record shaping | CorePure evaluator | Total, authority-free, non-recursive, no host effects or topology    |
+| Runtime-bounded iteration  | repeat a finite kernel under admitted policy          | Pulse              | Runtime count is data; finite budget, checkpoints, and trace govern  |
+| Executor-local computation | internal algorithm inside one stage action            | registered action  | Allowed as local authority; not graph-level iteration unless exposed |
+
+The important separation is not "loops bad, no loops." The separation is: **only Pulse may turn
+runtime data into repeated graph-level work, and only under a finite auditable policy**.
+
+## Boundary Rules
+
+### Runtime bound
+
+A runtime-dynamic count or guard is admissible only when paired with an enforceable finite budget.
+The budget must be stored and consumed by Pulse-owned runtime state, not merely promised by an
+executor prompt or returned in an unchecked payload.
+
+Examples:
+
+| Shape                                      | Status under this ADR                                      |
+| ------------------------------------------ | ---------------------------------------------------------- |
+| `repeat kernel 10`                         | Source-level static repetition candidate, outside this ADR |
+| `repeat kernel bound` where `bound <= cap` | Runtime-bounded Pulse iteration                            |
+| `repeat kernel until eof, max = cap`       | Runtime-bounded Pulse iteration                            |
+| `repeat kernel until model says stop`      | Runtime-bounded only with an explicit cap and policy       |
+| `repeat kernel forever`                    | Not a downstream-producing graph node                      |
+
+A guard such as EOF, score threshold, or queue emptiness is a stopping condition, not by itself a
+resource bound. The runtime policy must still include a finite cap or another finite resource
+witness that Pulse can enforce.
+
+The runtime-proposed bound is data. It may be absent, malformed, too large, stale, or adversarial.
+Admission must normalize or reject it before the first body execution. The admitted effective bound
+is the minimum of the validated request and the configured policy cap, unless the policy chooses a
+stricter rule.
+
+### Kernel boundary
+
+The repeated body must be a finite admitted kernel. Its continuation boundary is linear:
+
+```text
+state_in + item? -> state_out + emitted* + guard + terminal?
+```
+
+Each iteration consumes the current continuation state at most once and produces the next
+continuation state at most once. This is the runtime analogue of ADR 0047's linear frontier rule,
+not a license for graph cycles or implicit copying.
+
+The kernel may expose ordinary input/output contracts, but its external interface must say which
+ports are:
+
+- loop state consumed and produced across iterations;
+- per-iteration item input;
+- per-iteration emitted output;
+- terminal summary output;
+- runtime guard or continuation signal.
+
+The transition shape is:
+
+```text
+(i, state_i, item_i?)
+  -- admitted kernel execution -->
+(i + 1, state_(i+1), emitted_i*, guard_i, terminal_i?)
+```
+
+Pulse must preserve these invariants:
+
+- `i` is monotone and cannot exceed the admitted effective bound.
+- `state_i` has exactly one predecessor except at `i = 0`.
+- `state_(i+1)` has exactly one producer: the completed `i`th kernel execution.
+- emitted outputs are either accumulated, streamed, or reduced according to explicit policy.
+- checkpoint and provenance identify which iterations completed before resume.
+- graph topology and source node identities do not change because of the runtime count.
+
+An implementation may realize a kernel as one stage, a sealed local action, or child runs, but the
+observable runtime contract is the same: the trace must explain which iterations happened and why
+the loop stopped.
+
+### Loop policy
+
+A `LoopPolicy` or equivalent carrier must be explicit before runtime-bounded iteration is admitted.
+At minimum it must include:
+
+- maximum body executions;
+- how runtime-requested bounds are decoded, clamped, rejected, or defaulted;
+- budget-exhaustion behavior;
+- checkpoint cadence;
+- cancellation points;
+- emitted-output aggregation policy;
+- partial-result contract, if partial completion is allowed;
+- fallback contract, if fallback completion is allowed;
+- whether the kernel may propose rewrites.
+
+Prompt text, model instructions, executor config, or downstream product policy are not sufficient
+unless they lower to this Pulse-owned carrier.
+
+### Completion and budget exhaustion
+
+A runtime-bounded iteration node completes only when it reaches a terminal condition under its
+finite budget. Budget exhaustion is not silent success. The loop policy must choose one of the
+explicit outcomes:
+
+- fail the run with a typed budget-exhaustion error;
+- complete with an explicitly marked partial result;
+- degrade to a configured fallback result.
+
+The default should be failure unless the node's contract declares a partial-result shape. The
+ordinary success shape must not be reused for budget exhaustion, cancellation, or fallback; that
+would make downstream consumers unable to distinguish "finished" from "stopped safely."
+
+### Runtime lineage and recovery
+
+Durable Pulse must be able to resume from persisted state without replaying completed iterations
+incorrectly. The minimal durable lineage is:
+
+- admitted effective bound and policy version;
+- current iteration index;
+- continuation state or resumable state reference;
+- completed iteration ids;
+- emitted-output aggregation state;
+- terminal reason, when present;
+- budget-exhaustion, cancellation, fallback, or partial-result marker, when present.
+
+For irreversible host actions, the checkpoint boundary must be strong enough to avoid duplicating a
+completed irreversible effect after crash recovery. If that cannot be guaranteed for a kernel, the
+kernel is not admissible as a durable runtime-bounded iteration body under this ADR.
+
+### Runtime ownership
+
+Pulse owns:
+
+- admitting the requested dynamic bound against configured policy;
+- tracking remaining iteration budget;
+- checking cancellation between iterations and before irreversible host actions;
+- checkpointing enough state to resume without re-running completed iterations incorrectly;
+- recording iteration lineage, emitted outputs, terminal outcome, and budget exhaustion;
+- deciding how iteration interacts with rewrite budgets if the body can propose rewrites.
+
+Wire owns only the finite source kernel and value-level preparation of the requested bound.
+
+## Examples
+
+### Queue drain
+
+A node reads up to `maxItems = 100` queue messages. The guard is "queue empty." The budget is `100`.
+Completion is success only if the queue becomes empty before or at the cap. If the cap is exhausted
+while work remains, policy chooses typed budget exhaustion or an explicitly marked partial batch.
+
+### Paginated ingest
+
+A kernel fetches one page and returns `{ nextCursor, items, state }`. The loop stops when
+`nextCursor = null` or `maxPages` is reached. Emitted items are aggregated according to policy. On
+resume, completed page indexes and cursor state must prevent duplicate page effects.
+
+### Bounded refinement
+
+An upstream node proposes `requestedRounds = 12`. CorePure clamps or validates the request against
+local value rules. Pulse admits `effectiveRounds <= policy.maxRounds`. Each iteration consumes the
+previous draft and score, emits an optional candidate, and stops when `score >= threshold` or the
+budget is exhausted.
+
+### Poll external job
+
+A kernel checks external job status. The guard is "job complete." The budget is a maximum poll count
+or duration. Cancellation is checked between polls. A timeout-shaped outcome is not ordinary success
+unless the node contract explicitly declares a timeout/fallback result.
+
+### Runtime-sized fan-in without runtime topology
+
+A kernel may process N runtime items and aggregate them into one output value. It does not create N
+Wire nodes and it does not make N new graph edges. If the program needs N graph vertices, N must be
+known during source elaboration or introduced through admitted rewrites under the rewrite contract,
+not through this iteration feature.
+
+## Counterexamples And Rejections
+
+These are not edge cases to tolerate; they are the adversarial tests the model must reject or mark
+explicitly.
+
+| Candidate                                           | Why it fails this ADR                                                    | Repair direction                                      |
+| --------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| Runtime value drives `make(bound, K)`               | Source topology would depend on executor output                          | Use static `make`, admitted rewrite, or runtime loop  |
+| CorePure `while` computes until queue empty         | CorePure would gain recursion and host/runtime observation               | Move observation behind a registered executor kernel  |
+| Executor prompt says "loop at most 10 times"        | Prompt text is not an enforceable Pulse budget                           | Lower to `LoopPolicy` with stored remaining budget    |
+| Guard `until eof` with no cap                       | EOF is a stopping condition, not a resource bound                        | Add finite cap or finite resource witness             |
+| Model decides whether to continue with no hard cap  | The model may never stop or may ignore policy                            | Add explicit cap and typed exhaustion outcome         |
+| Budget exhaustion returns normal success payload    | Downstream cannot distinguish complete from partial/fallback             | Declare partial/fallback contract or fail             |
+| Crash repeats iteration 7 after irreversible action | Durable lineage/checkpoint was too weak for the action                   | Move checkpoint boundary or reject durable admission  |
+| Loop body emits unbounded list in memory            | Iteration budget does not bound output accumulation                      | Add aggregation/window/output-size policy             |
+| Nested loops multiply work silently                 | Local caps do not state global resource consumption                      | Require nested admission or product/global budget law |
+| Loop body proposes rewrites under unspecified gas   | Rewrite and iteration authorities interact without a shared law          | Reject v1 or define shared/per-iteration budgets      |
+| Runtime count changes node ids or graph hash        | Graph identity is source-elaborated and already witnessed                | Keep count as runtime data only                       |
+| Local runner succeeds without durable checkpoints   | Ephemeral success does not prove durable recovery or cancellation safety | Report missing durable guarantees                     |
+
+## Relationship To Existing Runtime Features
+
+Runtime-bounded iteration is similar to rewrite admission in one important respect: runtime
+authority is finite and explicit. ADR 0005 made rewrite budget a runtime law rather than a prompt
+convention. This ADR applies the same discipline to repetition.
+
+Runtime-bounded iteration is also distinct from child workflows. A durable implementation may
+realize large or long-running iterations through child runs or sub-runs, but parent-child lifecycle
+semantics are an implementation and API decision layered under this ADR. If child runs are used, the
+same budget, cancellation, checkpoint, and provenance obligations still apply.
+
+The in-memory Pulse runner from ADR 0043 may support runtime-bounded iteration for local execution,
+but it must report which durable guarantees are absent. Local success does not prove durable lease
+recovery, service API visibility, signal resume, or cancellation propagation.
+
+Runtime-bounded iteration is also distinct from stage retry. A retry policy re-executes the same
+stage after a retryable failure from the same checkpointed input. Runtime-bounded iteration advances
+a successful continuation state across body executions. A "refinement loop" is iteration only when
+each successful body execution produces the next state; retry remains the failure-recovery surface.
+
+## Alternatives considered
+
+- **Let runtime values drive Wire graph expansion** - rejected because source elaboration, port
+  matching, and proof witnesses happen before executor output exists. This would make topology
+  depend on execution.
+- **Add loops to CorePure** - rejected because CorePure is the deterministic authority-free value
+  layer. ADR 0050 explicitly keeps loops, recursion, host callbacks, and executor authority out of
+  CorePure.
+- **Hide iteration inside ordinary executors** - rejected as the general rule because Pulse would
+  not own per-iteration budget, checkpoints, cancellation, provenance, or partial progress. A
+  bounded executor-local algorithm is still allowed as an implementation detail, but it is not a
+  graph-level runtime iteration feature.
+- **Treat runtime iteration as a special rewrite loop** - rejected because the repeated work does
+  not necessarily change topology. Rewrites remain the bounded topology-evolution surface; this ADR
+  is bounded execution of a fixed admitted kernel. If a loop body can propose rewrites, the
+  interaction must be specified explicitly.
+- **Treat runtime iteration as stage retry** - rejected because retry is failure recovery for the
+  same stage input, while iteration is successful state transition under a continuation boundary.
+- **Require all iteration counts to be static** - rejected because finite runtime-sized work is
+  common and useful. A queue drain or chunk sweep can be finite without the exact count being known
+  during source elaboration.
+- **Accept unbounded downstream-producing loops** - rejected because a downstream graph node
+  requires a completed output. A truly unbounded service loop belongs to the Pulse or host process
+  boundary, not to an ordinary dataflow node.
+
+## Consequences
+
+### Positive
+
+- Runtime-sized finite work has a canonical home without making Wire or CorePure Turing-complete.
+- Executor outputs can influence iteration as data, while graph shape remains source-elaborated and
+  finite.
+- Pulse can enforce iteration budgets, checkpoint progress, expose operator visibility, and preserve
+  cancellation semantics.
+- The design extends the same bounded-authority discipline already used for rewrite materialization.
+- The tail-linearity intuition from bounded source repetition carries over as a runtime continuation
+  boundary rather than as graph recursion.
+
+### Negative
+
+- Pulse needs a new typed carrier for iteration policy, remaining budget, and iteration outcome.
+- Durable execution needs additional history/provenance rows or events to explain iteration
+  progress.
+- Local runner parity becomes more nuanced because local iteration can execute without durable
+  checkpoints or cross-process recovery.
+- The proof track must extend beyond the fixed-topology kernel to cover per-iteration preservation
+  or a bounded run trace over repeated kernels.
+- Syntax must be designed carefully so users do not read runtime-bounded iteration as ordinary Wire
+  graph expansion.
+- Runtime iteration adds another budget surface next to rewrite gas, retry policy, timeouts, and
+  task-level concurrency. Operator surfaces must make the distinctions legible.
+
+### Obligations
+
+- Define a `LoopPolicy` or equivalent runtime carrier with at least: maximum iteration count, budget
+  exhaustion behavior, checkpoint cadence, cancellation points, and emitted-output aggregation
+  policy.
+- Define `LoopState`, `LoopFrame`, and `LoopOutcome` or equivalent carriers so state lineage,
+  emitted-output aggregation, terminal reason, and budget exhaustion are represented in runtime data
+  rather than prose.
+- Define the admitted kernel boundary: continuation state in/out, optional item input, optional
+  emitted output, terminal summary, and guard/continuation signal.
+- Define how a runtime-proposed bound is validated against policy and how rejection is reported.
+- Define durable history/provenance for completed iterations, partial progress, cancellation, and
+  budget exhaustion.
+- Define output-size and aggregation policy; iteration count alone does not bound accumulated
+  payload size.
+- Define local-runner behavior separately from durable behavior, following ADR 0043's warning
+  against semantic overclaim.
+- State the rewrite interaction before admitting rewrite-capable loop bodies: shared parent budget,
+  per-iteration child budget, or rejection of rewrites inside loop kernels.
+- State the retry interaction: retry may recover a failed body execution, but it must not advance
+  the continuation state twice or duplicate emitted outputs.
+- Add reference documentation explaining that CorePure may compute loop-bound values but may not
+  feed source graph construction.
+- Add theorem targets:
+  - a finite admitted iteration budget bounds the number of body executions;
+  - each body execution preserves the admitted kernel boundary;
+  - continuation state is consumed and produced linearly across iterations;
+  - emitted outputs are owned by exactly one completed iteration and aggregated according to policy;
+  - cancellation and budget exhaustion preserve safe run state;
+  - resume from an iteration checkpoint does not duplicate completed iterations;
+  - runtime-bound values do not affect source elaboration or graph identity.
+
+## Related
+
+- [ADR 0003 - Pulse Service and Host-Action Boundary](0003-pulse-service-and-host-action-boundary.md)
+- [ADR 0005 - Budgeted Rewrite Admission and Materialization](0005-budgeted-rewrite-admission-and-materialization.md)
+- [ADR 0037 - Wire Latent Structural Control Operators](0037-wire-latent-structural-control.md)
+- [ADR 0043 - Pulse In-Memory Runner](0043-pulse-in-memory-runner.md)
+- [ADR 0046 - Wire Compile-Time Graph Forms](0046-wire-compile-time-graph-forms.md)
+- [ADR 0047 - Wire Frontier Linearity and Topology Operator Precedence](0047-wire-frontier-linearity-and-precedence.md)
+- [ADR 0048 - Wire Compile-Time Make for Bounded Node Generation](0048-wire-make-bounded-node-generation.md)
+- [ADR 0050 - Wire CorePure Output Residue](0050-wire-corepure-output-residue.md)
+- [Architecture 05 - Wire Language](../Architecture/05-wire-language.md)
+- [Architecture 06 - Pulse Runtime](../Architecture/06-pulse-runtime.md)

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -71,6 +71,7 @@ values: `proposed`, `accepted`, `superseded`, `deprecated`.
 | [0052](0052-wire-bounded-indexed-boundary-products.md)          | Wire Bounded Indexed Boundary Products                              | proposed   |
 | [0053](0053-executor-catalog-manifests-and-pulse-bindings.md)   | Executor Catalog Manifests and Pulse Runtime Bindings               | proposed   |
 | [0054](0054-downstream-wire-packages-and-host-bindings.md)      | Downstream Wire Packages and Host Runtime Bindings                  | proposed   |
+| [0055](0055-pulse-runtime-bounded-iteration.md)                 | Pulse Runtime-Bounded Iteration                                     | proposed   |
 
 ## Writing a new ADR
 

--- a/examples/wire/c-build/.gitignore
+++ b/examples/wire/c-build/.gitignore
@@ -1,2 +1,3 @@
 build/
 dist/
+release/

--- a/examples/wire/c-build/c-build.wire
+++ b/examples/wire/c-build/c-build.wire
@@ -2,30 +2,43 @@
 #
 #   nix run .#wire -- run examples/wire/c-build/c-build.wire
 #
-# This file is an educational build example. It deliberately avoids the
-# Makefile habit of hiding the build graph inside shell recipes:
+# This is a shell-backed example, but the shell is not the interesting part.
+# Wire owns the build topology: source discovery, generated compile nodes,
+# explicit fanout/fanin, gates between artifact steps, and typed reports.
 #
-#   * include_dir discovers source files at Wire elaboration time.
-#   * makeEach expands one fresh command node for each discovered file.
-#   * `*` gathers generated frontiers into nominal record contracts.
-#   * serial dependency gates carry earlier command results forward so the
-#     final report can gather them structurally.
+# Guarantees this gets from Wire:
 #
-# include_dir/include_str are Rust-style source includes. They are evaluated
-# before parsing this file. Missing files or directories are compile errors,
-# and runtime CorePure receives ordinary embedded data with no filesystem
-# authority.
+#   * include_dir/include_str fail at source elaboration if inputs are missing.
+#   * makeEach gives every discovered file/check a stable graph node.
+#   * `*` gathers only exact frontiers into nominal record contracts. Add a C
+#     source without updating the summary contract and compilation fails early.
+#   * forms keep reusable graph fragments explicit instead of hiding them in one
+#     long `sh -c '...'` command.
+#   * final reporting consumes structured CommandResult values with per-node
+#     lineage, status, stdout/stderr, and exit codes.
+#
+# The release section demonstrates the common deployment failure this example
+# is meant to prevent: testing one binary but promoting a different artifact.
+# Package, manifest, checksum audit, and promotion are wired as typed evidence.
+
+# ============================================================================
+# 1. Standard Executors
+# ============================================================================
 
 use std.io.{@command, @stdout, CommandSpec, CommandResult};
 
+# ============================================================================
+# 2. Contracts: Typed Build, Audit, And Release Boundaries
+# ============================================================================
+#
+# The records below are not documentation-only shapes. They are the nominal
+# contracts used by `*` gathers and by typed node ports. If a generated source
+# frontier grows or an audit output is accidentally dropped, the graph stops
+# compiling before a release command can run.
+
 contract BuildReport;
-contract BuildStart;
 contract BuildSummary;
 
-# makeEach names generated nodes as <binding>_<item.label>. The record fields
-# below are therefore the generated frontier labels. If a source file is added
-# to a directory, makeEach generates another node and this contract becomes the
-# visible place where the build graph must be amended.
 contract LibObjectResults {
   lib_objects_metrics: CommandResult;
   lib_objects_parse: CommandResult;
@@ -43,11 +56,19 @@ contract QualityResults {
   quality_checks_headers: CommandResult;
 };
 
-contract FinalResults {
+contract PackageAuditResults {
+  binaryAudit: CommandResult;
+  manifestAudit: CommandResult;
+  sizeAudit: CommandResult;
+  checksumAudit: CommandResult;
+};
+
+contract PreReleaseResults {
   libCompileReport: BuildSummary;
   appCompileReport: BuildSummary;
   testCompileReport: BuildSummary;
   qualityReport: BuildSummary;
+  packageAuditReport: BuildSummary;
   buildNote: BuildSummary;
   archive: CommandResult;
   linkApp: CommandResult;
@@ -57,41 +78,76 @@ contract FinalResults {
   runParseTest: CommandResult;
   smokeRun: CommandResult;
   package: CommandResult;
+  binaryAudit: CommandResult;
+  manifestAudit: CommandResult;
+  sizeAudit: CommandResult;
+  checksumAudit: CommandResult;
 };
 
-kind run_command(spec: PortLabel, result: PortLabel) =
-  <- spec: CommandSpec;
-  -> result: CommandResult = @command {} (spec);
-
-# makeEach can pass a source metadata record into a kind as a Value parameter.
-# This command kind does not need the item value at runtime; the item already
-# shaped the generated node name. The command spec with the same label supplies
-# the actual executor payload.
-kind generated_command(label: PortLabel, item: Value) =
-  <- label: CommandSpec;
-  -> label: CommandResult = @command {} (label);
-
-# A dependency gate turns "previous command must have happened" into an
-# explicit port. It also re-emits the previous result so later report stages can
-# still observe it without implicit graph fan-out.
-kind command_gate(spec: PortLabel, previous: PortLabel, ready: PortLabel) =
-  <- spec: CommandSpec;
-  <- previous: CommandResult;
-  -> previous: CommandResult = previous;
-  -> ready: CommandSpec = spec;
-
-form gated_command(spec: PortLabel, previous: PortLabel, ready: PortLabel, result: PortLabel) = {
-  node gate = command_gate(spec, previous, ready);
-  node run = run_command(ready, result);
-
-  gate
-    => run;
+contract ReleaseEvidence {
+  libCompileReport: BuildSummary;
+  appCompileReport: BuildSummary;
+  testCompileReport: BuildSummary;
+  qualityReport: BuildSummary;
+  packageAuditReport: BuildSummary;
+  archive: CommandResult;
+  linkApp: CommandResult;
+  linkMetricsTest: CommandResult;
+  linkParseTest: CommandResult;
+  runMetricsTest: CommandResult;
+  runParseTest: CommandResult;
+  smokeRun: CommandResult;
+  package: CommandResult;
+  binaryAudit: CommandResult;
+  manifestAudit: CommandResult;
+  sizeAudit: CommandResult;
+  checksumAudit: CommandResult;
 };
 
-# Source discovery. These are compile-time includes, not runtime reads.
+contract FinalResults {
+  libCompileReport: BuildSummary;
+  appCompileReport: BuildSummary;
+  testCompileReport: BuildSummary;
+  qualityReport: BuildSummary;
+  packageAuditReport: BuildSummary;
+  buildNote: BuildSummary;
+  archive: CommandResult;
+  linkApp: CommandResult;
+  linkMetricsTest: CommandResult;
+  linkParseTest: CommandResult;
+  runMetricsTest: CommandResult;
+  runParseTest: CommandResult;
+  smokeRun: CommandResult;
+  package: CommandResult;
+  binaryAudit: CommandResult;
+  manifestAudit: CommandResult;
+  sizeAudit: CommandResult;
+  checksumAudit: CommandResult;
+  promotedRelease: CommandResult;
+};
+
+# ============================================================================
+# 3. Tiny C Builder Vocabulary
+# ============================================================================
+#
+# These helpers are deliberately small. They are the part that should move into
+# a reusable `c-builder.wire` once file imports compile. The build graph below
+# stays readable because command construction is centralized here.
+#
+# The manifest records source discovery and compile flags at elaboration time,
+# then records the packaged binary hash at runtime. The checksum audit verifies
+# that the manifest describes the artifact being promoted.
+
+# A tiny in-file "C builder" library. These are CorePure constructors for
+# std.io.command specs; the executor leaves below remain separate graph nodes.
+let root = "examples/wire/c-build";
+let flags = "-std=c11 -Wall -Wextra -Werror -O2 -Iinclude";
+let smokeInput = "12,18,7,23,15";
+
 let lib_sources = include_dir("src/lib");
 let app_sources = include_dir("src/app");
 let test_sources = include_dir("src/tests");
+let buildNoteText = include_str("BUILD-NOTE.txt");
 
 let quality_units = [
   { label = "syntax"; },
@@ -99,137 +155,233 @@ let quality_units = [
   { label = "headers"; },
 ];
 
-# Generated command frontiers. Each binding expands to one node per item.
-let lib_objects = makeEach(lib_sources, generated_command);
-let app_objects = makeEach(app_sources, generated_command);
-let test_objects = makeEach(test_sources, generated_command);
-let quality_checks = makeEach(quality_units, generated_command);
+let shell = name: command: {
+  inherit name;
+  argv = ["sh", "-c", command];
+  cwd = root;
+  required = true;
+  skip = false;
+  echo = true;
+};
 
-node start_build
-  -> start: BuildStart = "build";
+let objectPath = unit: "build/${unit.label}.o";
+let executablePath = unit: "build/${unit.label}";
+let objectArgs = sources: sources |> map objectPath |> joinWith " ";
+let sourcePaths = [
+  lib_sources[0].path,
+  lib_sources[1].path,
+  lib_sources[2].path,
+  app_sources[0].path,
+  test_sources[0].path,
+  test_sources[1].path,
+] |> joinWith ",";
 
-# plan_build's where clause is source-elaboration/CorePure planning data. It
-# uses the same static includes as makeEach, so command specs and generated
-# node labels derive from one source directory snapshot. Shell strings remain
-# executor payloads; dependency shape lives in the graph below.
-node plan_build
-  <- start: BuildStart;
-  -> lib_objects_metrics: CommandSpec = libMetricsSpec;
-  -> lib_objects_parse: CommandSpec = libParseSpec;
-  -> lib_objects_render: CommandSpec = libRenderSpec;
-  -> app_objects_main: CommandSpec = appMainSpec;
-  -> test_objects_test_metrics: CommandSpec = testMetricsCompileSpec;
-  -> test_objects_test_parse: CommandSpec = testParseCompileSpec;
-  -> quality_checks_syntax: CommandSpec = syntaxCheckSpec;
-  -> quality_checks_todo: CommandSpec = todoCheckSpec;
-  -> quality_checks_headers: CommandSpec = headerCheckSpec;
-  -> archiveSpec: CommandSpec = archiveCommandSpec;
-  -> linkAppSpec: CommandSpec = linkAppCommandSpec;
-  -> linkMetricsTestSpec: CommandSpec = linkMetricsCommandSpec;
-  -> linkParseTestSpec: CommandSpec = linkParseCommandSpec;
-  -> runMetricsTestSpec: CommandSpec = runMetricsCommandSpec;
-  -> runParseTestSpec: CommandSpec = runParseCommandSpec;
-  -> smokeSpec: CommandSpec = smokeCommandSpec;
-  -> packageSpec: CommandSpec = packageCommandSpec;
-  -> buildNote: BuildSummary = buildNote;
-  where let
-    root = "examples/wire/c-build";
-    flags = "-std=c11 -Wall -Wextra -Werror -O2 -Iinclude";
-    libSources = include_dir("src/lib");
-    appSources = include_dir("src/app");
-    testSources = include_dir("src/tests");
-    buildNoteText = include_str("BUILD-NOTE.txt");
-    qualityUnits = [
-      { label = "syntax"; },
-      { label = "todo"; },
-      { label = "headers"; },
-    ];
-    objectPath = unit: "build/${unit.label}.o";
-    executablePath = unit: "build/${unit.label}";
-    shell = name: command: {
-      inherit name;
-      argv = ["sh", "-c", command];
-      cwd = root;
-      required = true;
-      skip = false;
-      echo = true;
-    };
-    compileSpec = unit:
-      shell "compile-${unit.label}"
-        "mkdir -p build dist && cc ${flags} -c ${unit.path} -o ${objectPath unit}";
-    qualitySpec = unit:
-      if unit.label == "syntax"
-      then shell "syntax-only" "cc -std=c11 -Wall -Wextra -Werror -Iinclude -fsyntax-only src/app/main.c src/lib/metrics.c src/lib/parse.c src/lib/render.c"
-      else
-        if unit.label == "todo"
-        then shell "todo-scan" "! grep -R TODO include src"
-        else shell "header-contracts" "test -f include/metrics.h && test -f include/parse.h && test -f include/render.h";
-    libObjectArgs = libSources |> map objectPath |> joinWith " ";
-    appObjectArgs = appSources |> map objectPath |> joinWith " ";
-    archiveCommandSpec =
-      shell "archive-libmetrics"
-        "ar rcs build/libmetrics.a ${libObjectArgs}";
-    linkAppCommandSpec =
-      shell "link-metrics-demo"
-        "cc ${flags} -o build/metrics-demo ${appObjectArgs} build/libmetrics.a";
-    linkTestSpec = unit:
-      shell "link-${unit.label}"
-        "cc ${flags} -o ${executablePath unit} ${objectPath unit} build/libmetrics.a";
-    runTestSpec = unit:
-      shell "run-${unit.label}"
-        "./${executablePath unit}";
-    smokeCommandSpec =
-      shell "run-smoke"
-        "./build/metrics-demo '12,18,7,23,15'";
-    packageCommandSpec =
-      shell "package-dist"
-        "mkdir -p dist && cp build/metrics-demo dist/metrics-demo && printf 'metrics-demo\n' > dist/manifest.txt";
-    libMetricsSpec = compileSpec libSources[0];
-    libParseSpec = compileSpec libSources[1];
-    libRenderSpec = compileSpec libSources[2];
-    appMainSpec = compileSpec appSources[0];
-    testMetricsCompileSpec = compileSpec testSources[0];
-    testParseCompileSpec = compileSpec testSources[1];
-    syntaxCheckSpec = qualitySpec qualityUnits[0];
-    todoCheckSpec = qualitySpec qualityUnits[1];
-    headerCheckSpec = qualitySpec qualityUnits[2];
-    linkMetricsCommandSpec = linkTestSpec testSources[0];
-    linkParseCommandSpec = linkTestSpec testSources[1];
-    runMetricsCommandSpec = runTestSpec testSources[0];
-    runParseCommandSpec = runTestSpec testSources[1];
-    buildNote = {
-      label = "source include";
-      ok = true;
-      summary = buildNoteText;
-    };
-  in
-  {
-    inherit
-      libMetricsSpec
-      libParseSpec
-      libRenderSpec
-      appMainSpec
-      testMetricsCompileSpec
-      testParseCompileSpec
-      syntaxCheckSpec
-      todoCheckSpec
-      headerCheckSpec
-      archiveCommandSpec
-      linkAppCommandSpec
-      linkMetricsCommandSpec
-      linkParseCommandSpec
-      runMetricsCommandSpec
-      runParseCommandSpec
-      smokeCommandSpec
-      packageCommandSpec
-      buildNote;
-  };
+let compileSpec = unit:
+  shell "compile-${unit.label}"
+    "mkdir -p build dist && cc ${flags} -c ${unit.path} -o ${objectPath unit}";
+
+let qualitySpec = unit:
+  if unit.label == "syntax"
+  then shell "syntax-only" "cc -std=c11 -Wall -Wextra -Werror -Iinclude -fsyntax-only src/app/main.c src/lib/metrics.c src/lib/parse.c src/lib/render.c"
+  else
+    if unit.label == "todo"
+    then shell "todo-scan" "grep -R TODO include src; status=$?; test $status -eq 1"
+    else shell "header-contracts" "test -f include/metrics.h && test -f include/parse.h && test -f include/render.h";
+
+let linkTestSpec = unit:
+  shell "link-${unit.label}"
+    "cc ${flags} -o ${executablePath unit} ${objectPath unit} build/libmetrics.a";
+
+let runTestSpec = unit:
+  shell "run-${unit.label}"
+    "./${executablePath unit}";
+
+let archiveSpec =
+  shell "archive-libmetrics"
+    "ar rcs build/libmetrics.a ${objectArgs lib_sources}";
+
+let linkAppSpec =
+  shell "link-metrics-demo"
+    "cc ${flags} -o build/metrics-demo ${objectArgs app_sources} build/libmetrics.a";
+
+let linkMetricsTestSpec = linkTestSpec test_sources[0];
+let linkParseTestSpec = linkTestSpec test_sources[1];
+let runMetricsTestSpec = runTestSpec test_sources[0];
+let runParseTestSpec = runTestSpec test_sources[1];
+
+let smokeSpec =
+  shell "run-smoke"
+    "./build/metrics-demo '${smokeInput}'";
+
+let packageSpec =
+  shell "package-dist"
+    "mkdir -p dist && cp build/metrics-demo dist/metrics-demo && hash=$(sha256sum dist/metrics-demo | cut -d ' ' -f 1) && case $hash in ?*) true;; *) false;; esac && { printf 'artifact metrics-demo\n'; printf 'sha256 %s\n' $hash; printf 'flags %s\n' '${flags}'; printf 'sources %s\n' '${sourcePaths}'; } > dist/manifest.txt";
+
+let binaryAuditSpec =
+  shell "audit-binary-executable"
+    "test -x dist/metrics-demo";
+
+let manifestAuditSpec =
+  shell "audit-manifest"
+    "grep -Fqx 'artifact metrics-demo' dist/manifest.txt && grep -Eq '^sha256 [0-9a-f]{64}$' dist/manifest.txt && grep -Fqx 'flags ${flags}' dist/manifest.txt && grep -Fqx 'sources ${sourcePaths}' dist/manifest.txt";
+
+let sizeAuditSpec =
+  shell "audit-size"
+    "bytes=$(wc -c < dist/metrics-demo) && test $bytes -gt 0 && printf 'bytes=%s\n' $bytes";
+
+let checksumAuditSpec =
+  shell "audit-checksum"
+    "expected=$(grep '^sha256 ' dist/manifest.txt | cut -d ' ' -f 2) && actual=$(sha256sum dist/metrics-demo | cut -d ' ' -f 1) && case $expected in ?*) true;; *) false;; esac && case $actual in ?*) true;; *) false;; esac && test x$actual = x$expected && printf 'sha256=%s\n' $actual";
+
+let promoteReleaseSpec =
+  shell "promote-release"
+    "rm -rf release && mkdir -p release && cp dist/metrics-demo release/metrics-demo && cp dist/manifest.txt release/manifest.txt && cmp -s dist/metrics-demo release/metrics-demo && cmp -s dist/manifest.txt release/manifest.txt";
+
+let blockedPromotionSpec =
+  shell "promote-release-blocked"
+    "printf 'release evidence failed; refusing to promote\n' >&2; exit 1";
+
+let releaseEvidenceOk = evidence:
+  evidence.libCompileReport.ok
+    && evidence.appCompileReport.ok
+    && evidence.testCompileReport.ok
+    && evidence.qualityReport.ok
+    && evidence.packageAuditReport.ok
+    && evidence.archive.ok
+    && evidence.linkApp.ok
+    && evidence.linkMetricsTest.ok
+    && evidence.linkParseTest.ok
+    && evidence.runMetricsTest.ok
+    && evidence.runParseTest.ok
+    && evidence.smokeRun.ok
+    && evidence.package.ok
+    && evidence.binaryAudit.ok
+    && evidence.manifestAudit.ok
+    && evidence.sizeAudit.ok
+    && evidence.checksumAudit.ok;
+
+let promotionSpecFor = evidence:
+  if releaseEvidenceOk evidence
+  then promoteReleaseSpec
+  else blockedPromotionSpec;
+
+let buildNote = {
+  label = "source include";
+  ok = true;
+  summary = buildNoteText;
+};
 
 let summarize = runs: label: {
   inherit label;
   ok = length (runs |> filter (run: !run.ok)) == 0;
   summary = runs |> map (run: "${run.name}=${run.status}") |> joinWith ", ";
 };
+
+# ============================================================================
+# 4. Reusable Graph Fragments
+# ============================================================================
+#
+# These kinds/forms are the graph vocabulary. The important part is that they
+# do not collapse several shell operations into one opaque script. Each command
+# remains a named node with its own result, and every dependency edge is visible
+# to Wire's checker.
+
+kind run_command(spec: PortLabel, result: PortLabel) =
+  <- spec: CommandSpec;
+  -> result: CommandResult = @command {} (spec);
+
+kind planned_command(label: PortLabel, item: Value) =
+  <- label: CommandSpec;
+  -> label: CommandResult = @command {} (label);
+
+# A gate records the dependency as a Wire edge while preserving the previous
+# CommandResult for later reporting. Make/CMake can order commands; here the
+# edge and the carried result are first-class graph structure.
+kind command_gate(previous: PortLabel, ready: PortLabel, spec: Value) =
+  <- previous: CommandResult;
+  -> previous: CommandResult = previous;
+  -> ready: CommandSpec = spec;
+
+kind command_prereq_gate(previous: PortLabel, ready: PortLabel, spec: Value) =
+  <- previous: CommandResult;
+  -> ready: CommandSpec = spec;
+
+kind command_result_fanout(source: PortLabel, first: PortLabel, second: PortLabel, third: PortLabel, fourth: PortLabel) =
+  <- source: CommandResult;
+  -> source: CommandResult = source;
+  -> first: CommandResult = source;
+  -> second: CommandResult = source;
+  -> third: CommandResult = source;
+  -> fourth: CommandResult = source;
+
+form gated_command(spec: Value, previous: PortLabel, result: PortLabel) = {
+  node gate = command_gate(previous, ready, spec);
+  node run = run_command(ready, result);
+
+  gate
+    => run;
+};
+
+# Package audit is an explicit fanout, not three hidden reads of "whatever is
+# in dist". The split node below gathers only the audit results, so accidental
+# pass-through ports cannot satisfy PackageAuditResults.
+form audit_package(package: PortLabel, binaryAudit: PortLabel, manifestAudit: PortLabel, sizeAudit: PortLabel, checksumAudit: PortLabel) = {
+  node fanout = command_result_fanout(package, binaryPrereq, manifestPrereq, sizePrereq, checksumPrereq);
+  node binary_gate = command_prereq_gate(binaryPrereq, binaryReady, binaryAuditSpec);
+  node manifest_gate = command_prereq_gate(manifestPrereq, manifestReady, manifestAuditSpec);
+  node size_gate = command_prereq_gate(sizePrereq, sizeReady, sizeAuditSpec);
+  node checksum_gate = command_prereq_gate(checksumPrereq, checksumReady, checksumAuditSpec);
+  node binary = run_command(binaryReady, binaryAudit);
+  node manifest = run_command(manifestReady, manifestAudit);
+  node size = run_command(sizeReady, sizeAudit);
+  node checksum = run_command(checksumReady, checksumAudit);
+
+  fanout
+    => (
+      (binary_gate
+        => binary)
+      <> (manifest_gate
+        => manifest)
+      <> (size_gate
+        => size)
+      <> (checksum_gate
+        => checksum)
+    );
+};
+
+# ============================================================================
+# 5. Source Discovery And Parallel Compile/Check Frontier
+# ============================================================================
+#
+# `include_dir` snapshots source files at Wire elaboration time. `makeEach`
+# turns those snapshots into graph nodes. The exact record contracts above are
+# intentionally the place where newly discovered files become visible.
+
+# Source-discovered frontiers. These are parallel compile/check nodes generated
+# from elaboration-time data, then exact-gathered into record summaries.
+#
+# Runtime command leaves consume simple input identifiers today, so this compact
+# planner materializes only the source-generated command specs as ports. The
+# artifact chain below keeps its specs inside reusable gates.
+node plan_specs
+  -> lib_objects_metrics: CommandSpec = compileSpec lib_sources[0];
+  -> lib_objects_parse: CommandSpec = compileSpec lib_sources[1];
+  -> lib_objects_render: CommandSpec = compileSpec lib_sources[2];
+  -> app_objects_main: CommandSpec = compileSpec app_sources[0];
+  -> test_objects_test_metrics: CommandSpec = compileSpec test_sources[0];
+  -> test_objects_test_parse: CommandSpec = compileSpec test_sources[1];
+  -> quality_checks_syntax: CommandSpec = qualitySpec quality_units[0];
+  -> quality_checks_todo: CommandSpec = qualitySpec quality_units[1];
+  -> quality_checks_headers: CommandSpec = qualitySpec quality_units[2];
+
+let lib_objects = makeEach(lib_sources, planned_command);
+let app_objects = makeEach(app_sources, planned_command);
+let test_objects = makeEach(test_sources, planned_command);
+let quality_checks = makeEach(quality_units, planned_command);
+
+# ============================================================================
+# 6. Frontier Summaries
+# ============================================================================
 
 node summarize_lib_objects
   <- libObjects: LibObjectResults;
@@ -247,15 +399,22 @@ node analyze_quality
   <- quality: QualityResults;
   -> qualityReport: BuildSummary = summarize ([quality.quality_checks_syntax, quality.quality_checks_todo, quality.quality_checks_headers]) "quality checks";
 
-# archive_gate is the point where all parallel source-generated frontiers must
-# be complete before artifact production starts.
+# ============================================================================
+# 7. Artifact Build, Package Audit, And Promotion Evidence
+# ============================================================================
+#
+# The promotion gate is the core release guarantee in this example. Promotion
+# does not depend on a vague "package succeeded" flag. It consumes typed
+# evidence for compile, link, test, package, and audit steps, then chooses the
+# only command allowed to touch `release/`. Failed evidence produces a failing
+# non-mutating command instead of deleting or replacing promoted artifacts. If a
+# refactor forgets one piece, the promotion gate cannot be wired.
+
 node archive_gate
   <- libCompileReport: BuildSummary;
   <- appCompileReport: BuildSummary;
   <- testCompileReport: BuildSummary;
   <- qualityReport: BuildSummary;
-  <- buildNote: BuildSummary;
-  <- archiveSpec: CommandSpec;
   -> libCompileReport: BuildSummary = libCompileReport;
   -> appCompileReport: BuildSummary = appCompileReport;
   -> testCompileReport: BuildSummary = testCompileReport;
@@ -265,13 +424,94 @@ node archive_gate
 
 node archive_core = run_command(archiveReady, archive);
 
-let link_app = gated_command(linkAppSpec, archive, linkAppReady, linkApp);
-let link_metrics_test = gated_command(linkMetricsTestSpec, linkApp, linkMetricsTestReady, linkMetricsTest);
-let link_parse_test = gated_command(linkParseTestSpec, linkMetricsTest, linkParseTestReady, linkParseTest);
-let run_metrics_test = gated_command(runMetricsTestSpec, linkParseTest, runMetricsTestReady, runMetricsTest);
-let run_parse_test = gated_command(runParseTestSpec, runMetricsTest, runParseTestReady, runParseTest);
-let run_smoke = gated_command(smokeSpec, runParseTest, smokeReady, smokeRun);
-let package_dist = gated_command(packageSpec, smokeRun, packageReady, package);
+let link_app = gated_command(linkAppSpec, archive, linkApp);
+let link_metrics_test = gated_command(linkMetricsTestSpec, linkApp, linkMetricsTest);
+let link_parse_test = gated_command(linkParseTestSpec, linkMetricsTest, linkParseTest);
+let run_metrics_test = gated_command(runMetricsTestSpec, linkParseTest, runMetricsTest);
+let run_parse_test = gated_command(runParseTestSpec, runMetricsTest, runParseTest);
+let run_smoke = gated_command(smokeSpec, runParseTest, smokeRun);
+let package_dist = gated_command(packageSpec, smokeRun, package);
+let package_audit = audit_package(package, binaryAudit, manifestAudit, sizeAudit, checksumAudit);
+
+node split_package_audit
+  <- package: CommandResult;
+  <- binaryAudit: CommandResult;
+  <- manifestAudit: CommandResult;
+  <- sizeAudit: CommandResult;
+  <- checksumAudit: CommandResult;
+  -> package: CommandResult = package;
+  -> audits: PackageAuditResults = {
+    inherit binaryAudit manifestAudit sizeAudit checksumAudit;
+  };
+
+node summarize_package_audit
+  <- audits: PackageAuditResults;
+  -> packageAuditReport: BuildSummary = summarize ([audits.binaryAudit, audits.manifestAudit, audits.sizeAudit, audits.checksumAudit]) "package audit";
+  -> binaryAudit: CommandResult = audits.binaryAudit;
+  -> manifestAudit: CommandResult = audits.manifestAudit;
+  -> sizeAudit: CommandResult = audits.sizeAudit;
+  -> checksumAudit: CommandResult = audits.checksumAudit;
+
+node collect_release_evidence
+  <- pre: PreReleaseResults;
+  -> pre: PreReleaseResults = pre;
+  -> releaseEvidence: ReleaseEvidence = {
+    libCompileReport = pre.libCompileReport;
+    appCompileReport = pre.appCompileReport;
+    testCompileReport = pre.testCompileReport;
+    qualityReport = pre.qualityReport;
+    packageAuditReport = pre.packageAuditReport;
+    archive = pre.archive;
+    linkApp = pre.linkApp;
+    linkMetricsTest = pre.linkMetricsTest;
+    linkParseTest = pre.linkParseTest;
+    runMetricsTest = pre.runMetricsTest;
+    runParseTest = pre.runParseTest;
+    smokeRun = pre.smokeRun;
+    package = pre.package;
+    binaryAudit = pre.binaryAudit;
+    manifestAudit = pre.manifestAudit;
+    sizeAudit = pre.sizeAudit;
+    checksumAudit = pre.checksumAudit;
+  };
+
+node release_gate
+  <- releaseEvidence: ReleaseEvidence;
+  -> promoteReady: CommandSpec = promotionSpecFor releaseEvidence;
+
+node promote_release = run_command(promoteReady, promotedRelease);
+
+node assemble_final_results
+  <- pre: PreReleaseResults;
+  <- promotedRelease: CommandResult;
+  -> final: FinalResults = {
+    libCompileReport = pre.libCompileReport;
+    appCompileReport = pre.appCompileReport;
+    testCompileReport = pre.testCompileReport;
+    qualityReport = pre.qualityReport;
+    packageAuditReport = pre.packageAuditReport;
+    buildNote = pre.buildNote;
+    archive = pre.archive;
+    linkApp = pre.linkApp;
+    linkMetricsTest = pre.linkMetricsTest;
+    linkParseTest = pre.linkParseTest;
+    runMetricsTest = pre.runMetricsTest;
+    runParseTest = pre.runParseTest;
+    smokeRun = pre.smokeRun;
+    package = pre.package;
+    binaryAudit = pre.binaryAudit;
+    manifestAudit = pre.manifestAudit;
+    sizeAudit = pre.sizeAudit;
+    checksumAudit = pre.checksumAudit;
+    inherit promotedRelease;
+  };
+
+# ============================================================================
+# 8. Human Report
+# ============================================================================
+#
+# The report is intentionally plain text, but it is not log scraping. It is a
+# deterministic summary built from typed CommandResult and BuildSummary values.
 
 node render_build_report
   <- final: FinalResults;
@@ -286,6 +526,11 @@ node render_build_report
       final.runParseTest,
       final.smokeRun,
       final.package,
+      final.binaryAudit,
+      final.manifestAudit,
+      final.sizeAudit,
+      final.checksumAudit,
+      final.promotedRelease,
     ];
     failures = commands |> filter (run: !run.ok);
     commandLines =
@@ -294,8 +539,16 @@ node render_build_report
         |> joinWith "\n";
     gate =
       if final.libCompileReport.ok && final.appCompileReport.ok && final.testCompileReport.ok && final.qualityReport.ok && length failures == 0
-      then "C build gate: open"
-      else "C build gate: blocked";
+      then "Release promotion gate: open"
+      else "Release promotion gate: blocked";
+    promotedArtifact =
+      if final.promotedRelease.ok
+      then "promoted-artifact: examples/wire/c-build/release/metrics-demo"
+      else "promoted-artifact: not promoted";
+    promotedManifest =
+      if final.promotedRelease.ok
+      then "promoted-manifest: examples/wire/c-build/release/manifest.txt"
+      else "promoted-manifest: not promoted";
     report =
       [
         gate,
@@ -303,10 +556,15 @@ node render_build_report
         "app: ${final.appCompileReport.summary}",
         "tests: ${final.testCompileReport.summary}",
         "quality: ${final.qualityReport.summary}",
+        "audit: ${final.packageAuditReport.summary}",
         "note: ${final.buildNote.summary}",
         "commands:",
         commandLines,
-        "artifact: examples/wire/c-build/dist/metrics-demo",
+        "artifact-size: ${final.sizeAudit.stdout}",
+        "artifact-sha256: ${final.checksumAudit.stdout}",
+        "tested-artifact: examples/wire/c-build/dist/metrics-demo",
+        promotedArtifact,
+        promotedManifest,
       ] |> joinWith "\n";
   in
   { inherit report; };
@@ -315,27 +573,33 @@ node print_report
   <- report: BuildReport;
   = @stdout { newline = true; } (report);
 
-let lib_object_stage =
-  lib_objects
-    * summarize_lib_objects;
+# ============================================================================
+# 9. Final Graph
+# ============================================================================
 
+let lib_object_stage = lib_objects * summarize_lib_objects;
 let app_object_stage =
   app_objects
     => summarize_app_objects;
-
-let test_object_stage =
-  test_objects
-    * summarize_test_objects;
-
-let quality_stage =
-  quality_checks
-    * analyze_quality;
+let test_object_stage = test_objects * summarize_test_objects;
+let quality_stage = quality_checks * analyze_quality;
 
 let source_frontiers =
   lib_object_stage
     <> app_object_stage
     <> test_object_stage
     <> quality_stage;
+
+let package_audit_stage =
+  package_audit
+    => split_package_audit
+    => summarize_package_audit;
+
+let release_promotion =
+  collect_release_evidence
+    => release_gate
+    => promote_release
+    => assemble_final_results;
 
 let artifact_sequence =
   archive_gate
@@ -346,14 +610,15 @@ let artifact_sequence =
     => run_metrics_test
     => run_parse_test
     => run_smoke
-    => package_dist;
+    => package_dist
+    => package_audit_stage;
 
 let report_stage =
   artifact_sequence
-    * render_build_report;
+    * release_promotion
+    => render_build_report;
 
-start_build
-  => plan_build
+plan_specs
   => source_frontiers
   => report_stage
   => print_report

--- a/test/Cortex/Wire/CompileSpec.hs
+++ b/test/Cortex/Wire/CompileSpec.hs
@@ -3468,10 +3468,70 @@ spec = describe "Cortex.Wire.Compile" $ do
       successors compiled.compiledCircuitTopology (Set.findMin gatherPhantoms)
         `shouldBe` Set.singleton (CircuitNodeRef "reduce_findings")
 
-    it "compiles the C build example" $ do
+    it "preserves the C build example as a structured shell graph" $ do
       source <- TIO.readFile "examples/wire/c-build/c-build.wire"
       expanded <- requireRight =<< expandWireSourceIncludes "examples/wire/c-build/c-build.wire" source
-      compileWireText expanded `shouldSatisfy` isRight
+      compiled <- requireRight (compileWireText expanded)
+      Set.fromList compiled.compiledCircuitEntryNodes
+        `shouldBe` Set.singleton (CircuitNodeRef "plan_specs")
+      Set.fromList compiled.compiledCircuitExitNodes
+        `shouldBe` Set.singleton (CircuitNodeRef "print_report")
+      let nodeRefs = Map.keysSet compiled.compiledCircuitNodes
+      nodeRefs `shouldSatisfy` Set.notMember (CircuitNodeRef "start_build")
+      nodeRefs `shouldSatisfy` Set.notMember (CircuitNodeRef "plan_build")
+      expectNodeRefs
+        compiled
+        [ CircuitNodeRef "plan_specs"
+        , CircuitNodeRef "lib_objects_metrics"
+        , CircuitNodeRef "app_objects_main"
+        , CircuitNodeRef "test_objects_test_metrics"
+        , CircuitNodeRef "quality_checks_todo"
+        , CircuitNodeRef "archive_core"
+        , CircuitNodeRef "link_app/gate"
+        , CircuitNodeRef "link_app/run"
+        , CircuitNodeRef "package_dist/run"
+        , CircuitNodeRef "package_audit/fanout"
+        , CircuitNodeRef "package_audit/binary_gate"
+        , CircuitNodeRef "package_audit/binary"
+        , CircuitNodeRef "package_audit/manifest"
+        , CircuitNodeRef "package_audit/size"
+        , CircuitNodeRef "package_audit/checksum_gate"
+        , CircuitNodeRef "package_audit/checksum"
+        , CircuitNodeRef "split_package_audit"
+        , CircuitNodeRef "summarize_package_audit"
+        , CircuitNodeRef "collect_release_evidence"
+        , CircuitNodeRef "release_gate"
+        , CircuitNodeRef "promote_release"
+        , CircuitNodeRef "assemble_final_results"
+        ]
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "link_app/gate")
+        `shouldSatisfy` Set.member (CircuitNodeRef "link_app/run")
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "package_audit/fanout")
+        `shouldBe` Set.fromList
+          [ CircuitNodeRef "package_audit/binary_gate"
+          , CircuitNodeRef "package_audit/manifest_gate"
+          , CircuitNodeRef "package_audit/size_gate"
+          , CircuitNodeRef "package_audit/checksum_gate"
+          , CircuitNodeRef "split_package_audit"
+          ]
+      let gatherRefs =
+            Set.filter
+              (("__star:gather:" `T.isPrefixOf`) . (.unCircuitNodeRef))
+              nodeRefs
+      Set.size gatherRefs `shouldSatisfy` (>= 4)
+      mapM_
+        (expectTaskExecutorTarget compiled "std.io.command")
+        [ CircuitNodeRef "lib_objects_metrics"
+        , CircuitNodeRef "quality_checks_todo"
+        , CircuitNodeRef "archive_core"
+        , CircuitNodeRef "link_app/run"
+        , CircuitNodeRef "package_dist/run"
+        , CircuitNodeRef "package_audit/binary"
+        , CircuitNodeRef "package_audit/manifest"
+        , CircuitNodeRef "package_audit/size"
+        , CircuitNodeRef "package_audit/checksum"
+        , CircuitNodeRef "promote_release"
+        ]
 
     it "compiles the quantum Bell-state example with consumer executor projections" $ do
       source <- TIO.readFile "examples/wire/quantum-bell-state.wire"
@@ -4341,6 +4401,19 @@ stdIoWriteFileBadShapeSourceText =
     , "  -> written: Report = @writeFile { path = \"/tmp/wire-report.txt\"; } (report) ;"
     , "bad_write"
     ]
+
+expectNodeRefs :: CompiledCircuit -> [CircuitNodeRef] -> Expectation
+expectNodeRefs compiled expected =
+  Set.fromList expected `Set.difference` Map.keysSet compiled.compiledCircuitNodes
+    `shouldBe` Set.empty
+
+expectTaskExecutorTarget :: CompiledCircuit -> T.Text -> CircuitNodeRef -> Expectation
+expectTaskExecutorTarget compiled expectedTarget ref =
+  case Map.lookup ref compiled.compiledCircuitNodes of
+    Just (CompiledCircuitTask taskNode) ->
+      taskNode.circuitTaskNodeMetadata `shouldSatisfy` metadataHasExecutorTarget expectedTarget
+    other ->
+      expectationFailure ("expected task node " <> show ref <> ", got: " <> show other)
 
 requireRight :: Show err => Either err a -> IO a
 requireRight = \case


### PR DESCRIPTION
Supersedes #233 after renaming the head branch from `codex/pr-183` to `wire-c-build-auditable-release`.

## Summary

- Hardens ADR 0052 with a concrete runtime-bounded iteration model, explicit boundary rules, adversarial counterexamples, and implementation obligations.
- Refactors the C build Wire example into a headline structured shell-wrapping example with generated command specs, typed audit fanout/gather boundaries, manifest/checksum verification, and release promotion evidence.
- Adds fixture assertions that the C build example retains generated nodes, form expansion, fanout/gather shape, release promotion gates, and `std.io.command` executor targets.
- Ignores generated c-build `build/`, `dist/`, and `release/` artifacts robustly.

## Why

This PR makes the runtime iteration ADR and shell-wrapping example harder to misread. The ADR separates source graph elaboration, CorePure value computation, executor-local loops, and Pulse-owned runtime-bounded iteration. The Wire example now demonstrates why shell wrapping is more than a pipeline string: dependency shape, fanout/fanin, typed joins, release evidence, and promotion gates remain inspectable graph structure.

## Validation

- `nix run .#wire -- run examples/wire/c-build/c-build.wire`
- `just test-match "C build example"`
- `just wire-style-check`
- `just fmt-check`
- Pre-commit hooks passed during the signed amended commit.
