### PR TITLE
docs(adr): split rewrite admission into witnessed materialization vs open gas

### DIFF
--- a/docs/ADRs/0036-wire-latent-branch-budget-recovery.md
+++ b/docs/ADRs/0036-wire-latent-branch-budget-recovery.md
@@ -10,6 +10,8 @@ status: proposed
 date: 2026-04-29
 superseded_by: null
 related:
+  - docs/ADRs/0057-wire-latent-branch-witnessing-and-closure-charging.md
+  - docs/ADRs/0056-admission-modes-witnessed-and-gas.md
   - docs/Architecture/07-rewrites-and-materialization.md
   - docs/Reference/rewrites.md
   - docs/Reference/Wire/conditionality.md
@@ -30,8 +32,12 @@ related:
 
 ## Status
 
-Proposed - documents the current selected-branch policy and separates it from possible reserved
-capacity policies.
+Proposed - documents the current selected-branch gas policy and separates it from possible reserved
+capacity policies. A proposed successor,
+[ADR 0057 - Latent Branch Witnessing and Proposal Closure Charging](0057-wire-latent-branch-witnessing-and-closure-charging.md),
+would replace this policy by witnessing author selects and charging open-introduced selects to gas
+at the admission boundary; that supersession takes effect only when ADR 0057 is accepted. Until then
+this ADR remains the active selected-cost policy.
 
 ## Context
 

