### PR TITLE
feat(wire): canonicalize the artifact boundary field as artifactKind

### DIFF
--- a/docs/Reference/Wire/configured-executors-and-execution-boundary.md
+++ b/docs/Reference/Wire/configured-executors-and-execution-boundary.md
@@ -54,6 +54,26 @@ executor is still only staged authority. The node body exists only after a decla
 typed boundary; the executor argument is ingress adaptation, and output validation/wrapping is
 egress adaptation.
 
+## Boundary Node Fields
+
+Two reserved config fields select special boundary node forms instead of plain task nodes:
+
+- `on = "signal-name"` declares a signal boundary: the node parks until the named signal is
+  delivered.
+- `artifactKind = "report"; to = artifacts.reports;` declares an artifact boundary: the node
+  persists its input as an artifact of the given kind at the target reference. Both fields are
+  required together.
+
+```wire
+node persist_report
+  <- report: ReportArtifact;
+  = @artifact.store { artifactKind = "report"; to = artifacts.reports; } (report);
+```
+
+`artifactKind` is the canonical field name. `kind` is a Wire keyword (kind declarations), so it is
+not writable as a config field name in source; the compiler keeps a `kind` lookup fallback only for
+field maps constructed outside the parser.
+
 ## Evaluation Boundary
 
 Wire type-checking admits graph values with open boundaries. Runtime preparation is stricter:

--- a/src/Cortex/Wire/Compile.hs
+++ b/src/Cortex/Wire/Compile.hs
@@ -2974,7 +2974,11 @@ loweredNodeFromExecutorCall compileEnv st nodeRef ports whereExpr executorCallVa
       runtimePorts = taskWirePortsFromLowered ports
       executorId = configuredExecutor.ceExecutorId
       maybeSignal = lookupMaybeTextField "on" exactFields
-      maybeKind = lookupMaybeTextField "kind" exactFields
+      -- `artifactKind` is the canonical field; `kind` stays accepted as a
+      -- deprecated alias because kinds are already a Wire language concept.
+      maybeArtifactKind =
+        lookupMaybeTextField "artifactKind" exactFields
+          <|> lookupMaybeTextField "kind" exactFields
       maybeTarget = lookupMaybeQNameField "to" exactFields
   validateStdIoExecutorShape nodeRef executorId runtimePorts
   compiledNode <- case () of
@@ -2997,8 +3001,12 @@ loweredNodeFromExecutorCall compileEnv st nodeRef ports whereExpr executorCallVa
                       (normalFormPorts normalForm)
                       (lookupMaybeInt32Field "timeout" exactFields)
                 }
-      | isJust maybeKind || isJust maybeTarget -> do
-          artifactKind <- requireTextField nodeRef "kind" exactFields
+      | isJust maybeArtifactKind || isJust maybeTarget -> do
+          artifactKind <-
+            maybe
+              (Left (WireCore.WireMissingRequiredField nodeRef "artifactKind"))
+              Right
+              maybeArtifactKind
           targetRef <- requireQNameField nodeRef "to" exactFields
           let normalForm =
                 artifactNodeBoundaryNormalForm
@@ -3093,6 +3101,7 @@ loweredNodeFromExecutorCall compileEnv st nodeRef ports whereExpr executorCallVa
       , "maxOutputTokens"
       , "reasoningEnabled"
       , "on"
+      , "artifactKind"
       , "kind"
       , "to"
       ]

--- a/test/Cortex/Wire/CompileSpec.hs
+++ b/test/Cortex/Wire/CompileSpec.hs
@@ -26,7 +26,7 @@ import Numeric.Natural (Natural)
 import Test.Hspec
 
 import Cortex.Algebra.Graph (successors)
-import Cortex.Wire (Connection (..), EndpointRef (..), WirePayloadKind (..))
+import Cortex.Wire (Connection (..), EndpointRef (..), WirePayloadKind (..), renderWireError)
 import Cortex.Wire.AdmissionArtifact
   ( AdmissionBoundaryPort (..)
   , AdmissionConnection (..)
@@ -63,7 +63,11 @@ import Cortex.Wire.Circuit.Artifact
   , CompiledCircuitFragment (..)
   , CompiledCircuitNode (..)
   )
