### PR TITLE
docs(publications): portfolio overhaul and frontier-calculus flagship paper

### DIFF
--- a/docs/Publications/Notes/index.md
+++ b/docs/Publications/Notes/index.md
@@ -3,7 +3,7 @@ title: Publication Notes
 description: Working notes and idea memos that feed the Cortex publication corpus.
 status: research
 date: 2026-04-28
-updated: 2026-04-28
+updated: 2026-06-10
 related:
   - docs/Publications/roadmap.md
   - docs/Publications/index.md
@@ -19,3 +19,5 @@ mature material moves into the relevant manuscript, artifact note, or roadmap pl
 - [frontier-ideas.md](frontier-ideas.md) — raw idea bank for paper and plan development.
 - [deterministic-multi-rewrite-admission.md](deterministic-multi-rewrite-admission.md) — runtime
   semantics and validation questions for same-wave multi-proposal admission.
+- [mined-contributions.md](mined-contributions.md) — inventory of contributions present in the Lean
+  proofs and implementation but not yet claimed by any manuscript.

--- a/docs/Publications/Notes/mined-contributions.md
+++ b/docs/Publications/Notes/mined-contributions.md
@@ -1,0 +1,157 @@
+---
+title: Mined Contributions
+description:
+  Inventory of contributions present in the Lean proofs and Haskell implementation but not yet
+  articulated in any manuscript, with evidence, nearest literature, proposed homes, and caveats.
+status: active
+date: 2026-06-10
+related:
+  - docs/Publications/roadmap.md
+  - docs/Publications/Paper-7-frontier-calculus/
+  - docs/Reference/proof-status.md
+---
+
+# Mined Contributions
+
+Findings from an adversarial mining pass (2026-06-10) over `theory/Cortex/Wire/`, the compiler, and
+the research notes: things the system already contains that no paper yet claims. Ranked by potential
+impact. Items 1, 2, and 8 have been integrated into Paper 7's structure and Paper 6; the rest live
+here until a paper claims them.
+
+## 1. Two-layer linear port semantics (latent/actualized) — INTEGRATED into Paper 7 §3.6
+
+**Claim shape:** port linearity is not one invariant but two, connected by a projection. The source
+layer (`LinearPortGraph.PortLinear`) governs authored composition; the actualized layer
+(`ActualizedPortGraph.ClosedPortLinear`) governs the running circuit, where every input has exactly
+one producer and every output exactly one consumer or terminal discharge. The source-to-actualized
+projection is exact: `compiledPortUseWitness_exact_output` / `_input`
+(`theory/Cortex/Wire/ActualizedBridge.lean`) prove every actualized port comes from a source port
+and vice versa, and `selectActualize_preserves_closedPortLinearity` carries the discipline through
+branch actualization.
+
+**Nearest literature / delta:** two-level resource readings exist in staged metaprogramming and in
+latent-vs-actual effect systems, but a latent/actualized **linearity** pair with a proved projection
+exactness over executable graphs appears unclaimed.
+
+**Caveat:** the modality framing ("latent" as a type operator) is ours to prove; the Lean has the
+carriers and the projection, not a modal type system.
+
+## 2. The certifying admission boundary — INTEGRATED into Paper 7 §5
+
+**Claim shape:** a compiler-certification architecture strictly between proof-carrying code and
+translation validation. The compiler emits proof-shaped admission artifacts (pure data, no proof
+terms); mirrored executable contracts validate them on both sides of the language boundary (Haskell
+`wireAdmissionArtifactValidatorReady` ↔ Lean `validatorReadyCheck` with
+`validatorReadyCheck_soundness : check = true → Sound`); reconstruction theorems recover proof
+witnesses from accepted artifacts (`Sound.toPrimitiveGraphReconstruction` and the
+generated/phantom/select counterparts); and a structural binding check
+(`Cortex.Wire.AdmissionBinding`, gated in `compileLoweredWireFile`) ties each artifact to the exact
+circuit it travels with, with mutation regression tests pinning a rejection per error constructor.
+
+**Nearest literature / delta:** PCC ships proof terms; translation validation re-checks semantic
+equivalence per compilation. Here: structured evidence + contract mirroring + value-level binding,
+each independently testable. The trust statement is explicit (binds values, not provenance).
+
+**Possible standalone venue:** CPP / CC / ITP-adjacent ("Certifying compilation by artifact contract
+mirroring").
+
+**Caveat:** the Lean checker does not yet consume actual Haskell output (hand-transcribed fixture
+only); a generator closes that.
+
+## 3. Boundary resource algebra with one-slot epochs
+
+**Claim shape:** rewrite admission carries a per-anchor resource discipline finer than budgets: each
+anchor exposes one rewrite slot per epoch; no two admitted rewrites spend the same slot
+(`RewriteSlot`, `SlotUnique`, `SlotUniqueTrace`, `rewriteSlot_spent_at_most_once`,
+`theory/Cortex/Wire/BoundaryResource.lean`); and the three rewrite families have distinct boundary
+laws — consuming substitution (`expandNode_resourceUse`), retaining append
+(`appendAfter_resourceUse`), guarded-affine select actualization.
+
+**Nearest literature / delta:** linear/affine type systems and separation logic provide the
+vocabulary; the per-anchor one-slot epoch discipline for graph rewriting, with a proof-relevant
+uniqueness trace, looks unclaimed.
+
+**Proposed home:** Paper 7 §4 row (added); fuller treatment in Paper 3 or a follow-up.
+
+**Caveat:** no fairness/liveness result; the connection to the budget algebra is stated but not
+unified.
+
+## 4. Latent branch families as guarded-affine resources
+
+**Claim shape:** `select(...)` is neither if-then-else nor fan-out: a latent branch family is
+admitted sealed (label-first resolution with unique contract fallback, total coverage —
+`SelectAdmission.admitClause`), exactly one arm actualizes as a deterministic retained-anchor append
+rewrite (`selectActualize_lowers_to_appendAfter`) consuming a guarded-affine boundary obligation,
+unselected bodies are provably excluded (`selectActualize_unselected_not_in_selectedFragment`), and
+recovery replays the same selection (`selectedBranch_recovery_deterministic`).
+
+**Nearest literature / delta:** session-type labeled choice is the nearest neighbor; the deltas are
+durability (recovery determinism from persisted admission) and the rewrite reading (actualization is
+a budgeted graph rewrite, not a process step).
+
+**Proposed home:** Paper 7 T-Select draft + a dedicated section; possibly its own workshop paper.
+
+**Caveat:** uniqueness of actualization (no two arms simultaneously) is enforced but the single
+clean theorem stating it should be named.
+
+## 5. Five-dimensional graded rewrite budgets
+
+**Claim shape:** rewrite costs and budgets are five-dimensional (added nodes, added edges, added
+depth, frontier-width delta, rewrite operations), with per-step fit
+(`ConstructedPlanningStep.boundaryResourceCost_fits_budget`) and chain-level monotonicity
+(`ConstructedPlanningChain.finalBudget_le_initial`); selected-branch actualization consumes exactly
+the constructed selected-fragment cost (`selectActualize_consumes_selected_cost`).
+
+**Nearest literature / delta:** graded/coeffect type systems track one grade; structured
+multi-dimensional grading over graph rewriting, with each dimension naming a distinct scarcity
+(memory, depth, parallel width, scheduler work), is a tidy generalizable structure.
+
+**Proposed home:** Paper 7 §4 row (added); generalization could be a short formal note.
+
+**Caveat:** no completeness argument for the five dimensions; no cross-dimension trade theory.
+
+## 6. Stage-structured causal pipelines (precedence as semantics)
+
+**Claim shape:** binding `<>` tighter than `=>` is a semantic decision, not syntax taste: it makes
+ordinary pipeline text denote stage-structured partial orders without parentheses, giving the ladder
+imperative (order first) → functional (names first) → frontier (stages first, order derived).
+Already half-written in
+`docs/Research-notes/Foundation/2026-05-09-stage-structured-causal-pipelines.md`; absent from the
+papers.
+
+**Proposed home:** Paper 6's framing (a sentence exists), Paper 7 §1 motivation, Paper 5's paradigm
+ladder.
+
+**Caveat:** framing, not theorem; needs one crisp definition of "stage" to be more than rhetoric.
+
+## 7. Frontier reclamation as linear resource deallocation
+
+**Claim shape:** finished frontiers are reclaimable (`FrontierFinished`,
+`frontierFinished_reclaimable`, `theory/Cortex/Wire/FrontierReclaim.lean`): once every endpoint is
+consumed or discharged, the in-memory endpoint resources are structurally dead and reusable — linear
+deallocation at the graph boundary, preventing frontier growth across long rewrite chains.
+
+**Proposed home:** Paper 3 resource-management section or Paper 7 §4 footnote.
+
+**Caveat:** runtime reclaim hooks and durable-profile retention are open; no non-conflict theorem
+for reclaimed vs live endpoints yet.
+
+## 8. Quantum circuits in the same linear frontier language — INTEGRATED into Paper 6
+
+**Claim shape:** the same port-linear calculus that explains causal provenance in durable workflows
+describes quantum circuits, where the linearity discipline coincides with the no-cloning constraint
+qubit-carrying ports require: an unmatched fan-out of a qubit-typed port is exactly the static error
+the calculus already rejects. Evidence: ~12 quantum examples under `examples/wire/`, including
+`quantum-eraser-experiment.wire` (540 lines) executed on IBM hardware (`ibm_fez`, job
+`d7rnnhst738s73cfpljg`).
+
+**Nearest literature / delta:** the linear-logic/quantum connection is classical (Abramsky,
+Selinger); the delta is one executable language spanning durable workflows and quantum circuit
+description with the same admission discipline, demonstrated on hardware.
+
+**Proposed home:** Paper 6 paragraph (done); potential standalone domain paper ("Quantum circuits as
+typed linear workflows").
+
+**Caveat:** no formal semantics of gates in the Wire model; no equivalence proof against the
+Qiskit-level representation; the no-cloning correspondence is structural, not a quantum-semantics
+theorem.

--- a/docs/Publications/Paper-1-staged-reduction/manuscript.md
+++ b/docs/Publications/Paper-1-staged-reduction/manuscript.md
@@ -8,7 +8,7 @@ status: draft
 authors:
   - Julius Koskela
 date: 2026-04-28
-updated: 2026-04-28
+updated: 2026-06-10
 related:
   - docs/Publications/Paper-1-staged-reduction/lean-haskell-boundary.md
   - docs/Publications/Paper-1-staged-reduction/lean-mechanization.md
@@ -28,11 +28,16 @@ of the paper is intentionally narrow: incremental persistence is **structurally 
 during accumulation because recovery normalizes partially persisted state and re-closes it before
 any authoritative lifecycle decision is taken. We define the recovered-state validity contract
 explicitly and show how the three-phase decomposition explains both normal execution and crash
-recovery. The paper reports the design as implemented in the Pulse runtime, contrasts it with the
-failure modes of an earlier imperative runtime, and supports the implementation claims with
-property-based validation plus a proof sketch of the core structural argument. We do not claim
-end-to-end workflow correctness, outcome reproducibility for nondeterministic stages, or
-topology-changing rewrite correctness in this paper.
+recovery. Throughout, we separate three layers of obligation: algebraic facts about accumulation,
+closure, and classification (proved, and mechanized in Lean 4); structural recovery theorems for
+fixed-topology execution (mechanized, with named persistence-boundary preconditions); and external
+assumptions about worker I/O reproducibility (stated, not claimed). We also characterize the
+extension boundary: which changes preserve the staged reduction and which require a different
+machine, with topology-changing rewriting as the canonical boundary crossing. The paper reports the
+design as implemented in the Pulse runtime, contrasts it with the failure modes of an earlier
+imperative runtime, and supports the implementation claims with property-based validation alongside
+the mechanized core. We do not claim end-to-end workflow correctness, outcome reproducibility for
+nondeterministic stages, or topology-changing rewrite correctness in this paper.
 
 ## Artifact Status
 
@@ -153,8 +158,11 @@ A graph is:
 - **terminal** when settled and either some node is Failed or all nodes are Completed or Skipped
 - **suspended** when at least one node is Waiting and no node is ready
 
-The runtime also has rewrite-capable extensions, but they are intentionally out of scope for this
-paper's theorem path.
+The full status type additionally carries `NodeInterrupted` (an input to crash normalization,
+removed by recovery) and `NodeRewritten` (from the rewrite-capable extension). Both appear in the
+validity contract below — recovery must eliminate the former, and readiness treats the latter as a
+satisfied predecessor — even though rewriting itself is intentionally out of scope for this paper's
+theorem path. The Lean model carries the same constructors.
 
 ## 3. The Staged Reduction
 
@@ -186,6 +194,18 @@ accumulation, idempotent failure closure, and exhaustive lifecycle classificatio
 coordinator (bottom) dispatches frontier work, persists state, and finalizes lifecycle outcomes from
 the classifier's verdict.
 
+Algebraically, the fixed-topology machine factors as
+
+$$
+\operatorname{reduce}(G, R, s) =
+\operatorname{classify}(G,\ \operatorname{close}(G,\ \operatorname{accumulate}(R, s)))
+$$
+
+with `accumulate = foldl (flip applyNodeFact)`, `close = propagateFailure`, and
+`classify = classifyGraphState`. The execution model uses barriered frontier waves, but the
+algebraic core only sees a set of node-local facts and a topology-indexed state. The rest of this
+section develops each factor and the properties that make the factorization load-bearing.
+
 ### 3.1 Frontier Computation
 
 The execution frontier is the set of Pending nodes whose predecessors are all Completed, Skipped, or
@@ -199,6 +219,10 @@ readyNodes rel state =
       , all (isCompletedOrSkipped state) (Set.toList (predecessors rel v))
   ]
 ```
+
+Despite its historical name, `isCompletedOrSkipped` also accepts `NodeRewritten`
+(`src/Cortex/Pulse/GraphRuntime.hs`), which is why the validity contract in Definition 1 lists all
+three satisfied-predecessor statuses.
 
 **Lemma 1 (Frontier antichain).** The ready set forms an antichain under reachability.
 
@@ -236,8 +260,21 @@ The outcome type partitions into two classes with different algebraic roles:
 - **forward outcomes** advance the node's status monotonically on the status partial order
 - **reset outcomes** revert the node to Pending and are explicitly non-monotone
 
+The forward statuses form the local monotone fragment:
+
+$$
+\begin{aligned}
+\text{Pending} &\leq \text{Running} \leq \text{Completed} \\
+\text{Pending} &\leq \text{Running} \leq \text{Failed} \\
+\text{Pending} &\leq \text{Running} \leq \text{Skipped} \\
+\text{Pending} &\leq \text{Running} \leq \text{Waiting}(signal)
+\end{aligned}
+$$
+
 Both classes commute for independent frontier nodes because they update disjoint keys. Only the
-forward fragment admits the stronger lattice-style monotonicity reading.
+forward fragment admits the stronger lattice-style monotonicity reading; cancellation, shutdown, and
+crash normalization are explicitly non-monotone, which is why no claim of global runtime
+monotonicity is made anywhere in this paper.
 
 ### 3.3 Phase 1: Accumulate
 
@@ -277,6 +314,19 @@ $$
 This lemma is deliberately weaker than the shared-state commutativity results studied in LVars or
 CRDTs. Here we exploit disjoint-key point updates, not conflict resolution on a shared key.
 
+The algebraic reading: let $F$ be the free commutative monoid of `NodeResult` values with distinct
+node identifiers — distinctness justified by Lemma 1. `applyNodeFact` induces a monoid action
+
+$$
+\operatorname{act} : F \times \mathit{GraphState} \to \mathit{GraphState},
+\qquad
+\operatorname{act}(S, s) = \operatorname{foldl}(\operatorname{flip}\ applyNodeFact,\ s,\ S),
+$$
+
+and Lemma 2 is exactly what makes the action well-defined on the commutative quotient. The
+load-bearing property is not a deep join law on shared state; it is this modest disjoint-key
+commutativity of point updates.
+
 ### 3.4 Phase 2: Close
 
 ```haskell
@@ -311,10 +361,10 @@ Items 5 and 6 are properties of the closed, normalized state used for classifica
 Arbitrary mid-accumulation persisted snapshots need not satisfy them before normalization and
 closure.
 
-#### Proposition 1 (Structural persistence safety, conditional on closure laws)
+#### Proposition 1 (Structural persistence safety)
 
-Assuming the closure laws above, let $S$ be a frontier result set and let $S' \subseteq S$ be the
-prefix whose facts were durably persisted before a crash. Define:
+Using the closure laws above — proven, not assumed — let $S$ be a frontier result set and let
+$S' \subseteq S$ be the prefix whose facts were durably persisted before a crash. Define:
 
 ```haskell
 gsPersisted  = foldl' (flip applyNodeFact) gs0 S'
@@ -340,12 +390,17 @@ _Proof sketch._ The proof obligation breaks into named parts:
 
 The proposition is therefore a structural statement: the recovered graph state is normalized,
 closed, and schedulable. It does not prove that replayed worker I/O yields the same business result
-as the pre-crash execution.
+as the pre-crash execution. The decomposition into named obligations — domain preservation,
+normalization, closure laws, readiness soundness — is what keeps the recovery theorem from being
+circular: only after each obligation is stated independently does "recovery re-closes to a valid
+state" become a theorem rather than a restatement of the definitions.
 
 Proposition 1 is mechanized in Lean 4 as `persistence_safety` in `theory/Cortex/Pulse/Recovery.lean`
-(see [lean-mechanization.md](lean-mechanization.md)). The Lean theorem is conditional on persisted
-topology-domain, output-ownership, output-completeness, and causal-history preconditions, which the
-runtime must establish at the persistence boundary.
+(see [lean-mechanization.md](lean-mechanization.md)). The closure laws it uses are themselves
+mechanized, so the only remaining hypotheses are the persistence-boundary preconditions: persisted
+topology-domain, output-ownership, output-completeness, and causal-history, which the runtime must
+establish at the persistence boundary. That residual conditionality is a statement about the Haskell
+correspondence, not about the theorem.
 
 ### 3.5 Phase 3: Classify
 
@@ -543,11 +598,13 @@ The implementation-level claims are backed by QuickCheck property tests on rando
 | Recovery normalization               | §3.4, §3.7 | Partial frontier + `resetRunningToPending` + classify yields a valid closed state |
 | Sequential = batch                   | §3.6       | Fold of single-element `applyFrontierResults` matches batch application           |
 
-Several of these properties are now mechanized in Lean 4 — frontier antichain, disjoint-key
-commutativity and fold permutation, closure extensiveness, monotonicity, idempotence, recovery
-normalization, and classification exhaustiveness — and the artifacts are listed in
+All of these properties are mechanized in Lean 4 — frontier antichain, disjoint-key commutativity
+and fold permutation, closure extensiveness, monotonicity, idempotence, recovery normalization, and
+classification exhaustiveness — with no axioms and no incomplete proofs in the theory tree as of
+2026-06-10 (per the project proof-status dashboard); the artifacts are listed in
 [lean-mechanization.md](lean-mechanization.md). The QuickCheck tests remain runtime evidence on the
-live Haskell implementation; they are not a substitute for the Lean proof surface.
+live Haskell implementation; they are not a substitute for the Lean proof surface, and conversely
+the Lean theorems do not certify the Haskell implementation beyond the tested correspondence.
 
 ## 5. Failure Modes Addressed by the Redesign
 
@@ -591,6 +648,17 @@ Haxl [\[14\]](#ref-14) and the Par monad [\[15\]](#ref-15) exploit independence 
 parallelism; our contribution extends that design pressure to long-running durable tasks with crash
 recovery and signal suspension.
 
+The barriered execution shape also resembles a BSP-style [\[17\]](#ref-17) fragment of concurrent
+Kleene algebra [\[16\]](#ref-16):
+
+$$
+(\text{wave}_1\ \text{workers}) ; \text{close} ; \text{classify} ;
+(\text{wave}_2\ \text{workers}) ; \text{close} ; \text{classify} ; \cdots
+$$
+
+This is useful intuition for barriered parallel composition, but we do not claim a full CKA
+embedding.
+
 ## 7. Discussion
 
 ### 7.1 Structural Safety Versus End-to-End Correctness
@@ -616,12 +684,44 @@ The node-outcome type partitions into monotone forward outcomes and explicitly n
 outcomes. The monotone core admits the cleaner algebraic story. Reset outcomes commute only because
 they remain node-local. This boundary is the honest edge of the model and should remain explicit.
 
-### 7.4 Boundary to Topology-Changing Execution
+### 7.4 The Extension Boundary
 
-Dynamic graph rewriting is no longer treated as part of this paper's theorem path. Once topology
-changes mid-run, the fixed-topology structural-safety theorem stated here is insufficient.
-Rewrite-capable execution needs an additional materialization boundary, durable identity story, and
-recovery theorem. That is now a separate paper track.
+The staged reduction has three load-bearing invariants:
+
+- **I.** accumulation commutativity for frontier facts
+- **II.** closure idempotence
+- **III.** frontier antichain / readiness soundness
+
+Extensions that preserve the core:
+
+| Extension                                           | I   | II            | III           | Reason                               |
+| --------------------------------------------------- | --- | ------------- | ------------- | ------------------------------------ |
+| new node-local forward outcome                      | yes | yes           | yes           | still a point update                 |
+| richer classification output                        | yes | yes           | yes           | classification is observational      |
+| additional closure commuting with failure closure   | yes | conditionally | yes           | composition of commuting closures    |
+| edge annotations preserving DAG readiness semantics | yes | yes           | conditionally | if readiness stays predecessor-based |
+
+Extensions that cross the boundary:
+
+| Extension                                       | Broken invariant | Why                                                    |
+| ----------------------------------------------- | ---------------- | ------------------------------------------------------ |
+| inter-node mutation in accumulation             | I                | facts no longer commute by disjoint key                |
+| compensating or oscillating propagation         | II               | closure may stop being idempotent                      |
+| topology mutation during accumulation           | III              | frontier and closure are computed over moving topology |
+| shared-key accumulation without a merge algebra | I                | update order becomes observable                        |
+
+Topology-changing execution is therefore not "just another extension." Once topology changes
+mid-run, the fixed-topology structural-safety theorem stated here is insufficient: rewrite-capable
+execution needs a materialization boundary, a durable identity story, and a different recovery
+theorem. That machine and its admission, budget, and recovery theorems are developed in the
+companion substitution-semantics and frontier-calculus work.
+
+### 7.5 Open Problems
+
+1. **Characterize the closed-state subspace.** The closure operator suggests a useful sub-poset of
+   normalized states, but its exact algebraic structure is still only partly understood.
+2. **Weaken replay assumptions.** Structural safety needs less than outcome identity. The weakest
+   useful replay-compatibility condition is still open.
 
 ## 8. Conclusion
 
@@ -664,3 +764,7 @@ and classified by a pure algebra with explicit assumptions and boundaries.
 14. <a id="ref-14"></a>Marlow, S. et al. (2014). _There is No Fork_. ICFP 2014.
 15. <a id="ref-15"></a>Marlow, S. et al. (2011). _A Monad for Deterministic Parallelism_.
     Haskell 2011.
+16. <a id="ref-16"></a>Hoare, C. A. R., Möller, B., Struth, G., Wehrman, I. (2009). _Foundations of
+    Concurrent Kleene Algebra_. RelMiCS 2009.
+17. <a id="ref-17"></a>Valiant, L. G. (1990). _A Bridging Model for Parallel Computation_.
+    Communications of the ACM 33(8):103–111.

--- a/docs/Publications/Paper-2-algebraic-foundations/index.md
+++ b/docs/Publications/Paper-2-algebraic-foundations/index.md
@@ -5,9 +5,9 @@ description:
 sidebar:
   label: Paper 2
   order: 2
-status: draft
+status: superseded
 date: 2026-04-28
-updated: 2026-04-28
+updated: 2026-06-10
 related:
   - docs/Publications/Paper-1-staged-reduction/
   - docs/Publications/Paper-3-graph-substitution-semantics/
@@ -17,12 +17,15 @@ related:
 
 # Paper 2 — Algebraic Foundations
 
-The keystone paper in the series: the algebraic calculus that the other papers refine, mechanize,
-and extend.
+The algebraic calculus of fixed-topology staged durable execution. **Superseded:** this material is
+merged into [Paper 1](../Paper-1-staged-reduction/), which now carries the algebraic framing, the
+forward-fragment order, the extension-boundary analysis, and the results table citing the delivered
+Lean mechanization. The directory is retained until Paper 1's submission freeze, then removed.
 
 ## Status
 
-Draft manuscript. See [manuscript.md](manuscript.md) for the full text.
+Superseded by the merged Paper 1 manuscript. The manuscript here is kept for reference; do not edit
+it further.
 
 ## Abstract
 

--- a/docs/Publications/Paper-2-algebraic-foundations/manuscript.md
+++ b/docs/Publications/Paper-2-algebraic-foundations/manuscript.md
@@ -1,12 +1,12 @@
 ---
 title: "Paper 2: Algebraic Foundations"
-description: Algebraic foundations of staged durable execution.
+description: Algebraic foundations of staged durable execution. Superseded; merged into Paper 1.
 kind: publication
-status: draft
+status: superseded
 authors:
   - Julius Koskela
 date: 2026-04-28
-updated: 2026-04-28
+updated: 2026-06-10
 related:
   - docs/Publications/Paper-1-staged-reduction/
   - docs/Publications/Paper-3-graph-substitution-semantics/

--- a/docs/Publications/Paper-3-graph-substitution-semantics/manuscript.md
+++ b/docs/Publications/Paper-3-graph-substitution-semantics/manuscript.md
@@ -8,7 +8,7 @@ status: draft
 authors:
   - Julius Koskela
 date: 2026-04-28
-updated: 2026-04-28
+updated: 2026-06-10
 related:
   - docs/Publications/Paper-2-algebraic-foundations/
   - docs/Roadmap/Plans/rewrite-materialization-and-recovery.md
@@ -82,6 +82,9 @@ fragment into a durable graph through a bounded, typed, interface-preserving rul
 ---
 
 ## 2. Glossary
+
+Wording is aligned with the shared publications glossary ([../glossary.md](../glossary.md)); the
+entries are restated locally so the paper stays self-contained at a venue.
 
 - **workflow**: a semantic program describing obligations, dependencies, branching, waiting, and
   artifact boundaries
@@ -864,19 +867,39 @@ convenience that lowers into the node-centered calculus.
 
 ### 12.1 Core Results
 
-The paper's core formal obligations are the following.
+The paper's core formal obligations are the following. Since the first draft of this paper, the Lean
+mechanization track has discharged substantial parts of each obligation; we state each result
+together with the declarations that carry it (theorem names as of 2026-06-10, per the project's
+proof-status dashboard). The mechanized statements are about the runtime-shaped admission and
+planner models, not about this paper's abstract calculus verbatim; the correspondence between the
+two is stated per result.
 
 #### Substitution Safety
 
 Admissible substitution preserves graph well-formedness, causal structure, and interface
 compatibility.
 
+Mechanized substance: `planGraphRewriteChecks_admissible` and
+`runtimePlannerConstruction_admissible` prove that the runtime-shaped planner checks imply the
+abstract admissible-rewrite predicate (anchor existence, subgraph validity, boundary non-emptiness,
+orphan-freedom, acyclicity, budget consumption); `BoundaryResource.substitution_preserves_boundary`
+and `appendContinuation_preserves_boundary` prove boundary preservation for the two rewrite law
+families; and `constructedPlanningChain_preserves_registryBoundary_of_constructedDelta` extends
+preservation across finite constructed chains. `selectActualize_preserves_closedPortLinearity` and
+`selectActualize_preserves_registryBoundary` carry the same discipline through selected-branch
+actualization. What remains open at this layer is executable witness production: the Haskell runtime
+is tested against, not extracted from, these models.
+
 #### Phase Determinism
 
 Within a fixed materialized topology, reducing a frontier phase is order-insensitive with respect to
 the accumulation order of independent node facts, provided that frontier execution emits node-local
-facts keyed by the executing node or else emits into a deterministic reducer. The intended proof
-strategy is:
+facts keyed by the executing node or else emits into a deterministic reducer.
+
+Mechanized substance: the three-step strategy below is no longer only intended — step 2 is
+`applyNodeFacts_perm_invariant` (permutation invariance of disjoint-key fact accumulation), and the
+composed determinism statement is `pulseReplayDeterminism_modulo_fixedOutcomes`, lifted to the
+Wire/Pulse envelope by `wirePulseExecutionFacts_replay_deterministic`:
 
 1. each node $v$ in the current frontier contributes facts affecting only the loci owned by $v$,
    such as $\sigma(v)$ and $o(v)$
@@ -893,6 +916,13 @@ outputs or mediated by a deterministic reduction step before the theorem applies
 Resume from materialized lineage prefix, compatibility witness, and integrity witness reconstructs
 the canonical schedulable state defined in §9.3.
 
+Mechanized substance: `pulseRecoveryStep_preserves_safeRunState` proves recovery normalization
+preserves the structural safe-run predicate; `AdmittedWirePulseTrace.preserves_safeRunState` (and
+its non-stuckness companion) extends this across admitted run traces; and
+`selectedBranch_recovery_deterministic` proves that recovery records loaded from the same persisted
+admission replay the same selected branch, constructed delta, and budget state. Durable lineage
+decoding from the persistence layer into these witnesses remains an open correspondence obligation.
+
 ### 12.2 Extension Program
 
 The following are intentionally outside the paper's core formal development but define its natural
@@ -908,25 +938,38 @@ $$
 
 for an appropriate denotational semantics of workflows, graphs, and their equivalence. This is a
 research program for the workflow/lowering boundary, not part of the minimal substitution calculus
-proved here.
+proved here. Fragments exist: `pureNode_lowering_evalOutputs_eq` proves the lowered native pure-task
+configuration evaluates like the source pure node, and `selectActualize_lowers_to_appendAfter`
+proves certified selected branches lower to retained-anchor append rewrites. The full-language
+theorem remains open.
 
 #### Routed Interfaces and Resource-Aware Contracts
 
 The minimal preorder on $\mathcal{K}$ intentionally leaves out named ports, arity constraints,
 linear or affine resources, and retention obligations for values that later substitutions may still
 depend on. A stronger interface calculus would enrich $\Gamma$ with those structures so that
-executable routing policies and resource-sensitive admissibility can be stated directly.
+executable routing policies and resource-sensitive admissibility can be stated directly. A
+substantial part of this program is now mechanized in a companion carrier: the source linear port
+graph (`LinearPortGraph.PortLinear`) and the closed actualized port discipline (`ClosedPortLinear`)
+give named, typed, linearity-checked ports through overlay and certified contraction. Linear/affine
+retention obligations across substitutions remain open.
 
 #### Concurrent Substitution Commutation
 
 For a richer extension, independent substitutions may admit a commutation law. That requires an
-explicit independence relation and belongs to a stronger calculus than the base one defined here.
+explicit independence relation and belongs to a stronger calculus than the base one defined here. No
+independence relation is mechanized; this remains genuinely open.
 
 #### Budget-Bounded Growth
 
 If substitution cost is tracked and budget decreases monotonically, one would like a bounded-growth
-result limiting the number or size of admitted substitutions in a run. That is an operational
-extension, not part of the minimal semantic core established here.
+result limiting the number or size of admitted substitutions in a run. The monotone half is no
+longer an extension: `ConstructedPlanningChain.finalBudget_le_initial` proves budget non-increase
+across finite constructed chains, `ConstructedPlanningStep.boundaryResourceCost_fits_budget` proves
+per-step cost fits the remaining budget, and `selectActualize_consumes_selected_cost` proves
+selected-branch actualization consumes exactly the constructed selected-fragment cost. What remains
+open is the derived combinatorial bound on the number or total size of admitted substitutions in a
+run.
 
 ---
 

--- a/docs/Publications/Paper-5-Causal-Programming/Figures/index.md
+++ b/docs/Publications/Paper-5-Causal-Programming/Figures/index.md
@@ -1,0 +1,23 @@
+---
+title: Paper 5 Figure Inventory
+description: Figure inventory and export status for the Causal Programming paper.
+date: 2026-06-10
+updated: 2026-06-10
+status: draft
+related:
+  - docs/Publications/Paper-5-Causal-Programming/manuscript.md
+  - docs/Publications/Paper-5-Causal-Programming/index.md
+---
+
+# Paper 5 Figure Inventory
+
+## Checked-in figure sources
+
+- none yet; the manuscript's diagrams are inline Mermaid blocks. Extract them here as `.mmd` sources
+  when the submission target is chosen.
+
+## Export status
+
+- no publication-exported vector figures checked in yet
+- candidate extractions: the order-receive-compute-log causal graph (§4.1), the fan-out example
+  (§4.1), and the quantum-eraser topology (Appendix C)

--- a/docs/Publications/Paper-5-Causal-Programming/index.md
+++ b/docs/Publications/Paper-5-Causal-Programming/index.md
@@ -1,0 +1,53 @@
+---
+title: "Paper 5 — Causal Programming"
+description:
+  Landing page for the Causal Programming paper. Abstract, status, figures, and related material.
+sidebar:
+  label: Paper 5
+  order: 5
+status: draft
+date: 2026-05-04
+updated: 2026-06-10
+related:
+  - docs/Publications/Paper-1-staged-reduction/
+  - docs/Publications/Paper-3-graph-substitution-semantics/
+  - docs/Publications/Paper-4-wire-language/
+  - docs/Architecture/05-wire-language.md
+  - docs/Architecture/06-pulse-runtime.md
+  - docs/Reference/proof-status.md
+---
+
+# Paper 5 — Causal Programming
+
+Causal programming is the paradigm umbrella over the Cortex papers: computation modeled as typed,
+partially ordered event flow, with **temporal honesty** — the program asserts no more temporal order
+than the computation possesses — as the foundational property.
+
+## Status
+
+Draft manuscript, position-paper shape. See [manuscript.md](manuscript.md) for the full text. Vision
+venue or journal target; the demonstrations (quantum eraser on IBM hardware, production agentic
+system) double as evidence sections for the technical papers.
+
+## Abstract
+
+Mainstream languages inherit a single-stack model that is dishonest about the temporal structure of
+distributed, durable, concurrent, and agentic systems. The paper makes three nested claims: a
+semantic diagnosis (many engineering burdens are the cost of reconstructing causal structure the
+language erased), a paradigm proposal (causal programming, organized around eight structural
+commitments), and an existence proof (Wire and the Pulse runtime, mechanized in Lean 4, show the
+proposal is workable and its central claims tractable to prove).
+
+## Figures
+
+- [Figures/index.md](Figures/index.md) — figure inventory and export status.
+
+## Related
+
+- [manuscript.md](manuscript.md) — full manuscript.
+- [../Paper-1-staged-reduction/](../Paper-1-staged-reduction/) — fixed-topology runtime kernel the
+  paradigm executes on.
+- [../Paper-4-wire-language/](../Paper-4-wire-language/) — the authoring language used as the
+  existence proof.
+- [../../Reference/proof-status.md](../../Reference/proof-status.md) — verification numbers cited by
+  the manuscript.

--- a/docs/Publications/Paper-5-Causal-Programming/manuscript.md
+++ b/docs/Publications/Paper-5-Causal-Programming/manuscript.md
@@ -8,7 +8,7 @@ status: draft
 authors:
   - Julius Koskela
 date: 2026-05-04
-updated: 2026-05-04
+updated: 2026-06-10
 related:
   - docs/Publications/Paper-1-staged-reduction/
   - docs/Publications/Paper-2-algebraic-foundations/
@@ -993,11 +993,14 @@ proposals whose serialized form cannot denote the proof-side sets and natural nu
 ### 5.4 The verification surface
 
 The Cortex proof-status dashboard is conservative by design. It tracks human-level claims, not raw
-theorem counts. As of the most recent revision, the dashboard contains 25 such claims. All 25 are
-mechanized in Lean 4. Of the 25, 17 are connected to executable Haskell correspondence through
-checks, witnesses, regression tests, or hooks; 2 are graph-vocabulary proof-only facts with no
-direct runtime analog; the remaining 6 have a Lean proof in place with executable correspondence
-work in progress.
+theorem counts. As of 2026-06-10, the dashboard contains 28 such claims. All 28 are mechanized in
+Lean 4, with no axioms and no incomplete proofs in the theory tree. Of the 28, 19 are connected to
+executable Haskell correspondence through checks, witnesses, regression tests, or hooks; 2 are
+graph-vocabulary proof-only facts with no direct runtime analog; the remaining 7 have a Lean proof
+in place with executable correspondence work in progress. Since this draft was first written, the
+correspondence layer has also gained an enforced compiler invariant: every compiled circuit is gated
+on a binding check that the admission artifact it carries describes exactly that circuit, so
+artifact-circuit drift is a compile failure rather than a silent possibility.
 
 The dashboard explicitly distinguishes Lean-side proof from runtime correspondence. A Lean proof is
 not the same thing as proof that the Haskell runtime conforms; the boundary witness must still be
@@ -1105,8 +1108,11 @@ eraser configuration preserves the no-signalling property—the unsorted screen 
 balanced regardless of phase—and recovers complementary fringes only when the data is conditioned on
 the marker observation. At 100 shots per circuit, this run is qualitative rather than a precision
 physics claim, but the expected pattern is clearly visible. The reproducibility artifacts include
-the Wire source, the report file, and the IBM Runtime job identifiers; the run reported here used
-the `ibm_fez` backend with job identifier `d7rnnhst738s73cfpljg`.
+the Wire source (`examples/wire/quantum-eraser-experiment.wire` in the Cortex repository), the
+report file, and the IBM Runtime job identifiers; the run reported here used the `ibm_fez` backend
+with job identifier `d7rnnhst738s73cfpljg`. At submission freeze, pin the Wire source and report to
+the repository commit used for the run so the artifact reference is exact rather than
+branch-relative.
 
 The demonstration is rhetorically apt for the paradigm. The whole point of the eraser experiment is
 that looking only at the screen marginal hides the joint causal structure: the unsorted distribution

--- a/docs/Publications/Paper-6-executable-diagrams/index.md
+++ b/docs/Publications/Paper-6-executable-diagrams/index.md
@@ -8,7 +8,7 @@ sidebar:
   order: 6
 status: draft
 date: 2026-05-08
-updated: 2026-05-13
+updated: 2026-06-10
 related:
   - docs/Publications/Paper-2-algebraic-foundations/
   - docs/Publications/Paper-3-graph-substitution-semantics/

--- a/docs/Publications/Paper-6-executable-diagrams/manuscript.md
+++ b/docs/Publications/Paper-6-executable-diagrams/manuscript.md
@@ -8,8 +8,9 @@ status: draft
 authors:
   - Julius Koskela
 date: 2026-05-08
-updated: 2026-05-13
+updated: 2026-06-10
 related:
+  - docs/Publications/glossary.md
   - docs/Publications/Paper-2-algebraic-foundations/
   - docs/Publications/Paper-3-graph-substitution-semantics/
   - docs/Publications/Paper-4-wire-language/
@@ -34,21 +35,98 @@ documentation: https://digimuoto.github.io/cortex/
 
 # Executable Causal Diagrams with Typed Linear Frontiers
 
-Wire makes a source program elaborate to the causal diagram scheduled, replayed, and explained by
-the runtime. The admitted diagram records which events depend on prior observations, which events
-are incomparable, and which typed values cross between them. Wire turns Lamport's partial-order view
-of distributed execution [\[1\]](#ref-1) into an authoring discipline for executable artifacts.
+Wire is a source language whose programs elaborate to directed graphs of typed events, and whose
+runtime schedules, replays, and explains exactly the graph that elaboration produced. The paper
+turns Lamport's partial-order view of distributed execution [\[1\]](#ref-1) into an authoring
+discipline: the diagram is the program, not a visualization of it.
 
-Conventional source forms tend to hide that structure. Imperative programs are ordered vectors of
-effects: a later read is meaningful only because the program counter supplies an ordered prefix.
-Pure functional `let` expressions move closer to named records of dependencies, but effectful
-programs usually regain a linear spine unless the author adds a separate parallel or applicative
-structure. Wire makes the next step explicit. A graph expression is read as a typed frontier
-transformer: `<>` unions incomparable boundary fragments, and `=>` matches compatible output-input
-endpoints while carrying unmatched endpoints forward. A written pipeline is therefore not a sequence
-of barriers; it is a compact description of a partial order.
+We make three claims. First, a **language claim**: graph expressions read as typed frontier
+transformers — composition either unions independent boundary fragments or matches compatible
+output-input ports — elaborate to port-linear diagrams in which every typed endpoint is used exactly
+once. Second, a **mechanization claim**: the linearity invariant and its preservation through
+elaboration (including bounded node generation and product adapters) are stated and proved in Lean 4
+over an accepted-object intermediate representation. Third, an **execution claim**: a durable
+runtime journals, replays, and reports provenance against the same admitted diagram, so recovery
+resumes from a recorded causal prefix and audit trails point at named nodes and typed edges rather
+than reconstructed traces.
 
-A dashboard request illustrates the gap:
+## Definitions
+
+The five terms the paper relies on are defined here, before use.
+
+A **port instance** is one occurrence of a typed, direction-tagged endpoint — a node name, a port
+name, a nominal payload contract, and an optional label — owned by the node that declares it. For a
+node $n$, $\operatorname{OwnedPorts}(n)$ is the finite set of port instances $n$ declares.
+
+The **frontier** of a graph expression is the multiset of port instances exposed on its boundary:
+the ports not yet consumed by composition. Composition operators are read as frontier transformers.
+**Overlay** (`<>`) unions fragments with disjoint node sets; the result's frontier is the union of
+the operands' frontiers. **Connect** (`=>`) is port-key-matched: an edge forms between a left output
+and a right input exactly when their (contract, label) match keys agree uniquely — direction is
+enforced by matching outputs against inputs; both matched ports leave the frontier, and every
+unmatched port is **carried** — it remains on the composed frontier, acting as an identity wire for
+an open boundary.
+
+A diagram is **admitted** when it passes elaboration and boundary admission; admitted diagrams are
+the objects the runtime executes and the theorems quantify over.
+
+For an admitted graph expression $g$ and a port instance $e \in \operatorname{OwnedPorts}(n)$ of a
+node $n$ in $g$, define two indicator functions
+$\operatorname{internal}_g, \operatorname{frontier}_g : \operatorname{OwnedPorts}(n) \to \{0,1\}$:
+$\operatorname{internal}_g(e) = 1$ iff $e$ is the endpoint of exactly one edge internal to $g$, and
+$\operatorname{frontier}_g(e) = 1$ iff $e$ occurs on the frontier of $g$.
+
+**Definition 1 (port linearity, node-boundary form).** An admitted diagram $g$ is port-linear when
+
+$$
+\forall n \in g,\ \forall e \in \operatorname{OwnedPorts}(n),\quad
+\operatorname{internal}_g(e) + \operatorname{frontier}_g(e) = 1 .
+$$
+
+Every owned endpoint is consumed by exactly one internal edge or exposed on the boundary — never
+both, never neither, never twice. This is the statement mechanized as `PortLinear` in the Lean
+development. Closedness (an empty frontier) is a property, not an admission requirement: admitted
+diagrams compile whether open or closed, with open inputs becoming entry ports and open outputs exit
+ports of the executable circuit. There is no ambient copying or discarding: weakening is not an
+operation, and contraction requires an explicit node that consumes one endpoint and produces fresh
+ones.
+
+## A Three-Node Example
+
+The smallest composition that shows both matching and carrying:
+
+```wire
+contract A;
+contract B;
+contract C;
+
+node source
+  -> left: A;
+  -> right: B;
+  = @demo.source ({});
+
+node use_left
+  <- left: A;
+  -> out: C = @demo.use_left (left);
+
+source => use_left
+```
+
+The frontiers are $\{\mathit{left}^{+}{:}A,\ \mathit{right}^{+}{:}B\}$ for `source` and
+$\{\mathit{left}^{-}{:}A,\ \mathit{out}^{+}{:}C\}$ for `use_left` (superscripts mark direction).
+Connect matches the unique compatible pair $\mathit{left}^{+}/\mathit{left}^{-}$ on key
+$(A, \mathit{left})$ and forms one edge; `right` and `out` are carried. The composed frontier is
+$\{\mathit{right}^{+}{:}B,\ \mathit{out}^{+}{:}C\}$, and Definition 1 checks per port: `source.left`
+and `use_left.left` are internal (indicator $1+0$), the other two are frontier ($0+1$). If a second
+node also declared `<- left: A`, the composition would be rejected — one produced endpoint with two
+compatible consumers has no linear reading, and the admission error says so at the source level.
+That rejection, scaled up, is the paper's running discipline.
+
+## A Realistic Diagram: the Dashboard Diamond
+
+A dashboard request shows what the discipline buys at realistic scale. Conventional source forms
+hide the causal structure: imperative programs are ordered vectors of effects, and effectful
+functional programs regain a linear spine unless the author adds separate parallel structure.
 
 ```python
 async def dashboard(uid):
@@ -68,20 +146,12 @@ reconstructs a DAG from spans after the fact. Durable workflow runtimes can jour
 expose the causal object directly.
 
 In Wire, the diamond is authored directly rather than inferred from spans, continuations, or runtime
-heuristics. Durable replay and provenance refer to the admitted diagram: recovery resumes from a
-recorded causal prefix, and audit trails can point to named nodes and typed edges instead of
-reconstructed traces outside the language.
-
-## The Dashboard Diamond in Wire
-
-The same request can be authored as a typed causal diagram. Contracts are nominal boundary
-interfaces, not first-class CorePure values. Wire's pure expression sublanguage, CorePure, computes
-JSON-shaped payloads; contracts classify the ports through which those payloads enter and leave the
-diagram. The `@` form is Wire's effect boundary: network calls, storage, model calls, tools, and
-other host effects stay behind registered executors, while deterministic payload shaping can stay in
-Wire. Pulse, Cortex's durable runtime, journals outcomes for those executor nodes over the admitted
-topology; CorePure expressions remain deterministic boundary equations rather than hidden host
-effects.
+heuristics. Contracts are nominal boundary interfaces. CorePure, the pure expression sublanguage,
+computes JSON-shaped payloads; contracts classify the ports through which those payloads enter and
+leave the diagram. The `@` form is the effect boundary: network calls, storage, model calls, and
+other host effects stay behind registered executors. Pulse, the durable runtime, journals outcomes
+for executor nodes over the admitted topology; CorePure expressions remain deterministic boundary
+equations rather than hidden host effects.
 
 ```wire
 # Registered facts that may cross node boundaries.
@@ -187,47 +257,51 @@ conjunctive over all predecessors. It records that `profile` has no causal reaso
 either branch.
 
 If the dashboard tried to wire `fetch_user` directly into two branches that both declared
-`<- user: UserProfile`, admission would reject the graph: one produced endpoint would have two
-consumers. This is a semantic rejection. A silent copy of `user` would remove the event that
-explains why two downstream observations are legitimate. The fix is to name the causal event that
-derives branch facts from one prior observation.
+`<- user: UserProfile`, admission would reject the graph — the three-node rejection from above at
+scale: one produced endpoint would have two consumers. This is a semantic rejection. A silent copy
+of `user` would remove the event that explains why two downstream observations are legitimate. The
+fix is `prepare_dashboard`: name the causal event that derives branch facts from one prior
+observation.
 
-## Linear Frontiers and Algebraic Graphs
+## Relation to Algebraic Graphs, Open Graphs, and Linear Logic
 
-Linearity supplies the accounting discipline behind the causal reading. It is the bridge from
-Lamport's partial-order view to source authoring: fan-out without a named event destroys the causal
-explanation for why two downstream observations share a prior source. Wire refines Mokhov's algebra
-of graphs [\[2\]](#ref-2): the source skeleton still has empty diagrams, vertices, overlay, and
-connect, but vertices carry named input and output ports, and each port endpoint is a resource. The
-same boundary admits graph expressions, determines executable topology, and exposes proof
-obligations.
+Linearity (Definition 1) supplies the accounting discipline behind the causal reading. It is the
+bridge from Lamport's partial-order view to source authoring: fan-out without a named event destroys
+the causal explanation for why two downstream observations share a prior source.
 
-At the node boundary, the intended invariant is small enough to state directly:
+**Against Mokhov's algebra of graphs** [\[2\]](#ref-2), the delta is precise. Wire keeps the
+four-constructor skeleton — empty, vertex, overlay, connect — but vertices carry named, typed ports,
+and connect changes meaning: Mokhov's connect adds the full cross-product of edges between operands,
+while Wire's `=>` adds an edge only per uniquely matched port key and carries the rest. Two
+algebraic consequences follow. Multiple compatible counterparts for one port are a static error
+rather than a fan-out, and source-level distributivity of connect over overlay deliberately
+**fails**: distributing a source expression across an overlay can duplicate an operand and with it a
+port resource, so `(down => some) <> (down => things)` is rejected where `down => some <> things` is
+admitted. Mokhov's laws are recovered after admission by a forgetful lowering that erases port
+identity into a plain edge relation; the laws hold of the lowered object, not of source expressions.
 
-$$
-\forall e \in \operatorname{OwnedPorts}(n),\quad
-\operatorname{internal}(e) + \operatorname{frontier}(e) = 1
-$$
+**Against cospan, open-graph, and string-diagram accounts of composition** [\[3\]](#ref-3),
+[\[4\]](#ref-4), [\[7\]](#ref-7), Wire's boundary is the same shape — a typed interface through
+which composition glues — but the interface is a multiset of contract-and-label-keyed ports with
+admission obligations attached, and the composite is not only a categorical object: it is the
+executable artifact a durable runtime schedules and replays, with the linearity obligation
+discharged by a mechanized check rather than by construction in a chosen category. We do not claim a
+functorial semantics into a cospan category here; stating one is future work, and the
+port-key-matched composition (partial, key-directed, carrying) is exactly where such a statement
+would have to differ from the standard symmetric monoidal setting.
 
-An owned endpoint is either used by exactly one internal edge or remains exposed on the frontier.
-The closed-circuit check is the final admission step requiring a top-level circuit to have no
-exposed endpoints. Overlay forms disjoint incomparable frontier union; connect matches and consumes
-compatible output-input endpoint pairs; unmatched endpoints remain open obligations on the composed
-boundary. Operationally, a carried endpoint plays the role of an identity wire for an open frontier:
-it crosses a composition unchanged until a later compatible input consumes it. The frontier is
-treated as a multiset of labelled ports, so exchange holds definitionally while source order is
-retained for diagnostics. Weakening is not an operation that discards resources. Contraction is not
-ambient either: reusing information requires a node that consumes one endpoint and produces fresh
-endpoints with their own labels and contracts.
+**Against linear logic and proof nets** [\[5\]](#ref-5), [\[6\]](#ref-6), Wire inherits the
+structural-rule vocabulary but uses a restricted fragment: exchange holds definitionally (the
+frontier is a multiset; source order is kept only for diagnostics), weakening is absent (no
+operation discards a resource), and contraction is never ambient — reusing information requires an
+explicit node consuming one endpoint and producing fresh ones, which is what makes every fan-out a
+named causal event. There is no exponential modality and no cut elimination claim; the linear
+discipline governs diagram admission, not proof reduction.
 
-Finite-product adapters support the same law. The artifact supports a `*` operator that elaborates
-to a generated phantom adapter for named records and bounded indexed products such as `[T; 4]`. The
-adapter crosses one product constructor, creates distinct leaf endpoints, and then ordinary connect
-consumes each leaf once. Static scatter/gather uses this mechanism, but it adds no copying rule and
-does not drive the paper's argument. The structural-rule vocabulary is inherited from linear logic
-and proof-net work [\[5\]](#ref-5), [\[6\]](#ref-6), while the interface shape places Wire near
-cospan, open-graph, and string-diagram accounts of composition [\[3\]](#ref-3), [\[4\]](#ref-4),
-[\[7\]](#ref-7).
+Finite-product adapters stay inside the same law. The `*` operator elaborates to a generated
+**phantom adapter** for named records and bounded indexed products such as `[T; 4]`: the adapter
+crosses one product constructor, creates distinct leaf endpoints, and ordinary connect consumes each
+leaf once. Static scatter/gather uses this mechanism; it adds no copying rule.
 
 ## One Object, Five Views
 
@@ -280,6 +354,14 @@ source-linearity preservation for certified bounded generation and product adapt
 source-to-actualized bridge proves port-domain exactness for aligned witnesses. Edge-side exactness,
 runtime-witness production, and correspondence to compiled Haskell artifacts remain open obligations
 in the verification story.
+
+The same discipline reaches an unplanned domain. Wire's examples include quantum circuit
+descriptions — among them a delayed-choice quantum eraser executed on IBM hardware — authored in the
+same language with no quantum-specific rules: qubit-carrying ports are linear resources, so the
+calculus's fan-out rejection coincides with the no-cloning constraint a qubit port requires, and
+gates are nodes whose typed frontiers enforce application order. One port-linear language spans
+durable workflows and quantum circuit description because both are causal diagrams over unforgeable
+resources.
 
 The submitted artifact exposes this boundary through a build-backed dashboard example, parser and
 compiler path, source includes, bounded graph generation, indexed family projection, finite-product

--- a/docs/Publications/Paper-7-frontier-calculus/Figures/elaboration-pipeline.mmd
+++ b/docs/Publications/Paper-7-frontier-calculus/Figures/elaboration-pipeline.mmd
@@ -1,0 +1,7 @@
+flowchart LR
+    src["Source program<br/>core + derived forms"] --> ir["Accepted IR<br/>reference-closed declarations"]
+    ir --> adm["Admitted diagram<br/>port-linear, typed frontiers"]
+    adm --> circ["Compiled circuit<br/>+ admission artifact"]
+    circ --> run["Durable run<br/>schedule, replay, provenance"]
+    circ -. "structural binding check" .-> adm
+    run -. "actualized layer,<br/>projection-exact" .-> adm

--- a/docs/Publications/Paper-7-frontier-calculus/Figures/frontier-transformer-example.mmd
+++ b/docs/Publications/Paper-7-frontier-calculus/Figures/frontier-transformer-example.mmd
@@ -1,0 +1,16 @@
+flowchart LR
+    subgraph stage1["source <> config"]
+        source["source"]
+        config["config"]
+    end
+    subgraph stage2["=> build"]
+        build["build"]
+    end
+    subgraph stage3["=> package"]
+        package["package"]
+    end
+    source -- "src: Sources" --> build
+    config -- "cfg: BuildConfig" --> build
+    build -- "bin: Binary" --> package
+    build -. "log: BuildLog (carried)" .-> out1["frontier"]
+    package -. "pkg: Package" .-> out1

--- a/docs/Publications/Paper-7-frontier-calculus/Figures/index.md
+++ b/docs/Publications/Paper-7-frontier-calculus/Figures/index.md
@@ -1,0 +1,27 @@
+---
+title: Paper 7 Figure Inventory
+description: Figure inventory and export status for the Typed Linear Frontier Calculus paper.
+date: 2026-06-10
+updated: 2026-06-10
+status: draft
+related:
+  - docs/Publications/Paper-7-frontier-calculus/manuscript.md
+  - docs/Publications/Paper-7-frontier-calculus/index.md
+---
+
+# Paper 7 Figure Inventory
+
+## Checked-in figure sources
+
+- [frontier-transformer-example.mmd](frontier-transformer-example.mmd) — the §3.1 build-pipeline
+  example as staged frontiers, with the carried `log` endpoint visible.
+- [elaboration-pipeline.mmd](elaboration-pipeline.mmd) — source → accepted IR → admitted diagram →
+  compiled circuit (+ artifact, binding check) → durable run.
+- [phantom-adapter-crossing.mmd](phantom-adapter-crossing.mmd) — `*` gather: three workers into a
+  bounded indexed product through one constructor crossing.
+- [select-latent-actualize.mmd](select-latent-actualize.mmd) — latent branch family at admission;
+  selected-branch actualization as an append rewrite; unselected body excluded.
+
+## Export status
+
+- no publication-exported vector figures checked in yet; export at submission freeze

--- a/docs/Publications/Paper-7-frontier-calculus/Figures/phantom-adapter-crossing.mmd
+++ b/docs/Publications/Paper-7-frontier-calculus/Figures/phantom-adapter-crossing.mmd
@@ -1,0 +1,5 @@
+flowchart LR
+    w0["worker_0<br/>-> out: Shard"] -- "out: Shard (0)" --> phi["phantom adapter φ<br/>one constructor crossing"]
+    w1["worker_1<br/>-> out: Shard"] -- "out: Shard (1)" --> phi
+    w2["worker_2<br/>-> out: Shard"] -- "out: Shard (2)" --> phi
+    phi -- "all: [Shard; 3]" --> merge["merge<br/>&lt;- all: [Shard; 3]"]

--- a/docs/Publications/Paper-7-frontier-calculus/Figures/select-latent-actualize.mmd
+++ b/docs/Publications/Paper-7-frontier-calculus/Figures/select-latent-actualize.mmd
@@ -1,0 +1,13 @@
+flowchart LR
+    subgraph admitted["Admitted (static)"]
+        base["validate<br/>-> ok | issue (exclusive sum)"] --> chi["condition node χ<br/>bridge: common boundary"]
+        armOk["arm ok: latent body"]
+        armIssue["arm issue: latent body"]
+        chi -.- armOk
+        chi -.- armIssue
+    end
+    subgraph actualized["Actualized (run time)"]
+        chi2["χ"] -- "selected: issue" --> body["issue body<br/>appended, budgeted"]
+        pruned["ok body: excluded,<br/>never instantiated"]
+    end
+    admitted -- "selection = append rewrite" --> actualized

--- a/docs/Publications/Paper-7-frontier-calculus/index.md
+++ b/docs/Publications/Paper-7-frontier-calculus/index.md
@@ -1,0 +1,62 @@
+---
+title: "Paper 7 — Keyed Frontier Calculus"
+description:
+  Landing page for the flagship frontier-calculus paper. Abstract, status, structure, and related
+  material.
+sidebar:
+  label: Paper 7
+  order: 7
+status: draft
+date: 2026-06-10
+updated: 2026-06-10
+related:
+  - docs/Publications/glossary.md
+  - docs/Publications/Paper-3-graph-substitution-semantics/
+  - docs/Publications/Paper-4-wire-language/
+  - docs/Publications/Paper-6-executable-diagrams/
+  - docs/Reference/proof-status.md
+  - theory/Cortex/Wire/PortLinearity.lean
+  - theory/Cortex/Wire/GeneratedForms.lean
+  - theory/Cortex/Wire/SelectAdmission.lean
+---
+
+# Paper 7 — Keyed Frontier Calculus
+
+The flagship paper: the Wire calculus stated on paper in standard notation — keyed connect with
+carried frontiers, certified elaborations, and the single admitted referent — with metatheory cited
+to the Lean mechanization and the compiler (with enforced artifact-to-circuit binding) as the
+implementation claim. Port linearity is presented as inherited lineage (interaction nets), not as
+the contribution.
+
+## Status
+
+Complete draft, pre-submission: all sections drafted, four Mermaid figure sources checked in;
+typeset export and figure exports happen at submission freeze. Target: ICFP-tier venue (deadline
+~Feb-Mar 2027); a POPL-shaped distillation is deliberately deferred until reviews identify the novel
+core.
+
+## Structure
+
+1. Motivation (compressed from Paper 4: closed alphabets, open composition, registered authority).
+2. Definitions (shared-glossary-consistent, Paper 3 glossary-first template).
+3. **The calculus** — worked example first, then syntax, frontier typing (the judgment produces the
+   diagram, edges included), port linearity, forgetful lowering, and the latent/actualized layer.
+   The genuinely new on-paper work. Dynamics are deliberately NOT part of the core calculus.
+4. Metatheory — theorems stated in the paper's notation, discharged by citation to the Lean track,
+   including the boundary resource algebra (one-slot epochs) and the five-dimensional graded
+   budgets.
+5. Executing admitted diagrams (application section) — staged reduction + admitted substitution
+   imported from Papers 1 and 3; the certifying admission boundary (mirrored contracts + structural
+   binding check); Wire CLI, examples, the quantum-eraser demonstration.
+6. Related work with theorem-level deltas (Mokhov, cospans, string diagrams, linear logic, graded
+   types, session types, certifying compilation, durable execution).
+
+## Related
+
+- [manuscript.md](manuscript.md) — the draft.
+- [Figures/index.md](Figures/index.md) — figure inventory.
+- [../Paper-3-graph-substitution-semantics/](../Paper-3-graph-substitution-semantics/) — metatheory
+  source (absorption decision pending).
+- [../Paper-4-wire-language/](../Paper-4-wire-language/) — motivation source (absorption decision
+  pending).
+- [../../Reference/proof-status.md](../../Reference/proof-status.md) — verification ground truth.

--- a/docs/Publications/Paper-7-frontier-calculus/manuscript.md
+++ b/docs/Publications/Paper-7-frontier-calculus/manuscript.md
@@ -1,0 +1,827 @@
+---
+title: "A Keyed Frontier Calculus for Executable Open Graphs"
+description:
+  Flagship draft. The Wire calculus on paper - keyed connect, carried frontiers, certified
+  elaborations, and the single admitted referent - with mechanized metatheory and an executing
+  compiler.
+kind: publication
+status: draft
+authors:
+  - Julius Koskela
+date: 2026-06-10
+updated: 2026-06-10
+related:
+  - docs/Publications/glossary.md
+  - docs/Publications/Paper-3-graph-substitution-semantics/
+  - docs/Publications/Paper-4-wire-language/
+  - docs/Publications/Paper-6-executable-diagrams/
+  - docs/Reference/proof-status.md
+---
+
+# A Keyed Frontier Calculus for Executable Open Graphs
+
+> Complete draft, pre-submission. All sections are drafted; figures and the typeset export are
+> pending. Verification claims are stated against the project proof-status dashboard as of
+> 2026-06-10 and must be refreshed at any submission freeze.
+
+## Abstract
+
+We present a typed calculus of open directed graphs whose composition transforms **frontiers**: the
+multisets of named, contract-typed ports a fragment exposes on its boundary. The calculus adopts the
+no-implicit-copy port discipline of interaction nets and proof-net descendants — each endpoint used
+exactly once, copying only through an explicit node — and contributes three things that family does
+not have. First, **keyed connect**: composition is computed, not hand-wired — an edge forms only per
+uniquely matched port key, and unmatched endpoints are **carried** unchanged to the composite
+boundary, so source expressions compose as frontier transformers. Two consequences are the point of
+the design: source-level distributivity fails — distributing duplicates an operand, and an operand
+owns resources — and every fan-out is a named event. Second, richer source forms (product adapters,
+bounded generation, latent branch selection) are certified **elaborations** — statically admitted
+expansions into a four-form core — not new primitives, so the trusted theory never grows. Third, the
+**single admitted referent**: source typing, the compiler's executable artifact, the runtime's
+durable replay and provenance, and the proof-facing validation all refer to one admitted diagram,
+with the correspondence compiler-enforced by a structural binding check. The linearity theorem, the
+elaboration corollaries, the lowering equations relating the calculus to the algebra of graphs, and
+the admission, budget, and recovery theorems for dynamic extension are mechanized in Lean 4 with no
+axioms; the metatheory table states each claim's exact strength, including what remains open. The
+system is demonstrated on workloads from build pipelines to a quantum-eraser experiment executed on
+physical hardware, where port linearity structurally mirrors the no-cloning constraint that
+qubit-carrying ports require.
+
+## 1. Introduction
+
+Most programming notations make time primary and structure derived. An imperative program is an
+ordered vector of effects: a later read means something only because the program counter supplies an
+ordered prefix. Pure functional programs recover dependencies through names; effectful programs fall
+back to an ordered spine unless the author maintains parallel structure by hand. This paper develops
+the next rung of that ladder: a notation in which the **causal diagram** — an open graph of typed
+events — **is the primary object**, order is derived from it, and the type discipline makes the
+diagram trustworthy enough to schedule, replay, and audit.
+
+The object is an open directed graph of typed events. Each node owns named, contract-typed ports;
+each composition step is read as a transformer of the **frontier**, the multiset of typed port
+instances not yet consumed. Two operators suffice for composition: overlay unions independent
+fragments, and connect matches compatible output-input port keys, forming one edge per uniquely
+matched key and **carrying** every unmatched endpoint forward as an open obligation. The discipline
+underneath is **port linearity**: every owned endpoint is consumed by exactly one internal edge or
+exposed on the boundary — never both, never twice, never silently dropped. That discipline is
+inherited, not invented here: interaction nets and their proof-net ancestry already connect each
+typed port at most once, expose free ports as the interface, and route all copying through explicit
+agents (§6). What this calculus adds on top is the composition story — connect by key, carry the
+rest: there is no ambient copying, reusing a value requires a named node that consumes one endpoint
+and produces fresh ones, so every fan-out in the executed topology is a causal event with a name,
+and provenance questions ("why do these two observations share a source?") have answers in the
+diagram rather than in reconstructed traces. The algebraic signature of this choice is that connect
+does not distribute over overlay: distributing duplicates an operand, and an operand owns resources
+(§3.6).
+
+A second commitment is what makes admission decidable for programs nobody hand-wrote: **authority
+stays closed while composition stays open**. The calculus composes references to _registered_
+capability — executors, payload contracts, node kinds are declared outside the graph language — and
+the grammar offers a small, fixed operator alphabet over those references. Programs, including
+machine-generated ones, can therefore compose rich behavior without ever minting new runtime
+authority, and admission can check every composition against declarations it already knows. The
+derived source forms that make the language practical — product adapters for fan-shaped topologies,
+bounded generation of node families, latent branch selection — obey the same rule: each is a
+certified elaboration into the four-form core, so the trusted theory never grows.
+
+The practical stakes are why precision is worth the trouble. Durable workflow systems — runtimes
+that record execution so a crashed or suspended run can resume — journal and replay behavior;
+distributed tracing rebuilds causal graphs from timing spans; agentic systems compose tools and
+models into evolving plans. All three spend their complexity budget reconstructing, at run time and
+after the fact, causal structure the source language erased. Here the admitted diagram **is** that
+structure from the start — the **single admitted referent**: source typing, the compiler's
+executable artifact, the runtime's replay and provenance, and the proof assistant's obligations all
+refer to the same object, and a certification architecture (§5) makes those references checkable
+rather than aspirational. The implemented language is called **Wire** and its durable runtime
+**Pulse**; the body of the paper uses the proper names only where the implementation is concerned.
+
+The paper makes its claims at stated strength. §2-§3 develop the calculus: definitions, a worked
+example before any rule, four core typing rules, the derived forms as certified elaborations, the
+linearity theorem and its elaboration corollary, the forgetful lowering that recovers the algebra of
+graphs, and the two-layer (latent/actualized) reading. §4 is the metatheory table: every claim
+classified as core theorem, elaboration corollary, implementation check, or open correspondence
+obligation, with the mechanized declaration and the residual assumption per row. §5 presents
+execution and the certifying admission boundary. §6 positions the calculus against algebraic graphs,
+open-graph and string-diagram composition, linear logic, session types, graded types, certifying
+compilation, and durable execution.
+
+## 2. Definitions
+
+Consistent with the shared publications glossary; restated here in the paper's notation.
+
+Fix countable sets of node names, port names, contract names, and labels. A **port instance** is a
+tuple $p = (n, a, c, \ell, d)$: owner node $n$, port name $a$, contract $c$, optional label
+$\ell \in \mathcal{L} \cup \{\bot\}$, and direction $d \in \{{-}, {+}\}$ (input, output). The
+**key** of a port instance is $\operatorname{key}(p) = (d, c, \ell)$: direction, contract, and
+label; its direction-erased **match key** is $\operatorname{mkey}(p) = (c, \ell)$. Identity uses the
+full key; matching uses the match key, because matching always crosses an output frontier and an
+input frontier — direction is enforced by that partition, so a direction-bearing key could never
+occur on both sides of a match. The owner and port name are deliberately excluded from both, and an
+absent label is itself a key component, not a wildcard. Port instances may additionally carry an
+exclusive-group component marking membership in an exclusive output sum; the core rules ignore it,
+and E-Select (§3.4) is where it enters the discipline.
+
+A **diagram** is a triple $D = \langle N, E, \Phi \rangle$: a finite node set $N$, an edge set $E$
+of ordered pairs of port instances (producer output, consumer input), and a **frontier** $\Phi$, a
+finite multiset of port instances not consumed by $E$. We write $\Phi^{-}$ and $\Phi^{+}$ for the
+input and output restrictions of $\Phi$, $\uplus$ for multiset sum, and $\setminus$ for multiset
+difference. For a node $n$ declaring inputs $I$ and outputs $O$, we write
+$\operatorname{OwnedPorts}(n) = I \cup O$ for the instances it owns. In every diagram produced by
+the typing rules, an owned port instance occurs in $\Phi$ with multiplicity at most one — a
+consequence of node-disjoint composition. The frontier is nonetheless kept a multiset rather than a
+set, so that reordering ports (exchange) is definitional rather than an imposed identification.
+
+## 3. The Calculus
+
+### 3.1 A worked example, first
+
+Four registered nodes; bodies elided, boundaries shown:
+
+```wire
+node source  -> src: Sources;
+node config  -> cfg: BuildConfig;
+node build   <- src: Sources;  <- cfg: BuildConfig;
+             -> bin: Binary;   -> log: BuildLog;
+node package <- bin: Binary;   -> pkg: Package;
+
+source <> config => build => package
+```
+
+Overlay binds tighter than connect, so the expression parses as
+$((\textit{source} \mathrel{<>} \textit{config}) \Rightarrow \textit{build}) \Rightarrow
+\textit{package}$.
+The frontier computation:
+
+1. $\textit{source} \mathrel{<>} \textit{config}$: node sets are disjoint; the composite has no
+   edges and output frontier
+   $\{\mathit{src}^{+}{:}\textit{Sources},\
+   \mathit{cfg}^{+}{:}\textit{BuildConfig}\}$.
+2. $\Rightarrow \textit{build}$: match keys $(\textit{Sources},\bot)$ and
+   $(\textit{BuildConfig},\bot)$ each match exactly one input on the right; two edges form; the
+   composite frontier is
+   $\{\mathit{bin}^{+}{:}\textit{Binary},\
+   \mathit{log}^{+}{:}\textit{BuildLog}\}$.
+3. $\Rightarrow \textit{package}$: the $\textit{Binary}$ key matches and becomes an edge;
+   $\mathit{log}^{+}$ has no compatible consumer and is **carried** — it crosses the composition and
+   remains on the final frontier together with $\mathit{pkg}^{+}{:}\textit{Package}$.
+
+Carrying is the calculus doing real work: the build log is a typed resource that survives the
+pipeline without flowing through `package`, and the final topology records that directly. The
+rejection dual: if a second consumer of $\textit{Binary}$ were overlaid with `package`, the
+$\textit{Binary}$ key would have two compatible inputs, and the composition is a static error — one
+produced endpoint with two consumers has no linear reading. Reuse requires a named node that
+consumes the endpoint and produces fresh ones.
+
+### 3.2 Syntax: a four-form core, and derived forms that elaborate to it
+
+The **core grammar** has exactly four forms:
+
+$$
+\begin{aligned}
+e \ ::= \ & ()                              && \text{empty diagram} \\
+   \mid\ & n                                && \text{registered node reference} \\
+   \mid\ & e_1 \mathrel{<>} e_2             && \text{overlay} \\
+   \mid\ & e_1 \Rightarrow e_2              && \text{connect}
+\end{aligned}
+$$
+
+The surface language additionally offers four **derived source forms**:
+
+$$
+\begin{aligned}
+s \ ::= \ & e_1 * e_2                        && \text{product adapter (gather/scatter)} \\
+   \mid\ & \operatorname{make}(k, K)        && \text{bounded generation, static count } k \\
+   \mid\ & \operatorname{makeEach}(\vec{v}, K) && \text{bounded generation over static items} \\
+   \mid\ & e \ \operatorname{select}(k_1{:}\,e_1, \ldots, k_m{:}\,e_m) && \text{latent branch family}
+\end{aligned}
+$$
+
+The derived forms introduce **no new primitive semantics**: each elaborates, during admission, to
+core expressions over a context extended with generated node declarations (§3.4). This split is
+deliberate and load-bearing — the trusted composition theory stays four rules, and everything richer
+is a certified construction over them.
+
+Node declarations live in a context $\Gamma$ mapping node names to boundary signatures
+$n : \langle I; O \rangle$ (finite sets of input and output port instances owned by $n$), kind names
+to boundary templates, and contract names to their registrations. $\Gamma$ is produced by
+elaboration (source includes, kind expansion) and is closed: expressions may reference only
+registered names.
+
+### 3.3 Frontier typing: connect by key, carry the rest
+
+The judgment
+
+$$
+\Gamma \vdash e \,\triangleright\, \langle N;\ E;\ \Phi^{-};\ \Phi^{+} \rangle
+$$
+
+reads: under context $\Gamma$, expression $e$ elaborates to the diagram with node set $N$, edge set
+$E$, open input frontier $\Phi^{-}$, and open output frontier $\Phi^{+}$. The judgment produces the
+diagram, not only its boundary; Theorem 1 quantifies over exactly this object.
+
+$$
+\frac{}{\Gamma \vdash () \,\triangleright\,
+\langle \varnothing; \varnothing; \varnothing; \varnothing \rangle}
+\ \textsf{(T-Empty)}
+\qquad
+\frac{(n : \langle I; O \rangle) \in \Gamma}
+     {\Gamma \vdash n \,\triangleright\, \langle \{n\}; \varnothing; I; O \rangle}
+\ \textsf{(T-Node)}
+$$
+
+$$
+\frac{\Gamma \vdash e_1 \,\triangleright\, \langle N_1; E_1; \Phi^{-}_1; \Phi^{+}_1 \rangle
+\quad
+\Gamma \vdash e_2 \,\triangleright\, \langle N_2; E_2; \Phi^{-}_2; \Phi^{+}_2 \rangle
+\quad
+N_1 \cap N_2 = \varnothing}
+{\Gamma \vdash e_1 \mathrel{<>} e_2 \,\triangleright\,
+\langle N_1 \cup N_2;\ E_1 \cup E_2;\ \Phi^{-}_1 \uplus \Phi^{-}_2;\ \Phi^{+}_1 \uplus \Phi^{+}_2 \rangle}
+\ \textsf{(T-Overlay)}
+$$
+
+For connect, write $\Phi^{+}_1{\restriction}k$ and $\Phi^{-}_2{\restriction}k$ for the multisets of
+left outputs and right inputs whose match key $\operatorname{mkey}(p)$ equals $k$. The side
+condition is **per-key singleton matching**: for every match key $k$ present on both sides,
+
+$$
+|\Phi^{+}_1{\restriction}k| = 1
+\quad\text{and}\quad
+|\Phi^{-}_2{\restriction}k| = 1 .
+$$
+
+If one key matches two or more outputs, or two or more inputs, the composition is rejected: there is
+no implicit copy and no implicit merge, and reuse requires an explicit node. When the side condition
+holds, the match $M$ is the partial bijection pairing the unique output and input per shared match
+key; we write $\operatorname{dom} M$ and $\operatorname{rng} M$ for the matched outputs and matched
+inputs:
+
+$$
+\frac{\begin{array}{c}
+\Gamma \vdash e_1 \,\triangleright\, \langle N_1; E_1; \Phi^{-}_1; \Phi^{+}_1 \rangle
+\quad
+\Gamma \vdash e_2 \,\triangleright\, \langle N_2; E_2; \Phi^{-}_2; \Phi^{+}_2 \rangle
+\quad
+N_1 \cap N_2 = \varnothing \\
+\text{per-key singleton matching holds; } M \text{ the induced partial bijection}
+\end{array}}
+{\Gamma \vdash e_1 \Rightarrow e_2 \,\triangleright\,
+\langle N_1 \cup N_2;\
+E_1 \cup E_2 \cup M;\
+\Phi^{-}_1 \uplus (\Phi^{-}_2 \setminus \operatorname{rng} M);\
+(\Phi^{+}_1 \setminus \operatorname{dom} M) \uplus \Phi^{+}_2 \rangle}
+\ \textsf{(T-Connect)}
+$$
+
+Matched pairs enter the edge set; unmatched frontier endpoints are **carried**. Carrying is the
+open-graph identity wire: a carried endpoint crosses the composition unchanged and remains available
+to a later compatible consumer. The compiler implements exactly this side condition: a candidate
+multiplicity above one on either side is rejected with a source-level diagnostic (Appendix A).
+
+### 3.4 Derived forms as certified elaborations
+
+The four derived source forms elaborate to core expressions. We write the elaboration judgment
+
+$$
+\Gamma \vdash s \,\hookrightarrow\, \langle \Gamma';\ e^{\circ} \rangle
+$$
+
+read: under context $\Gamma$, source form $s$ elaborates to core expression $e^{\circ}$ under the
+extended context $\Gamma'$ ($\Gamma$ plus the generated node declarations the elaboration
+introduces). Typability of the target is part of the judgment:
+$\Gamma \vdash s
+\,\hookrightarrow\, \langle \Gamma'; e^{\circ} \rangle$ holds only when
+$\Gamma' \vdash e^{\circ} \,\triangleright\, \langle N; E; \Phi^{-}; \Phi^{+} \rangle$ for some
+composite — elaboration and core typing are one admission pass, and a failure of either is the same
+static error at the source level. Each elaboration additionally carries its own admission premises.
+The relation is deterministic by construction: generated names are a function of the generation site
+and the child index or item label, so a source form has at most one elaboration. For the generation
+forms, $\Gamma$ additionally carries **graph bindings** — names bound to core expressions — and a
+bound name occurring in expression position denotes its core expression. This mirrors both the
+compiler (derived forms are expanded before graph admission) and the mechanization (each form is an
+admission predicate over the core algebra, accepted only with a construction witness).
+
+#### E-Star: product adapters
+
+For $e_1 * e_2$, exactly one operand boundary is **singular** (one port whose contract is a product
+— a named record or a bounded indexed product $[T;\,k]$) and the other is **multi** (one port per
+product component). Direction is determined by which side is which: multi-to-singular is a
+**gather**, singular-to-multi is a **scatter**. The elaboration generates one fresh **phantom
+adapter** node $\varphi$ whose boundary crosses exactly one product constructor — on the multi side,
+one leaf port per record field or index, each keyed by the component contract and label; on the
+singular side, the product port itself — and the form elaborates to two ordinary connects:
+
+$$
+\Gamma \vdash e_1 * e_2 \,\hookrightarrow\,
+\langle \Gamma, \varphi : \langle I_{\varphi}; O_{\varphi} \rangle;\
+e_1 \Rightarrow \varphi \Rightarrow e_2 \rangle
+$$
+
+where $\varphi$'s boundary is determined by the operands: in a gather, $I_{\varphi}$ is one leaf
+input per product component, keyed by the component contract and label so that each matches exactly
+one multi-side output, and $O_{\varphi}$ is the singular product port; in a scatter the directions
+are swapped. Both connects are instances of T-Connect; the adapter introduces no copying rule — each
+leaf endpoint is matched and consumed exactly once. Rejected at this elaboration: both operands
+multi; both operands flat singular (ordinary connect already covers that case); a singular contract
+that is neither a registered record nor a bounded indexed product; component arity or contract
+mismatch between the product and the multi side; and products whose element contract is itself an
+indexed product. One-component products ($[T;\,1]$, single-field records) are admitted — the
+degenerate adapter is still a named constructor crossing, not a rename.
+
+#### E-Make and E-MakeEach: bounded generation
+
+Generated families are admitted through a **named binding whose right-hand side is the generation
+form** — the grammar offers `make`/`makeEach` only in that position, at the top level or local to a
+form. A kind $K$ is a node-body template with a label formal (and, for `makeEach`, an optional value
+formal). For a binding $b$:
+
+$$
+\Gamma \vdash b = \operatorname{make}(k, K) \,\hookrightarrow\,
+\langle \Gamma,\ n_{b,0}, \ldots, n_{b,k-1},\
+b \mapsto n_{b,0} \mathrel{<>} \cdots \mathrel{<>} n_{b,k-1};\
+\ n_{b,0} \mathrel{<>} \cdots \mathrel{<>} n_{b,k-1} \rangle
+$$
+
+This is a declaration elaboration: the extended context gains both the fresh node declarations
+$n_{b,i}$ (each instantiating $K$'s boundary template with the generated label $i$) and the graph
+binding $b$, bound to the overlay of the children; the elaborated core expression is that overlay,
+and subsequent occurrences of $b$ in expression position denote it. `makeEach` is the same scheme
+over a static item vector: one child per item, labelled by the item, with the item's static value
+supplied to $K$'s value formal. Generated names are fresh by construction and deterministic — from
+the binding name and index for `make`, from the binding name and item label for `makeEach` — so
+re-elaboration is stable. A zero count is admitted: $\operatorname{make}(0, K)$ generates the empty
+family and the binding denotes the empty diagram. Rejected: a count that is not compile-time
+resolvable (admitted forms: integer literals and preceding closed numeric bindings); an unknown
+kind; a kind whose formals do not match the generation form; items outside the static-value
+sublanguage; duplicate item labels.
+
+#### E-Select: latent branch families
+
+Select is the richest derived form, and four concerns must be kept separate.
+
+**Source admission** (the premises). The left operand's output frontier must be exactly one
+**exclusive output sum**: two or more output ports forming a single exclusive group, with no other
+exits. Arm keys resolve against the sum's variants **label-first**, falling back to a **unique
+contract** match; an arm key matching several variants, or none, is rejected. Coverage is total in
+both directions: every variant has exactly one arm and every arm names a variant. Each arm body is a
+graph expression with no external inputs beyond its variant's payload. Finally, the arms must
+**converge**: writing the boundary shape of a port as its (contract, label, exclusivity) triple, the
+list of output boundary shapes of every arm — for an identity arm, the shape of its own variant —
+must equal one common downstream boundary shape list. Convergence is what makes the composite
+boundary independent of which arm is later selected.
+
+**Latent bodies.** Admitted arm bodies are _not_ part of the composite's node set. They are sealed
+latent objects carrying source provenance: declared and admitted now, instantiated only if their arm
+is selected at run time (§3.7). This is the one place the calculus deliberately suspends the
+frontier discipline — a latent body's resources do not exist yet, so they appear on no frontier.
+
+**Elaboration target.** An admitted select elaborates to a generated **condition node** $\chi$ that
+consumes the exclusive sum and exposes the common downstream boundary as ordinary output ports:
+
+$$
+\Gamma \vdash e \ \operatorname{select}(k_1{:}\,e_1, \ldots, k_m{:}\,e_m)
+\,\hookrightarrow\,
+\langle \Gamma, \chi : \langle I_{\chi}; O_{\chi} \rangle;\
+e \Rightarrow \chi \rangle
+$$
+
+where $I_{\chi}$ is the variant sum and $O_{\chi}$ is the common boundary established by
+convergence. The composite frontier is the left operand's open **input** endpoints — by the
+admission premise its output frontier is exactly the sum, all of it consumed by $\chi$, so no left
+output is carried — together with the condition node's bridge outputs; both facts are readable
+directly off T-Connect. One reading deserves a sentence: the surface syntax reuses `()` in arm
+position, but select admission normalizes an empty arm to the **identity arm** — the selected
+variant passes through unchanged — before core elaboration, so the token does not carry two
+denotations: in expression position `()` is T-Empty's empty diagram; in arm position it is shorthand
+for identity, and an identity arm's boundary contribution is its own variant's shape, not the empty
+boundary. One case the rule never produces follows: a select in which **every** arm is the identity
+is rejected by convergence, because the variants of an exclusive sum carry pairwise distinct labels
+— so at least one arm is always a real body, and the condition node always exists. (The
+implementation contains a pass-through path for an all-identity select; it sits behind the
+convergence check and is unreachable, which the test suite pins.)
+
+**What this rule does not say.** Selection — the run-time instantiation of one latent body as a
+budgeted append rewrite — and the correspondence between the condition node and the evidence the
+compiler emits for it are run-time and certification concerns, deferred to §3.7 and §5. Folding them
+into the admission premise would overstate what source typing decides.
+
+### 3.5 Linearity
+
+**Definition 1 (port linearity, node-boundary form).** For an elaborated diagram
+$D = \langle N, E, \Phi \rangle$ define indicator functions on owned port instances:
+$\operatorname{internal}_D(p) = 1$ iff $p$ is an endpoint of exactly one edge in $E$ (and $0$
+otherwise), and $\operatorname{frontier}_D(p) = 1$ iff $p$ occurs in $\Phi$ with multiplicity
+exactly one (and $0$ otherwise — both absence and any higher multiplicity). $D$ is **port-linear**
+when
+
+$$
+\forall n \in N,\ \forall p \in \operatorname{OwnedPorts}(n),\quad
+\operatorname{internal}_D(p) + \operatorname{frontier}_D(p) = 1 .
+$$
+
+Of the structural rules, only exchange comes for free: the frontier is a multiset, so reordering is
+definitional. Weakening (discarding a resource) is not an operation at all, and contraction
+(copying) is never ambient — it happens only when an explicit node consumes one endpoint and
+produces fresh ones.
+
+The definition quantifies over all of a node's owned instances, so it presupposes a totality
+invariant: every owned instance of every node in the diagram is accounted for — internal or on the
+frontier, never neither. The typing rules maintain this by construction: T-Node places all declared
+ports on the frontier, T-Overlay touches no port accounting (node sets are disjoint), and T-Connect
+moves matched instances from frontier to internal without dropping any.
+
+**Theorem 1 (linearity preservation, core calculus).** If
+$\Gamma \vdash e \,\triangleright\, \langle N; E; \Phi^{-}; \Phi^{+} \rangle$ for a **core**
+expression $e$, then $\langle N, E, \Phi \rangle$ with $\Phi := \Phi^{-} \uplus \Phi^{+}$ (all
+frontier instances, both directions) is port-linear.
+
+_Proof._ By rule induction **on core expressions** — four cases. T-Empty and T-Node are immediate:
+the empty diagram has no owned ports, and a node's declared ports all sit on the frontier with
+multiplicity one. T-Overlay preserves the invariant because the operands' node sets are disjoint, so
+each owned port's accounting is untouched by the union (mechanized as
+`overlay_preserves_portLinear`, whose hypotheses are exactly the rule's premises: both operands
+port-linear, domains disjoint). T-Connect moves each matched pair from frontier to internal —
+indicator $0{+}1$ becomes $1{+}0$ on both endpoints — and touches nothing else; the per-key
+singleton condition is what guarantees no endpoint is matched twice (mechanized per pair as
+`contract_preserves_portLinear`, and for the induced sequence of contractions as
+`bulkContract_preserves_portLinear`). $\square$
+
+The mechanized statements live over an explicit carrier — a graph of port instances with membership
+invariants — rather than over the typing rules' frontier computations; the correspondence between a
+typing derivation and a certified carrier construction is summarized in §4, where each citation
+states its actual hypothesis shape.
+
+**Corollary 1 (linearity preservation, source forms).** If a derived source form is admitted —
+$\Gamma \vdash s \,\hookrightarrow\, \langle \Gamma'; e^{\circ} \rangle$ — then the composite
+diagram of $e^{\circ}$ under $\Gamma'$ is port-linear.
+
+_Proof discharge._ The elaboration target $e^{\circ}$ is a core expression over $\Gamma'$, so
+Theorem 1 applies once the generated declarations are well-formed; what each derived form adds is
+the proof that its admission produces well-formed fresh declarations. These are mechanized as
+acceptance theorems whose hypothesis is precisely a successful admission: when the certified
+constructor for bounded generation returns a result (over an abstract injective naming policy and
+caller-supplied per-child frontier instances), the constructed object is port-linear
+(`Make.accept_portLinear`, `MakeEach.accept_portLinear`); the same holds for the phantom adapter's
+witnessed construction (`Star.accept_portLinear`). For select, the convergence premise guarantees a
+condition node always exists (§3.4), and that node is an ordinary declared node, so Theorem 1
+already covers the composite; the latent arm bodies are outside the diagram and therefore outside
+this statement — their discipline at instantiation time is §3.7's subject. The corollary is not
+circular: typability of the target is definitional, and the substance is that each admission
+produces well-formed fresh declarations, which is exactly what the acceptance theorems prove.
+$\square$
+
+The phrase "by induction on source syntax" is deliberately avoided: Theorem 1 is a four-case core
+theorem, and source forms enter only through Corollary 1's admission hypotheses.
+
+**Definition 2 (closed diagram).** A diagram is **closed** when its frontier is empty.
+
+Closedness is a property, not an admission requirement. Top-level admission checks acyclicity of the
+node-level projection; the compiler packages every admitted diagram, closed or open, as an
+executable circuit artifact, with the frontier becoming the artifact's external interface — open
+inputs become entry ports the runtime feeds, open outputs become exit ports whose values leave the
+diagram. (The test suite pins both directions: open-input and open-output programs compile to
+circuits.) Where everything must in the end be used exactly once is the **actualized** layer of the
+running circuit, developed in §3.7, where exposed outputs are consumed by terminal discharge rather
+than left dangling.
+
+### 3.6 Forgetful lowering and the algebraic delta
+
+Define $\lfloor D \rfloor$ as the node-level relation graph obtained by erasing port identity:
+vertices $N$, and one relation edge per distinct owner-node pair of an element of $E$ — parallel
+port edges between the same node pair collapse to one relation edge, since the lowered object is a
+relation, not a multigraph. Wire expressions erase to ordinary relation graphs, but the two
+operators lower differently: **overlay lowers homomorphically**
+($\lfloor D_1 \mathrel{<>} D_2 \rfloor = \lfloor D_1 \rfloor \oplus \lfloor D_2
+\rfloor$, mechanized
+as `forgetPorts_overlay`), while **source connect lowers to insertion of the matched endpoint
+relation** — the node pairs of $M$ — **not** to Mokhov's total connect, which would add the full
+cross-product of edges. Mokhov's laws, including `connect_decomposition` (proven at relation,
+denotational, and quotient levels), hold of the relation algebra in which the lowered graphs live;
+they are not equations on source expressions. In particular **source-level distributivity of
+$\Rightarrow$ over $<>$ deliberately fails**: distributing duplicates an operand and with it a port
+resource — $(d \Rightarrow a) \mathrel{<>} (d \Rightarrow b)$ is rejected where
+$d \Rightarrow a \mathrel{<>} b$ is admitted.
+
+Three lowering equations are mechanized and carry the delta precisely. Lowering commutes with
+overlay: $\lfloor D_1 \mathrel{<>} D_2 \rfloor = \lfloor D_1 \rfloor \oplus \lfloor D_2 \rfloor$
+(`forgetPorts_overlay`). Lowering a sequence of contractions adds exactly the lowered matched edges
+and nothing else: the result has the same vertex set and the edge set extended by precisely the node
+pairs of the consumed port pairs (`forgetPorts_bulkContract`) — this equation _is_ the formal
+statement that source connect inserts the matched endpoint relation rather than a cross-product. And
+lowered graphs are endpoint-closed: every lowered edge's endpoints are lowered vertices
+(`forgetPorts_edgeEndpointsInVertices`), which is what lets the relation-algebra vocabulary (paths,
+acyclicity, decomposition) apply downstream.
+
+### 3.7 Latent and actualized layers
+
+The calculus above types the **source** layer: declared boundaries composed by the rules of §3.3. A
+running circuit lives at a second layer, and the two must not be identified. A resource is
+**latent** when it is declared and admitted but not yet instantiated — a select arm body before its
+arm is chosen, a generated-form template before expansion. A resource is **actualized** when it is a
+port instance of the running circuit, carrying values under the runtime's schedule. The two-layer
+reading is what lets one diagram serve authoring (source) and replay and provenance (actualized)
+without conflating a declaration with an execution.
+
+**The actualized discipline.** An actualized port graph assigns each output port instance its
+consumers — either edges to input instances or **terminal discharges**, the runtime's named exits
+for values that leave the diagram — and each input instance its producers. It is **closed
+port-linear** when every output is consumed exactly once (one edge or one terminal discharge) and
+every input is produced exactly once. Two differences from Definition 1 are deliberate: there is no
+frontier (a running circuit is closed), and terminal discharge exists only at this layer — the
+source calculus has no notion of a value leaving.
+
+**The projection, and what is proved about it.** The proof-side actualized model expects, for each
+compiled circuit, a **port-use witness**: the actualized instances together with their use
+assignment. Producing that witness is the compiler's obligation and remains open correspondence work
+(§4); the mechanized facts are conditional on a supplied witness. First, any well-formed witness
+induces a closed port-linear actualized graph (`portUseWitness_toGraph_closedPortLinear`) —
+closedness is a consequence of the witness shape, not a separate check. Second, when a witness is
+**aligned** with an admitted source object, the projection is exact in both directions: an instance
+is an actualized port of the witness if and only if it is the projection of a source port of the
+object (`compiledPortUseWitness_exact_output`, `compiledPortUseWitness_exact_input`). Nothing
+appears at run time that was not declared, and nothing declared goes missing.
+
+**Actualization preserves both layers.** When a latent select arm is chosen, its body is
+instantiated and overlaid into the running circuit. The mechanized preservation statement is
+conditional and we state its hypotheses plainly: if the current actualized graph and the selected
+fragment's graph are each closed port-linear, and the current graph's ports are disjoint from the
+selected fragment's nodes, then the overlay is closed port-linear
+(`selectActualize_preserves_closedPortLinearity`). The disjointness hypotheses are discharged in
+practice by the freshness discipline of admission — selected bodies are namespaced away from the
+live graph — but that discharge is part of the certification story (§5), not of this theorem.
+
+**The trust seam, stated.** Alignment is a _compiler-supplied_ witness: the theorems above say that
+aligned witnesses have exact projections and closed actualized graphs, not that the compiler always
+produces aligned witnesses. Producing and checking alignment is an executable correspondence
+obligation, tracked openly (§4), and it is precisely the kind of obligation the certification
+architecture of §5 is designed to make testable.
+
+## 4. Metatheory: What Is Proved, and at What Strength
+
+Every formal claim in this paper is one of four kinds: a **core theorem** (mechanized over the core
+calculus or a carrier for it), an **elaboration corollary** (mechanized acceptance of a derived
+form), an **implementation check** (an executable, tested gate), or an **open correspondence
+obligation** (stated, tracked, not claimed). The table gives each claim with the Lean declarations
+that carry it and — just as deliberately — the column saying what remains assumed or open. All
+declarations live in the project's public mechanization (Appendix A); the development has **no
+axioms and no incomplete proofs**, with 28 of 28 dashboard claims mechanized and 19 of 28 carrying
+executable Haskell correspondence, as of 2026-06-10.
+
+| Claim (this paper's notation)                                                                                 | Mechanized as                                                                                                                                                                           | What remains assumed or open                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Theorem 1: core composition preserves port linearity                                                          | `overlay_preserves_portLinear`, `contract_preserves_portLinear`, `bulkContract_preserves_portLinear` over the source linear-port carrier                                                | The interpretation of typing derivations as certified carrier constructions is stated on paper (§3.5); the interpretation itself is not a Lean theorem                     |
+| Corollary 1: admitted source forms preserve port linearity                                                    | `Make.accept_portLinear`, `MakeEach.accept_portLinear`, `Star.accept_portLinear`                                                                                                        | Acceptance quantifies over an abstract injective naming policy and caller-supplied per-child frontiers; the compiler's concrete instantiation is tested, not proved        |
+| Lowering equations: overlay homomorphic; connect inserts the matched relation; lowered graphs endpoint-closed | `forgetPorts_overlay`, `forgetPorts_bulkContract`, `forgetPorts_edgeEndpointsInVertices`; relation algebra incl. `connect_decomposition` at relation, denotational, and quotient levels | Nothing open at this layer (proof-only facts; no runtime analog claimed)                                                                                                   |
+| E-Select source admission: key coverage and provenance                                                        | `admitClause_entries_keys_eq_shape` (admitted entries' keys are exactly the sum's arm keys), `admitClause_fromClause` (each entry ties to its source arm)                               | The exclusive-sum shape itself is supplied by the compiler's boundary resolution — tested correspondence, not a derived object                                             |
+| Select actualization: lowering, exclusion, preservation, recovery                                             | `selectActualize_lowers_to_appendAfter`, `selectActualize_unselected_not_in_selectedFragment`, `selectActualize_preserves_closedPortLinearity`, `selectedBranch_recovery_deterministic` | Preservation's disjointness hypotheses are discharged by namespace freshness in practice — that discharge is a correspondence obligation; durable lineage decoding is open |
+| Two-layer projection exactness (§3.7)                                                                         | `compiledPortUseWitness_exact_output`, `compiledPortUseWitness_exact_input`, `portUseWitness_toGraph_closedPortLinear`                                                                  | `AlignedWith` is a compiler-supplied witness; producing and independently checking alignment is open executable correspondence                                             |
+| Boundary resources: one-slot epochs, law families                                                             | `rewriteSlot_spent_at_most_once` with the proof-relevant `SlotUniqueTrace`; `substitution_preserves_boundary`, `appendContinuation_preserves_boundary` per rewrite family               | The three law families are mechanized per rewrite kind; a unified boundary-law algebra is not; executable epoch production is open                                         |
+| Graded budgets: five-dimensional cost, fit, chain monotonicity                                                | `consume_le`, `ConstructedPlanningChain.finalBudget_le_initial`, `selectActualize_consumes_selected_cost`                                                                               | No completeness claim for the five dimensions; runtime budget accounting is tested, not proved                                                                             |
+| Rewrite admission soundness (planner checks imply abstract admissibility)                                     | `planGraphRewriteChecks_admissible`, `runtimePlannerConstruction_admissible`                                                                                                            | Field-by-field runtime witness production is open                                                                                                                          |
+
+Two absences are stated rather than implied. There is **no unified dynamics theorem**: nothing
+mechanized says "every admitted run step preserves Theorem 1's invariant at both layers" — the
+closest results are the per-step preservation theorems above, and unifying them is named future
+work, not background assumption. And the **compiler is engineered, not extracted**: the Lean proves
+models and contracts; the Haskell is held to them by the tested and gated correspondence machinery
+of §5, which reduces — but does not eliminate — trust in the compiler.
+
+## 5. Executing Admitted Diagrams
+
+This section is deliberately outside the core calculus: the calculus is the contribution, and the
+runtime story is evidence that the typed object is executable, durable, and certifiable.
+
+### 5.1 Dynamics, imported
+
+Execution over an admitted diagram — its open frontier, if any, supplied at entry ports and
+discharged at exit ports by the runtime — is a two-level operational story, and both levels are
+developed and mechanized in companion work; this paper imports them by citation rather than
+re-proving. Within fixed topology, the runtime is a staged pure reduction — commutative accumulation
+of node-local facts, idempotent failure closure, deterministic lifecycle classification — whose
+structural recovery safety and replay determinism are mechanized in the staged-reduction paper. At
+admitted boundaries, topology evolves by budgeted, vertex-anchored substitution and by
+selected-branch actualization, with the admission, budget, exclusion, and recovery theorems of §4.
+The two levels alternate: reduce within a topology, substitute at its admitted boundaries, reduce
+again. What does not yet exist is the single theorem composing the two levels with linearity — the
+open obligation named in §4 — and until it does, the dynamics remain an application of the calculus
+rather than part of its metatheory.
+
+### 5.2 The certifying admission boundary
+
+The compiler does not merely emit circuits; it emits a proof-shaped **admission artifact** alongside
+every circuit compiled on the Wire source path, and the architecture makes that artifact trustworthy
+in three independently checkable steps.
+
+First, **artifact-internal validity** is decided by mirrored executable contracts: a validator in
+the compiler's language and an independent checker in the proof assistant (`validatorReadyCheck`),
+with a soundness theorem (`validatorReadyCheck_soundness`) packaging acceptance into the
+proof-facing contract from which reconstruction theorems recover the witnesses the metatheory
+consumes — replay frames for primitive composition, provenance for generated forms, latent-admission
+shape for selects, bulk-replay evidence for adapters.
+
+Concretely, the artifact is pure data with no proof terms: a summary of the admitted diagram (its
+node rows, raw connections, and open boundary) together with a replay trace of the composition steps
+that built it, plus one evidence row per derived-form instance — which children a generation
+produced and from which static items, which leaf endpoints an adapter crossed, which arms a select
+admitted under which resolution. Internal validity means the summary and the trace agree: the
+checker replays the recorded steps and requires the result to match the summary exactly, so an
+artifact cannot claim a diagram its own history does not rebuild.
+
+Second, **artifact-to-circuit correspondence is compiler-enforced by a structural binding check**: a
+compilation on this path cannot succeed unless the artifact it attaches describes exactly the
+circuit it travels with — schema, node set, the node-level projection of its connections rebuilding
+the circuit topology, the derived entry/exit boundary, exact metadata embedding, and the select rows
+replaying the condition-node tree. Mutation tests cover every error constructor — fourteen in all —
+on both the artifact and the circuit side: mutate a valid artifact against its unchanged circuit, or
+the circuit against its unchanged artifact, and compilation is refused.
+
+Third, **what remains trusted is stated**. The binding check ties values, not provenance: it does
+not prove the compiler emitted the artifact it validated, and circuits constructed outside this
+compile path are not gated. Nor does the proof-assistant checker yet run on compiler output as part
+of the build — its first emitted-artifact fixture is hand-transcribed, and automating that
+transcription is tracked, open work. This architecture sits strictly between proof-carrying code and
+translation validation: no proof terms travel with the artifact, and no recompilation or semantic
+re-execution occurs — the compiler emits structured evidence, mirrored contracts validate it, and a
+structural check binds it to the executable object. Each of the three steps is independently
+testable, which is the practical point: drift between proofs, compiler, and runtime becomes a
+failing check rather than a latent divergence.
+
+### 5.3 Implementation surface
+
+The calculus is implemented end to end. Wire's compiler carries the admission and binding machinery
+above; a command-line interface compiles, checks, and formats programs; and Pulse, the durable
+runtime, journals execution and replays runs against the admitted diagram, so provenance queries
+resolve to named nodes and typed edges. An example corpus exercises the calculus across data
+pipelines, build systems, planners, and dashboards (Appendix A).
+
+The corpus's quantum examples deserve their own sentence, because they are evidence for the calculus
+rather than decoration. A delayed-choice quantum-eraser experiment is authored in the same language
+with no quantum-specific rules and was executed on physical quantum hardware. Qubit-carrying ports
+are linear resources, so the fan-out rejection of §3.3 is exactly the static error that copying a
+qubit-typed port would require, and gate application order is enforced by the same typed frontiers
+that order workflow effects. This is a structural correspondence with the no-cloning discipline, not
+a quantum-semantics theorem — no formal semantics of gates is claimed — but it is a striking one: a
+single port-linear language spans durable workflows and quantum circuit description because both are
+causal diagrams over unforgeable resources.
+
+## 6. Related Work
+
+**Interaction nets and port-graph formalisms — the nearest neighbors, addressed first.** The
+port-linearity discipline itself is inherited lineage. Interaction nets [\[18\]](#ref-18), arising
+from proof-net reduction [\[19\]](#ref-19), already give agents with typed ports, each port incident
+to at most one edge, free ports forming the open interface, and copying and erasing routed through
+explicit agents — precisely the no-implicit-copy, named-fan-out discipline this calculus enforces,
+and we claim none of it as new. The deltas are elsewhere. Interaction nets are a reduction system:
+their content is the rewrite relation on active pairs, and their edges are drawn by the author. Here
+there is no reduction at the source layer — composition is admission of a static object — and edges
+are not drawn but **computed**: keyed connect induces them from typed port keys, with unmatched
+endpoints carried as live boundary resources, so that source expressions compose as frontier
+transformers. And no formalism in this family has the calculus's third leg, the single admitted
+referent with its certifying boundary (§5.2). Bigraphs [\[20\]](#ref-20) are the adjacent account of
+graph-based reactive systems with typed interfaces and composition; they carry reaction rules and a
+nesting structure this calculus lacks, and lack its linearity invariant and admission/replay
+correspondence. Wiring diagrams and their operads [\[21\]](#ref-21) compose boxes with typed ports
+along wiring patterns — the purest prior account of typed-port composition — but a wire there may
+split; the prohibition of splitting, and partial carrying composition computed per key, are exactly
+this calculus's departures.
+
+**Algebraic graphs.** Mokhov's algebra of graphs [\[2\]](#ref-2), and its application to build
+systems [\[3\]](#ref-3), supplies the four-constructor skeleton this calculus inherits — empty,
+vertex, overlay, connect. The delta is precise and theorem-shaped. Vertices carry named, typed
+ports, and connect changes meaning: Mokhov's connect adds the full cross-product of edges between
+operands, while $\Rightarrow$ adds one edge per uniquely matched port key and carries the rest. Two
+algebraic consequences follow. Multiple compatible counterparts for one key are a static error
+rather than a fan-out, and source-level distributivity of connect over overlay deliberately fails,
+because distributing duplicates an operand and with it a port resource. Mokhov's laws are recovered
+after admission by the forgetful lowering of §3.6 — overlay lowers homomorphically, connect lowers
+to insertion of the matched endpoint relation — so the laws hold of the relation algebra in which
+lowered graphs live, not of source expressions.
+
+**Open graphs, cospans, and string diagrams.** Decorated cospans [\[4\]](#ref-4), graphical
+languages for monoidal categories [\[5\]](#ref-5), and open-graph reasoning [\[6\]](#ref-6) give
+composition-by-boundary its categorical home, and the frontier of §2 is recognizably such a
+boundary. The differences are where the calculus earns its keep: the boundary is a multiset of
+contract-and-label-keyed ports with admission obligations attached; composition is partial,
+key-directed, and carrying rather than total gluing along a chosen interface; and the composite is
+not only a categorical object but the executable artifact a durable runtime schedules and replays,
+with linearity discharged by a mechanized check rather than by construction in a chosen category.
+The sharpest contrast is with string-diagram rewrite theory over hypergraph categories
+[\[22\]](#ref-22): there, copying and sharing are obtained through Frobenius structure. This
+calculus deliberately omits ambient copy and delete at the source level — copying must be
+represented by a named node — so a categorical semantics would have to model key-directed partial
+composition **without** the comonoid structure the calculus rejects. That, precisely, is the open
+semantic question, and it is sharper than a generic appeal to future work.
+
+**Linear logic and linear types.** The structural-rule vocabulary is inherited from linear logic and
+proof nets [\[7\]](#ref-7), [\[8\]](#ref-8) and from linear type systems [\[9\]](#ref-9), but the
+calculus uses a deliberately restricted fragment: exchange holds definitionally (the frontier is a
+multiset; source order survives only in diagnostics), weakening is absent (no operation discards a
+resource), and contraction is never ambient — it requires an explicit node consuming one endpoint
+and producing fresh ones, which is what turns the type discipline into a provenance semantics. There
+is no exponential modality and no cut-elimination claim; linearity here governs diagram admission,
+not proof reduction.
+
+**Session types.** Latent branch families are the nearest relative of labeled choice in session
+types [\[10\]](#ref-10), [\[11\]](#ref-11): an exclusive output sum offers variants, exactly one of
+which is taken. The deltas are durability and the rewrite reading. Selection is not a step of a
+process protocol but a budgeted append rewrite into a durable graph, with mechanized exclusion of
+unselected bodies and recovery determinism — the same selection replays from persisted admission.
+There is no duality story and no channel discipline; arms converge to a common downstream boundary
+instead of continuing a dialogue.
+
+**Graded and quantitative types.** The five-dimensional rewrite budget of §4 — added nodes, edges,
+depth, frontier width, rewrite operations — is a coeffect-like grading [\[12\]](#ref-12) on
+structural change rather than on variable use: each dimension names a distinct scarcity, and the
+mechanized facts are per-step fit and chain-level monotonicity. We make no claim that the five
+dimensions are complete, and no cross-dimension trade theory is developed.
+
+**Certifying compilation.** The admission boundary of §5.2 sits between proof-carrying code
+[\[13\]](#ref-13) and translation validation [\[14\]](#ref-14). PCC ships proof terms with the code;
+here no proof terms travel — the artifact is structured evidence, and proof obligations are
+reconstructed from accepted artifacts on the proof-assistant side. Translation validation re-checks
+each compilation semantically; here nothing is re-executed — mirrored executable contracts validate
+the artifact, and a structural binding check ties it to the emitted object, with the residual trust
+stated (values, not provenance). The architecture trades the strength of those guarantees for
+independent testability of each step.
+
+**Durable execution.** Temporal [\[15\]](#ref-15), Azure Durable Functions [\[16\]](#ref-16), and
+Restate [\[17\]](#ref-17) journal and replay workflow execution, recovering effective topology from
+runtime behavior; tracing standards reconstruct causal DAGs from spans after the fact. The
+relationship here is inverted: topology is authored, admitted, and typed before execution, and
+replay and provenance refer to the admitted diagram. Lamport's partial-order view of distributed
+execution [\[1\]](#ref-1) is the common ancestor; this calculus turns it into an authoring
+discipline with a linearity theorem.
+
+## 7. Conclusion
+
+The paper's object is small: four typing rules over typed port frontiers, one linearity invariant,
+and a forgetful lowering into the algebra of graphs. Everything else is discipline about how to grow
+from that object without diluting it — derived forms as certified elaborations so the core never
+grows; a metatheory table that grades every claim as core theorem, elaboration corollary,
+implementation check, or open obligation; an execution and certification story that makes the gap
+between proofs and compiler testable instead of rhetorical. The deliberate law failure — no source
+distributivity — and the deliberate absence — no ambient contraction — are the contributions as much
+as the theorems are: they are what make the admitted diagram a causal explanation rather than a
+drawing. Open problems are stated where they live: a unified dynamics theorem composing reduction
+and admitted substitution with linearity (§4), compiler-produced alignment witnesses for the
+two-layer projection (§3.7), and a categorical statement of key-directed partial composition (§6).
+The artifact — mechanization, compiler, runtime, and example corpus through to quantum hardware — is
+public (Appendix A).
+
+## References
+
+1. <a id="ref-1"></a>Leslie Lamport. _Time, Clocks, and the Ordering of Events in a Distributed
+   System_. Communications of the ACM 21(7), 1978.
+2. <a id="ref-2"></a>Andrey Mokhov. _Algebraic Graphs with Class (Functional Pearl)_. Haskell
+   Symposium, 2017.
+3. <a id="ref-3"></a>Andrey Mokhov, Neil Mitchell, Simon Peyton Jones. _Build Systems à la Carte_.
+   ICFP 2018.
+4. <a id="ref-4"></a>Brendan Fong. _Decorated Cospans_. Theory and Applications of Categories
+   30(33), 2015.
+5. <a id="ref-5"></a>Peter Selinger. _A Survey of Graphical Languages for Monoidal Categories_.
+   Lecture Notes in Physics 813, 2011.
+6. <a id="ref-6"></a>Lucas Dixon, Ross Duncan, Aleks Kissinger. _Open Graphs and Computational
+   Reasoning_. EPTCS 26, 2010.
+7. <a id="ref-7"></a>Jean-Yves Girard. _Linear Logic_. Theoretical Computer Science 50(1), 1987.
+8. <a id="ref-8"></a>Vincent Danos, Laurent Regnier. _The Structure of Multiplicatives_. Archive for
+   Mathematical Logic 28(3), 1989.
+9. <a id="ref-9"></a>Philip Wadler. _Linear Types Can Change the World!_ Programming Concepts and
+   Methods, 1990.
+10. <a id="ref-10"></a>Kohei Honda, Vasco T. Vasconcelos, Makoto Kubo. _Language Primitives and Type
+    Discipline for Structured Communication-Based Programming_. ESOP 1998.
+11. <a id="ref-11"></a>Kohei Honda, Nobuko Yoshida, Marco Carbone. _Multiparty Asynchronous Session
+    Types_. POPL 2008.
+12. <a id="ref-12"></a>Tomas Petricek, Dominic Orchard, Alan Mycroft. _Coeffects: A Calculus of
+    Context-Dependent Computation_. ICFP 2014.
+13. <a id="ref-13"></a>George C. Necula. _Proof-Carrying Code_. POPL 1997.
+14. <a id="ref-14"></a>Amir Pnueli, Michael Siegel, Eli Singerman. _Translation Validation_.
+    TACAS 1998.
+15. <a id="ref-15"></a>Temporal Technologies. _Temporal_. <https://temporal.io>
+16. <a id="ref-16"></a>Microsoft. _Azure Durable Functions_.
+    <https://learn.microsoft.com/en-us/azure/azure-functions/durable/>
+17. <a id="ref-17"></a>Restate. _Restate_. <https://restate.dev>
+18. <a id="ref-18"></a>Yves Lafont. _Interaction Nets_. POPL 1990.
+19. <a id="ref-19"></a>Yves Lafont. _From Proof Nets to Interaction Nets_. In Advances in Linear
+    Logic, Cambridge University Press, 1995.
+20. <a id="ref-20"></a>Robin Milner. _Bigraphical Reactive Systems: Basic Theory_. Technical Report
+    UCAM-CL-TR-523, University of Cambridge, 2001.
+21. <a id="ref-21"></a>Dmitry Vagner, David I. Spivak, Eugene Lerman. _Algebras of Open Dynamical
+    Systems on the Operad of Wiring Diagrams_. Theory and Applications of Categories 30(51), 2015.
+22. <a id="ref-22"></a>Filippo Bonchi, Fabio Gadducci, Aleks Kissinger, Paweł Sobociński, Fabio
+    Zanasi. _String Diagram Rewrite Theory III: Confluence with and without Frobenius_. Mathematical
+    Structures in Computer Science, 2022.
+
+## Appendix A: Artifact
+
+The implementation and mechanization are public in the Cortex repository
+(<https://github.com/Digimuoto/cortex>). The Lean development lives under `theory/Cortex/` (graph
+algebra, port linearity and the actualized bridge, generated forms and phantom adapters, select
+admission and recovery, boundary resources and budgets, admission artifacts); the declaration names
+cited in §3-§4 resolve there, and the generated documentation and the proof-status dashboard — the
+per-claim grading this paper's counts are drawn from, as of 2026-06-10 — are published from the same
+sources. The compiler and runtime live under `src/` (the binding check of §5.2 is
+`Cortex.Wire.AdmissionBinding`, enforced in the compile path), with the Wire command-line interface
+under `app/wire/`. The example corpus referenced in §5.3 lives under `examples/wire/`, including the
+dashboard pipeline, the build-system examples, and the quantum experiments; the quantum-eraser run
+on IBM hardware is reported, with its job identifier and reproduction notes, in the companion
+causal-programming paper.

--- a/docs/Publications/glossary.md
+++ b/docs/Publications/glossary.md
@@ -1,0 +1,89 @@
+---
+title: Publications Glossary
+description:
+  Canonical one-line definitions for terms shared across Cortex publication manuscripts. Each
+  paper's local glossary must be a consistent subset of this page.
+sidebar:
+  label: Glossary
+  order: 2
+status: active
+date: 2026-06-10
+related:
+  - docs/Publications/index.md
+  - docs/glossary.md
+  - docs/Architecture/03-formalism-stack.md
+---
+
+# Publications Glossary
+
+Canonical definitions for the load-bearing vocabulary the papers share. The DIALOCO'26 review of
+Paper 6 demonstrated the cost of using these terms before defining them; every manuscript defines
+the subset it uses, in wording consistent with this page, before first substantive use.
+
+## Graph and frontier vocabulary
+
+- **frontier**: the multiset of typed port instances exposed on the boundary of a graph expression —
+  the ports not yet consumed by composition. Composition operators are read as frontier
+  transformers.
+- **port instance**: one occurrence of a typed, direction-tagged endpoint (node, port name,
+  contract, optional label) owned by a node.
+- **carried endpoint**: a frontier endpoint that crosses a composition unmatched and remains on the
+  result's frontier, acting as an open-boundary identity wire.
+- **port linearity** (also "node-boundary linearity"; Lean: `PortLinear`): every owned port instance
+  is either consumed by exactly one internal edge or exposed on the frontier with multiplicity one —
+  never both, never duplicated. There is no ambient copying or contraction.
+- **latent**: declared and admitted but not yet instantiated in the running circuit — select arm
+  bodies before selection, generated-form templates before expansion.
+- **actualized**: instantiated as a port/node of the running circuit; the actualized layer carries
+  its own closed linearity discipline (Lean: `ClosedPortLinear`).
+- **overlay (`<>`)**: union of fragments with disjoint node sets; frontiers union.
+- **connect (`=>`)**: port-key-matched composition — an edge forms between a left output and a right
+  input only when their `(contract, label)` match keys agree uniquely; direction is enforced by
+  matching outputs against inputs, and unmatched endpoints are carried. Deliberately not Mokhov's
+  cross-product connect.
+- **phantom adapter**: the generated node that the `*` operator elaborates to, crossing one product
+  constructor between a singular record/indexed port and its distinct leaf endpoints, without
+  introducing a copying rule.
+- **generated form**: nodes produced by compile-time bounded generation (`make`, `makeEach`),
+  certified against the source expression that generated them.
+
+## Admission and artifact vocabulary
+
+- **admitted**: accepted by the relevant admission check (graph admission, select admission, rewrite
+  admission); admitted objects are the ones theorems quantify over.
+- **single admitted referent**: the discipline that source typing, the compiler's executable
+  artifact, the runtime's replay and provenance, and proof-facing validation all refer to one
+  admitted diagram, with the correspondence compiler-enforced by the binding check.
+- **compiled circuit / compiled workflow artifact**: the executable result of lowering source into a
+  graph package — topology, node definitions, typed interfaces, compatibility witness.
+- **admission artifact**: the proof-shaped evidence record the compiler attaches to a compiled
+  circuit, validated for internal consistency and bound to the circuit it travels with.
+- **compatibility witness**: a fingerprint or derivation witness tying a compiled artifact to the
+  semantics that produced it; in the substitution-semantics paper's notation
+  $\kappa = (\nu, \lambda, h)$ — lowering family, contract/interface regime, and digest of the
+  normalized source under both.
+
+## Execution vocabulary
+
+- **Pulse**: the durable runtime that schedules, journals, and replays execution over the admitted
+  graph.
+- **CorePure**: the deterministic pure sublanguage that shapes payloads; effects stay behind
+  registered executors.
+- **materialized run state**: the currently executable graph and node/output state obtained by
+  applying a lineage prefix to an original compiled artifact.
+- **lineage**: append-only history of admitted substitutions.
+- **materialization**: durable installation of admitted substitutions into the graph state.
+- **replay**: deterministic re-execution over the journaled durable prefix; fixed recorded outcomes
+  are reused rather than re-observed.
+- **provenance**: the recorded derivation of a value or topology change, referring back to the
+  admitted diagram.
+- **substitution**: splicing a fragment into a graph through an explicit boundary contract.
+- **fragment**: a graph package intended to be substituted into another graph.
+
+## Sources
+
+Wording is aligned with the Paper 3 glossary (substitution vocabulary), the architecture chapters
+([../Architecture/03-formalism-stack.md](../Architecture/03-formalism-stack.md),
+[../Architecture/05-wire-language.md](../Architecture/05-wire-language.md)), and the Lean
+definitions cited by [../Reference/proof-status.md](../Reference/proof-status.md) (`PortLinear`,
+admission artifact contracts).

--- a/docs/Publications/index.md
+++ b/docs/Publications/index.md
@@ -16,16 +16,28 @@ now holds the active paper candidates. Companion theory and proof plans live und
 
 ## Papers
 
-- **[Paper-1-staged-reduction/](Paper-1-staged-reduction/)** — fixed-topology staged reduction and
-  structural recovery safety.
-- **[Paper-2-algebraic-foundations/](Paper-2-algebraic-foundations/)** — algebraic kernel and
-  extension boundary of the fixed-topology calculus.
+- **[Paper-1-staged-reduction/](Paper-1-staged-reduction/)** — fixed-topology staged reduction,
+  structural recovery safety, the algebraic kernel, and the extension boundary (absorbed Paper 2).
+- **[Paper-2-algebraic-foundations/](Paper-2-algebraic-foundations/)** — superseded; merged into
+  Paper 1.
 - **[Paper-3-graph-substitution-semantics/](Paper-3-graph-substitution-semantics/)** — compiled
   artifacts, graph substitution, and dynamic-topology semantics.
 - **[Paper-4-wire-language/](Paper-4-wire-language/)** — authoring language for typed topology,
   registered authority, and bounded structural proposals.
+- **[Paper-5-Causal-Programming/](Paper-5-Causal-Programming/)** — causal programming and temporal
+  honesty: the paradigm umbrella over the other papers, with Wire and Pulse as the existence proof.
 - **[Paper-6-executable-diagrams/](Paper-6-executable-diagrams/)** — executable causal diagrams,
   tying Wire source, durable replay, and proof-facing admission together.
+- **[Paper-7-frontier-calculus/](Paper-7-frontier-calculus/)** — the flagship: the typed linear
+  frontier calculus on paper, with mechanized metatheory and the compiler as implementation claim.
+
+## Claims policy
+
+Any manuscript that cites verification numbers (mechanized-claim counts, Haskell-correspondence
+counts, axiom status) states the date it was checked against
+[../Reference/proof-status.md](../Reference/proof-status.md). A manuscript is stale when the
+proof-status page is newer than its stated as-of date; refresh the numbers before any submission
+freeze.
 
 ## Supporting material
 

--- a/docs/Publications/roadmap.md
+++ b/docs/Publications/roadmap.md
@@ -14,35 +14,47 @@ Plan and state of the current Cortex publication portfolio.
 
 ## Paper status
 
-| #   | Title                                                                 | Status | Role                                               |
-| --- | --------------------------------------------------------------------- | ------ | -------------------------------------------------- |
-| 1   | [Staged reduction](Paper-1-staged-reduction/)                         | Draft  | Runtime-grounded fixed-topology paper              |
-| 2   | [Algebraic foundations](Paper-2-algebraic-foundations/)               | Draft  | Core fixed-topology theory                         |
-| 3   | [Graph substitution semantics](Paper-3-graph-substitution-semantics/) | Draft  | Dynamic substitution theory                        |
-| 4   | [Wire language](Paper-4-wire-language/)                               | Draft  | Authoring language and authority-composition paper |
-| 6   | [Executable causal diagrams](Paper-6-executable-diagrams/)            | Draft  | Short artifact paper on executable causal diagrams |
+| #   | Title                                                                 | Status         | Role                                                              |
+| --- | --------------------------------------------------------------------- | -------------- | ----------------------------------------------------------------- |
+| 1   | [Staged reduction](Paper-1-staged-reduction/)                         | Draft          | Lead submission: fixed-topology runtime + algebra (absorbing 2)   |
+| 2   | [Algebraic foundations](Paper-2-algebraic-foundations/)               | Superseded     | Merged into Paper 1; directory retained until submission freeze   |
+| 3   | [Graph substitution semantics](Paper-3-graph-substitution-semantics/) | Draft          | Dynamic substitution theory; metatheory source for Paper 7        |
+| 4   | [Wire language](Paper-4-wire-language/)                               | Draft          | Authoring-layer design narrative; motivation source for Paper 7   |
+| 5   | [Causal programming](Paper-5-Causal-Programming/)                     | Draft          | Paradigm umbrella over Papers 1–4; vision-venue / journal target  |
+| 6   | [Executable causal diagrams](Paper-6-executable-diagrams/)            | Rewriting      | Short diagrams-workshop paper (rejected at DIALOCO'26; in rework) |
+| 7   | [Typed linear frontier calculus](Paper-7-frontier-calculus/)          | Complete draft | Flagship: the Wire calculus on paper, ICFP-tier target            |
 
 ## Supporting research plans
 
-| Plan                                                                                             | Status   | Role                                                |
-| ------------------------------------------------------------------------------------------------ | -------- | --------------------------------------------------- |
-| [Lean mechanization](../Roadmap/Plans/lean-mechanization.md)                                     | Proposed | Machine-checked support for the fixed-topology core |
-| [Rewrite materialization and recovery](../Roadmap/Plans/rewrite-materialization-and-recovery.md) | Proposed | Runtime-grounded rewrite and recovery theory        |
+| Plan                                                                                             | Status    | Role                                                |
+| ------------------------------------------------------------------------------------------------ | --------- | --------------------------------------------------- |
+| [Lean mechanization](../Roadmap/Plans/lean-mechanization.md)                                     | Delivered | Machine-checked support for the fixed-topology core |
+| [Rewrite materialization and recovery](../Roadmap/Plans/rewrite-materialization-and-recovery.md) | Proposed  | Runtime-grounded rewrite and recovery theory        |
 
 ## Dependency sketch
 
-Paper 2 is the keystone paper.
+Paper 1 is the lead submission; Paper 5 is the paradigm umbrella; Paper 7 is the planned flagship.
 
-- Paper 1 sharpens the fixed-topology runtime story and narrows the structural-safety claim to what
-  the runtime actually needs.
-- The Lean mechanization plan supports Papers 1 and 2 with machine-checked closure and recovery
-  obligations.
+- Paper 1 absorbs Paper 2: the runtime-grounded fixed-topology story gains the algebraic framing,
+  the extension-boundary analysis, and a results table citing the delivered Lean mechanization
+  (closure laws, recovery safety, classification exhaustiveness are proven, not proof debt).
 - Paper 3 extends the theory from fixed topology to compiled artifacts, substitution, and
-  lineage-plus-materialization semantics.
-- Paper 4 explains the authoring layer above that substrate: closed authority registration,
-  endpoint-typed composition, partial reuse, and bounded proposal authoring.
-- Paper 6 extracts the diagrammatic-computation story from Wire: source causal diagrams, typed
-  linear frontiers, circuit lowering, durable replay, and proof-facing accepted objects.
+  lineage-plus-materialization semantics. Its core obligations are now substantially mechanized in
+  the Lean rewrite track; the manuscript cites those theorems. Paper 3 remains a draft until Paper 7
+  shows how much of its metatheory the flagship absorbs.
+- Paper 4 explains the authoring layer: closed authority registration, endpoint-typed composition,
+  partial reuse, and bounded proposal authoring. Its design narrative seeds Paper 7's motivation; it
+  remains a draft pending the same absorption decision.
+- Paper 5 articulates causal programming and temporal honesty as the paradigm the other papers
+  instantiate, with Wire/Pulse as the existence proof. Vision venue or journal.
+- Paper 6 extracts the diagrammatic-computation story from Wire. The DIALOCO'26 submission was
+  rejected for presentation (undefined-before-use vocabulary, informal invariant statement,
+  unengaged prior work); the rework defines terms first, formalizes the linearity invariant, and
+  states precise deltas against Mokhov's algebra and open-graph composition.
+- Paper 7 is the flagship: the keyed frontier calculus stated in standard notation — syntax, typing
+  rules, small-step semantics — with metatheory cited to the Lean track and the compiler (enforced
+  artifact-to-circuit binding) as the implementation claim. Targets the ICFP tier first; a
+  POPL-shaped distillation is deliberately deferred until reviews identify the novel core.
 - The rewrite materialization and recovery plan connects Paper 3's substitution theory back to
   runtime recovery and admission policy.
 
@@ -55,6 +67,9 @@ notes:
   papers and plans as they mature.
 - **[Notes/deterministic-multi-rewrite-admission.md](Notes/deterministic-multi-rewrite-admission.md)**
   — current runtime semantics and validation questions for same-wave multi-proposal admission.
+- **[Notes/mined-contributions.md](Notes/mined-contributions.md)** — inventory of contributions
+  present in the Lean proofs and implementation but not yet claimed by any manuscript, with evidence
+  and proposed homes.
 
 ## Related
 

--- a/test/Cortex/Wire/CompileSpec.hs
+++ b/test/Cortex/Wire/CompileSpec.hs
@@ -3873,6 +3873,83 @@ spec = describe "Cortex.Wire.Compile" $ do
         artifact
         compiled {compiledCircuitMetadata = Aeson.String "not-an-object"}
 
+  describe "frontier calculus paper claims" $ do
+    it "compiles the worked build pipeline with the claimed topology and frontier" $ do
+      compiled <- requireRight (compileWireText paperBuildPipelineSourceText)
+      Set.fromList compiled.compiledCircuitEntryNodes
+        `shouldBe` Set.fromList [CircuitNodeRef "source", CircuitNodeRef "config"]
+      compiled.compiledCircuitExitNodes `shouldBe` [CircuitNodeRef "package"]
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "source")
+        `shouldBe` Set.singleton (CircuitNodeRef "build")
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "config")
+        `shouldBe` Set.singleton (CircuitNodeRef "build")
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "build")
+        `shouldBe` Set.singleton (CircuitNodeRef "package")
+      expectWireAdmissionArtifact compiled $ \artifact -> do
+        Set.fromList
+          [ (boundary.admissionBoundaryNode, boundary.admissionBoundaryPort)
+          | boundary <- artifact.wireAdmissionExits
+          ]
+          `shouldBe` Set.fromList
+            [ (CircuitNodeRef "build", "log")
+            , (CircuitNodeRef "package", "pkg")
+            ]
+        artifact.wireAdmissionEntries `shouldBe` []
+
+    it "rejects the worked example's fan-out dual on the Binary key" $
+      compileWireText paperBuildPipelineFanOutSourceText
+        `shouldSatisfy` isWireParseFailureContaining "would copy output endpoint"
+
+    it "packages an open-output diagram as a circuit (carried log endpoint)" $ do
+      compiled <- requireRight (compileWireText paperBuildPipelineSourceText)
+      expectWireAdmissionArtifact compiled $ \artifact ->
+        artifact.wireAdmissionExits `shouldSatisfy` (not . null)
+
+    it "packages an open-input diagram as a circuit with an entry port" $ do
+      compiled <- requireRight (compileWireText paperOpenInputSourceText)
+      compiled.compiledCircuitEntryNodes `shouldBe` [CircuitNodeRef "sink"]
+      expectWireAdmissionArtifact compiled $ \artifact ->
+        fmap (.admissionBoundaryPort) artifact.wireAdmissionEntries `shouldBe` ["x"]
+
+    it "rejects two outputs sharing one key against one input (fan-in)" $
+      compileWireText paperFanInSameKeySourceText
+        `shouldSatisfy` isWireParseFailureContaining "would merge multiple output endpoints"
+
+    it "rejects one output against two inputs sharing one key (fan-out)" $
+      compileWireText paperFanOutSameKeySourceText
+        `shouldSatisfy` isWireParseFailureContaining "would copy output endpoint"
+
+    it "rejects same-key multiplicity above one on both sides" $
+      compileWireText paperTwoTwoSameKeySourceText
+        `shouldSatisfy` isWireParseFailureContaining "would copy output endpoint"
+
+    it "rejects a select whose left boundary has an exit outside the exclusive sum" $
+      compileWireText paperSelectExtraExitSourceText
+        `shouldSatisfy` isWireParseFailureContaining "exactly one exclusive output boundary"
+
+    it "compiles the three-node example with one matched key and carried frontier" $ do
+      compiled <- requireRight (compileWireText paperThreeNodeExampleSourceText)
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "source")
+        `shouldBe` Set.singleton (CircuitNodeRef "use_left")
+      expectWireAdmissionArtifact compiled $ \artifact -> do
+        Set.fromList
+          [ (boundary.admissionBoundaryNode, boundary.admissionBoundaryPort)
+          | boundary <- artifact.wireAdmissionExits
+          ]
+          `shouldBe` Set.fromList
+            [ (CircuitNodeRef "source", "right")
+            , (CircuitNodeRef "use_left", "out")
+            ]
+        artifact.wireAdmissionEntries `shouldBe` []
+
+    it "rejects an all-identity select: variant shapes cannot converge" $
+      -- Identity arms expose their variant at the common boundary; distinct port
+      -- names give distinct labels, so an all-identity select never satisfies the
+      -- convergence premise. The implementation's pass-through branch for this
+      -- case sits after validation and is unreachable.
+      compileWireText paperAllIdentitySelectSourceText
+        `shouldSatisfy` isWireParseFailureContaining "does not converge"
+
 simpleChainSourceText :: T.Text
 simpleChainSourceText =
   T.unlines
@@ -4336,6 +4413,173 @@ selectContractFallbackSourceText =
     , "  ResearchPlan: (),"
     , "  PlanIssue: (gather_missing_constraints => repair_plan)"
     , ") => publish_report"
+    ]
+
+paperBuildPipelineSourceText :: T.Text
+paperBuildPipelineSourceText =
+  T.unlines
+    [ "node source"
+    , "  -> src: Sources = @demo.source ({});"
+    , "node config"
+    , "  -> cfg: BuildConfig = @demo.config ({});"
+    , "node build"
+    , "  <- src: Sources;"
+    , "  <- cfg: BuildConfig;"
+    , "  -> bin: Binary = {"
+    , "    src = src;"
+    , "  };"
+    , "  -> log: BuildLog = {"
+    , "    cfg = cfg;"
+    , "  };"
+    , "node package"
+    , "  <- bin: Binary;"
+    , "  -> pkg: Package = {"
+    , "    bin = bin;"
+    , "  };"
+    , "source <> config => build => package"
+    ]
+
+paperBuildPipelineFanOutSourceText :: T.Text
+paperBuildPipelineFanOutSourceText =
+  T.unlines
+    [ "node source"
+    , "  -> src: Sources = @demo.source ({});"
+    , "node config"
+    , "  -> cfg: BuildConfig = @demo.config ({});"
+    , "node build"
+    , "  <- src: Sources;"
+    , "  <- cfg: BuildConfig;"
+    , "  -> bin: Binary = {"
+    , "    src = src;"
+    , "  };"
+    , "  -> log: BuildLog = {"
+    , "    cfg = cfg;"
+    , "  };"
+    , "node package"
+    , "  <- bin: Binary;"
+    , "  -> pkg: Package = {"
+    , "    bin = bin;"
+    , "  };"
+    , "node archive"
+    , "  <- bin: Binary;"
+    , "  -> arc: Archive = {"
+    , "    bin = bin;"
+    , "  };"
+    , "source <> config => build => package <> archive"
+    ]
+
+paperOpenInputSourceText :: T.Text
+paperOpenInputSourceText =
+  T.unlines
+    [ "node sink"
+    , "  <- x: Thing;"
+    , "  -> y: Out = {"
+    , "    x = x;"
+    , "  };"
+    , "sink"
+    ]
+
+paperFanInSameKeySourceText :: T.Text
+paperFanInSameKeySourceText =
+  T.unlines
+    [ "node alpha"
+    , "  -> v: K = @demo.alpha ({});"
+    , "node beta"
+    , "  -> v: K = @demo.beta ({});"
+    , "node gamma"
+    , "  <- v: K;"
+    , "  -> out: Done = {"
+    , "    v = v;"
+    , "  };"
+    , "alpha <> beta => gamma"
+    ]
+
+paperFanOutSameKeySourceText :: T.Text
+paperFanOutSameKeySourceText =
+  T.unlines
+    [ "node alpha"
+    , "  -> v: K = @demo.alpha ({});"
+    , "node gammaOne"
+    , "  <- v: K;"
+    , "  -> out: DoneOne = {"
+    , "    v = v;"
+    , "  };"
+    , "node gammaTwo"
+    , "  <- v: K;"
+    , "  -> res: DoneTwo = {"
+    , "    v = v;"
+    , "  };"
+    , "alpha => gammaOne <> gammaTwo"
+    ]
+
+paperTwoTwoSameKeySourceText :: T.Text
+paperTwoTwoSameKeySourceText =
+  T.unlines
+    [ "node alpha"
+    , "  -> v: K = @demo.alpha ({});"
+    , "node beta"
+    , "  -> v: K = @demo.beta ({});"
+    , "node gammaOne"
+    , "  <- v: K;"
+    , "  -> out: DoneOne = {"
+    , "    v = v;"
+    , "  };"
+    , "node gammaTwo"
+    , "  <- v: K;"
+    , "  -> res: DoneTwo = {"
+    , "    v = v;"
+    , "  };"
+    , "alpha <> beta => gammaOne <> gammaTwo"
+    ]
+
+paperSelectExtraExitSourceText :: T.Text
+paperSelectExtraExitSourceText =
+  T.unlines
+    [ "node draft_plan"
+    , "  -> draft: DraftPlan = @review.plan ({});"
+    , "node validate_plan"
+    , "  <- draft: DraftPlan;"
+    , "  -> ok: ResearchPlan | issue: PlanIssue;"
+    , "  = @review.validate_plan (draft);"
+    , "node side"
+    , "  -> extra: SideChannel = @demo.side ({});"
+    , -- Parenthesized: select binds tighter than <>, and the claim under test
+      -- is a select over the composite boundary (sum plus an extra exit).
+      "draft_plan => (validate_plan <> side) select("
+    , "  ok: (),"
+    , "  issue: ()"
+    , ")"
+    ]
+
+paperAllIdentitySelectSourceText :: T.Text
+paperAllIdentitySelectSourceText =
+  T.unlines
+    [ "node draft_plan"
+    , "  -> draft: DraftPlan = @review.plan ({});"
+    , "node validate_plan"
+    , "  <- draft: DraftPlan;"
+    , "  -> ok: ResearchPlan | issue: PlanIssue;"
+    , "  = @review.validate_plan (draft);"
+    , "draft_plan => validate_plan select("
+    , "  ok: (),"
+    , "  issue: ()"
+    , ")"
+    ]
+
+paperThreeNodeExampleSourceText :: T.Text
+paperThreeNodeExampleSourceText =
+  T.unlines
+    [ "contract A;"
+    , "contract B;"
+    , "contract C;"
+    , "node source"
+    , "  -> left: A;"
+    , "  -> right: B;"
+    , "  = @demo.source ({});"
+    , "node use_left"
+    , "  <- left: A;"
+    , "  -> out: C = @demo.use_left (left);"
+    , "source => use_left"
     ]
 
 threeArmSelectSourceText :: T.Text


### PR DESCRIPTION
## Summary

Publications portfolio overhaul following the DIALOCO'26 review cycle, centered on a new flagship paper.

- **Paper 7 (new flagship): "A Keyed Frontier Calculus for Executable Open Graphs"** — complete draft. Core typing rules (T-Empty/T-Node/T-Overlay/T-Connect with direction-erased match keys), derived forms as certified elaborations, forgetful lowering, latent/actualized split, nine-row metatheory table with explicit open columns, related-work section that kills nearest neighbors first (interaction nets, bigraphs, wiring diagrams), and an artifact appendix. Hardened through an independent code re-derivation gate, a POPL-level three-lens adversarial review with executable falsification, a seven-lens readability/novelty pass, and two conformance reviews.
- **Paper claims bound to the compiler**: 9 new tests ("frontier calculus paper claims" in `CompileSpec`) pin the manuscript's operational claims — worked-pipeline topology, carrying, fan-in/fan-out rejections, open-frontier packaging, select premises — as permanent regressions. Two paper claims were falsified by execution during review and corrected (closedness as property not requirement; all-identity select rejection).
- **Paper 1 absorbs Paper 2**: algebra section, monoid action, forward-fragment order, extension-boundary tables merged into the staged-reduction paper; Paper 2 marked superseded.
- **Paper 6 rewritten self-contained** per the DIALOCO reviews, with the closedness and match-key corrections propagated.
- **Portfolio hygiene**: shared glossary (single admitted referent, port linearity, latent/actualized), index/roadmap refresh, claims policy, mined-contributions inventory.

## Verification

- `just check` green; `just docs-check` green; 9 paper-claims tests green within the full suite.
- All cited Lean theorem names verified against `theory/`; zero axioms/sorries.
- Commit provenance checked over the full range.

Pre-submission follow-ups are tracked in #245.