--- a/docs/ADRs/0056-admission-modes-witnessed-and-gas.md
+++ b/docs/ADRs/0056-admission-modes-witnessed-and-gas.md
@@ -1,0 +1,172 @@
+---
+title: "ADR 0056 - Admission Modes: Witnessed Materialization and Open Rewrite Gas"
+description:
+  "Splits topology admission into compile-witnessed materialization (asserted, never
+  operator-gassed) and open rewrite gas (tunable, rejectable), discriminated by provenance and the
+  admission boundary at which the shape is fixed."
+sidebar:
+  label: "0056. Witnessed vs gas admission"
+  order: 56
+status: proposed
+date: 2026-06-14
+superseded_by: null
+related:
+  - docs/Architecture/06-pulse-runtime.md
+  - docs/Architecture/07-rewrites-and-materialization.md
+  - docs/Reference/rewrites.md
+  - docs/ADRs/0005-budgeted-rewrite-admission-and-materialization.md
+  - docs/ADRs/0009-rewrite-provenance-and-topology-integrity.md
+  - docs/ADRs/0036-wire-latent-branch-budget-recovery.md
+  - docs/ADRs/0037-wire-latent-structural-control.md
+  - docs/ADRs/0048-wire-make-bounded-node-generation.md
+  - docs/ADRs/0050-wire-corepure-output-residue.md
+  - docs/ADRs/0055-pulse-runtime-bounded-iteration.md
+  - docs/ADRs/0057-wire-latent-branch-witnessing-and-closure-charging.md
+  - "GitHub #181"
+---
+
+# ADR 0056 - Admission Modes: Witnessed Materialization and Open Rewrite Gas
+
+## Status
+
+Proposed - refines ADR 0005. ADR 0005 remains canon; this ADR narrows the meaning of rewrite gas and
+introduces a second admission mode beside it. It does not edit ADR 0005.
+
+## Context
+
+Rewrite gas (ADR 0005) was introduced to bound runtime topology proposed by an executor — originally
+an LLM/planner node — so an agent cannot grow the graph without limit. That is a real and wanted
+safety feature.
+
+Since then the same five-dimensional gas account has become the _universal_ admission gate. Every
+runtime materialization — including structure whose worst-case shape is already fixed before the run
+— flows through `admitRewriteDelta` against one shared, operator-tunable pool. Consequences observed
+in the live system:
+
+- A `select` whose branch family is compile-bounded still debits the shared pool when its chosen arm
+  actualizes (`lowerConditionNode`), so operators can be forced to raise gas just to let a provably
+  finite graph run, and a statically valid shape can fail with `rewrite_budget_exceeded`.
+- Admission is asymmetric by accident: an absent `else` arm completes for free (`StageComplete`),
+  while every productive arm debits gas — "do nothing" is free only via one code path.
+- Runtime-bounded iteration (ADR 0055) would multiply the conflation: a `select` inside a fixed
+  kernel would redraw structural budget every turn for a shape that is fixed per turn.
+
+The underlying error is using a _gate_ (which can reject) for shapes that need only a _metric_
+(which reports). The right discriminator is not static-vs-runtime, and not bare knowability either;
+it is **provenance and the admission boundary**: who fixes the worst-case shape — the compiler, or
+an open producer — and at which boundary.
+
+## Decision
+
+Topology admission has two modes, chosen by **provenance and the boundary at which the shape is
+fixed** — not by bare knowability. An open proposal also becomes knowable once the producer returns
+it, yet it is still gassed; only author/compiler provenance makes structure witnessed.
+
+**Witnessed materialization.** Structure whose worst-case shape is fixed by the compiler carries a
+`StructuralWitness`. Materialization _asserts_ its cost is within the witness; it cannot be rejected
+by operator gas. Its cost is recorded and surfaced as an operator metric, never as an admission
+gate. Covers author-static graphs, `make(N, K)` and forms (ADR 0048), and author-written `select`
+branch families (charging detailed in ADR 0057). The witnessed substructure inside an admitted open
+proposal is also asserted this way — after the proposal's one-time gas charge has already paid for
+it.
+
+**Open rewrite gas.** Structure whose shape is unknowable before run — executor/planner/LLM topology
+proposals — is admitted against the operator-tunable five-dimensional gas of ADR 0005. Fail-fast and
+rejectable. This is exactly, and only, what gas is for.
+
+The two modes are joined by one invariant:
+
+> Gas is charged **once, at the admission boundary, over the static/witnessed closure already fixed
+> in the admitted structure** — the directly added topology plus the worst-case witness of any
+> witnessed sub-structure (e.g. selects) the compiled structure already contains. After that single
+> charge, witnessed actualization is **gas-neutral**. The charge does **not** reach through nodes
+> that carry open rewrite authority: those are themselves open producers, gas-admitted again at
+> their own boundaries. Open authority chains across boundaries, each charged once for its own
+> static closure.
+
+This is what keeps witnessed mode from becoming a laundering hole (an open proposal smuggling heavy
+latent branches in cheaply) without overreaching into unknowable future proposals (which cannot be
+priced up front). The closure rule for the `select` case is specified in ADR 0057.
+
+## Mental Model
+
+The discriminator is **provenance and boundary**, not bare knowability — an open proposal also
+becomes knowable once the producer returns it, but it is still gassed.
+
+| Who fixes the shape, and where              | Mechanism                   | Owner         | Can operator gas reject it? |
+| ------------------------------------------- | --------------------------- | ------------- | --------------------------- |
+| author source / compiler-minted             | structural witness          | Wire compiler | no — asserted, metered      |
+| an open producer, at its admission boundary | open rewrite gas            | Pulse         | yes — fail-fast             |
+| repeated execution under a cap              | iteration budget (ADR 0055) | Pulse         | yes — exhaustion            |
+
+"Gas" names only the middle row, and it is paid **once per admission boundary** over that boundary's
+static closure (ADR 0057). A structure being "known after the producer returned it" does not make it
+witnessed — only author/compiler provenance does. Compile-bounded shape is witnessed, not gassed.
+Iteration is a distinct budget. CorePure stays total (ADR 0050) — no fourth budget is introduced
+here.
+
+## Boundary Rules
+
+- A **witness** is derived by the compiler (or by compiling an admitted proposal) and is not
+  operator-tunable. Raising or lowering operator gas never changes whether a witnessed shape admits.
+- **Open authority chains; it does not nest into one charge.** A node introduced by an open producer
+  that itself carries open rewrite authority is a new open producer. Its future proposals are
+  gas-admitted at their own boundaries; the introducing proposal's charge covers only its own static
+  closure, never structure that does not yet exist.
+- **Cost is always recorded**; mode decides only whether cost _gates_. Run-wide structural cost may
+  be surfaced as a metric without ever rejecting.
+- **Recovery is mode-aware.** Gas is reconstructed by summing **admission events** (one per admitted
+  open boundary), not by re-subtracting every materialized row. Witnessed actualizations replay
+  gas-neutral. Persisted rewrite rows must carry their admission mode and, for gas-charged
+  structure, a reference to the owning admission event, so replay neither re-debits nor loses
+  provenance. ADR 0057 pins the admission-event contract (identity, persistence point,
+  one-per-boundary, linkage).
+- A **witnessed actualization** fails only on compiler/runtime drift (stale artifact, invalid
+  registry, single-use/owner violation), never on "operator gas too low."
+
+## Consequences
+
+### Positive
+
+- Static and compile-bounded graphs never require gas tuning to run.
+- Gas returns to its original scope: bounding unknowable, agent-authored topology.
+- The same witness/gas discipline is reusable by ADR 0055 iteration (the `loopRewrites` question
+  becomes "does the kernel propose _open_ topology?").
+
+### Negative
+
+- Two admission modes instead of one uniform gate.
+- Recovery becomes lineage-driven (admission events own gas debits) rather than row-subtraction.
+- The proof track must restate the select-consumes-gas theorems (see ADR 0057); accounting laws that
+  quantify over the budget abstractly survive.
+
+### Obligations
+
+- Define a `StructuralWitness` carrier and a witnessed-vs-gas admission-mode tag on persisted
+  rewrites.
+- Make `resume` reconstruct open gas from admission events and replay witnessed actualizations
+  gas-neutral.
+- Theory: restate `Select.lean` consume theorems for witnessed mode; confirm `BoundaryResource`
+  accounting laws (budget-generic) are unaffected; track names in ADR 0038's ledger.
+- Docs: update Architecture 07 and `rewrites.md` to distinguish witnessed cost from gas admission.
+
+## Alternatives considered
+
+- **Keep one universal gas gate** - rejected; it forces operators to tune a safety throttle to admit
+  provably finite shapes and entangles every new budget surface.
+- **Make witnessed structure free with no metric** - rejected; loses operator visibility into graph
+  size.
+- **Make everything witnessed** - rejected; open agent-authored topology is genuinely unknowable
+  before run and must remain rejectable.
+
+## Related
+
+- [0005 - Budgeted Rewrite Admission and Materialization](0005-budgeted-rewrite-admission-and-materialization.md)
+- [0009 - Rewrite Provenance and Topology Integrity](0009-rewrite-provenance-and-topology-integrity.md)
+- [0036 - Latent Branch Budget and Recovery Policy](0036-wire-latent-branch-budget-recovery.md)
+- [0037 - Wire Latent Structural Control Operators](0037-wire-latent-structural-control.md)
+- [0048 - Wire Compile-Time Make for Bounded Node Generation](0048-wire-make-bounded-node-generation.md)
+- [0050 - Wire CorePure Output Residue](0050-wire-corepure-output-residue.md)
+- [0055 - Pulse Runtime-Bounded Iteration](0055-pulse-runtime-bounded-iteration.md)
+- [0057 - Latent Branch Witnessing and Proposal Closure Charging](0057-wire-latent-branch-witnessing-and-closure-charging.md)
+- [Architecture 07 - Rewrites and Materialization](../Architecture/07-rewrites-and-materialization.md)