-import Cortex.Wire.Circuit.IR (CircuitNodeRef (..), CircuitTaskNode (..))
+import Cortex.Wire.Circuit.IR
+  ( CircuitArtifactBoundary (..)
+  , CircuitNodeRef (..)
+  , CircuitTaskNode (..)
+  )
 import Cortex.Wire.Compile
   ( compileWireFragmentText
   , compileWireFragmentTextWithEnv
@@ -3272,6 +3276,23 @@ spec = describe "Cortex.Wire.Compile" $ do
       compileWireTextWithEnv knownContractsEnv typoContractSourceText
         `shouldBe` Left (WireUnknownContract "node ports" "PlannerOuput")
 
+  describe "artifact boundary nodes" $ do
+    it "compiles the canonical artifactKind field" $ do
+      compiled <- requireRight (compileWireText (artifactBoundarySourceText "artifactKind"))
+      artifactBoundaryKind compiled `shouldBe` Just "report"
+
+    it "rejects the reserved word kind as a config field name at parse time" $
+      -- `kind` is a Wire keyword (kind declarations), so the legacy field
+      -- spelling was never reachable from source text; the lowering keeps a
+      -- lookup fallback for field maps built outside the parser.
+      compileWireText (artifactBoundarySourceText "kind")
+        `shouldSatisfy` isLeft
+
+    it "names artifactKind in the missing-field error" $
+      case compileWireText (artifactBoundarySourceTextWith "") of
+        Left err -> renderWireError err `shouldSatisfy` T.isInfixOf "artifactKind"
+        Right _compiled -> expectationFailure "expected a missing-field error"
+
   describe "executor projections" $ do
     it "allows a strict registered executor projection with matching ports" $
       compileWireTextWithEnv strictExecutorEnv projectedExecutorSourceText
@@ -5161,6 +5182,27 @@ expectTaskExecutorTarget compiled expectedTarget ref =
     other ->
       expectationFailure ("expected task node " <> show ref <> ", got: " <> show other)
 
+artifactBoundarySourceText :: T.Text -> T.Text
+artifactBoundarySourceText fieldName =
+  artifactBoundarySourceTextWith (fieldName <> " = \"report\";")
+
+artifactBoundarySourceTextWith :: T.Text -> T.Text
+artifactBoundarySourceTextWith kindFields =
+  T.unlines
+    [ "node make_report"
+    , "  -> report: ReportArtifact = @report.build ({}) ;"
+    , "node persist_report"
+    , "  <- report: ReportArtifact ;"
+    , "  = @artifact.store { " <> kindFields <> " to = artifacts.reports; } (report) ;"
+    , "make_report => persist_report"
+    ]
+
+artifactBoundaryKind :: CompiledCircuit -> Maybe T.Text
+artifactBoundaryKind compiled =
+  case [boundary | CompiledCircuitArtifact boundary <- Map.elems compiled.compiledCircuitNodes] of
+    [boundary] -> Just boundary.circuitArtifactKind
+    _boundaries -> Nothing
+
 requireRight :: Show err => Either err a -> IO a
 requireRight = \case
   Left err ->
@@ -6201,6 +6243,9 @@ isRight :: Either err ok -> Bool
 isRight = \case
   Right _ -> True
   Left _ -> False
+
+isLeft :: Either err ok -> Bool
+isLeft = not . isRight
 
 isParseFailure :: Either WireError ok -> Bool
 isParseFailure = \case


### PR DESCRIPTION
## Summary

Canonicalizes the artifact boundary node's kind field as `artifactKind`, closing #256 and unblocking the downstream patch deletion + pin bump.

## The discovery that reframed the issue

The issue was filed as "upstream the downstream alias." Implementing it surfaced the real story: **the documented `kind` field was never writable from Wire source at all** — `kind` is a Wire keyword (kind declarations), and the parser rejects it as a config field name. The compile path requiring `kind` was unreachable from source text, which is why it had zero tests, zero docs, and zero in-repo usage, and why the only known artifact-boundary author (Portman) carried a Nix patch introducing `artifactKind` — not as a preference, but as the only way to express the field.

## Changes

- `Compile.hs`: the artifact boundary branch keys on `artifactKind` (with a `kind` lookup fallback kept for field maps constructed outside the parser); the missing-field error names `artifactKind`; `artifactKind` joins the known-fields list.
- `docs/Reference/Wire/configured-executors-and-execution-boundary.md`: new "Boundary Node Fields" section — first reference documentation for the signal (`on`) and artifact (`artifactKind` + `to`) boundary field forms, including the keyword-collision note.
- `CompileSpec`: first compile tests for artifact boundary nodes — canonical field compiles to `circuitArtifactKind`, missing-field error names `artifactKind`, and a test documenting that `kind` as a config field is a parse error.

## Downstream coordination (per #256 and the 2026-06-11 handoff)

After this lands, Portman: delete `nix/patches/cortex-wire-artifact-kind-alias.patch`, bump the pin from `17984f7` (checking `03e625c`'s nested-indexed-product rejection against Portman wires first), and expect the nested-select canary to keep passing (that limitation is #255, unchanged here).

## Verification

771 examples green (4 new), lint no hints, fmt-check, docs-check, library build, provenance verified.

Closes #256