--- a/docs/ADRs/0057-wire-latent-branch-witnessing-and-closure-charging.md
+++ b/docs/ADRs/0057-wire-latent-branch-witnessing-and-closure-charging.md
@@ -1,0 +1,185 @@
+---
+title: "ADR 0057 - Latent Branch Witnessing and Proposal Closure Charging"
+description:
+  "Applies ADR 0056's admission modes to select/latent branches: author selects are witnessed at the
+  componentwise max of the planned actualization delta and asserted per-site; open proposals charge
+  their static branch closure to gas at admission. Proposes to supersede ADR 0036 on acceptance."
+sidebar:
+  label: "0057. Latent witness & closure charge"
+  order: 57
+status: proposed
+date: 2026-06-14
+superseded_by: null
+related:
+  - docs/ADRs/0056-admission-modes-witnessed-and-gas.md
+  - docs/ADRs/0005-budgeted-rewrite-admission-and-materialization.md
+  - docs/ADRs/0007-latent-branch-conditional-lowering.md
+  - docs/ADRs/0009-rewrite-provenance-and-topology-integrity.md
+  - docs/ADRs/0033-wire-select-guarded-affine-collapse.md
+  - docs/ADRs/0034-wire-pure-select-actualization-authority.md
+  - docs/ADRs/0036-wire-latent-branch-budget-recovery.md
+  - docs/ADRs/0038-wire-proof-track-theorem-ledger.md
+  - docs/Architecture/07-rewrites-and-materialization.md
+  - docs/Reference/Wire/conditionality.md
+  - docs/Reference/rewrites.md
+  - "GitHub #99"
+---
+
+# ADR 0057 - Latent Branch Witnessing and Proposal Closure Charging
+
+## Status
+
+Proposed - depends on ADR 0056. Proposes to supersede ADR 0036, which documented the current
+selected-branch gas policy and explicitly deferred the capacity question; this ADR answers it. The
+supersession takes effect only on acceptance of this ADR; until then ADR 0036 remains the active
+policy.
+
+## Context
+
+ADR 0036 (proposed) records today's behavior: a selected branch actualizes through an ordinary
+admitted rewrite and consumes shared gas; unselected branches are free; no compiled branch is
+guaranteed admissible, because earlier rewrites can exhaust the pool first.
+
+Under ADR 0056, author-written selects are compile-bounded and belong in _witnessed_ mode, not gas.
+But selects are not always author-written: an open proposal (LLM/planner) can introduce a condition
+node whose branches are LLM-authored Wire. Verified current behavior:
+
+- A proposal is fully compiled to a `CompiledCircuit` before admission
+  (`compileWireAppendProposalWithEnv`); the closure is therefore computable from existing data, no
+  new compile stage.
+- The proposal's gas cost counts the condition node as one node; its latent then/else fragments
+  materialize _later_ via the condition's own `StageRewrite ... AppendAfter` (`lowerConditionNode`),
+  so they are not in the proposal's admitted delta.
+
+So a blanket "selects are witnessed/free" rule would let an open proposal add a cheap condition and
+actualize an arbitrarily heavy branch for free — a gas-laundering hole that defeats the feature gas
+exists for. Provenance must decide.
+
+## Decision
+
+**Author / compile-bounded selects are witnessed.** The witness of a select is the **componentwise
+max, over its arms, of the fully planned actualization delta at that select site** — not merely each
+branch fragment's internal nodes and edges. The planned `AppendAfter` delta for an arm includes its
+anchor-to-entry edges, exit-to-successor edges, added depth, frontier delta, and rewrite op; the
+witness takes the per-dimension maximum across arms of that full `RewriteCost`. Defining it on the
+planned delta rather than the fragment interior is what prevents an implementation from
+undercounting the wiring and reopening the laundering problem. The identity/empty arm contributes a
+zero delta (already `StageComplete` today, now made principled and symmetric). Nested selects
+recurse (an arm's planned delta includes the witness of any select within it); serial selects on a
+path sum their per-site witnesses; statically parallel branches that both run add. Actualization
+_asserts_ the chosen arm's planned delta is within the family witness and is **gas-neutral**.
+
+**Open-introduced selects charge their static closure at admission.** When an open proposal is
+admitted, its gas charge MUST include the **recursive static witness envelope of the admitted
+`CompiledCircuit`** — the same rule used for a single select above, applied to the whole compiled
+proposal: serial path costs add, statically parallel branches add, select alternatives take the
+componentwise max, and a nested select's witness enters only through the arm or path that contains
+it. This is an envelope, not a sum over select sites: mutually exclusive arms are maxed, never added
+(per the sum-prepay rejection below). After that single charge, those inner selects actualize
+gas-neutral. The closure is bounded to what the compiled proposal already fixes; it does **not**
+reach through nodes the proposal introduces that themselves carry open rewrite authority. Such a
+node is simply another open producer: any future `StageRewrite` it emits is separately gas-admitted
+at its own admission boundary, charged over its own static closure. Open authority therefore chains
+across boundaries — each boundary charged exactly once for its own compiled structure — and the
+global bound is the sum of per-boundary charges, not a single up-front number.
+
+**What gates vs. what reports.** Two distinct quantities, and they must not be conflated. The
+**per-boundary closure envelope** of an open proposal (and each author-select's family witness)
+**gates**: it is debited against the budget at its admission boundary and can reject. The
+**run-wide** worst-reachable-static-path figure **reports**: it is operator-facing accounting, never
+an admission object, never debited. An implementer must not treat the per-boundary open-proposal
+envelope as merely informational — it is the charge that gates; only the aggregate run-wide total is
+informational.
+
+**Admission events own gas; recovery replays from them.** The durable unit of gas accounting is the
+**admission event** — exactly one per admitted open boundary (one per admitted open
+rewrite/proposal), written **in the same transaction** that admits the proposal and debits its
+closure-envelope cost. Each admission event carries: a stable admission id, the boundary it
+admitted, and the gas it debited. Witnessed actualizations (author selects, and the latent branches
+a charged proposal introduced) create **no** admission event — they are gas-neutral — but every
+persisted actualization/rewrite row records an `admission mode` and, for gas-charged structure, a
+reference to the **owning admission event**. Recovery therefore reconstructs remaining gas by
+**summing admission events**, never by re-subtracting every materialized row (the ADR 0036 model): a
+witnessed actualization replayed on resume is gas-neutral and links back to the admission event that
+already paid for it, so replay can neither re-debit nor lose provenance. (Implementation: the
+rewrite re-admission on resume in `Executor/Resume.hs`.)
+
+**Failure semantics.** A witnessed branch actualization can fail only on compiler/runtime drift
+(stale artifact, invalid registry, single-use/owner violation), not on "operator gas too low."
+
+## Examples
+
+### Author select
+
+`required_evidence_gate select(...)` has two arms compiled from source. Its witness is the heavier
+arm. Whichever arm the runtime selects, materialization asserts the selected cost is within that
+witness and debits no operator gas. An operator never tunes gas to let this run; raising or lowering
+gas cannot change whether it admits.
+
+### Open proposal introducing a select
+
+An LLM append proposal compiles to a `CompiledCircuit` containing a condition node with two branch
+fragments. Admission charges the static closure: the directly appended nodes plus the
+componentwise-max planned actualization delta of the two arms. After that single debit, the branch
+actualizes gas-neutral when the condition fires. The LLM cannot add a cheap condition now and
+actualize a heavy branch for free later.
+
+### Open proposal introducing a further open producer
+
+A proposal introduces a node that carries propagated rewrite authority (in Portman terms,
+`propagateRewriteAuthority = true`) — it may itself later propose topology. Admission charges only
+this proposal's static closure; the introduced node's future proposals are not charged now, because
+their shape is not yet fixed. Each such future proposal is gas-admitted at its own boundary over its
+own static closure. The run-wide bound is the sum of per-boundary charges.
+
+### Nested select on a path
+
+`a => select(...) => select(...)`: each site asserts against its own family witness. The run-wide
+metric reports the sum of the two per-site witnesses as the worst reachable static path, but
+enforcement remains per-site; there is no global gas object.
+
+## Consequences
+
+### Positive
+
+- A compiled author select can always actualize within its witness; no operator tuning, no
+  `rewrite_budget_exceeded` on a provably finite branch family.
+- The laundering hole is closed: open structure pays its full closure once, upfront.
+- Answers ADR 0036's deferred capacity question: a witnessed per-family bound (the componentwise max
+  of arms' planned deltas), asserted — the guarantee without escrow accounting.
+
+### Negative
+
+- A closure-cost pass over admitted proposals is required (cheap; data already exists).
+- Persisted rewrite rows gain an admission-mode and charging-event reference; resume changes
+  accordingly.
+
+### Obligations
+
+- Implement closure-witness folding over `CompiledCircuit` at proposal admission.
+- Add admission-mode and charging-event lineage to persisted rewrites; make resume mode-aware.
+- Theory: restate `Select.lean` `selectActualize_consumes_selected_cost` and siblings as "chosen-arm
+  cost is within the family witness; open gas unchanged"; confirm graph-preservation,
+  branch-disjointness, and namespacing theorems survive; record in ADR 0038's ledger.
+- Docs: update Architecture 07, `rewrites.md`, and `conditionality.md` to witnessed semantics.
+
+## Alternatives considered
+
+- **Keep ADR 0036 selected-cost-gas** - rejected; it is the design debt (tuning gas for finite
+  shapes).
+- **Blanket-free selects** - rejected; gas-laundering via open-introduced selects.
+- **Sum-prepay all branches** - rejected (per ADR 0036; charges mutually exclusive futures).
+- **Max-escrow reservation of branch capacity** - deferred; witnessed assertion gives the guarantee
+  without a new escrow account.
+
+## Related
+
+- [0056 - Admission Modes: Witnessed Materialization and Open Rewrite Gas](0056-admission-modes-witnessed-and-gas.md)
+- [0005 - Budgeted Rewrite Admission and Materialization](0005-budgeted-rewrite-admission-and-materialization.md)
+- [0007 - Latent Branch Conditional Lowering](0007-latent-branch-conditional-lowering.md)
+- [0033 - Wire Select as Guarded Affine Collapse](0033-wire-select-guarded-affine-collapse.md)
+- [0034 - Pure Selectors and Restricted Actualization Authority](0034-wire-pure-select-actualization-authority.md)
+- [0036 - Latent Branch Budget and Recovery Policy](0036-wire-latent-branch-budget-recovery.md)
+- [0038 - Wire Proof-Track Theorem Ledger](0038-wire-proof-track-theorem-ledger.md)
+- [Architecture 07 - Rewrites and Materialization](../Architecture/07-rewrites-and-materialization.md)
+- [Wire Conditionality Reference](../Reference/Wire/conditionality.md)

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -15,63 +15,65 @@ values: `proposed`, `accepted`, `superseded`, `deprecated`.
 
 ## Current ADRs
 
-| #                                                               | Title                                                               | Status     |
-| --------------------------------------------------------------- | ------------------------------------------------------------------- | ---------- |
-| [0001](0001-structured-report-ir.md)                            | Structured Document IR                                              | superseded |
-| [0002](0002-cortex-downstream-ownership-boundary.md)            | Cortex and Downstream Ownership Boundary                            | accepted   |
-| [0003](0003-pulse-service-and-host-action-boundary.md)          | Pulse Service and Host-Action Boundary                              | accepted   |
-| [0004](0004-graph-native-pulse-execution.md)                    | Graph-Native Pulse Execution                                        | accepted   |
-| [0005](0005-budgeted-rewrite-admission-and-materialization.md)  | Budgeted Rewrite Admission and Materialization                      | accepted   |
-| [0006](0006-compiled-workflow-artifact-boundary.md)             | Compiled Workflow Artifact Boundary                                 | accepted   |
-| [0007](0007-latent-branch-conditional-lowering.md)              | Latent-Branch Conditional Lowering                                  | accepted   |
-| [0008](0008-pulse-operator-visibility-surfaces.md)              | Pulse Operator Visibility Surfaces                                  | accepted   |
-| [0009](0009-rewrite-provenance-and-topology-integrity.md)       | Rewrite Provenance and Topology Integrity                           | accepted   |
-| [0010](0010-wire-closed-authority-and-three-layer-stack.md)     | Wire as Closed-Authority Language over the Graph/Circuit/Wire Stack | accepted   |
-| [0011](0011-compatibility-barriers-and-fresh-run-recovery.md)   | Compatibility Barriers and Fresh-Run Recovery                       | accepted   |
-| [0012](0012-topological-memory-as-deterministic-graph-query.md) | Topological Memory as Deterministic Graph Query                     | accepted   |
-| [0013](0013-report-provenance-artifact-contract.md)             | Artifact Provenance Contract                                        | accepted   |
-| [0014](0014-executor-taxonomy-model-vs-external-call.md)        | Model vs External Call                                              | proposed   |
-| [0015](0015-canonical-logos-archetypes.md)                      | Canonical Logos Archetypes                                          | proposed   |
-| [0016](0016-cortex-roots-and-logos-pattern-extraction.md)       | Cortex Roots and Logos Pattern Extraction                           | proposed   |
-| [0017](0017-wire-executor-and-port-catalog-boundary.md)         | Wire Executor and Port Catalog Boundary                             | proposed   |
-| [0018](0018-canonical-haskell-module-tree.md)                   | Canonical Haskell Module Tree                                       | proposed   |
-| [0019](0019-executor-registration-and-binding.md)               | Executor Registration and Binding                                   | proposed   |
-| [0020](0020-wire-pure-output-equations.md)                      | Wire Pure Output Equations                                          | accepted   |
-| [0021](0021-wire-source-elaborates-to-circuits.md)              | Wire Source Elaborates to Circuits                                  | proposed   |
-| [0022](0022-wire-node-clause-grammar.md)                        | Wire Node Clause Grammar                                            | proposed   |
-| [0023](0023-corepure-expression-surface.md)                     | CorePure Expression Surface                                         | proposed   |
-| [0024](0024-typed-executor-node-interface.md)                   | Typed Executor Node Interface                                       | proposed   |
-| [0025](0025-configured-executor-values.md)                      | Configured Executor Values                                          | proposed   |
-| [0026](0026-wire-failure-taxonomy.md)                           | Wire Failure Taxonomy                                               | proposed   |
-| [0027](0027-typed-llm-output-binding.md)                        | Typed LLM Output Binding                                            | proposed   |
-| [0028](0028-wire-topology-composition-and-boundary-labels.md)   | Wire Topology Composition and Boundary Labels                       | proposed   |
-| [0029](0029-corepure-structured-serialization.md)               | CorePure Structured Serialization                                   | proposed   |
-| [0030](0030-wire-node-implementation-forms.md)                  | Wire Node Implementation Forms                                      | proposed   |
-| [0031](0031-wire-binding-forms-and-where-clauses.md)            | Wire Binding Forms and Node Where Clauses                           | proposed   |
-| [0032](0032-wire-boundary-contract-resources.md)                | Wire Boundary Contracts as Planning Resources                       | proposed   |
-| [0033](0033-wire-select-guarded-affine-collapse.md)             | Wire Select as Guarded Affine Collapse                              | proposed   |
-| [0034](0034-wire-pure-select-actualization-authority.md)        | Pure Selectors and Restricted Actualization Authority               | proposed   |
-| [0035](0035-wire-rewrite-algebra-forms.md)                      | Wire Rewrite Algebra Forms                                          | proposed   |
-| [0036](0036-wire-latent-branch-budget-recovery.md)              | Latent Branch Budget and Recovery Policy                            | proposed   |
-| [0037](0037-wire-latent-structural-control.md)                  | Wire Latent Structural Control Operators                            | proposed   |
-| [0038](0038-wire-proof-track-theorem-ledger.md)                 | Wire Proof-Track Theorem Ledger                                     | proposed   |
-| [0039](0039-wire-node-boundary-transform-normal-form.md)        | Wire Node Boundary Transform Normal Form                            | proposed   |
-| [0040](0040-logos-owned-reasoning-surfaces.md)                  | Logos-Owned Reasoning Surfaces                                      | accepted   |
-| [0041](0041-wire-cli-command-surface.md)                        | Wire CLI Command Surface                                            | proposed   |
-| [0042](0042-wire-standard-effect-executors.md)                  | Wire Standard Effect Executors                                      | proposed   |
-| [0043](0043-pulse-in-memory-runner.md)                          | Pulse In-Memory Runner                                              | proposed   |
-| [0044](0044-wire-namespace-use-imports.md)                      | Wire Namespace Use Imports                                          | proposed   |
-| [0045](0045-wire-compile-time-node-body-kinds.md)               | Wire Compile-Time Node-Body Kinds                                   | proposed   |
-| [0046](0046-wire-compile-time-graph-forms.md)                   | Wire Compile-Time Graph Forms                                       | proposed   |
-| [0047](0047-wire-frontier-linearity-and-precedence.md)          | Wire Frontier Linearity and Topology Operator Precedence            | proposed   |
-| [0048](0048-wire-make-bounded-node-generation.md)               | Wire Compile-Time Make for Bounded Node Generation                  | proposed   |
-| [0049](0049-wire-fan-phantom-adapter.md)                        | Wire Phantom Record↔Ports Adapter for Topology Fans                | proposed   |
-| [0050](0050-wire-corepure-output-residue.md)                    | Wire CorePure Output Residue                                        | proposed   |
-| [0051](0051-wire-source-includes-and-item-generation.md)        | Wire Source Includes and Item Generation                            | proposed   |
-| [0052](0052-wire-bounded-indexed-boundary-products.md)          | Wire Bounded Indexed Boundary Products                              | proposed   |
-| [0053](0053-executor-catalog-manifests-and-pulse-bindings.md)   | Executor Catalog Manifests and Pulse Runtime Bindings               | proposed   |
-| [0054](0054-downstream-wire-packages-and-host-bindings.md)      | Downstream Wire Packages and Host Runtime Bindings                  | proposed   |
-| [0055](0055-pulse-runtime-bounded-iteration.md)                 | Pulse Runtime-Bounded Iteration                                     | proposed   |
+| #                                                                  | Title                                                               | Status     |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------- | ---------- |
+| [0001](0001-structured-report-ir.md)                               | Structured Document IR                                              | superseded |
+| [0002](0002-cortex-downstream-ownership-boundary.md)               | Cortex and Downstream Ownership Boundary                            | accepted   |
+| [0003](0003-pulse-service-and-host-action-boundary.md)             | Pulse Service and Host-Action Boundary                              | accepted   |
+| [0004](0004-graph-native-pulse-execution.md)                       | Graph-Native Pulse Execution                                        | accepted   |
+| [0005](0005-budgeted-rewrite-admission-and-materialization.md)     | Budgeted Rewrite Admission and Materialization                      | accepted   |
+| [0006](0006-compiled-workflow-artifact-boundary.md)                | Compiled Workflow Artifact Boundary                                 | accepted   |
+| [0007](0007-latent-branch-conditional-lowering.md)                 | Latent-Branch Conditional Lowering                                  | accepted   |
+| [0008](0008-pulse-operator-visibility-surfaces.md)                 | Pulse Operator Visibility Surfaces                                  | accepted   |
+| [0009](0009-rewrite-provenance-and-topology-integrity.md)          | Rewrite Provenance and Topology Integrity                           | accepted   |
+| [0010](0010-wire-closed-authority-and-three-layer-stack.md)        | Wire as Closed-Authority Language over the Graph/Circuit/Wire Stack | accepted   |
+| [0011](0011-compatibility-barriers-and-fresh-run-recovery.md)      | Compatibility Barriers and Fresh-Run Recovery                       | accepted   |
+| [0012](0012-topological-memory-as-deterministic-graph-query.md)    | Topological Memory as Deterministic Graph Query                     | accepted   |
+| [0013](0013-report-provenance-artifact-contract.md)                | Artifact Provenance Contract                                        | accepted   |
+| [0014](0014-executor-taxonomy-model-vs-external-call.md)           | Model vs External Call                                              | proposed   |
+| [0015](0015-canonical-logos-archetypes.md)                         | Canonical Logos Archetypes                                          | proposed   |
+| [0016](0016-cortex-roots-and-logos-pattern-extraction.md)          | Cortex Roots and Logos Pattern Extraction                           | proposed   |
+| [0017](0017-wire-executor-and-port-catalog-boundary.md)            | Wire Executor and Port Catalog Boundary                             | proposed   |
+| [0018](0018-canonical-haskell-module-tree.md)                      | Canonical Haskell Module Tree                                       | proposed   |
+| [0019](0019-executor-registration-and-binding.md)                  | Executor Registration and Binding                                   | proposed   |
+| [0020](0020-wire-pure-output-equations.md)                         | Wire Pure Output Equations                                          | accepted   |
+| [0021](0021-wire-source-elaborates-to-circuits.md)                 | Wire Source Elaborates to Circuits                                  | proposed   |
+| [0022](0022-wire-node-clause-grammar.md)                           | Wire Node Clause Grammar                                            | proposed   |
+| [0023](0023-corepure-expression-surface.md)                        | CorePure Expression Surface                                         | proposed   |
+| [0024](0024-typed-executor-node-interface.md)                      | Typed Executor Node Interface                                       | proposed   |
+| [0025](0025-configured-executor-values.md)                         | Configured Executor Values                                          | proposed   |
+| [0026](0026-wire-failure-taxonomy.md)                              | Wire Failure Taxonomy                                               | proposed   |
+| [0027](0027-typed-llm-output-binding.md)                           | Typed LLM Output Binding                                            | proposed   |
+| [0028](0028-wire-topology-composition-and-boundary-labels.md)      | Wire Topology Composition and Boundary Labels                       | proposed   |
+| [0029](0029-corepure-structured-serialization.md)                  | CorePure Structured Serialization                                   | proposed   |
+| [0030](0030-wire-node-implementation-forms.md)                     | Wire Node Implementation Forms                                      | proposed   |
+| [0031](0031-wire-binding-forms-and-where-clauses.md)               | Wire Binding Forms and Node Where Clauses                           | proposed   |
+| [0032](0032-wire-boundary-contract-resources.md)                   | Wire Boundary Contracts as Planning Resources                       | proposed   |
+| [0033](0033-wire-select-guarded-affine-collapse.md)                | Wire Select as Guarded Affine Collapse                              | proposed   |
+| [0034](0034-wire-pure-select-actualization-authority.md)           | Pure Selectors and Restricted Actualization Authority               | proposed   |
+| [0035](0035-wire-rewrite-algebra-forms.md)                         | Wire Rewrite Algebra Forms                                          | proposed   |
+| [0036](0036-wire-latent-branch-budget-recovery.md)                 | Latent Branch Budget and Recovery Policy                            | proposed   |
+| [0037](0037-wire-latent-structural-control.md)                     | Wire Latent Structural Control Operators                            | proposed   |
+| [0038](0038-wire-proof-track-theorem-ledger.md)                    | Wire Proof-Track Theorem Ledger                                     | proposed   |
+| [0039](0039-wire-node-boundary-transform-normal-form.md)           | Wire Node Boundary Transform Normal Form                            | proposed   |
+| [0040](0040-logos-owned-reasoning-surfaces.md)                     | Logos-Owned Reasoning Surfaces                                      | accepted   |
+| [0041](0041-wire-cli-command-surface.md)                           | Wire CLI Command Surface                                            | proposed   |
+| [0042](0042-wire-standard-effect-executors.md)                     | Wire Standard Effect Executors                                      | proposed   |
+| [0043](0043-pulse-in-memory-runner.md)                             | Pulse In-Memory Runner                                              | proposed   |
+| [0044](0044-wire-namespace-use-imports.md)                         | Wire Namespace Use Imports                                          | proposed   |
+| [0045](0045-wire-compile-time-node-body-kinds.md)                  | Wire Compile-Time Node-Body Kinds                                   | proposed   |
+| [0046](0046-wire-compile-time-graph-forms.md)                      | Wire Compile-Time Graph Forms                                       | proposed   |
+| [0047](0047-wire-frontier-linearity-and-precedence.md)             | Wire Frontier Linearity and Topology Operator Precedence            | proposed   |
+| [0048](0048-wire-make-bounded-node-generation.md)                  | Wire Compile-Time Make for Bounded Node Generation                  | proposed   |
+| [0049](0049-wire-fan-phantom-adapter.md)                           | Wire Phantom Record↔Ports Adapter for Topology Fans                | proposed   |
+| [0050](0050-wire-corepure-output-residue.md)                       | Wire CorePure Output Residue                                        | proposed   |
+| [0051](0051-wire-source-includes-and-item-generation.md)           | Wire Source Includes and Item Generation                            | proposed   |
+| [0052](0052-wire-bounded-indexed-boundary-products.md)             | Wire Bounded Indexed Boundary Products                              | proposed   |
+| [0053](0053-executor-catalog-manifests-and-pulse-bindings.md)      | Executor Catalog Manifests and Pulse Runtime Bindings               | proposed   |
+| [0054](0054-downstream-wire-packages-and-host-bindings.md)         | Downstream Wire Packages and Host Runtime Bindings                  | proposed   |
+| [0055](0055-pulse-runtime-bounded-iteration.md)                    | Pulse Runtime-Bounded Iteration                                     | proposed   |
+| [0056](0056-admission-modes-witnessed-and-gas.md)                  | Admission Modes: Witnessed Materialization and Open Rewrite Gas     | proposed   |
+| [0057](0057-wire-latent-branch-witnessing-and-closure-charging.md) | Latent Branch Witnessing and Proposal Closure Charging              | proposed   |
 
 ## Writing a new ADR
 


### PR DESCRIPTION
Extracts the Wire rewrite-admission design ADRs from the iteration-runway / run-terminal work (#262/#263) into their own review thread — they are pure design docs unrelated to the Pulse runtime.

- **ADR 0056** — admission modes: compile-witnessed materialization (asserted, metered) vs open rewrite gas (tunable, rejectable), discriminated by provenance + boundary.
- **ADR 0057** — latent-branch witnessing + proposal closure charging; proposes to supersede ADR 0036 on acceptance.

Both `proposed`. Lifted verbatim from the original commit (identical patch). Part of cleaning the iteration-runway track into reviewable units.