### PR TITLE
Add Wire QEC repetition-code workbench

### DIFF
--- a/app/wire/Main.hs
+++ b/app/wire/Main.hs
@@ -109,6 +109,8 @@ import Cortex.Wire.LeanFixture
   , renderEmittedFixtureModule
   , renderEmittedUmbrellaModule
   )
+import Cortex.Wire.Package (packageNamespaceRegistry)
+import Cortex.Wire.Quantum (quantumPackages)
 import Cortex.Wire.Use
   ( WireUseError (..)
   , WireUseScope
@@ -1019,7 +1021,7 @@ topologyLevels relation =
 
 useScopeFromWireFile :: WireFile -> Either Text WireUseScope
 useScopeFromWireFile wireFile =
-  case applyWireUseSpecs (const False) useSpecs of
+  case applyWireUseSpecs (packageNamespaceRegistry quantumPackages) (const False) useSpecs of
     Left err -> Left (renderRunUseError err)
     Right scope -> Right scope
   where

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -144,6 +144,7 @@ library
         Cortex.Capability.Catalog.ExecutorManifest
         Cortex.Capability.Catalog.RuntimeBindingRecord
         Cortex.Capability.BindingPack
+        Cortex.Capability.BindingPack.Braket
         Cortex.Capability.Executor
         Cortex.Capability.Executor.Pure
         Cortex.Pulse
@@ -286,6 +287,7 @@ test-suite cortex-test
         Cortex.Algebra.GraphSpec
         Cortex.CanonicalModuleTreeSpec
         Cortex.Capability.CatalogSpec
+        Cortex.Capability.BindingPack.BraketSpec
         Cortex.Wire.PackageSpec
         Cortex.Wire.QuantumPackageSpec
         Cortex.Pulse.FrontierContractionSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -155,6 +155,7 @@ library
         Cortex.Pulse.Executor.Attempt
         Cortex.Pulse.Executor.Events
         Cortex.Pulse.Executor.Frontier
+        Cortex.Pulse.Executor.ExternalCall
         Cortex.Pulse.Executor.Loop
         Cortex.Pulse.Executor.Outcome
         Cortex.Pulse.Executor.Persistence
@@ -287,6 +288,7 @@ test-suite cortex-test
         Cortex.Wire.QuantumPackageSpec
         Cortex.Pulse.FrontierContractionSpec
         Cortex.Pulse.Executor.ExternalCallAttemptSpec
+        Cortex.Pulse.Executor.ExternalCallSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -290,6 +290,7 @@ test-suite cortex-test
         Cortex.Capability.BindingPack.BraketSpec
         Cortex.Wire.PackageSpec
         Cortex.Wire.QuantumPackageSpec
+        Cortex.Wire.RealizeCompileSpec
         Cortex.Pulse.FrontierContractionSpec
         Cortex.Pulse.Executor.ExternalCallAttemptSpec
         Cortex.Pulse.Executor.ExternalCallSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -200,6 +200,7 @@ library
         Cortex.Wire.Circuit.NodeKind
         Cortex.Pulse.GraphRuntime
         Cortex.Pulse.Health
+        Cortex.Pulse.Lowering.FusedPlan
         Cortex.Pulse.Materialization
         Cortex.Pulse.Memory
         Cortex.Pulse.Memory.Query
@@ -289,6 +290,7 @@ test-suite cortex-test
         Cortex.Pulse.FrontierContractionSpec
         Cortex.Pulse.Executor.ExternalCallAttemptSpec
         Cortex.Pulse.Executor.ExternalCallSpec
+        Cortex.Pulse.Lowering.FusedPlanSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -139,6 +139,10 @@ library
         Cortex.Algebra.Graph.Search
         Cortex.Algebra.Graph.Validate
         Cortex.Capability
+        Cortex.Capability.Catalog.AdmissionProjection
+        Cortex.Capability.Catalog.AwaitStrategy
+        Cortex.Capability.Catalog.ExecutorManifest
+        Cortex.Capability.Catalog.RuntimeBindingRecord
         Cortex.Capability.Executor
         Cortex.Capability.Executor.Pure
         Cortex.Pulse
@@ -273,6 +277,7 @@ test-suite cortex-test
     other-modules:
         Cortex.Algebra.GraphSpec
         Cortex.CanonicalModuleTreeSpec
+        Cortex.Capability.CatalogSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -143,6 +143,7 @@ library
         Cortex.Capability.Catalog.AwaitStrategy
         Cortex.Capability.Catalog.ExecutorManifest
         Cortex.Capability.Catalog.RuntimeBindingRecord
+        Cortex.Capability.BindingPack
         Cortex.Capability.Executor
         Cortex.Capability.Executor.Pure
         Cortex.Pulse
@@ -183,6 +184,7 @@ library
         Cortex.Wire.Pure
         Cortex.Wire.Std
         Cortex.Wire.Syntax
+        Cortex.Wire.Package
         Cortex.Wire.Use
         Cortex.Wire.Circuit
         Cortex.Wire.Circuit.Artifact
@@ -278,6 +280,7 @@ test-suite cortex-test
         Cortex.Algebra.GraphSpec
         Cortex.CanonicalModuleTreeSpec
         Cortex.Capability.CatalogSpec
+        Cortex.Wire.PackageSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -210,6 +210,7 @@ library
         Cortex.Pulse.PlanHydration
         Cortex.Pulse.Query
         Cortex.Pulse.Rewrite
+        Cortex.Pulse.Rewrite.Contract
         Cortex.Pulse.Schema
         Cortex.Pulse.Signal
         Cortex.Pulse.Scheduler
@@ -281,6 +282,7 @@ test-suite cortex-test
         Cortex.CanonicalModuleTreeSpec
         Cortex.Capability.CatalogSpec
         Cortex.Wire.PackageSpec
+        Cortex.Pulse.FrontierContractionSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -209,6 +209,7 @@ library
         Cortex.Pulse.Plan
         Cortex.Pulse.PlanHydration
         Cortex.Pulse.Query
+        Cortex.Pulse.Query.ExternalCall
         Cortex.Pulse.Rewrite
         Cortex.Pulse.Rewrite.Contract
         Cortex.Pulse.Schema
@@ -283,6 +284,7 @@ test-suite cortex-test
         Cortex.Capability.CatalogSpec
         Cortex.Wire.PackageSpec
         Cortex.Pulse.FrontierContractionSpec
+        Cortex.Pulse.Executor.ExternalCallAttemptSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -200,6 +200,7 @@ library
         Cortex.Wire.Circuit.NodeKind
         Cortex.Pulse.GraphRuntime
         Cortex.Pulse.Health
+        Cortex.Pulse.Lowering.Circuit
         Cortex.Pulse.Lowering.FusedPlan
         Cortex.Pulse.Materialization
         Cortex.Pulse.Memory
@@ -291,6 +292,7 @@ test-suite cortex-test
         Cortex.Pulse.Executor.ExternalCallAttemptSpec
         Cortex.Pulse.Executor.ExternalCallSpec
         Cortex.Pulse.Lowering.FusedPlanSpec
+        Cortex.Pulse.Lowering.CircuitSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -185,6 +185,7 @@ library
         Cortex.Wire.Std
         Cortex.Wire.Syntax
         Cortex.Wire.Package
+        Cortex.Wire.Quantum
         Cortex.Wire.Use
         Cortex.Wire.Circuit
         Cortex.Wire.Circuit.Artifact
@@ -283,6 +284,7 @@ test-suite cortex-test
         Cortex.CanonicalModuleTreeSpec
         Cortex.Capability.CatalogSpec
         Cortex.Wire.PackageSpec
+        Cortex.Wire.QuantumPackageSpec
         Cortex.Pulse.FrontierContractionSpec
         Cortex.Pulse.Executor.ExternalCallAttemptSpec
         Cortex.Capability.Executor.PureSpec

--- a/docs/ADRs/0059-durable-external-call-frontiers-on-pulse.md
+++ b/docs/ADRs/0059-durable-external-call-frontiers-on-pulse.md
@@ -2,9 +2,9 @@
 title: "ADR 0059 - Durable External-Call Frontiers on Pulse"
 description:
   "How a Wire subgraph bound to an external backend (quantum, OpenAPI, WASM, MCP) runs durably on
-  Pulse: the host binds an external-call capability, a connected same-backend frontier projects to a
-  single Pulse stage, and long-running backends use idempotent submit/park/resume over the
-  run-terminal await."
+  Pulse: the host binds an external-call capability, a connected same-backend frontier contracts to
+  a single Pulse stage, and long-running backends use idempotent submit/park/resume over an ordinary
+  durable Pulse signal settled by ADR 0058's atomic suspend settlement."
 sidebar:
   label: "0059. Durable external-call frontiers"
   order: 59
@@ -16,6 +16,12 @@ related:
   - docs/ADRs/0014-executor-taxonomy-model-vs-external-call.md
   - docs/ADRs/0019-executor-registration-and-binding.md
   - docs/ADRs/0024-typed-executor-node-interface.md
+  - docs/ADRs/0026-wire-failure-taxonomy.md
+  - docs/ADRs/0032-wire-boundary-contract-resources.md
+  - docs/ADRs/0035-wire-rewrite-algebra-forms.md
+  - docs/ADRs/0053-executor-catalog-manifests-and-pulse-bindings.md
+  - docs/ADRs/0054-downstream-wire-packages-and-host-bindings.md
+  - docs/ADRs/0056-admission-modes-witnessed-and-gas.md
   - docs/ADRs/0058-pulse-atomic-suspend-settlement.md
   - docs/Architecture/06-pulse-runtime.md
   - docs/Consumers/Quantum.md
@@ -29,9 +35,10 @@ related:
 Proposed. Motivated by the QEC repetition-code workbench (#269), whose quantum circuits today run
 through a standalone Python bridge under the local `wire run` interpreter, with Pulse uninvolved.
 This ADR records how such a Wire-authored external-backend graph should instead run as a durable
-Pulse run, and pins the two pieces the existing executor ADRs leave open. It does not change the
-registration model (ADR 0019), the executor taxonomy (ADR 0014), or the host-action boundary (ADR
-0003); it composes them and adds frontier projection.
+Pulse run, and pins the frontier projection plus durable execution contract the existing executor
+ADRs leave open. It does not change the registration model (ADR 0019), the executor taxonomy (ADR
+0014), or the host-owned authority boundary (ADR 0003); it composes them and adds frontier
+projection.
 
 ## Context
 
@@ -46,10 +53,18 @@ already decides how that authority is registered and bound:
   into runnable code.
 - **ADR 0014** classifies a registered external backend as an `ExternalCallExecutor` (typed I/O
   under a registered name), distinct from `ModelExecutor`.
-- **ADR 0003** restricts how Pulse reaches domain behavior: only through authenticated, idempotent
-  host-action APIs, never by writing host tables or running domain backends in the runtime process.
-- **ADR 0058** gives Pulse a durable await: a run can suspend on a `run-terminal:` (or general)
-  signal and be woken without polling.
+- **ADR 0053** is the catalog bridge: an executor id resolves to an inert admission projection
+  consumed by Wire and Capability for static checking, an executor manifest (build + host binding),
+  and a runtime binding record (Circuit emission + Pulse dispatch). Pulse dispatches the bound
+  `StageAction`; it does not interpret backend categories.
+- **ADR 0003** keeps domain authority outside the Pulse runtime: Pulse reaches host-owned behavior
+  only across authenticated, idempotent boundaries, never by writing host tables or owning domain
+  backends. A `host-action-v1` endpoint is one such boundary, not the only executor ABI.
+- **ADR 0058** gives Pulse a durable await: a run can suspend on a signal and be woken without
+  polling. The `run-terminal:` family is **reserved for child Pulse runs** — external/host delivery
+  of it is refused (anti-forgery, see `Cortex.Pulse.Query`). External job completion must therefore
+  ride an **ordinary durable signal**, not `run-terminal:`, unless the job is itself modeled as a
+  child Pulse run.
 
 Despite all of this, no decision says how a Wire **subgraph** bound to an external backend becomes a
 **durable Pulse stage**. Two facts collide:
@@ -60,8 +75,8 @@ Despite all of this, no decision says how a Wire **subgraph** bound to an extern
    appends operations to the selected quantum circuit"_: fusion is a host responsibility today,
    performed outside Pulse. Materializing each gate as a durable stage would be absurd.
 2. **Lifetime.** A local simulator call is synchronous and cheap; a hardware submission is
-   long-running, externally stateful, and non-idempotent (submit returns a job id; you poll). The
-   first needs no durability; the second is a textbook durable-task shape.
+   long-running, externally stateful, and non-idempotent unless guarded by a provider or host
+   idempotency key. The first needs no durability; the second is a textbook durable-task shape.
 
 Because neither is pinned, external backends sit outside Pulse entirely (the #269 bridge),
 forfeiting durable scheduling, recovery, observability, and the await primitive — exactly the
@@ -74,11 +89,47 @@ composed from the existing layers without weakening any boundary.
 
 ### 1. Binding stays in Capability, not Pulse
 
-The host registers the backend as an `ExternalCallExecutor` Capability spec (ADR 0019/0014) and
-binds it to a runnable `StageAction` in the host process that embeds Pulse. Pulse does not gain a
-backend registry, an in-process Qiskit handler, or knowledge of `quantum.*`. "Run it on Pulse" means
-_the bound stage runs under Pulse's scheduler_, not _Pulse owns the backend_ — consistent with ADR
-0019's "Pulse does not own executor registration" and ADR 0003's host-action boundary.
+The host registers the backend as an `ExternalCallExecutor` Capability spec (ADR 0019/0014) and the
+host runtime binding pack supplies the runnable `StageAction`. Pulse does not gain a backend
+registry, an in-process Qiskit handler, or knowledge of `quantum.*`. "Run it on Pulse" means _the
+bound stage runs under Pulse's scheduler_, not _Pulse owns the backend_ — consistent with ADR 0019's
+"Pulse does not own executor registration" and ADR 0003's host-owned authority boundary.
+
+**The packaging mechanism is ADR 0054, not a new one.** The backend ships as two artifacts whose
+dependency direction is one-way:
+
+- A **Wire package** — inert compile-time vocabulary, imported with `use`. It exports contracts
+  (`QuantumResult`, `MeasurementCounts`, `ShotCount`, `BackendConfig`), executor admission
+  projections (`quantum.prepare_zero`, `quantum.x`, `quantum.cnot`, `quantum.measure_z`,
+  `quantum.realize`), and reusable `.wire` modules (repetition-code helpers). It carries **no**
+  credentials, SDK authority, or `StageAction`.
+- A **host runtime binding pack** — the only artifact with runtime authority. It resolves
+  `quantum.realize` (or `quantum.braket.realize`) to a Pulse `StageAction`, injects the AWS
+  profile/region/device ARN/S3 bucket, performs OpenQASM lowering, Braket submit, park/resume, and
+  result fetch, and mints the ADR 0053 runtime binding records.
+
+`use quantum.braket.{@realize}` brings the **name** into source scope only; it does not grant AWS
+access. Compile and `wire build`/check succeed without the binding pack — runnable Pulse lowering is
+what fails, with a typed `missing runtime binding`. This is the ADR 0054 invariant (importing a Wire
+package never grants runtime authority; only a host binding pack does), specialized to quantum:
+
+```wire
+use quantum.core.{@prepare_zero, @x, @cnot, @measure_z};
+use quantum.braket.{@realize};
+use quantum.qec.{RepetitionResult, Syndrome};
+
+# circuit authored as native Wire topology; final frontier collected by @realize
+```
+
+```sh
+wire pulse run examples/wire/qec-repetition-code.wire \
+  --wire-package quantum --binding-pack braket --config braket-local.json
+```
+
+This makes the quantum surface the **first real downstream Wire package**: `quantum.core` (generic
+circuit vocabulary), `quantum.qec` (reusable QEC modules/contracts), `quantum.braket` (the Braket
+realization projection, until realization can be kept fully generic), and a Braket host binding pack
+(the AWS/Pulse implementation).
 
 ### 2. Frontier projection via an explicit realize node
 
@@ -94,29 +145,96 @@ build_circuit  =>  realize        =>  decode      =>  report
 
 The realize node's **payload is the fused sub-plan** (the backend-neutral operation list the bridge
 builds today, gathered from the upstream same-backend nodes feeding it); the gate-nodes are payload,
-never stages. Its **output ports are the labeled measurement results** — `s01`, `s12`, `final_d0`, …
-become the realize node's result fields, consumed by downstream stages. The realize node cannot
-consume post-measurement values as _inputs_, because those exist only after it executes; it consumes
-the frontier and produces the results. This is the author-explicit form of the host-walks-nodes
-behavior `Quantum.md` documents, and it mirrors the existing `std.io.command` send-spec /
-await-result / continue pattern the eraser already uses.
+never stages. Its **output ports are one per named measurement** — `s01`, `s12`, `final_d0`, … are
+distinct typed result ports, not a single results record. Per-measurement ports keep the
+substructural discipline native: a results record would need a `*` (copy) to fan it to multiple
+downstream consumers, reintroducing the linearity question the typed ports avoid. The realize node
+cannot consume post-measurement values as _inputs_, because those exist only after it executes; it
+consumes the frontier and produces the results. This is the author-explicit form of the
+host-walks-nodes behavior `Quantum.md` documents, and it mirrors the existing `std.io.command`
+send-spec / await-result / continue pattern the eraser already uses.
 
-At materialization, the realize node is the **projection sink**: upstream nodes sharing its
-external-call authority and effect class fuse into its payload; everything downstream is ordinary
-Pulse stages.
+**Collection is a contraction with a decidable admission check.** Sinking the frontier into the
+realize node is a rewrite that collapses the collected subgraph into one node — structurally a
+contraction. Two obligations follow, and both are decisions, not open questions:
 
-### 3. Execution goes through the host-action boundary (ADR 0003)
+- **Admission.** A frontier is admissible iff, for the nodes **inside the collected set**: every
+  node shares one external-call authority and one await strategy, and no non-backend node
+  intervenes. The constraint is on the collected set, **not** on the realize node's **frozen
+  boundary inputs**: classical parameters fed to the realize node (shot count, rotation angles,
+  `BackendConfig`) are legitimate inbound edges, not cross-authority violations — requiring every
+  parameter to be static config would block parameterized external calls. A collected set that mixes
+  authorities or pulls in a non-backend node is **rejected** (the author/materializer must place
+  separate realize nodes); the validator does not silently split it. This is a decidable check in
+  the `validatorReady_sound` lineage — the same machinery that admits other rewrites — not host-side
+  guesswork.
+- **Port linearity.** The contraction must preserve port linearity. The ADR's position is that
+  realize **reduces to `bulkContract`**, discharged by the existing
+  `bulkContract_preserves_portLinear` (no new proof — the strong outcome). If realize turns out not
+  to reduce (e.g. because measurement ports re-emerge as realize outputs in a way `bulkContract`
+  does not model), it is a new rewrite carrying its own `realize_preserves_portLinear`. This is a
+  **formal obligation** (see _Obligations_), and it is governed by ADR 0035's rewrite boundary laws;
+  the collected external-call resource is accounted under ADR 0032's boundary resource algebra.
 
-The stage's external call is an idempotent host action. Two execution shapes, selected by the
-backend's declared effect class:
+**Fused-plan emission is canonical.** The payload is built from a partial order (gates on disjoint
+qubits are unordered), so the builder must emit a **deterministic, canonical linearization** of the
+frozen subgraph. Non-commuting gates are already forced by qubit dataflow; the canonical rule fixes
+the order of the commuting/independent set so the plan — and its hash — is identical across replays
+of the same topology.
 
-- **Synchronous** (local simulator, fast pure-ish backends): the host action runs the fused circuit
-  and returns results inline; the stage completes in one transaction.
-- **Submit/park/resume** (hardware, any long-running async backend): the host action _submits_ under
-  an idempotency key and returns a job handle; the run **parks** (ADR 0058) on that job's completion
-  signal; the host delivers a `run-terminal`-style signal when the job finishes; the run **resumes**
-  with results. No poll loop; a crash recovers to the parked-and-awaiting state, and the idempotency
-  key prevents double submission on replay.
+### 3. Execution is a host-owned external effect via the bound StageAction
+
+The realize stage is a **host-owned external effect executed through the bound `StageAction`**,
+under ADR 0003's trust boundary (domain authority lives in the host, not Pulse). The host-action-v1
+protocol is **one possible ABI/driver** for that effect — not the required mechanism: per
+`docs/Reference/Pulse/host-actions.md`, capability/executor calls do not use the host-action
+protocol unless a host explicitly registers an executor that calls back into its own service. The
+host may equally implement the `StageAction` as a direct provider SDK call (Braket submit), a
+subprocess, or a brokered process. Pulse dispatches the **opaque bound `StageAction`** and observes
+only its result — _complete_ or _suspend_. The **await strategy** that decides which shape applies
+is binding metadata declared in the ADR 0053 admission projection / runtime binding record
+(alongside replay, effect, and isolation), **not** a category Pulse interprets. Two strategies:
+
+- **Synchronous** (local simulator, fast pure-ish backends): the action runs the fused circuit and
+  returns results inline; the stage completes in one transaction.
+- **Submit/park/resume** (hardware, any long-running async backend — and equally a slow
+  `ModelExecutor`): the action _submits_ and returns a job handle, then suspends. The run **parks**
+  via ADR 0058's atomic suspend settlement on an **ordinary durable signal** (delivered by the host
+  through the service API on job completion — _not_ the reserved `run-terminal:` family). On
+  delivery the run **resumes**; the resumed `StageAction` reads the attempt record and provider
+  completion state, then maps the result to the realize node's output ports or to a typed failure.
+  No poll loop; a crash recovers to the parked-and-awaiting state.
+
+**Idempotency is anchored to a durable attempt record, not the live graph and not the signal rows.**
+ADR 0058's settlement transaction commits only graph state, `pulse.signals` wait rows, and
+`runs.status` — it does not carry executor metadata. The host binding therefore uses a separate
+Pulse-owned external-call attempt record, keyed by run, stage, runtime binding id, and frontier id.
+Pulse stores provider-specific fields as opaque data; it does not interpret the backend.
+
+The submit protocol is crash-safe:
+
+1. reserve the attempt record before provider submission, storing the frozen fused plan and a
+   deterministic idempotency key derived from the frozen materialized frontier;
+2. submit to the provider outside the database transaction using that key;
+3. persist the external job handle on the attempt record before returning `StageSuspend`;
+4. during ADR 0058 suspend settlement, atomically link the waiting node and ordinary durable signal
+   to the attempt record.
+
+If the process dies after reservation but before submit, recovery re-enters the stage and submits
+with the same key. If it dies after provider submit but before the handle is recorded, recovery must
+either replay the idempotent submit and recover the same handle or consult a host idempotency store;
+a backend that cannot provide one of those guarantees is not admissible for `submit_park_resume`.
+Once the handle is recorded, recovery reconnects to that attempt instead of creating a fresh
+provider task. The completion signal is a wake token carrying completion status and optional
+provider result locator; the resumed `StageAction` reads the attempt record, fetches or validates
+the provider result, and maps it to output envelopes or a typed failure.
+
+**The failure path is typed.** Job reject, calibration error, queue timeout, and async-submit
+failure propagate through the **failure closure** (ADR 0026): the realize stage fails with a typed
+reason, delivered as a failure outcome on the same durable signal, and downstream stages observe the
+closed failure rather than a missing result. A realize node _may_ additionally expose a typed error
+output for recoverable backend errors an author wants to branch on, but the default negative path is
+closure, not silence.
 
 ### 4. Analysis is ordinary downstream Pulse stages
 
@@ -139,15 +257,27 @@ executor.
   non-durable dev use — the Capability binding is the shared seam, so a backend is registered once
   and reachable from both runtimes.
 - **Frontier, not node, is the unit of durable work.** Durability attaches at the
-  submission/frontier boundary. There is no per-gate checkpoint; a circuit is re-submitted whole on
-  recovery, guarded by the idempotency key.
-- **One executor authority per frontier.** A frontier mixing two backends does not project to one
-  call; it splits at the authority boundary into separate stages with typed ports between them.
-- **Idempotency is mandatory for async submits.** Every mutating host-action submit carries an
-  idempotency key derived from the run, the frontier, and the fused-plan hash, so replay after a
-  crash never double-submits.
-- **Effect class decides the shape.** A backend declares synchronous vs submit/park/resume in its
-  Capability spec; Pulse does not infer it.
+  submission/frontier boundary. There is no per-gate checkpoint; recovery re-enters the frontier and
+  uses the attempt record plus idempotency key to reconnect to, fetch, or idempotently re-submit the
+  whole provider task.
+- **One authority per frontier, by decidable check.** A collected set mixing two backend authorities
+  (or pulling in a non-backend node) is **rejected** by the admission validator — the author places
+  separate realize nodes; the validator never silently splits. Frozen classical parameters fed to a
+  realize node are not authority violations.
+- **Idempotency is anchored to a durable attempt record.** A separate external-call attempt record
+  holds the idempotency key, external job handle, frozen fused plan, and completion signal name.
+  Attempt reservation precedes provider submit; the provider call happens outside the DB
+  transaction; ADR 0058 settlement atomically links the waiting node and signal to the attempt
+  record. The key is read back from the attempt record on resume, never recomputed from the
+  rewritable graph, so replay after a crash never double-submits. Signal/wait rows are not
+  overloaded with this metadata.
+- **Fused-plan emission is canonical.** The payload is a deterministic canonical linearization of
+  the frozen subgraph, so the same topology yields the same plan and hash across replays.
+- **Await strategy is binding metadata, not Pulse interpretation.** The synchronous vs
+  submit/park/resume choice lives in the ADR 0053 admission projection / binding record; Pulse
+  dispatches an opaque `StageAction` and reacts only to complete-or-suspend.
+- **The negative path is closed, not silent.** Backend failures propagate through the ADR 0026
+  failure closure with a typed reason; the realize node never resumes with a missing result.
 
 ## Consequences
 
@@ -155,35 +285,70 @@ executor.
 
 - The hardware quantum path gains durable submission, recovery, and await-without-polling for free
   by reusing ADR 0058 — the single most valuable Pulse capability for long-running jobs.
-- Generalizes beyond quantum: OpenAPI, WASM, and MCP backends (ADR 0014) all land as durable
-  external-call frontiers through the same mechanism.
-- No boundary erosion: registration stays in Capability, domain effects stay behind host actions.
+- Generalizes beyond quantum: OpenAPI, WASM, and MCP backends (ADR 0014), and equally a slow
+  `ModelExecutor` (long generation), all land as durable submit/park/resume stages through the same
+  await strategy — the field belongs at the executor level, not just `ExternalCallExecutor`.
+- No boundary erosion: registration stays in Capability, domain authority stays host-owned.
 
 ### Negative
 
-- Frontier projection is new machinery: a realize-node executor plus materialization that sinks the
-  upstream same-backend frontier into its payload is more than 1:1 node-to-stage materialization.
-- Two execution shapes (sync vs submit/park/resume) widen the host-action contract a backend must
-  satisfy.
-- Re-submitting a whole circuit on recovery wastes the prior (uncommitted) backend run; acceptable
-  because partial-circuit resumption is not physically meaningful.
+- Frontier collection is new machinery: a realize-node executor, a decidable admission check, and a
+  contraction rewrite with a discharged linearity proof — more than 1:1 node-to-stage
+  materialization.
+- Two await strategies (sync vs submit/park/resume) widen the external-effect contract a backend's
+  bound `StageAction` must satisfy, and add a binding-metadata field threaded through the ADR 0053
+  catalog.
+- Re-entering a frontier on recovery can require a reconnect, fetch, or idempotent whole-task
+  re-submit. Partial-circuit resumption is not physically meaningful, so the attempt-record
+  idempotency key is the safety boundary.
 
 ### Obligations
 
-- Add a realize-node (`collect`-style) external-call executor and the materialization rule that
-  sinks its upstream same-authority, same-effect-class frontier into one stage carrying the fused
-  plan, with the realize node's result fields as the stage's output ports.
-- Define the `ExternalCallExecutor` effect-class field (`synchronous` | `submit_park_resume`) in the
-  Capability spec and have Pulse dispatch on it.
-- Specify the idempotency-key derivation (run id + frontier id + fused-plan hash).
-- Wire the submit/park/resume host action to ADR 0058's run-terminal await for completion delivery.
+#### Implementation
+
+- Add a realize-node (`collect`-style) external-call executor with one typed output port per named
+  measurement, and the materialization rule that sinks its upstream same-authority,
+  same-await-strategy frontier into one stage carrying the canonically-serialized fused plan.
+- Implement the decidable admission validator in the `validatorReady` lineage: nodes inside the
+  collected set share one backend authority and await strategy, no non-backend node intervenes, and
+  mixed collected authorities are rejected. Frozen classical boundary inputs to the realize node are
+  allowed and are not cross-authority violations.
+- Add an **await strategy** field (`synchronous` | `submit_park_resume`) to the ADR 0053 admission
+  projection / runtime binding record — at the executor level, covering `ModelExecutor` too. Pulse
+  dispatches the opaque `StageAction` and reacts only to complete-or-suspend; it does not read the
+  field.
+- Define a Pulse-owned durable **external-call attempt record** holding
+  `{idempotency key, external job handle, frozen fused plan, completion signal name}` as opaque
+  provider-aware runtime state. Reserve it before provider submit, persist the handle before
+  returning `StageSuspend`, and have ADR 0058 settlement atomically link the waiting node/signal to
+  that attempt. Deliver completion through an **ordinary durable signal** via the service API (never
+  the reserved `run-terminal:` family). The signal wakes the run and may carry completion status or
+  a result locator, but the resumed `StageAction` remains responsible for fetching/validating
+  provider results and producing output envelopes or a typed failure.
+- Route backend failures (reject, timeout, calibration, submit failure) through the ADR 0026 failure
+  closure with a typed reason.
+- Ship the quantum surface as ADR 0054 artifacts: a `quantum.*` Wire package (contracts + admission
+  projections + reusable `.wire` modules) and a Braket host runtime binding pack that mints the ADR
+  0053 runtime binding records; runnable lowering without the pack fails with
+  `missing runtime binding`.
 - Keep the standalone bridge and `wire run` path working; both consume the same Capability binding.
+
+#### Formal (theory/)
+
+- Discharge port-linearity for the realize contraction: establish that it reduces to `bulkContract`
+  (cite `bulkContract_preserves_portLinear`) or, failing that, prove `realize_preserves_portLinear`.
+- Account the collected external-call resource under ADR 0032's boundary resource algebra, and show
+  the contraction obeys ADR 0035's rewrite boundary laws.
+- Confirm the gas treatment against ADR 0056: a **source-authored** realize contraction is
+  compile-witnessed materialization — **gas-neutral as an admission gate, recorded as cost/metric**,
+  never rejected for gas. When an **open producer** introduces the frontier it pays once at its own
+  admission boundary (ADR 0056/0057); the later witnessed realization does not refill or recharge.
 
 ## Alternatives Considered
 
 - **Register a quantum `TaskHandler` directly in Pulse's `TaskRegistry`.** Rejected: it would put
-  backend code in the runtime process and bypass the Capability layer, contradicting ADR 0019
-  ("Pulse does not own executor registration") and ADR 0003 (domain effects via host actions only).
+  backend semantics in the runtime process and bypass the Capability layer, contradicting ADR 0019
+  ("Pulse does not own executor registration") and ADR 0003 (domain authority stays host-owned).
 - **Materialize each gate as a durable stage.** Rejected: gates are coherent and sub-millisecond;
   per-gate durability is meaningless and would multiply scheduling cost by ~50x for a trivial
   circuit.
@@ -193,27 +358,27 @@ executor.
 
 ## Open Questions
 
-1. **Realize-node ergonomics.** With an explicit realize node the author draws the boundary, so the
-   materializer no longer infers a maximal subgraph — but it must still validate that everything
-   collected into a realize node shares one backend authority/effect class, and reject a frontier
-   that mixes backends or smuggles a non-fusible node. What is the exact admission rule?
-2. **Where fusion lives.** Does the fused-plan builder move from the Python bridge into Pulse
-   materialization, or stay host-side and get handed the realize node's collected frontier? The
-   host-action boundary argues host-side; materialization needs at least to identify the frontier
-   the realize node sinks.
-3. **Realize node typing.** Are the realize node's result fields declared per-measurement (one
-   output port per named measurement) or as a single results record the decoder destructures? The
-   former keeps Wire's typed-port discipline; the latter is terser for many measurements.
-4. **Idempotency-key stability under rewrite.** If a rewrite changes the frontier between attempts,
-   the fused-plan hash changes; is that a fresh submission (correct) or a recovery hazard?
-5. **Local-sim durability.** Should synchronous local simulation run as a Pulse stage at all, or
+(The admission rule, per-measurement typing, idempotency anchoring, the linearity discharge, and the
+gas treatment were open questions in earlier drafts; review promoted them to the decisions and
+obligations above — the gas treatment resolves to ADR 0056's witnessed-neutral rule.)
+
+1. **Does realize reduce to `bulkContract`?** The ADR's position is yes (reuse the existing proof);
+   the formal obligation will confirm or refute it. If it does not reduce,
+   `realize_preserves_portLinear` is a genuinely new proof, and that changes the cost of this ADR.
+2. **Where fusion lives.** Does the canonical fused-plan builder run in Pulse materialization or
+   stay host-side and get handed the collected frontier? The host-owned-effect boundary (ADR 0003)
+   argues host-side; materialization must at least identify and freeze the frontier the realize node
+   sinks.
+3. **Local-sim durability.** Should synchronous local simulation run as a Pulse stage at all, or
    stay on the `wire run` path? Uniformity vs overhead.
-6. **Effect-class taxonomy.** Is `synchronous | submit_park_resume` sufficient, or do streaming and
-   partial-result backends need a third shape?
+4. **Await-strategy taxonomy.** Is `synchronous | submit_park_resume` sufficient, or do streaming
+   and partial-result backends need a third shape?
 
 ## First Consumer
 
-The QEC repetition-code workbench (#269) is the prototype. Its offline-simulator milestone validates
-the boundary on the `wire run` + bridge path; its hardware extension is the first
-`submit_park_resume` external-call frontier. This ADR should be revisited once that hardware path is
-built, per the "ADR after the prototype clarifies the boundary" sequencing.
+The QEC repetition-code workbench (#269) is the prototype, and it validates the boundary on the
+`wire run` + bridge path. Hardware execution itself already exists through the standalone OpenQASM
+bridge(s) — it is **not** the future work. The remaining work this ADR scopes is the **Pulse-durable
+frontier integration**: the realize-node contraction, the await strategy, and submit/park/resume
+over an ordinary durable signal. The first such durable frontier becomes the revisit point for this
+ADR, per the "ADR after the prototype clarifies the boundary" sequencing.

--- a/docs/ADRs/0059-durable-external-call-frontiers-on-pulse.md
+++ b/docs/ADRs/0059-durable-external-call-frontiers-on-pulse.md
@@ -1,0 +1,219 @@
+---
+title: "ADR 0059 - Durable External-Call Frontiers on Pulse"
+description:
+  "How a Wire subgraph bound to an external backend (quantum, OpenAPI, WASM, MCP) runs durably on
+  Pulse: the host binds an external-call capability, a connected same-backend frontier projects to a
+  single Pulse stage, and long-running backends use idempotent submit/park/resume over the
+  run-terminal await."
+sidebar:
+  label: "0059. Durable external-call frontiers"
+  order: 59
+status: proposed
+date: 2026-06-16
+superseded_by: null
+related:
+  - docs/ADRs/0003-pulse-service-and-host-action-boundary.md
+  - docs/ADRs/0014-executor-taxonomy-model-vs-external-call.md
+  - docs/ADRs/0019-executor-registration-and-binding.md
+  - docs/ADRs/0024-typed-executor-node-interface.md
+  - docs/ADRs/0058-pulse-atomic-suspend-settlement.md
+  - docs/Architecture/06-pulse-runtime.md
+  - docs/Consumers/Quantum.md
+  - "GitHub #269"
+---
+
+# ADR 0059 - Durable External-Call Frontiers on Pulse
+
+## Status
+
+Proposed. Motivated by the QEC repetition-code workbench (#269), whose quantum circuits today run
+through a standalone Python bridge under the local `wire run` interpreter, with Pulse uninvolved.
+This ADR records how such a Wire-authored external-backend graph should instead run as a durable
+Pulse run, and pins the two pieces the existing executor ADRs leave open. It does not change the
+registration model (ADR 0019), the executor taxonomy (ADR 0014), or the host-action boundary (ADR
+0003); it composes them and adds frontier projection.
+
+## Context
+
+A Wire program can name an external backend by executor authority — `@quantum.cnot`,
+`@quantum.measure_z`, and (anticipated by ADR 0014) OpenAPI, WASM, and MCP surfaces. The substrate
+already decides how that authority is registered and bound:
+
+- **ADR 0019** splits executor meaning into four layers: Wire projection (inert ports/effect), a
+  Capability spec (inert authority: config decoder, providers, codec, host-bound flag), Pulse
+  execution of _already-bound_ stage actions, and Logos profiles. Capability specs **do not embed a
+  Pulse `StageAction`**, and **Pulse does not own executor registration** — the host turns a spec
+  into runnable code.
+- **ADR 0014** classifies a registered external backend as an `ExternalCallExecutor` (typed I/O
+  under a registered name), distinct from `ModelExecutor`.
+- **ADR 0003** restricts how Pulse reaches domain behavior: only through authenticated, idempotent
+  host-action APIs, never by writing host tables or running domain backends in the runtime process.
+- **ADR 0058** gives Pulse a durable await: a run can suspend on a `run-terminal:` (or general)
+  signal and be woken without polling.
+
+Despite all of this, no decision says how a Wire **subgraph** bound to an external backend becomes a
+**durable Pulse stage**. Two facts collide:
+
+1. **Granularity.** Wire models a quantum circuit as many gate-nodes, but the backend executes the
+   whole circuit as one coherent submission — gates are sub-millisecond and cannot be checkpointed
+   between. `docs/Consumers/Quantum.md` already states the host _"walks the materialized nodes and
+   appends operations to the selected quantum circuit"_: fusion is a host responsibility today,
+   performed outside Pulse. Materializing each gate as a durable stage would be absurd.
+2. **Lifetime.** A local simulator call is synchronous and cheap; a hardware submission is
+   long-running, externally stateful, and non-idempotent (submit returns a job id; you poll). The
+   first needs no durability; the second is a textbook durable-task shape.
+
+Because neither is pinned, external backends sit outside Pulse entirely (the #269 bridge),
+forfeiting durable scheduling, recovery, observability, and the await primitive — exactly the
+capabilities the hardware path most needs.
+
+## Decision
+
+A Wire subgraph bound to an external backend runs on Pulse as a **durable external-call frontier**,
+composed from the existing layers without weakening any boundary.
+
+### 1. Binding stays in Capability, not Pulse
+
+The host registers the backend as an `ExternalCallExecutor` Capability spec (ADR 0019/0014) and
+binds it to a runnable `StageAction` in the host process that embeds Pulse. Pulse does not gain a
+backend registry, an in-process Qiskit handler, or knowledge of `quantum.*`. "Run it on Pulse" means
+_the bound stage runs under Pulse's scheduler_, not _Pulse owns the backend_ — consistent with ADR
+0019's "Pulse does not own executor registration" and ADR 0003's host-action boundary.
+
+### 2. Frontier projection via an explicit realize node
+
+The author marks the frontier boundary explicitly with a **realize node** — a `collect`-style
+external-call executor (e.g. `@quantum.realize`) — rather than the materializer inferring a maximal
+subgraph. The circuit is authored as ordinary Wire topology (gate-nodes, for composition and typing)
+and **collected into the realize node**, which is the durable external-call stage:
+
+```
+build_circuit  =>  realize        =>  decode      =>  report
+(gate frontier)    (submit+wait)      downstream Pulse stages
+```
+
+The realize node's **payload is the fused sub-plan** (the backend-neutral operation list the bridge
+builds today, gathered from the upstream same-backend nodes feeding it); the gate-nodes are payload,
+never stages. Its **output ports are the labeled measurement results** — `s01`, `s12`, `final_d0`, …
+become the realize node's result fields, consumed by downstream stages. The realize node cannot
+consume post-measurement values as _inputs_, because those exist only after it executes; it consumes
+the frontier and produces the results. This is the author-explicit form of the host-walks-nodes
+behavior `Quantum.md` documents, and it mirrors the existing `std.io.command` send-spec /
+await-result / continue pattern the eraser already uses.
+
+At materialization, the realize node is the **projection sink**: upstream nodes sharing its
+external-call authority and effect class fuse into its payload; everything downstream is ordinary
+Pulse stages.
+
+### 3. Execution goes through the host-action boundary (ADR 0003)
+
+The stage's external call is an idempotent host action. Two execution shapes, selected by the
+backend's declared effect class:
+
+- **Synchronous** (local simulator, fast pure-ish backends): the host action runs the fused circuit
+  and returns results inline; the stage completes in one transaction.
+- **Submit/park/resume** (hardware, any long-running async backend): the host action _submits_ under
+  an idempotency key and returns a job handle; the run **parks** (ADR 0058) on that job's completion
+  signal; the host delivers a `run-terminal`-style signal when the job finishes; the run **resumes**
+  with results. No poll loop; a crash recovers to the parked-and-awaiting state, and the idempotency
+  key prevents double submission on replay.
+
+### 4. Analysis is ordinary downstream Pulse stages
+
+Syndrome extraction, decoding, and reporting are not external-backend work. They are pure or
+host-effecting stages downstream of the measurement frontier, scheduled like any other Pulse stage.
+The QEC decoder is data-pipeline post-processing on labeled measurement outputs, not a quantum
+executor.
+
+## Mental Model
+
+> A backend is bound once as a Capability and runs as a Pulse stage. The author builds the circuit
+> as Wire and _collects_ it into a realize node: its payload is the fused gates, its outputs are the
+> measurement results. Cheap backends return inline; long-running backends submit, park on a
+> completion signal, and resume. Decoding is just the next stage.
+
+## Boundary Rules
+
+- **No backend code in Pulse.** Pulse schedules a bound `StageAction`; the backend lives in the host
+  per ADR 0003/0019. The local `wire run` interpreter and the standalone bridge remain valid for
+  non-durable dev use — the Capability binding is the shared seam, so a backend is registered once
+  and reachable from both runtimes.
+- **Frontier, not node, is the unit of durable work.** Durability attaches at the
+  submission/frontier boundary. There is no per-gate checkpoint; a circuit is re-submitted whole on
+  recovery, guarded by the idempotency key.
+- **One executor authority per frontier.** A frontier mixing two backends does not project to one
+  call; it splits at the authority boundary into separate stages with typed ports between them.
+- **Idempotency is mandatory for async submits.** Every mutating host-action submit carries an
+  idempotency key derived from the run, the frontier, and the fused-plan hash, so replay after a
+  crash never double-submits.
+- **Effect class decides the shape.** A backend declares synchronous vs submit/park/resume in its
+  Capability spec; Pulse does not infer it.
+
+## Consequences
+
+### Positive
+
+- The hardware quantum path gains durable submission, recovery, and await-without-polling for free
+  by reusing ADR 0058 — the single most valuable Pulse capability for long-running jobs.
+- Generalizes beyond quantum: OpenAPI, WASM, and MCP backends (ADR 0014) all land as durable
+  external-call frontiers through the same mechanism.
+- No boundary erosion: registration stays in Capability, domain effects stay behind host actions.
+
+### Negative
+
+- Frontier projection is new machinery: a realize-node executor plus materialization that sinks the
+  upstream same-backend frontier into its payload is more than 1:1 node-to-stage materialization.
+- Two execution shapes (sync vs submit/park/resume) widen the host-action contract a backend must
+  satisfy.
+- Re-submitting a whole circuit on recovery wastes the prior (uncommitted) backend run; acceptable
+  because partial-circuit resumption is not physically meaningful.
+
+### Obligations
+
+- Add a realize-node (`collect`-style) external-call executor and the materialization rule that
+  sinks its upstream same-authority, same-effect-class frontier into one stage carrying the fused
+  plan, with the realize node's result fields as the stage's output ports.
+- Define the `ExternalCallExecutor` effect-class field (`synchronous` | `submit_park_resume`) in the
+  Capability spec and have Pulse dispatch on it.
+- Specify the idempotency-key derivation (run id + frontier id + fused-plan hash).
+- Wire the submit/park/resume host action to ADR 0058's run-terminal await for completion delivery.
+- Keep the standalone bridge and `wire run` path working; both consume the same Capability binding.
+
+## Alternatives Considered
+
+- **Register a quantum `TaskHandler` directly in Pulse's `TaskRegistry`.** Rejected: it would put
+  backend code in the runtime process and bypass the Capability layer, contradicting ADR 0019
+  ("Pulse does not own executor registration") and ADR 0003 (domain effects via host actions only).
+- **Materialize each gate as a durable stage.** Rejected: gates are coherent and sub-millisecond;
+  per-gate durability is meaningless and would multiply scheduling cost by ~50x for a trivial
+  circuit.
+- **Keep external backends outside Pulse permanently (the current bridge).** Rejected for the
+  hardware path: long-running async jobs are precisely what durable runs + the await primitive exist
+  for. Retained for local dev simulation, where durability adds nothing.
+
+## Open Questions
+
+1. **Realize-node ergonomics.** With an explicit realize node the author draws the boundary, so the
+   materializer no longer infers a maximal subgraph — but it must still validate that everything
+   collected into a realize node shares one backend authority/effect class, and reject a frontier
+   that mixes backends or smuggles a non-fusible node. What is the exact admission rule?
+2. **Where fusion lives.** Does the fused-plan builder move from the Python bridge into Pulse
+   materialization, or stay host-side and get handed the realize node's collected frontier? The
+   host-action boundary argues host-side; materialization needs at least to identify the frontier
+   the realize node sinks.
+3. **Realize node typing.** Are the realize node's result fields declared per-measurement (one
+   output port per named measurement) or as a single results record the decoder destructures? The
+   former keeps Wire's typed-port discipline; the latter is terser for many measurements.
+4. **Idempotency-key stability under rewrite.** If a rewrite changes the frontier between attempts,
+   the fused-plan hash changes; is that a fresh submission (correct) or a recovery hazard?
+5. **Local-sim durability.** Should synchronous local simulation run as a Pulse stage at all, or
+   stay on the `wire run` path? Uniformity vs overhead.
+6. **Effect-class taxonomy.** Is `synchronous | submit_park_resume` sufficient, or do streaming and
+   partial-result backends need a third shape?
+
+## First Consumer
+
+The QEC repetition-code workbench (#269) is the prototype. Its offline-simulator milestone validates
+the boundary on the `wire run` + bridge path; its hardware extension is the first
+`submit_park_resume` external-call frontier. This ADR should be revisited once that hardware path is
+built, per the "ADR after the prototype clarifies the boundary" sequencing.

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -75,6 +75,7 @@ values: `proposed`, `accepted`, `superseded`, `deprecated`.
 | [0056](0056-admission-modes-witnessed-and-gas.md)                  | Admission Modes: Witnessed Materialization and Open Rewrite Gas     | proposed   |
 | [0057](0057-wire-latent-branch-witnessing-and-closure-charging.md) | Latent Branch Witnessing and Proposal Closure Charging              | proposed   |
 | [0058](0058-pulse-atomic-suspend-settlement.md)                    | Pulse Atomic Suspend Settlement                                     | proposed   |
+| [0059](0059-durable-external-call-frontiers-on-pulse.md)           | Durable External-Call Frontiers on Pulse                            | proposed   |
 
 ## Writing a new ADR
 

--- a/docs/Consumers/Braket.md
+++ b/docs/Consumers/Braket.md
@@ -1,0 +1,645 @@
+---
+title: Amazon Braket Consumer Setup
+description:
+  AWS account, IAM, S3, and OpenQASM smoke-test setup for an Amazon Braket quantum host binding.
+sidebar:
+  label: Amazon Braket
+  order: 5
+status: draft
+---
+
+# Amazon Braket Consumer Setup
+
+This page is a consumer setup guide. It prepares an AWS account for a quantum host that submits
+Wire-authored circuits to Amazon Braket as OpenQASM 3. Cortex still owns Wire parsing, typed graph
+composition, and executor admission. The Braket host owns AWS credentials, S3 result storage, device
+choice, queue policy, shot count, spending limits, and result interpretation.
+
+Braket does not use a separate Braket API key. Local code authenticates with normal AWS IAM
+credentials, and the Braket service uses AWS service roles inside the account.
+
+The Cortex development shell includes AWS CLI v2. The repository's Braket runner also receives the
+AWS CLI store path from its Nix app, so `nix run .#wire-quantum-braket` works without separately
+installing the Amazon Braket Python SDK.
+
+## Environment Names
+
+Use these local environment variables for Cortex-side Braket setup:
+
+```bash
+export CORTEX_BRAKET_ACCESS_KEY="<aws-access-key-id>"
+export CORTEX_BRAKET_SECRET_KEY="<aws-secret-access-key>"
+export CORTEX_BRAKET_BUCKET="amazon-braket-cortex-results-<account-id>-us-east-1"
+export CORTEX_BRAKET_PREFIX="cortex/dev"
+export CORTEX_BRAKET_REGION="us-east-1"
+```
+
+Older notes may call the access-key variable `CORTEX_BRAKET_ACCESS`. Map it before configuring AWS:
+
+```bash
+export CORTEX_BRAKET_ACCESS_KEY="${CORTEX_BRAKET_ACCESS_KEY:-${CORTEX_BRAKET_ACCESS:-}}"
+```
+
+Do not commit access keys, generated AWS credential files, or local Braket config files.
+
+## Enable Braket
+
+In the AWS Console, open **Amazon Braket** and complete the onboarding wizard. The wizard may
+create:
+
+- `AWSServiceRoleForAmazonBraket`
+- `AmazonBraketJobsExecutionRole`
+- third-party device enablement
+- provider spending limits
+
+You do not need to attach these service roles to the IAM user used by Cortex. The IAM user is the
+local API identity. `AWSServiceRoleForAmazonBraket` is used internally by AWS for Braket tasks.
+`AmazonBraketJobsExecutionRole` is only needed for Braket Hybrid Jobs. A notebook instance is not
+required for the CLI or SDK smoke tests.
+
+Check the roles:
+
+```bash
+aws iam get-role \
+  --role-name AWSServiceRoleForAmazonBraket \
+  --profile cortex-braket \
+  --region us-east-1
+
+aws iam get-role \
+  --role-name AmazonBraketJobsExecutionRole \
+  --profile cortex-braket \
+  --region us-east-1
+```
+
+If the service-linked role is missing and your identity is allowed to create it:
+
+```bash
+aws iam create-service-linked-role \
+  --aws-service-name braket.amazonaws.com \
+  --profile cortex-braket
+```
+
+Without `AWSServiceRoleForAmazonBraket`, `create-quantum-task` fails before a task is queued.
+
+## Create IAM Access
+
+Create an IAM user for local API access, for example:
+
+```text
+cortex-braket
+```
+
+Create or use a group such as:
+
+```text
+cortex-braket-users
+```
+
+For initial testing, attach the AWS managed policy:
+
+```text
+AmazonBraketFullAccess
+```
+
+This is intentionally broad for setup validation. Replace it with a least-privilege policy once the
+backend is working.
+
+Then create an access key:
+
+```text
+IAM -> Users -> cortex-braket -> Security credentials -> Access keys -> Create access key
+```
+
+Use case:
+
+```text
+Command Line Interface (CLI)
+```
+
+AWS will show `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. Store them in your local secret
+manager and export them as `CORTEX_BRAKET_ACCESS_KEY` and `CORTEX_BRAKET_SECRET_KEY`.
+
+## Create The S3 Result Bucket
+
+Braket writes task results to S3. Create a private S3 bucket in the same region used for Braket.
+
+Recommended starting region:
+
+```text
+us-east-1
+```
+
+Bucket names should start with:
+
+```text
+amazon-braket-
+```
+
+Example:
+
+```text
+amazon-braket-cortex-results-<account-id>-us-east-1
+```
+
+Recommended bucket settings:
+
+```text
+Bucket type: General purpose
+Object ownership: ACLs disabled / bucket owner enforced
+Block all public access: enabled
+Versioning: disabled
+Encryption: SSE-S3
+Object Lock: disabled
+```
+
+Use a prefix for development results:
+
+```text
+cortex/dev
+```
+
+The IAM identity used for local smoke tests needs list, read, write, and usually delete access for
+that prefix. If delete is omitted, task submission can still work, but cleanup commands will leave
+test objects behind. A prefix-scoped S3 policy has this shape:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ListBraketResultPrefix",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::BUCKET_NAME",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": ["cortex/dev", "cortex/dev/*"]
+        }
+      }
+    },
+    {
+      "Sid": "UseBraketResultPrefix",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+      "Resource": "arn:aws:s3:::BUCKET_NAME/cortex/dev/*"
+    }
+  ]
+}
+```
+
+Replace `BUCKET_NAME` and `cortex/dev` with the bucket and prefix used by the account.
+
+## Configure The Local AWS Profile
+
+From the Cortex repository, enter the development shell:
+
+```bash
+nix develop
+aws --version
+```
+
+Or, outside the repository, use a temporary Nix shell with AWS CLI v2:
+
+```bash
+nix shell nixpkgs#awscli2
+```
+
+Create the AWS profile from the Cortex environment variables:
+
+```bash
+set -euo pipefail
+
+export CORTEX_BRAKET_ACCESS_KEY="${CORTEX_BRAKET_ACCESS_KEY:-${CORTEX_BRAKET_ACCESS:-}}"
+: "${CORTEX_BRAKET_ACCESS_KEY:?set CORTEX_BRAKET_ACCESS_KEY}"
+: "${CORTEX_BRAKET_SECRET_KEY:?set CORTEX_BRAKET_SECRET_KEY}"
+: "${CORTEX_BRAKET_BUCKET:?set CORTEX_BRAKET_BUCKET}"
+export CORTEX_BRAKET_PREFIX="${CORTEX_BRAKET_PREFIX:-cortex/dev}"
+export CORTEX_BRAKET_REGION="${CORTEX_BRAKET_REGION:-us-east-1}"
+
+mkdir -p ~/.aws
+
+aws configure set aws_access_key_id "$CORTEX_BRAKET_ACCESS_KEY" \
+  --profile cortex-braket
+
+aws configure set aws_secret_access_key "$CORTEX_BRAKET_SECRET_KEY" \
+  --profile cortex-braket
+
+aws configure set region "$CORTEX_BRAKET_REGION" \
+  --profile cortex-braket
+
+aws configure set output json \
+  --profile cortex-braket
+```
+
+For SDKs and subprocesses that rely on standard AWS environment variables:
+
+```bash
+export AWS_PROFILE="cortex-braket"
+export AWS_REGION="${CORTEX_BRAKET_REGION:-us-east-1}"
+export AWS_DEFAULT_REGION="${CORTEX_BRAKET_REGION:-us-east-1}"
+export AWS_ACCESS_KEY_ID="$CORTEX_BRAKET_ACCESS_KEY"
+export AWS_SECRET_ACCESS_KEY="$CORTEX_BRAKET_SECRET_KEY"
+```
+
+## Verify Identity And S3
+
+Check the profile:
+
+```bash
+aws configure list-profiles
+
+aws sts get-caller-identity \
+  --profile cortex-braket
+```
+
+The identity response should contain the AWS account ID and the IAM user ARN.
+
+Check bucket listing:
+
+```bash
+aws s3 ls "s3://${CORTEX_BRAKET_BUCKET}" \
+  --profile cortex-braket \
+  --region "${CORTEX_BRAKET_REGION:-us-east-1}"
+```
+
+Check write, read, and delete under the configured prefix:
+
+```bash
+echo "braket test $(date -Iseconds)" > /tmp/braket-test.txt
+
+aws s3 cp /tmp/braket-test.txt \
+  "s3://${CORTEX_BRAKET_BUCKET}/${CORTEX_BRAKET_PREFIX}/braket-test.txt" \
+  --profile cortex-braket \
+  --region "${CORTEX_BRAKET_REGION:-us-east-1}"
+
+aws s3 cp \
+  "s3://${CORTEX_BRAKET_BUCKET}/${CORTEX_BRAKET_PREFIX}/braket-test.txt" \
+  - \
+  --profile cortex-braket \
+  --region "${CORTEX_BRAKET_REGION:-us-east-1}"
+
+aws s3 rm \
+  "s3://${CORTEX_BRAKET_BUCKET}/${CORTEX_BRAKET_PREFIX}/braket-test.txt" \
+  --profile cortex-braket \
+  --region "${CORTEX_BRAKET_REGION:-us-east-1}"
+```
+
+If the last command fails with `s3:DeleteObject`, add delete permission for the result prefix or
+clean up test objects through another administrative identity.
+
+## Verify Braket Device Access
+
+Some AWS CLI versions require `--filters` for `braket search-devices`, and currently only document
+`deviceArn` as a filter name. Use an empty filter list for an unfiltered search:
+
+```bash
+aws braket search-devices \
+  --profile cortex-braket \
+  --region "${CORTEX_BRAKET_REGION:-us-east-1}" \
+  --filters '[]' \
+  --query 'devices[*].{name:deviceName,status:deviceStatus,type:deviceType,arn:deviceArn}' \
+  --output table
+```
+
+The managed simulators `SV1`, `TN1`, and `dm1` should appear as `ONLINE` in `us-east-1`. QPUs may be
+online, offline, retired, or gated by provider setup and spending limits.
+
+## Run The Wire Braket Runner
+
+After identity, S3, and device checks pass, validate the repository runner without submitting a
+task:
+
+```bash
+nix run .#wire-quantum-braket -- \
+  examples/wire/quantum-bell-state-ibm-rest.wire \
+  --dry-run \
+  --json
+```
+
+Submit the same Wire-authored Bell circuit to the managed simulator `SV1`:
+
+```bash
+nix run .#wire-quantum-braket -- \
+  examples/wire/quantum-bell-state-ibm-rest.wire \
+  --shots 100 \
+  --confirm-hardware \
+  --json
+```
+
+If the bucket or profile is not exported in the shell, pass them explicitly:
+
+```bash
+nix run .#wire-quantum-braket -- \
+  examples/wire/quantum-bell-state-ibm-rest.wire \
+  --shots 100 \
+  --s3-bucket "$CORTEX_BRAKET_BUCKET" \
+  --s3-prefix "${CORTEX_BRAKET_PREFIX:-cortex/dev}" \
+  --profile cortex-braket \
+  --confirm-hardware \
+  --json
+```
+
+The runner defaults to:
+
+```text
+device: arn:aws:braket:::device/quantum-simulator/amazon/sv1
+region: us-east-1
+profile: cortex-braket
+shots: 100
+```
+
+Use `--backend sv1`, `--backend tn1`, `--backend dm1`, or `--device-arn <arn>` to select another
+Braket device. Start with `SV1`; third-party QPUs should be gated by provider setup and spending
+limits.
+
+The runner lowers the admitted Wire quantum plan into Braket OpenQASM 3. Current lowering details:
+
+- Wire `@quantum.sx` is emitted as Braket `v`.
+- Wire `@quantum.rzz` is decomposed into `cnot/rz/cnot`.
+- Unmeasured qubits are measured into extra classical bits when needed so managed simulator results
+  contain a full measurement row.
+- Result JSON is normalized into the same `counts`, `labeled_counts`, and `output_counts` shape used
+  by the existing Qiskit and IBM REST runners.
+- Result JSON includes a `cost_estimate` object and top-level `estimated_cost_usd` when the runner
+  has enough pricing data. QPU estimates use public Braket per-task and per-shot pricing. SV1
+  estimates use public per-minute simulator pricing and task start/end metadata. These are
+  estimates, not AWS billing records.
+
+The estimate excludes S3, taxes, discounts, credits, reservations, free-tier credits, and later AWS
+billing adjustments. For devices not in the embedded pricing table, override pricing explicitly:
+
+```bash
+export CORTEX_BRAKET_TASK_PRICE_USD="0.30"
+export CORTEX_BRAKET_SHOT_PRICE_USD="0.00160"
+```
+
+For managed simulator experiments with a custom rate:
+
+```bash
+export CORTEX_BRAKET_SIMULATOR_MINUTE_PRICE_USD="0.075"
+```
+
+The IBM-era Wire experiments can now run through Braket by swapping the app:
+
+```bash
+nix run .#wire-quantum-qec-repetition-braket -- --confirm-hardware
+```
+
+```bash
+nix run .#wire-quantum-eraser-braket -- --confirm-hardware
+```
+
+```bash
+nix run .#wire-quantum-ipea-braket -- --bits 3 --shots 100 --confirm-hardware
+```
+
+For the larger QEC and eraser sweeps, inspect individual selected circuits first:
+
+```bash
+nix run .#wire-quantum-braket -- \
+  examples/wire/qec-repetition-code-forced-errors.wire \
+  --return qec_repetition_x1 \
+  --dry-run \
+  --json
+```
+
+```bash
+nix run .#wire-quantum-braket -- \
+  examples/wire/quantum-eraser-experiment.wire \
+  --return eraser_phase_0 \
+  --dry-run \
+  --json
+```
+
+The QEC wrapper submits four Braket tasks. The eraser wrapper submits nine Braket tasks. The IPEA
+wrapper submits one Braket task per measured phase bit.
+
+## Submit A CLI OpenQASM Smoke Test
+
+This test submits a two-qubit Bell-state circuit to the managed simulator `SV1`. It validates the
+same OpenQASM and S3 result path a Braket host binding needs, without requiring the Braket Python
+SDK.
+
+Create the OpenQASM source and Braket action payload:
+
+```bash
+cat > /tmp/braket-bell.qasm <<'QASM'
+OPENQASM 3.0;
+qubit[2] q;
+bit[2] c;
+
+h q[0];
+cnot q[0], q[1];
+
+c[0] = measure q[0];
+c[1] = measure q[1];
+QASM
+
+ACTION="$(jq -Rs \
+  '{braketSchemaHeader:{name:"braket.ir.openqasm.program",version:"1"},source:.}' \
+  /tmp/braket-bell.qasm)"
+```
+
+Submit the task:
+
+```bash
+RUN_PREFIX="${CORTEX_BRAKET_PREFIX%/}/cli-openqasm-$(date -u +%Y%m%dT%H%M%SZ)"
+
+TASK_ARN="$(aws braket create-quantum-task \
+  --profile cortex-braket \
+  --region "${CORTEX_BRAKET_REGION:-us-east-1}" \
+  --device-arn arn:aws:braket:::device/quantum-simulator/amazon/sv1 \
+  --shots 100 \
+  --output-s3-bucket "$CORTEX_BRAKET_BUCKET" \
+  --output-s3-key-prefix "$RUN_PREFIX" \
+  --action "$ACTION" \
+  --query quantumTaskArn \
+  --output text)"
+
+echo "$TASK_ARN"
+```
+
+Poll until the task settles. Do not name the shell variable `status` in zsh; it is read-only there.
+
+```bash
+while true; do
+  task_state="$(aws braket get-quantum-task \
+    --quantum-task-arn "$TASK_ARN" \
+    --profile cortex-braket \
+    --region "${CORTEX_BRAKET_REGION:-us-east-1}" \
+    --query status \
+    --output text)"
+
+  echo "status=${task_state}"
+
+  case "$task_state" in
+    COMPLETED|FAILED|CANCELLED)
+      break
+      ;;
+  esac
+
+  sleep 5
+done
+```
+
+Fetch the metadata and result URI:
+
+```bash
+TASK_JSON="$(aws braket get-quantum-task \
+  --quantum-task-arn "$TASK_ARN" \
+  --profile cortex-braket \
+  --region "${CORTEX_BRAKET_REGION:-us-east-1}" \
+  --output json)"
+
+echo "$TASK_JSON" | jq '{
+  status: .status,
+  quantumTaskArn: .quantumTaskArn,
+  deviceArn: .deviceArn,
+  shots: .shots,
+  outputS3Bucket: .outputS3Bucket,
+  outputS3Directory: .outputS3Directory,
+  failureReason: .failureReason
+}'
+
+RESULT_URI="$(echo "$TASK_JSON" | jq -r \
+  '"s3://\(.outputS3Bucket)/\(.outputS3Directory)/results.json"')"
+
+echo "$RESULT_URI"
+```
+
+Read and count the measurements:
+
+```bash
+aws s3 cp "$RESULT_URI" - \
+  --profile cortex-braket \
+  --region "${CORTEX_BRAKET_REGION:-us-east-1}" |
+  jq '{
+    shots: .taskMetadata.shots,
+    counts: (
+      .measurements
+      | map(join(""))
+      | group_by(.)
+      | map({key: .[0], value: length})
+      | from_entries
+    )
+  }'
+```
+
+Expected result: 100 shots split mostly between `00` and `11`, for example:
+
+```json
+{
+  "shots": 100,
+  "counts": {
+    "00": 56,
+    "11": 44
+  }
+}
+```
+
+For CLI-submitted OpenQASM tasks, the raw result JSON may contain `measurements` but no populated
+`measurementCounts` field. Counting `measurements` directly is portable for this smoke test.
+
+## Optional Python SDK Smoke Test
+
+Use the Python SDK when the project environment includes it. The Cortex dev shell does not currently
+ship `amazon-braket-sdk`, so use a separate virtual environment if needed:
+
+```bash
+python -m venv /tmp/braket-sdk
+source /tmp/braket-sdk/bin/activate
+pip install amazon-braket-sdk
+```
+
+Create `/tmp/test-qasm-braket.py`:
+
+```python
+import os
+
+from braket.aws import AwsDevice
+from braket.ir.openqasm import Program
+
+bucket = os.environ["CORTEX_BRAKET_BUCKET"]
+prefix = os.environ.get("CORTEX_BRAKET_PREFIX", "cortex/dev")
+
+qasm = """
+OPENQASM 3.0;
+qubit[2] q;
+bit[2] c;
+
+h q[0];
+cnot q[0], q[1];
+
+c[0] = measure q[0];
+c[1] = measure q[1];
+"""
+
+device = AwsDevice("arn:aws:braket:::device/quantum-simulator/amazon/sv1")
+
+task = device.run(
+    Program(source=qasm),
+    s3_folder=(bucket, prefix),
+    shots=100,
+)
+
+print("Task ARN:", task.id)
+result = task.result()
+print(result.measurement_counts)
+```
+
+Run it:
+
+```bash
+AWS_PROFILE=cortex-braket \
+AWS_DEFAULT_REGION="${CORTEX_BRAKET_REGION:-us-east-1}" \
+python /tmp/test-qasm-braket.py
+```
+
+Expected result: counts mostly split between `00` and `11`.
+
+## Troubleshooting
+
+`The config profile (cortex-braket) could not be found`
+
+: Run the profile setup commands again from a shell where the `CORTEX_BRAKET_*` variables are
+exported.
+
+`search-devices` requires `--filters`
+
+: Use `--filters '[]'`. Some AWS CLI versions reject `deviceType` filters even though they can
+return `deviceType` in the output.
+
+`AWSServiceRoleForAmazonBraket role doesn't exist`
+
+: Complete the Braket onboarding wizard or create the service-linked role with
+`aws iam create-service-linked-role --aws-service-name braket.amazonaws.com`.
+
+`AccessDenied` on `s3:DeleteObject`
+
+: The account can write and read results but cannot clean up test objects. Add `s3:DeleteObject` for
+the result prefix if automatic cleanup matters.
+
+No `measurementCounts` in `results.json`
+
+: Count `.measurements` directly, as shown in the CLI smoke test. SDK helpers may compute
+measurement counts client-side.
+
+## Cost Notes
+
+Braket can incur costs for:
+
+- QPU shots
+- managed simulators
+- notebooks
+- hybrid jobs
+- S3 storage
+
+For development, start with `SV1`, low shot counts, and a development-only S3 prefix. Configure
+provider spending limits before using third-party QPUs.
+
+## Related
+
+- [Quantum Consumer Binding Example](Quantum.md)
+- [QEC Repetition-Code Consumer Example](QEC.md)
+- [../Reference/Wire/executors-and-alphabet.md](../Reference/Wire/executors-and-alphabet.md)
+- [../Reference/Wire/configured-executors-and-execution-boundary.md](../Reference/Wire/configured-executors-and-execution-boundary.md)

--- a/docs/Consumers/QEC.md
+++ b/docs/Consumers/QEC.md
@@ -30,9 +30,9 @@ The ownership split follows the quantum consumer binding:
 | `std.io.command` orchestration and pure `fromJson` report rendering.  | Backend result production and any future real-time decoding policy.   |
 | The checked-in experiment topology and expected forced-error table.   | General QEC research semantics beyond this repetition-code workbench. |
 
-The hardware execution path uses the existing `wire-quantum-ibm-rest` bridge. There is no
-QEC-specific Python analyzer: the bridge produces JSON counts, and Wire computes the syndrome-table
-report with pure expressions.
+The hardware execution path uses the selected quantum runner. There is no QEC-specific Python
+analyzer: the runner produces JSON counts, and Wire computes the syndrome-table report with pure
+expressions.
 
 ## Circuit Shape
 
@@ -70,16 +70,28 @@ Run the full Wire experiment on IBM Quantum Runtime hardware:
 nix run .#wire-quantum-qec-repetition -- --confirm-hardware
 ```
 
-The app places `wire-quantum-ibm-rest` on `PATH` and then runs:
+Run the same Wire experiment on Amazon Braket:
+
+```sh
+nix run .#wire-quantum-qec-repetition-braket -- --confirm-hardware
+```
+
+The provider app places a `wire-quantum-runner` command on `PATH` and then runs:
 
 ```sh
 wire run examples/wire/qec-repetition-code-forced-errors.wire
 ```
 
 The Wire graph creates four `std.io.command` leaves, one per exported circuit graph. Each command
-selects its circuit with `wire build --return`, submits it through IBM Runtime REST with `--json`,
-and returns a `CommandResult`. The final Wire nodes parse those JSON payloads with `fromJson`, check
-the forced-error table, print the report, and write `./wire-qec-repetition-report.txt`.
+selects its circuit with `wire build --return`, submits it through the selected runner with
+`--json`, and returns a `CommandResult`. The final Wire nodes parse those JSON payloads with
+`fromJson`, check the forced-error table, print the report, and write
+`./wire-qec-repetition-report.txt`.
+
+When every selected runner result includes `estimated_cost_usd`, the pure Wire report also sums the
+four task estimates and prints a `Cost estimate` section. The Braket runner provides this field for
+known QPU pricing and SV1 simulator runs. The value is an estimate, not an AWS billing record, and
+excludes S3, taxes, discounts, credits, reservations, and billing adjustments.
 
 Each selected circuit carries:
 
@@ -102,6 +114,10 @@ of `least_busy`:
 If the Runtime service CRN is regional, keep `api_base_url` in the same region as the CRN. For
 example, `eu-de` service instances should use `https://eu-de.quantum.cloud.ibm.com/api/v1`.
 
+The Braket runner ignores the IBM config node as orchestration data and instead reads AWS settings
+from `CORTEX_BRAKET_BUCKET`, `CORTEX_BRAKET_PREFIX`, `CORTEX_BRAKET_REGION`, and `AWS_PROFILE`, or
+from equivalent command-line flags.
+
 ## Local Inspection
 
 To inspect one circuit through the local simulator instead of hardware:
@@ -117,8 +133,8 @@ nix run .#wire-quantum-qiskit -- \
 
 ## OpenQASM Dry-Run
 
-The same exported graphs can be lowered through the IBM Runtime REST dry-run path. The dry-run
-builds the OpenQASM 3 request locally and does not submit a hardware job:
+The same exported graphs can be lowered through the IBM Runtime REST or Braket dry-run paths. The
+dry-run builds the OpenQASM 3 request locally and does not submit a hardware job:
 
 ```sh
 nix run .#wire-quantum-ibm-rest -- \
@@ -128,7 +144,17 @@ nix run .#wire-quantum-ibm-rest -- \
   --config examples/wire/quantum-ibm-runtime.config.example.json
 ```
 
-Hardware submission remains explicitly gated by the IBM runner's credentials and
+For Braket:
+
+```sh
+nix run .#wire-quantum-braket -- \
+  examples/wire/qec-repetition-code-forced-errors.wire \
+  --return qec_repetition_x1 \
+  --dry-run \
+  --json
+```
+
+Hardware submission remains explicitly gated by each provider runner's credentials and
 `--confirm-hardware` policy. This example remains a forced-error workbench until reset, layout,
 timing, and real-time/feedforward semantics are designed.
 

--- a/docs/Consumers/QEC.md
+++ b/docs/Consumers/QEC.md
@@ -30,9 +30,9 @@ The ownership split follows the quantum consumer binding:
 | `std.io.command` orchestration and pure `fromJson` report rendering.  | Backend result production and any future real-time decoding policy.   |
 | The checked-in experiment topology and expected forced-error table.   | General QEC research semantics beyond this repetition-code workbench. |
 
-The local execution path uses the existing `wire-quantum-qiskit` bridge. There is no QEC-specific
-Python analyzer: the bridge produces JSON counts, and Wire computes the syndrome-table report with
-pure expressions.
+The hardware execution path uses the existing `wire-quantum-ibm-rest` bridge. There is no
+QEC-specific Python analyzer: the bridge produces JSON counts, and Wire computes the syndrome-table
+report with pure expressions.
 
 ## Circuit Shape
 
@@ -62,26 +62,36 @@ analyzer expects this lookup table:
 | x1   | `010`    | `11`     | `X d1`     |
 | x2   | `001`    | `01`     | `X d2`     |
 
-## Local Run
+## Hardware Run
 
-Run the full Wire experiment:
+Run the full Wire experiment on IBM Quantum Runtime hardware:
 
 ```sh
-nix run .#wire-quantum-qec-repetition
+nix run .#wire-quantum-qec-repetition -- --confirm-hardware
 ```
 
-The app places `wire-quantum-qiskit` on `PATH` and then runs:
+The app places `wire-quantum-ibm-rest` on `PATH` and then runs:
 
 ```sh
 wire run examples/wire/qec-repetition-code-forced-errors.wire
 ```
 
 The Wire graph creates four `std.io.command` leaves, one per exported circuit graph. Each command
-selects its circuit with `wire build --return`, executes it on local Qiskit Aer with `--json`, and
-returns a `CommandResult`. The final Wire nodes parse those JSON payloads with `fromJson`, check the
-forced-error table, print the report, and write `./wire-qec-repetition-report.txt`.
+selects its circuit with `wire build --return`, submits it through IBM Runtime REST with `--json`,
+and returns a `CommandResult`. The final Wire nodes parse those JSON payloads with `fromJson`, check
+the forced-error table, print the report, and write `./wire-qec-repetition-report.txt`.
 
-To inspect one circuit directly:
+Each selected circuit carries:
+
+```wire
+@quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; }
+```
+
+so real credentials should live in the ignored file `examples/wire/quantum-ibm-runtime.local.json`.
+
+## Local Inspection
+
+To inspect one circuit through the local simulator instead of hardware:
 
 ```sh
 nix run .#wire-quantum-qiskit -- \
@@ -106,7 +116,7 @@ nix run .#wire-quantum-ibm-rest -- \
 ```
 
 Hardware submission remains explicitly gated by the IBM runner's credentials and
-`--confirm-hardware` policy. This example should remain a local workbench until reset, layout,
+`--confirm-hardware` policy. This example remains a forced-error workbench until reset, layout,
 timing, and real-time/feedforward semantics are designed.
 
 ## Limitations
@@ -117,7 +127,7 @@ This is a forced-error repetition-code workbench, not a full QEC stack:
 - ancillas are fresh, not reset and reused;
 - no stochastic noise model or repeated syndrome rounds are included yet;
 - the report checks a deterministic forced-error table rather than estimating thresholds;
-- hardware execution should be treated as an inspection path, not an endorsed QEC experiment.
+- hardware execution submits four independent sampler jobs, not a live QEC control loop.
 
 ## Related
 

--- a/docs/Consumers/QEC.md
+++ b/docs/Consumers/QEC.md
@@ -88,6 +88,19 @@ Each selected circuit carries:
 ```
 
 so real credentials should live in the ignored file `examples/wire/quantum-ibm-runtime.local.json`.
+For accounts that cannot list provider backends, set a concrete backend in that local config instead
+of `least_busy`:
+
+```json
+{
+  "api_key_env": "QISKIT_IBM_API_KEY",
+  "instance_crn": "crn:v1:...",
+  "backend": "ibm_backend_name"
+}
+```
+
+If the Runtime service CRN is regional, keep `api_base_url` in the same region as the CRN. For
+example, `eu-de` service instances should use `https://eu-de.quantum.cloud.ibm.com/api/v1`.
 
 ## Local Inspection
 

--- a/docs/Consumers/QEC.md
+++ b/docs/Consumers/QEC.md
@@ -1,0 +1,126 @@
+---
+title: QEC Repetition-Code Consumer Example
+description:
+  A small Wire-authored quantum error-correction workbench over the quantum consumer binding.
+sidebar:
+  label: QEC repetition code
+  order: 4
+status: draft
+---
+
+# QEC Repetition-Code Consumer Example
+
+This page is a consumer binding example. It shows how Wire can host a small quantum
+error-correction-shaped workflow without making Cortex a QEC platform.
+
+The workbench source is
+[`../../examples/wire/qec-repetition-code-forced-errors.wire`](../../examples/wire/qec-repetition-code-forced-errors.wire).
+It is a single Wire file with two roles:
+
+- a catalog of four exported circuit graph values;
+- a default experiment graph that runs those circuits and renders the report in pure Wire.
+
+## Boundary
+
+The ownership split follows the quantum consumer binding:
+
+| Cortex / Wire owns                                                    | Quantum or QEC host owns                                              |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Wire parsing, graph composition, typed ports, selected graph returns. | Gate semantics, simulator/hardware binding, provider credentials.     |
+| `std.io.command` orchestration and pure `fromJson` report rendering.  | Backend result production and any future real-time decoding policy.   |
+| The checked-in experiment topology and expected forced-error table.   | General QEC research semantics beyond this repetition-code workbench. |
+
+The local execution path uses the existing `wire-quantum-qiskit` bridge. There is no QEC-specific
+Python analyzer: the bridge produces JSON counts, and Wire computes the syndrome-table report with
+pure expressions.
+
+## Circuit Shape
+
+The circuit is the distance-3 bit-flip repetition-code memory check for logical zero:
+
+```text
+|0_L> = |000>
+S01 = Z0 Z1
+S12 = Z1 Z2
+```
+
+The file exports four graph values:
+
+- `qec_repetition_none`
+- `qec_repetition_x0`
+- `qec_repetition_x1`
+- `qec_repetition_x2`
+
+Each selected graph prepares three data qubits and two fresh syndrome ancillas, injects at most one
+forced `X` error, measures the two parity checks, and measures the final data bits. The pure Wire
+analyzer expects this lookup table:
+
+| case | raw data | syndrome | correction |
+| ---- | -------- | -------- | ---------- |
+| none | `000`    | `00`     | none       |
+| x0   | `100`    | `10`     | `X d0`     |
+| x1   | `010`    | `11`     | `X d1`     |
+| x2   | `001`    | `01`     | `X d2`     |
+
+## Local Run
+
+Run the full Wire experiment:
+
+```sh
+nix run .#wire-quantum-qec-repetition
+```
+
+The app places `wire-quantum-qiskit` on `PATH` and then runs:
+
+```sh
+wire run examples/wire/qec-repetition-code-forced-errors.wire
+```
+
+The Wire graph creates four `std.io.command` leaves, one per exported circuit graph. Each command
+selects its circuit with `wire build --return`, executes it on local Qiskit Aer with `--json`, and
+returns a `CommandResult`. The final Wire nodes parse those JSON payloads with `fromJson`, check the
+forced-error table, print the report, and write `./wire-qec-repetition-report.txt`.
+
+To inspect one circuit directly:
+
+```sh
+nix run .#wire-quantum-qiskit -- \
+  examples/wire/qec-repetition-code-forced-errors.wire \
+  --return qec_repetition_x1 \
+  --shots 128 \
+  --seed 7 \
+  --json
+```
+
+## OpenQASM Dry-Run
+
+The same exported graphs can be lowered through the IBM Runtime REST dry-run path. The dry-run
+builds the OpenQASM 3 request locally and does not submit a hardware job:
+
+```sh
+nix run .#wire-quantum-ibm-rest -- \
+  examples/wire/qec-repetition-code-forced-errors.wire \
+  --return qec_repetition_x1 \
+  --dry-run \
+  --config examples/wire/quantum-ibm-runtime.config.example.json
+```
+
+Hardware submission remains explicitly gated by the IBM runner's credentials and
+`--confirm-hardware` policy. This example should remain a local workbench until reset, layout,
+timing, and real-time/feedforward semantics are designed.
+
+## Limitations
+
+This is a forced-error repetition-code workbench, not a full QEC stack:
+
+- decoding is offline report logic, not active mid-circuit feedforward;
+- ancillas are fresh, not reset and reused;
+- no stochastic noise model or repeated syndrome rounds are included yet;
+- the report checks a deterministic forced-error table rather than estimating thresholds;
+- hardware execution should be treated as an inspection path, not an endorsed QEC experiment.
+
+## Related
+
+- [Quantum Consumer Binding Example](Quantum.md)
+- [../Reference/Wire/executors-and-alphabet.md](../Reference/Wire/executors-and-alphabet.md)
+- [../Reference/Wire/configured-executors-and-execution-boundary.md](../Reference/Wire/configured-executors-and-execution-boundary.md)

--- a/docs/Consumers/Quantum.md
+++ b/docs/Consumers/Quantum.md
@@ -97,6 +97,10 @@ The runner:
 - executes it on Qiskit Aer `aer_simulator`;
 - prints a concise run summary with label-decoded counts.
 
+JSON output includes raw bitstring counts, label-ordered counts, and per-output counts keyed by
+measurement output name. The per-output shape lets pure Wire analyzers consume backend JSON without
+depending on topology-specific measurement label ordering.
+
 Machine-readable output is available with `--json`:
 
 ```sh
@@ -134,9 +138,10 @@ The runner treats that node as the source of the provider config path. The confi
 relative to the `.wire` file. The example threads the config token into the first prepare node only
 to make the Wire graph connected; the runner treats it as orchestration data, not quantum state. The
 hardware example authors the Bell circuit from backend primitive gates: `h` is decomposed as
-`rz(pi/2) => sx => rz(pi/2)`, and `cnot` as `h(target) => cz => h(target)`. `*.local.json` files are
-ignored by git, so real credentials should live in `examples/wire/quantum-ibm-runtime.local.json`.
-The tracked template at
+`rz(pi/2) => sx => rz(pi/2)`, and `cnot` as `h(target) => cz => h(target)`. The runner also applies
+those decompositions while lowering `@quantum.h` and `@quantum.cnot`, and omits zero-angle `rz`
+wiring identities from emitted OpenQASM 3. `*.local.json` files are ignored by git, so real
+credentials should live in `examples/wire/quantum-ibm-runtime.local.json`. The tracked template at
 [`../../examples/wire/quantum-ibm-runtime.config.example.json`](../../examples/wire/quantum-ibm-runtime.config.example.json)
 shows the expected shape:
 
@@ -217,6 +222,23 @@ nix run .#wire-quantum-ipea -- --hardware --shots 100 --confirm-hardware
 
 Because each round is a separate provider job, this demo spends hardware budget per measured phase
 bit. Use `--dry-run` first to inspect the generated rounds and OpenQASM 3.
+
+## QEC Repetition-Code Workbench
+
+[`QEC.md`](QEC.md) documents a small distance-3 repetition-code forced-error workbench. The example
+keeps QEC analysis in Wire: command leaves run four exported circuit graph values through the
+generic local Qiskit bridge, then pure Wire expressions parse JSON output counts, apply the lookup
+decoder table, render the report, and write `./wire-qec-repetition-report.txt`.
+
+Run it locally with:
+
+```sh
+nix run .#wire-quantum-qec-repetition
+```
+
+The same exported circuit graphs can be inspected through the IBM REST OpenQASM dry-run path with
+`--dry-run --config`, but hardware execution remains explicitly gated and is not the default QEC
+workflow.
 
 ## Quantum Eraser Wire Experiment
 

--- a/docs/Consumers/Quantum.md
+++ b/docs/Consumers/Quantum.md
@@ -170,6 +170,32 @@ builds the OpenQASM 3 sampler request locally without requesting an IAM token an
 job. `backend = "least_busy"` asks the runner to choose an online non-simulator backend with enough
 qubits; a concrete backend can be selected with the config `backend` field or the `--backend` flag.
 
+## Amazon Braket OpenQASM Runner
+
+The repository includes a second explicit hardware runner for Amazon Braket. It uses AWS CLI v2
+through the Nix app, lowers the same admitted Wire quantum plan to Braket OpenQASM 3, submits a
+Braket task, polls it, reads `results.json` from S3, and normalizes counts into the same JSON shape
+used by the other runners.
+
+Inspect the Bell circuit locally:
+
+```sh
+nix run .#wire-quantum-braket -- examples/wire/quantum-bell-state-ibm-rest.wire --dry-run --json
+```
+
+Submit it to the default managed simulator `SV1`:
+
+```sh
+nix run .#wire-quantum-braket -- examples/wire/quantum-bell-state-ibm-rest.wire --shots 100 --confirm-hardware --json
+```
+
+The runner reads `CORTEX_BRAKET_BUCKET`, `CORTEX_BRAKET_PREFIX`, `CORTEX_BRAKET_REGION`, and
+`AWS_PROFILE` unless equivalent command-line flags are provided. See [`Braket.md`](Braket.md) for
+the AWS setup checklist.
+
+Braket lowering differs from the IBM lowering where the provider gate vocabulary differs: Wire `sx`
+is emitted as Braket `v`, and Wire `rzz` is decomposed into `cnot/rz/cnot`.
+
 ## Iterative Phase Estimation Runner
 
 The `wire-quantum-ipea` app demonstrates adaptive phase estimation as a sequence of fresh Wire
@@ -186,9 +212,10 @@ nix run .#wire-quantum-ipea -- --shots 100 --seed 7
 The default target phase is `5/8` with `3` measured bits, so an ideal run estimates bitstring `101`.
 The generated round shape is represented by
 [`../../examples/wire/quantum-ipea-round.wire`](../../examples/wire/quantum-ipea-round.wire). The
-Wire round uses `rz`, `sx`, `x`, and `rzz` executor nodes. For IBM Runtime REST, the OpenQASM
-lowerer expands `rzz` into `rz/sx/cz` operations because IBM's current standard QASM loaders do not
-define an `rzz` gate name. The Wire file binds the round fragments with graph-valued `let`s:
+Wire round uses `rz`, `sx`, `x`, and `rzz` executor nodes. The provider lowerers expand that shared
+plan into the target gate vocabulary: IBM Runtime REST lowers `rzz` through `rz/sx/cz`, while Amazon
+Braket lowers `sx` to `v` and lowers `rzz` through `cnot/rz/cnot`. The Wire file binds the round
+fragments with graph-valued `let`s:
 
 ```wire
 let h_control =
@@ -220,6 +247,16 @@ requires explicit confirmation:
 nix run .#wire-quantum-ipea -- --hardware --shots 100 --confirm-hardware
 ```
 
+The Braket app uses the same generated rounds with AWS credentials and S3 result storage:
+
+```sh
+nix run .#wire-quantum-ipea-braket -- --dry-run --bits 3 --json
+```
+
+```sh
+nix run .#wire-quantum-ipea-braket -- --bits 3 --shots 100 --confirm-hardware
+```
+
 Because each round is a separate provider job, this demo spends hardware budget per measured phase
 bit. Use `--dry-run` first to inspect the generated rounds and OpenQASM 3.
 
@@ -227,8 +264,8 @@ bit. Use `--dry-run` first to inspect the generated rounds and OpenQASM 3.
 
 [`QEC.md`](QEC.md) documents a small distance-3 repetition-code forced-error workbench. The example
 keeps QEC analysis in Wire: command leaves run four exported circuit graph values through the
-generic IBM Runtime REST bridge, then pure Wire expressions parse JSON output counts, apply the
-lookup decoder table, render the report, and write `./wire-qec-repetition-report.txt`.
+selected quantum runner, then pure Wire expressions parse JSON output counts, apply the lookup
+decoder table, render the report, and write `./wire-qec-repetition-report.txt`.
 
 Run it on hardware with the same explicit confirmation pattern as the eraser example:
 
@@ -236,8 +273,14 @@ Run it on hardware with the same explicit confirmation pattern as the eraser exa
 nix run .#wire-quantum-qec-repetition -- --confirm-hardware
 ```
 
+or on Braket:
+
+```sh
+nix run .#wire-quantum-qec-repetition-braket -- --confirm-hardware
+```
+
 The same exported circuit graphs can still be inspected locally through `wire-quantum-qiskit`, or
-through the IBM REST OpenQASM dry-run path with `--dry-run --config`.
+through the IBM REST or Braket OpenQASM dry-run paths.
 
 ## Quantum Eraser Wire Experiment
 
@@ -254,17 +297,23 @@ experiment rather than retrocausality: the later marker-basis choice does not ch
 unconditional screen statistics. Interference is recovered only after sorting the results by the
 marker outcome.
 
-The full scaffold is a hardware sweep and queues nine IBM Runtime sampler jobs:
+The full scaffold is a hardware sweep. The IBM app queues nine IBM Runtime sampler jobs:
 
 ```sh
 nix run .#wire-quantum-eraser -- --confirm-hardware
 ```
 
-The app runs the Wire file through `wire run` and places `wire-quantum-ibm-rest` on `PATH` for the
-command leaves. The command leaves request JSON output, and the final pure Wire analyzer renders a
-compact table framed around the three-circular-polarizer analogy: path marking flattens the
-unconditional screen, while eraser-basis marker slices recover complementary fringes. The experiment
-executes these exported graph values from the same Wire source:
+The Braket app queues nine Braket tasks:
+
+```sh
+nix run .#wire-quantum-eraser-braket -- --confirm-hardware
+```
+
+Each app runs the Wire file through `wire run` and places a provider-specific `wire-quantum-runner`
+on `PATH` for the command leaves. The command leaves request JSON output, and the final pure Wire
+analyzer renders a compact table framed around the three-circular-polarizer analogy: path marking
+flattens the unconditional screen, while eraser-basis marker slices recover complementary fringes.
+The experiment executes these exported graph values from the same Wire source:
 
 - `open_phase_{0,1_4,1_2}`
 - `which_path_phase_{0,1_4,1_2}`
@@ -296,11 +345,21 @@ request without provider submission:
 nix run .#wire-quantum-ibm-rest -- examples/wire/quantum-eraser-experiment.wire --return eraser_phase_0 --dry-run --config examples/wire/quantum-ibm-runtime.config.example.json
 ```
 
+For the Braket path:
+
+```sh
+nix run .#wire-quantum-braket -- examples/wire/quantum-eraser-experiment.wire --return eraser_phase_0 --dry-run --json
+```
+
 Hardware execution of an individual row submits the selected Wire-authored circuit as one provider
 job:
 
 ```sh
 nix run .#wire-quantum-ibm-rest -- examples/wire/quantum-eraser-experiment.wire --return eraser_phase_0 --shots 100 --confirm-hardware
+```
+
+```sh
+nix run .#wire-quantum-braket -- examples/wire/quantum-eraser-experiment.wire --return eraser_phase_0 --shots 100 --confirm-hardware --json
 ```
 
 ## Linearity Caveat
@@ -316,6 +375,7 @@ rewrite and `select(...)` surfaces rather than through hidden backend callbacks.
 
 ## Related
 
+- [Amazon Braket Consumer Setup](Braket.md)
 - [../Architecture/02-ownership-and-boundaries.md](../Architecture/02-ownership-and-boundaries.md)
 - [../Architecture/05-wire-language.md](../Architecture/05-wire-language.md)
 - [../Reference/Wire/executors-and-alphabet.md](../Reference/Wire/executors-and-alphabet.md)

--- a/docs/Consumers/Quantum.md
+++ b/docs/Consumers/Quantum.md
@@ -227,18 +227,17 @@ bit. Use `--dry-run` first to inspect the generated rounds and OpenQASM 3.
 
 [`QEC.md`](QEC.md) documents a small distance-3 repetition-code forced-error workbench. The example
 keeps QEC analysis in Wire: command leaves run four exported circuit graph values through the
-generic local Qiskit bridge, then pure Wire expressions parse JSON output counts, apply the lookup
-decoder table, render the report, and write `./wire-qec-repetition-report.txt`.
+generic IBM Runtime REST bridge, then pure Wire expressions parse JSON output counts, apply the
+lookup decoder table, render the report, and write `./wire-qec-repetition-report.txt`.
 
-Run it locally with:
+Run it on hardware with the same explicit confirmation pattern as the eraser example:
 
 ```sh
-nix run .#wire-quantum-qec-repetition
+nix run .#wire-quantum-qec-repetition -- --confirm-hardware
 ```
 
-The same exported circuit graphs can be inspected through the IBM REST OpenQASM dry-run path with
-`--dry-run --config`, but hardware execution remains explicitly gated and is not the default QEC
-workflow.
+The same exported circuit graphs can still be inspected locally through `wire-quantum-qiskit`, or
+through the IBM REST OpenQASM dry-run path with `--dry-run --config`.
 
 ## Quantum Eraser Wire Experiment
 

--- a/docs/Consumers/index.md
+++ b/docs/Consumers/index.md
@@ -22,6 +22,8 @@ runtimes. These pages show binding patterns without making any consumer the fram
 - **[Quantum](Quantum.md)** - consumer binding example. Shows how Wire can author quantum circuit
   topology while a host owns gate semantics and backend execution, including a local Qiskit
   simulator bridge.
+- **[Amazon Braket](Braket.md)** - consumer setup guide. Shows how to prepare AWS IAM, S3, Braket
+  roles, and an OpenQASM smoke test for a Braket host binding.
 - **[QEC repetition code](QEC.md)** - quantum consumer workbench. Shows a Wire-authored distance-3
   repetition-code forced-error experiment with pure Wire JSON analysis and reporting.
 

--- a/docs/Consumers/index.md
+++ b/docs/Consumers/index.md
@@ -22,6 +22,8 @@ runtimes. These pages show binding patterns without making any consumer the fram
 - **[Quantum](Quantum.md)** - consumer binding example. Shows how Wire can author quantum circuit
   topology while a host owns gate semantics and backend execution, including a local Qiskit
   simulator bridge.
+- **[QEC repetition code](QEC.md)** - quantum consumer workbench. Shows a Wire-authored distance-3
+  repetition-code forced-error experiment with pure Wire JSON analysis and reporting.
 
 ## What belongs here
 

--- a/docs/Reference/Pulse/schema.md
+++ b/docs/Reference/Pulse/schema.md
@@ -198,6 +198,31 @@ pulse.signals
 Durable external-event storage. The signal protocol, delivery semantics, and `StageSuspend`
 interaction are in [`signals.md`](./signals.md).
 
+## 10. External-call attempts
+
+```
+pulse.external_call_attempts
+  attempt_id          bigserial primary key
+  run_id              uuid not null
+  node_id             text not null            -- the realize stage node
+  runtime_binding_id  text not null
+  frontier_id         text not null            -- canonical hash of the frozen frontier
+  idempotency_key     text not null
+  frozen_plan         jsonb not null           -- the canonical fused sub-plan
+  job_handle          jsonb                     -- null until the provider submit is recorded
+  signal_name         text                      -- the ordinary durable signal woken on completion
+  status              text not null default 'reserved'   -- reserved | submitted | settled | failed
+  created_at, submitted_at, settled_at  timestamptz
+
+  unique index (run_id, node_id, runtime_binding_id, frontier_id)
+```
+
+The Pulse-owned durable home for a `submit_park_resume` external call's executor metadata (ADR 0059
+§3). ADR 0058 suspend settlement commits only graph state, signal wait rows, and run status, so this
+record — not the signal rows — carries the idempotency key, frozen fused plan, and provider job
+handle. Reserve is idempotent on the key, so crash recovery re-entry never creates a duplicate
+provider task; provider fields are opaque JSON that Pulse does not interpret.
+
 ## Appendix A — Ownership
 
 The `pulse` DB role has full ownership of every table in this schema and no access to host tables.

--- a/examples/wire/qec-repetition-code-forced-errors.wire
+++ b/examples/wire/qec-repetition-code-forced-errors.wire
@@ -1,0 +1,458 @@
+# Distance-3 repetition-code forced-error workbench.
+#
+# Run:
+#
+#   nix run .#wire-quantum-qec-repetition
+#
+# This file is both the circuit catalog and the executable experiment scaffold.
+# The four exported graph values are selected by std.io.command leaves below and
+# run through the generic local Qiskit bridge. The final analyzer is pure Wire:
+# it parses JSON stdout with fromJson, checks the syndrome table, renders a
+# report, and writes it to ./wire-qec-repetition-report.txt.
+
+use std.io.{@stdout, @command, @writeFile, CommandSpec, CommandResult};
+
+# `@quantum.*` executors are host-provided configured executor ids. They are not
+# imported from a Wire stdlib module; the generic quantum bridges admit this
+# namespace when they compile a selected circuit graph.
+
+contract ExperimentStart;
+contract QecRunResults {
+  none: CommandResult;
+  x0: CommandResult;
+  x1: CommandResult;
+  x2: CommandResult;
+};
+contract QecAnalysis;
+contract QecReport;
+contract Qubit;
+contract Bit;
+
+let quantum_x = @quantum.x {};
+let quantum_cnot = @quantum.cnot {};
+
+kind prepare_qubit(label: PortLabel, index: Value) =
+  -> label: Qubit = @quantum.prepare_zero { inherit index; } (null);
+
+kind qubit_gate(label: PortLabel, gate: ConfiguredExecutor) =
+  <- label: Qubit;
+  -> label: Qubit;
+  = gate (label);
+
+kind carry_qubit(label: PortLabel) =
+  <- label: Qubit;
+  -> label: Qubit = @quantum.rz { angle = 0.0; } (label);
+
+kind relabel_qubit(input: PortLabel, output: PortLabel) =
+  <- input: Qubit;
+  -> output: Qubit = @quantum.rz { angle = 0.0; } (input);
+
+kind two_qubit_gate(control: PortLabel, target: PortLabel, gate: ConfiguredExecutor) =
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = gate ({ inherit control; inherit target; });
+
+kind qubit_measure(input: PortLabel, output: PortLabel) =
+  <- input: Qubit;
+  -> output: Bit;
+  = @quantum.measure_z {} (input);
+
+kind run_command(spec: PortLabel, result: PortLabel) =
+  <- spec: CommandSpec;
+  -> result: CommandResult = @command {} (spec);
+
+kind command_gate(spec: PortLabel, previous: PortLabel, ready: PortLabel) =
+  <- spec: CommandSpec;
+  <- previous: CommandResult;
+  -> previous: CommandResult = previous;
+  -> ready: CommandSpec = spec;
+
+form first_command(spec: PortLabel, result: PortLabel) = {
+  node run = run_command(spec, result);
+
+  run;
+};
+
+form gated_command(spec: PortLabel, previous: PortLabel, ready: PortLabel, result: PortLabel) = {
+  node gate = command_gate(spec, previous, ready);
+  node run = run_command(ready, result);
+
+  gate
+    => run;
+};
+
+form prepare_all() = {
+  node prepare_d0 = prepare_qubit(d0, 0);
+  node prepare_d1 = prepare_qubit(d1, 1);
+  node prepare_d2 = prepare_qubit(d2, 2);
+  node prepare_a01 = prepare_qubit(a01, 3);
+  node prepare_a12 = prepare_qubit(a12, 4);
+
+  prepare_d0
+    <> prepare_d1
+    <> prepare_d2
+    <> prepare_a01
+    <> prepare_a12;
+};
+
+form no_error_layer() = {
+  node carry_d0 = carry_qubit(d0);
+  node carry_d1 = carry_qubit(d1);
+  node carry_d2 = carry_qubit(d2);
+  node carry_a01 = carry_qubit(a01);
+  node carry_a12 = carry_qubit(a12);
+
+  carry_d0
+    <> carry_d1
+    <> carry_d2
+    <> carry_a01
+    <> carry_a12;
+};
+
+form x_error_layer(target: PortLabel, carryA: PortLabel, carryB: PortLabel, carryC: PortLabel, carryD: PortLabel) = {
+  node x_target = qubit_gate(target, quantum_x);
+  node carry_a = carry_qubit(carryA);
+  node carry_b = carry_qubit(carryB);
+  node carry_c = carry_qubit(carryC);
+  node carry_d = carry_qubit(carryD);
+
+  x_target
+    <> carry_a
+    <> carry_b
+    <> carry_c
+    <> carry_d;
+};
+
+form cnot_live5(controlIn: PortLabel, targetIn: PortLabel, carryA: PortLabel, carryB: PortLabel, carryC: PortLabel) = {
+  node control_to_gate = relabel_qubit(controlIn, control);
+  node target_to_gate = relabel_qubit(targetIn, target);
+  node carry_a_pre = carry_qubit(carryA);
+  node carry_b_pre = carry_qubit(carryB);
+  node carry_c_pre = carry_qubit(carryC);
+  node cnot = two_qubit_gate(control, target, quantum_cnot);
+  node carry_a_mid = carry_qubit(carryA);
+  node carry_b_mid = carry_qubit(carryB);
+  node carry_c_mid = carry_qubit(carryC);
+  node control_from_gate = relabel_qubit(control, controlIn);
+  node target_from_gate = relabel_qubit(target, targetIn);
+  node carry_a_post = carry_qubit(carryA);
+  node carry_b_post = carry_qubit(carryB);
+  node carry_c_post = carry_qubit(carryC);
+
+  (control_to_gate
+    <> target_to_gate
+    <> carry_a_pre
+    <> carry_b_pre
+    <> carry_c_pre)
+    => (cnot
+        <> carry_a_mid
+        <> carry_b_mid
+        <> carry_c_mid)
+    => (control_from_gate
+        <> target_from_gate
+        <> carry_a_post
+        <> carry_b_post
+        <> carry_c_post);
+};
+
+form readout_all() = {
+  node measure_s01 = qubit_measure(a01, s01);
+  node measure_s12 = qubit_measure(a12, s12);
+  node measure_d0 = qubit_measure(d0, final_d0);
+  node measure_d1 = qubit_measure(d1, final_d1);
+  node measure_d2 = qubit_measure(d2, final_d2);
+
+  measure_s01
+    <> measure_s12
+    <> measure_d0
+    <> measure_d1
+    <> measure_d2;
+};
+
+form repetition_case(error_layer: Graph) = {
+  let encode = prepare_all();
+  let check_d0_a01 = cnot_live5(d0, a01, d1, d2, a12);
+  let check_d1_a01 = cnot_live5(d1, a01, d0, d2, a12);
+  let check_d1_a12 = cnot_live5(d1, a12, d0, d2, a01);
+  let check_d2_a12 = cnot_live5(d2, a12, d0, d1, a01);
+  let readout = readout_all();
+
+  encode
+    => error_layer
+    => check_d0_a01
+    => check_d1_a01
+    => check_d1_a12
+    => check_d2_a12
+    => readout;
+};
+
+let no_error = no_error_layer();
+let x0_error = x_error_layer(d0, d1, d2, a01, a12);
+let x1_error = x_error_layer(d1, d0, d2, a01, a12);
+let x2_error = x_error_layer(d2, d0, d1, a01, a12);
+
+export let qec_repetition_none = repetition_case(no_error);
+export let qec_repetition_x0 = repetition_case(x0_error);
+export let qec_repetition_x1 = repetition_case(x1_error);
+export let qec_repetition_x2 = repetition_case(x2_error);
+
+let experiment_source = "examples/wire/qec-repetition-code-forced-errors.wire";
+let experiment_report_path = "./wire-qec-repetition-report.txt";
+let experiment_shots = "1024";
+let experiment_seed = "7";
+let emptyText = "";
+let spaceText = " ";
+let noneText = "none";
+let noStderrText = "(empty)";
+
+let qiskitSpec = name: returnName: {
+  inherit name;
+  target = "${experiment_source}#${returnName}";
+  argv = [
+    "wire-quantum-qiskit",
+    experiment_source,
+    "--return",
+    returnName,
+    "--shots",
+    experiment_shots,
+    "--seed",
+    experiment_seed,
+    "--json"
+  ];
+  cwd = ".";
+  required = true;
+  skip = false;
+  echo = false;
+};
+
+let commandRuns = results: [
+  results.none,
+  results.x0,
+  results.x1,
+  results.x2
+];
+
+let runStatuses = runs:
+  runs |> map (run: "${run.name}=${run.status}") |> joinWith ", ";
+
+let runTargets = runs:
+  runs |> map (run: run.target) |> joinWith "\n  ";
+
+let failureDetails = failures:
+  failures
+    |> map (run: ''
+      ${run.name}
+        exit: ${if run.exitCode == null then noneText else run.exitCode}
+        target: ${run.target}
+        argv: ${run.argv |> joinWith spaceText}
+        stderr: ${if run.stderr == emptyText then noStderrText else run.stderr}
+
+    '')
+    |> joinWith "";
+
+let min2 = left: right:
+  if left < right then left else right;
+
+let min5 = a: b: c: d: e:
+  min2 (min2 (min2 (min2 a b) c) d) e;
+
+let outputHits = decoded: output: bit:
+  decoded.complete_output_counts[output][bit];
+
+let caseRow = name: expectedSyndrome: correction: d0: d1: d2: s01: s12: decoded:
+  let
+    shots = decoded.shots;
+    d0Hits = outputHits decoded "final_d0" d0;
+    d1Hits = outputHits decoded "final_d1" d1;
+    d2Hits = outputHits decoded "final_d2" d2;
+    s01Hits = outputHits decoded "s01" s01;
+    s12Hits = outputHits decoded "s12" s12;
+    hits = min5 d0Hits d1Hits d2Hits s01Hits s12Hits;
+    logicalFailures = shots - hits;
+  in
+  {
+    inherit name expectedSyndrome correction shots hits logicalFailures;
+    expected = "${d0}${d1}${d2}/${s01}${s12}";
+  };
+
+let qecRows = decoded: [
+  caseRow
+    "none"
+    "00"
+    "none"
+    "0"
+    "0"
+    "0"
+    "0"
+    "0"
+    decoded[0],
+  caseRow
+    "x0"
+    "10"
+    "X d0"
+    "1"
+    "0"
+    "0"
+    "1"
+    "0"
+    decoded[1],
+  caseRow
+    "x1"
+    "11"
+    "X d1"
+    "0"
+    "1"
+    "0"
+    "1"
+    "1"
+    decoded[2],
+  caseRow
+    "x2"
+    "01"
+    "X d2"
+    "0"
+    "0"
+    "1"
+    "0"
+    "1"
+    decoded[3]
+];
+
+let analyzeQec = results:
+  let
+    runs = commandRuns results;
+    failures = runs |> filter (run: !run.ok);
+    success = length failures == 0;
+    statuses = runStatuses runs;
+    targets = runTargets runs;
+  in
+  if success then
+    let
+      decoded = runs |> map (run: fromJson(run.stdout));
+      rows = qecRows decoded;
+      complete = rows |> all (row: row.logicalFailures == 0);
+    in
+    { inherit runs failures success statuses targets decoded rows complete; }
+  else
+    {
+      inherit runs failures success statuses targets;
+      decoded = [];
+      rows = [];
+      complete = false;
+    };
+
+let reportTitle = ''
+  Wire QEC repetition-code experiment
+  ===================================
+
+'';
+
+let runBlock = targets: ''
+  Run
+    source: ${experiment_source}
+    execution: one Wire orchestration graph + std.io.command leaves
+    backend: local Qiskit Aer through the generic wire-quantum-qiskit bridge
+    shots: ${experiment_shots} per circuit
+    seed: ${experiment_seed}
+    circuits: 4 exported graph values selected from this same Wire file
+    report file: ${experiment_report_path}
+
+  Circuit graph values submitted
+    ${targets}
+
+'';
+
+let resultRow = row:
+  "  ${row.name} | ${row.expectedSyndrome} | ${row.expected} | ${row.correction} | ${row.hits}/${row.shots} | ${row.logicalFailures}/${row.shots}\n";
+
+let resultRows = rows:
+  rows |> map resultRow |> joinWith "";
+
+let successReport = analysis: ''
+  ${reportTitle}${runBlock analysis.targets}What Wire did
+    Wire authored the repetition-code circuit catalog, selected each
+    exported graph with wire build --return through command leaves,
+    parsed each simulator JSON result with fromJson, applied the
+    distance-3 lookup table as pure Wire dataflow, and rendered this
+    report in a pure Wire node.
+
+  Results
+    case | expected syndrome | expected data/syndrome | correction | matching shots | logical failures
+    ---- | ----------------- | ---------------------- | ---------- | -------------- | ----------------
+  ${resultRows analysis.rows}
+
+  Lookup table
+    00 -> no correction
+    10 -> X d0
+    11 -> X d1
+    01 -> X d2
+
+  Run gate: ${if analysis.complete then "complete" else "incomplete"}
+'';
+
+let failureReport = analysis: ''
+  ${reportTitle}${runBlock analysis.targets}At least one simulator command failed before analysis, so the pure Wire analyzer did not parse stdout.
+
+  Results
+    ${analysis.statuses}
+
+  Failed rows
+  ${failureDetails analysis.failures}Run gate: failed
+'';
+
+let renderQecReport = analysis:
+  if analysis.success then successReport analysis else failureReport analysis;
+
+node start_experiment
+  -> start: ExperimentStart = "start";
+
+node plan_experiment
+  <- start: ExperimentStart;
+  -> noneSpec: CommandSpec = qiskitSpec "clean memory" "qec_repetition_none";
+  -> x0Spec: CommandSpec = qiskitSpec "forced X on d0" "qec_repetition_x0";
+  -> x1Spec: CommandSpec = qiskitSpec "forced X on d1" "qec_repetition_x1";
+  -> x2Spec: CommandSpec = qiskitSpec "forced X on d2" "qec_repetition_x2";
+
+let run_none = first_command(noneSpec, none);
+let run_x0 = gated_command(x0Spec, none, x0Ready, x0);
+let run_x1 = gated_command(x1Spec, x0, x1Ready, x1);
+let run_x2 = gated_command(x2Spec, x1, x2Ready, x2);
+
+node analyze_qec
+  <- results: QecRunResults;
+  -> analysis: QecAnalysis = analyzeQec results;
+
+node render_qec_report
+  <- analysis: QecAnalysis;
+  -> print_summary: QecReport = summary;
+  -> write_summary: QecReport = summary;
+  where let
+    summary = renderQecReport analysis;
+  in
+  { inherit summary; };
+
+node print_report
+  <- print_summary: QecReport;
+  = @stdout { newline = true; } (print_summary);
+
+node write_report
+  <- write_summary: QecReport;
+  = @writeFile { path = "./wire-qec-repetition-report.txt"; } (write_summary);
+
+let command_sequence =
+  run_none
+    => run_x0
+    => run_x1
+    => run_x2;
+
+let analyzed_sequence =
+  command_sequence
+    * analyze_qec;
+
+start_experiment
+  => plan_experiment
+  => analyzed_sequence
+  => render_qec_report
+  => print_report <> write_report

--- a/examples/wire/qec-repetition-code-forced-errors.wire
+++ b/examples/wire/qec-repetition-code-forced-errors.wire
@@ -2,11 +2,11 @@
 #
 # Run:
 #
-#   nix run .#wire-quantum-qec-repetition
+#   nix run .#wire-quantum-qec-repetition -- --confirm-hardware
 #
 # This file is both the circuit catalog and the executable experiment scaffold.
 # The four exported graph values are selected by std.io.command leaves below and
-# run through the generic local Qiskit bridge. The final analyzer is pure Wire:
+# run through the generic IBM Runtime REST bridge. The final analyzer is pure Wire:
 # it parses JSON stdout with fromJson, checks the syndrome table, renders a
 # report, and writes it to ./wire-qec-repetition-report.txt.
 
@@ -25,6 +25,7 @@ contract QecRunResults {
 };
 contract QecAnalysis;
 contract QecReport;
+contract IBMQuantumConfig;
 contract Qubit;
 contract Bit;
 
@@ -84,17 +85,22 @@ form gated_command(spec: PortLabel, previous: PortLabel, ready: PortLabel, resul
 };
 
 form prepare_all() = {
-  node prepare_d0 = prepare_qubit(d0, 0);
+  node ibm_runtime_config
+    -> config: IBMQuantumConfig = @quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; } (null);
+  node prepare_d0
+    <- config: IBMQuantumConfig;
+    -> d0: Qubit = @quantum.prepare_zero { index = 0; } ({ inherit config; });
   node prepare_d1 = prepare_qubit(d1, 1);
   node prepare_d2 = prepare_qubit(d2, 2);
   node prepare_a01 = prepare_qubit(a01, 3);
   node prepare_a12 = prepare_qubit(a12, 4);
 
-  prepare_d0
-    <> prepare_d1
-    <> prepare_d2
-    <> prepare_a01
-    <> prepare_a12;
+  ibm_runtime_config
+    => (prepare_d0
+        <> prepare_d1
+        <> prepare_d2
+        <> prepare_a01
+        <> prepare_a12);
 };
 
 form no_error_layer() = {
@@ -200,25 +206,23 @@ export let qec_repetition_x2 = repetition_case(x2_error);
 
 let experiment_source = "examples/wire/qec-repetition-code-forced-errors.wire";
 let experiment_report_path = "./wire-qec-repetition-report.txt";
-let experiment_shots = "1024";
-let experiment_seed = "7";
+let experiment_shots = "100";
 let emptyText = "";
 let spaceText = " ";
 let noneText = "none";
 let noStderrText = "(empty)";
 
-let qiskitSpec = name: returnName: {
+let hardwareSpec = name: returnName: {
   inherit name;
   target = "${experiment_source}#${returnName}";
   argv = [
-    "wire-quantum-qiskit",
+    "wire-quantum-ibm-rest",
     experiment_source,
     "--return",
     returnName,
     "--shots",
     experiment_shots,
-    "--seed",
-    experiment_seed,
+    "--confirm-hardware",
     "--json"
   ];
   cwd = ".";
@@ -331,14 +335,16 @@ let analyzeQec = results:
   if success then
     let
       decoded = runs |> map (run: fromJson(run.stdout));
-      rows = qecRows decoded;
-      complete = rows |> all (row: row.logicalFailures == 0);
+      hasCounts = decoded |> all (result: result.complete_output_counts != null);
+      rows = if hasCounts then qecRows decoded else [];
+      complete = hasCounts && (rows |> all (row: row.logicalFailures == 0));
     in
-    { inherit runs failures success statuses targets decoded rows complete; }
+    { inherit runs failures success statuses targets decoded hasCounts rows complete; }
   else
     {
       inherit runs failures success statuses targets;
       decoded = [];
+      hasCounts = false;
       rows = [];
       complete = false;
     };
@@ -353,9 +359,8 @@ let runBlock = targets: ''
   Run
     source: ${experiment_source}
     execution: one Wire orchestration graph + std.io.command leaves
-    backend: local Qiskit Aer through the generic wire-quantum-qiskit bridge
+    backend: IBM Quantum Runtime REST hardware through the generic wire-quantum-ibm-rest bridge
     shots: ${experiment_shots} per circuit
-    seed: ${experiment_seed}
     circuits: 4 exported graph values selected from this same Wire file
     report file: ${experiment_report_path}
 
@@ -374,7 +379,8 @@ let successReport = analysis: ''
   ${reportTitle}${runBlock analysis.targets}What Wire did
     Wire authored the repetition-code circuit catalog, selected each
     exported graph with wire build --return through command leaves,
-    parsed each simulator JSON result with fromJson, applied the
+    submitted each selected circuit through IBM Runtime REST, parsed
+    each hardware JSON result with fromJson, applied the
     distance-3 lookup table as pure Wire dataflow, and rendered this
     report in a pure Wire node.
 
@@ -392,8 +398,18 @@ let successReport = analysis: ''
   Run gate: ${if analysis.complete then "complete" else "incomplete"}
 '';
 
+let decodeWarningReport = analysis: ''
+  ${reportTitle}${runBlock analysis.targets}The IBM REST runner completed, but at least one result did not contain decoded output counts.
+  Re-run the failed circuit directly with --json and inspect raw_result.
+
+  Results
+    ${analysis.statuses}
+
+  Run gate: result decoder needs attention
+'';
+
 let failureReport = analysis: ''
-  ${reportTitle}${runBlock analysis.targets}At least one simulator command failed before analysis, so the pure Wire analyzer did not parse stdout.
+  ${reportTitle}${runBlock analysis.targets}At least one hardware command failed before analysis, so the pure Wire analyzer did not parse stdout.
 
   Results
     ${analysis.statuses}
@@ -403,17 +419,20 @@ let failureReport = analysis: ''
 '';
 
 let renderQecReport = analysis:
-  if analysis.success then successReport analysis else failureReport analysis;
+  if analysis.success then
+    if analysis.hasCounts then successReport analysis else decodeWarningReport analysis
+  else
+    failureReport analysis;
 
 node start_experiment
   -> start: ExperimentStart = "start";
 
 node plan_experiment
   <- start: ExperimentStart;
-  -> noneSpec: CommandSpec = qiskitSpec "clean memory" "qec_repetition_none";
-  -> x0Spec: CommandSpec = qiskitSpec "forced X on d0" "qec_repetition_x0";
-  -> x1Spec: CommandSpec = qiskitSpec "forced X on d1" "qec_repetition_x1";
-  -> x2Spec: CommandSpec = qiskitSpec "forced X on d2" "qec_repetition_x2";
+  -> noneSpec: CommandSpec = hardwareSpec "clean memory" "qec_repetition_none";
+  -> x0Spec: CommandSpec = hardwareSpec "forced X on d0" "qec_repetition_x0";
+  -> x1Spec: CommandSpec = hardwareSpec "forced X on d1" "qec_repetition_x1";
+  -> x2Spec: CommandSpec = hardwareSpec "forced X on d2" "qec_repetition_x2";
 
 let run_none = first_command(noneSpec, none);
 let run_x0 = gated_command(x0Spec, none, x0Ready, x0);

--- a/examples/wire/qec-repetition-code-forced-errors.wire
+++ b/examples/wire/qec-repetition-code-forced-errors.wire
@@ -3,10 +3,11 @@
 # Run:
 #
 #   nix run .#wire-quantum-qec-repetition -- --confirm-hardware
+#   nix run .#wire-quantum-qec-repetition-braket -- --confirm-hardware
 #
 # This file is both the circuit catalog and the executable experiment scaffold.
 # The four exported graph values are selected by std.io.command leaves below and
-# run through the generic IBM Runtime REST bridge. The final analyzer is pure Wire:
+# run through the selected quantum bridge. The final analyzer is pure Wire:
 # it parses JSON stdout with fromJson, checks the syndrome table, renders a
 # report, and writes it to ./wire-qec-repetition-report.txt.
 
@@ -207,6 +208,7 @@ export let qec_repetition_x2 = repetition_case(x2_error);
 let experiment_source = "examples/wire/qec-repetition-code-forced-errors.wire";
 let experiment_report_path = "./wire-qec-repetition-report.txt";
 let experiment_shots = "100";
+let acceptanceMinHits = 90;
 let emptyText = "";
 let spaceText = " ";
 let noneText = "none";
@@ -216,7 +218,7 @@ let hardwareSpec = name: returnName: {
   inherit name;
   target = "${experiment_source}#${returnName}";
   argv = [
-    "wire-quantum-ibm-rest",
+    "wire-quantum-runner",
     experiment_source,
     "--return",
     returnName,
@@ -275,9 +277,10 @@ let caseRow = name: expectedSyndrome: correction: d0: d1: d2: s01: s12: decoded:
     s12Hits = outputHits decoded "s12" s12;
     hits = min5 d0Hits d1Hits d2Hits s01Hits s12Hits;
     logicalFailures = shots - hits;
+    gatePass = hits >= acceptanceMinHits;
   in
   {
-    inherit name expectedSyndrome correction shots hits logicalFailures;
+    inherit name expectedSyndrome correction shots hits logicalFailures gatePass;
     expected = "${d0}${d1}${d2}/${s01}${s12}";
   };
 
@@ -324,6 +327,12 @@ let qecRows = decoded: [
     decoded[3]
 ];
 
+let hasCostEstimate = decoded:
+  decoded |> all (result: result.estimated_cost_usd != null);
+
+let totalEstimatedCost = decoded:
+  decoded |> map (result: result.estimated_cost_usd) |> sum;
+
 let analyzeQec = results:
   let
     runs = commandRuns results;
@@ -336,15 +345,32 @@ let analyzeQec = results:
     let
       decoded = runs |> map (run: fromJson(run.stdout));
       hasCounts = decoded |> all (result: result.complete_output_counts != null);
+      hasCost = hasCostEstimate decoded;
+      estimatedCostUsd = if hasCost then totalEstimatedCost decoded else null;
       rows = if hasCounts then qecRows decoded else [];
-      complete = hasCounts && (rows |> all (row: row.logicalFailures == 0));
+      complete = hasCounts && (rows |> all (row: row.gatePass));
     in
-    { inherit runs failures success statuses targets decoded hasCounts rows complete; }
+    {
+      inherit
+        runs
+        failures
+        success
+        statuses
+        targets
+        decoded
+        hasCounts
+        hasCost
+        estimatedCostUsd
+        rows
+        complete;
+    }
   else
     {
       inherit runs failures success statuses targets;
       decoded = [];
       hasCounts = false;
+      hasCost = false;
+      estimatedCostUsd = null;
       rows = [];
       complete = false;
     };
@@ -359,7 +385,7 @@ let runBlock = targets: ''
   Run
     source: ${experiment_source}
     execution: one Wire orchestration graph + std.io.command leaves
-    backend: IBM Quantum Runtime REST hardware through the generic wire-quantum-ibm-rest bridge
+    backend: selected quantum runner
     shots: ${experiment_shots} per circuit
     circuits: 4 exported graph values selected from this same Wire file
     report file: ${experiment_report_path}
@@ -375,15 +401,29 @@ let resultRow = row:
 let resultRows = rows:
   rows |> map resultRow |> joinWith "";
 
+let costBlock = analysis:
+  if analysis.hasCost then ''
+  Cost estimate
+    estimated total: $${analysis.estimatedCostUsd} USD
+    scope: Braket quantum-task estimates reported by the selected runner
+    note: estimate excludes S3, taxes, discounts, credits, reservations, and later AWS billing adjustments
+
+  '' else ''
+  Cost estimate
+    unavailable: selected runner did not report estimated_cost_usd for every circuit
+
+  '';
+
 let successReport = analysis: ''
   ${reportTitle}${runBlock analysis.targets}What Wire did
     Wire authored the repetition-code circuit catalog, selected each
     exported graph with wire build --return through command leaves,
-    submitted each selected circuit through IBM Runtime REST, parsed
+    submitted each selected circuit through the selected runner, parsed
     each hardware JSON result with fromJson, applied the
     distance-3 lookup table as pure Wire dataflow, and rendered this
     report in a pure Wire node.
 
+  ${costBlock analysis}
   Results
     case | expected syndrome | expected data/syndrome | correction | matching shots | logical failures
     ---- | ----------------- | ---------------------- | ---------- | -------------- | ----------------
@@ -394,6 +434,9 @@ let successReport = analysis: ''
     10 -> X d0
     11 -> X d1
     01 -> X d2
+
+  Acceptance threshold
+    per circuit: at least ${acceptanceMinHits}/${experiment_shots} matching shots
 
   Run gate: ${if analysis.complete then "complete" else "incomplete"}
 '';

--- a/examples/wire/quantum-eraser-experiment.wire
+++ b/examples/wire/quantum-eraser-experiment.wire
@@ -1,11 +1,12 @@
-# Full delayed-choice quantum eraser experiment scaffold over IBM Runtime REST.
+# Full delayed-choice quantum eraser experiment scaffold over a quantum hardware runner.
 #
 # Run:
 #
 #   nix run .#wire-quantum-eraser -- --confirm-hardware
+#   nix run .#wire-quantum-eraser-braket -- --confirm-hardware
 #
 # The experiment graph is Wire. Each command leaf selects one exported circuit
-# graph value from this file and submits it through the IBM Runtime REST bridge.
+# graph value from this file and submits it through the selected quantum bridge.
 # The final analyzer is a short pure Wire subgraph that parses JSON stdout with fromJson.
 
 use std.io.{@stdout, @command, @writeFile, CommandSpec, CommandResult};
@@ -94,7 +95,7 @@ let hardwareSpec = name: returnName: {
   inherit name;
   target = "${experiment_source}#${returnName}";
   argv = [
-    "wire-quantum-ibm-rest",
+    "wire-quantum-runner",
     experiment_source,
     "--return",
     returnName,
@@ -229,7 +230,7 @@ let runBlock = targets: ''
   Run
     source: ${experiment_source}
     execution: one Wire orchestration graph + std.io.command leaves
-    backend: IBM Quantum Runtime REST hardware
+    backend: selected quantum runner
     shots: ${experiment_shots} per circuit
     circuits: 9 exported graph values selected from this same Wire file
     report file: ${experiment_report_path}

--- a/examples/wire/quantum-realize-collect.wire
+++ b/examples/wire/quantum-realize-collect.wire
@@ -1,0 +1,45 @@
+# Minimal demonstration of the ADR 0059 realize collect-node on the ADR 0054
+# quantum Wire packages.
+#
+# The gate frontier is authored as native Wire topology and *collected* into a
+# single `@realize` node whose outputs are the named measurements (ADR 0059 §2).
+# `use quantum.core` / `use quantum.braket` bring the vocabulary into scope but
+# grant no runtime authority: `wire build`/check succeed with no host binding
+# pack present, and only `wire pulse run --binding-pack braket` lowers this to a
+# durable submit/park/resume stage (the ADR 0054 invariant).
+#
+# A larger crossing-qubit circuit (the distance-3 repetition code) needs the same
+# identity-threading the generator emits; this file keeps the topology linear so
+# it reads as a clean realize example. The standalone-bridge QEC workbench remains
+# qec-repetition-code-forced-errors.wire.
+
+use quantum.core.{@prepare_zero, @cnot};
+use quantum.braket.{@realize};
+
+contract Qubit;
+contract Bit;
+
+node prep_control
+  -> control: Qubit = @prepare_zero { index = 0; } (null);
+node prep_target
+  -> target: Qubit = @prepare_zero { index = 1; } (null);
+
+node entangle
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @cnot ({ inherit control; inherit target; });
+
+# Collect the frontier: realize consumes the final qubits and produces the named
+# measurement outputs the offline analyzer reads.
+node collect
+  <- control: Qubit;
+  <- target: Qubit;
+  -> m_control: Bit;
+  -> m_target: Bit;
+  = @realize ({ inherit control; inherit target; });
+
+(prep_control <> prep_target)
+  => entangle
+  => collect

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -54,6 +54,10 @@
           # Wire DSL
           tree-sitter
           hl-wire
+          config.packages.wire-quantum-braket
+          config.packages.wire-quantum-qec-repetition-braket
+          config.packages.wire-quantum-ipea-braket
+          config.packages.wire-quantum-eraser-braket
 
           # Lean 4 mechanization track (theory/).
           # `elan` resolves the toolchain version pinned in
@@ -93,6 +97,8 @@
 
         Cloud tooling:
           aws --version          # AWS CLI v2
+          wire-quantum-braket --help
+          wire-quantum-qec-repetition-braket --confirm-hardware
 
         Lean 4 theory:
           just lean-build       # Build the proof tree

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -44,6 +44,7 @@
           ripgrep
           fd
           just
+          awscli2
 
           # Formatters
           alejandra
@@ -89,6 +90,9 @@
 
         Wire DSL:
           hl-wire <path.wire>   # Terminal-highlight a .wire file
+
+        Cloud tooling:
+          aws --version          # AWS CLI v2
 
         Lean 4 theory:
           just lean-build       # Build the proof tree

--- a/nix/quantum.nix
+++ b/nix/quantum.nix
@@ -46,6 +46,20 @@
       '';
     };
 
+    wire-quantum-qec-repetition = pkgs.writeShellApplication {
+      name = "wire-quantum-qec-repetition";
+      text = ''
+        set -euo pipefail
+        if [ "$#" -ne 0 ]; then
+          echo "usage: wire-quantum-qec-repetition" >&2
+          echo "runs the Wire-authored distance-3 repetition-code workbench through local Qiskit Aer" >&2
+          exit 64
+        fi
+        export PATH="${wire-quantum-qiskit}/bin:$PATH"
+        exec ${config.packages.wire}/bin/wire run examples/wire/qec-repetition-code-forced-errors.wire
+      '';
+    };
+
     wire-quantum-eraser = pkgs.writeShellApplication {
       name = "wire-quantum-eraser";
       text = ''
@@ -68,6 +82,7 @@
       // lib.optionalAttrs qiskitSupported {
         wire-quantum-qiskit = wire-quantum-qiskit;
         wire-quantum-ipea = wire-quantum-ipea;
+        wire-quantum-qec-repetition = wire-quantum-qec-repetition;
       };
 
     apps =
@@ -93,6 +108,11 @@
           type = "app";
           program = "${wire-quantum-ipea}/bin/wire-quantum-ipea";
           meta.description = "Run iterative phase estimation as composed Wire quantum rounds";
+        };
+        wire-quantum-qec-repetition = {
+          type = "app";
+          program = "${wire-quantum-qec-repetition}/bin/wire-quantum-qec-repetition";
+          meta.description = "Run the distance-3 repetition-code QEC workbench through a local Qiskit Aer simulator";
         };
       };
   };

--- a/nix/quantum.nix
+++ b/nix/quantum.nix
@@ -35,6 +35,34 @@
       '';
     };
 
+    wire-quantum-braket = pkgs.writeShellApplication {
+      name = "wire-quantum-braket";
+      text = ''
+        set -euo pipefail
+        scripts_dir="${../scripts}"
+        exec ${pkgs.python313}/bin/python "$scripts_dir/wire-quantum-braket.py" \
+          --wire-bin ${config.packages.wire}/bin/wire \
+          --aws-bin ${pkgs.awscli2}/bin/aws \
+          "$@"
+      '';
+    };
+
+    wire-quantum-runner-ibm = pkgs.writeShellApplication {
+      name = "wire-quantum-runner";
+      text = ''
+        set -euo pipefail
+        exec ${wire-quantum-ibm-rest}/bin/wire-quantum-ibm-rest "$@"
+      '';
+    };
+
+    wire-quantum-runner-braket = pkgs.writeShellApplication {
+      name = "wire-quantum-runner";
+      text = ''
+        set -euo pipefail
+        exec ${wire-quantum-braket}/bin/wire-quantum-braket "$@"
+      '';
+    };
+
     wire-quantum-ipea = pkgs.writeShellApplication {
       name = "wire-quantum-ipea";
       text = ''
@@ -42,6 +70,20 @@
         scripts_dir="${../scripts}"
         exec ${qiskitPython}/bin/python "$scripts_dir/wire-quantum-ipea.py" \
           --wire-bin ${config.packages.wire}/bin/wire \
+          "$@"
+      '';
+    };
+
+    wire-quantum-ipea-braket = pkgs.writeShellApplication {
+      name = "wire-quantum-ipea-braket";
+      text = ''
+        set -euo pipefail
+        scripts_dir="${../scripts}"
+        exec ${pkgs.python313}/bin/python "$scripts_dir/wire-quantum-ipea.py" \
+          --wire-bin ${config.packages.wire}/bin/wire \
+          --aws-bin ${pkgs.awscli2}/bin/aws \
+          --hardware \
+          --provider braket \
           "$@"
       '';
     };
@@ -55,7 +97,21 @@
           echo "runs four selected QEC repetition-code circuit graphs as IBM Runtime REST hardware jobs" >&2
           exit 64
         fi
-        export PATH="${wire-quantum-ibm-rest}/bin:$PATH"
+        export PATH="${wire-quantum-runner-ibm}/bin:${wire-quantum-ibm-rest}/bin:$PATH"
+        exec ${config.packages.wire}/bin/wire run examples/wire/qec-repetition-code-forced-errors.wire
+      '';
+    };
+
+    wire-quantum-qec-repetition-braket = pkgs.writeShellApplication {
+      name = "wire-quantum-qec-repetition-braket";
+      text = ''
+        set -euo pipefail
+        if [ "$#" -ne 1 ] || [ "$1" != "--confirm-hardware" ]; then
+          echo "usage: wire-quantum-qec-repetition-braket --confirm-hardware" >&2
+          echo "runs four selected QEC repetition-code circuit graphs as Amazon Braket tasks" >&2
+          exit 64
+        fi
+        export PATH="${wire-quantum-runner-braket}/bin:${wire-quantum-braket}/bin:$PATH"
         exec ${config.packages.wire}/bin/wire run examples/wire/qec-repetition-code-forced-errors.wire
       '';
     };
@@ -69,15 +125,33 @@
           echo "runs nine selected circuit graphs from examples/wire/quantum-eraser-experiment.wire as IBM Runtime REST hardware jobs" >&2
           exit 64
         fi
-        export PATH="${wire-quantum-ibm-rest}/bin:$PATH"
+        export PATH="${wire-quantum-runner-ibm}/bin:${wire-quantum-ibm-rest}/bin:$PATH"
+        exec ${config.packages.wire}/bin/wire run examples/wire/quantum-eraser-experiment.wire
+      '';
+    };
+
+    wire-quantum-eraser-braket = pkgs.writeShellApplication {
+      name = "wire-quantum-eraser-braket";
+      text = ''
+        set -euo pipefail
+        if [ "$#" -ne 1 ] || [ "$1" != "--confirm-hardware" ]; then
+          echo "usage: wire-quantum-eraser-braket --confirm-hardware" >&2
+          echo "runs nine selected circuit graphs from examples/wire/quantum-eraser-experiment.wire as Amazon Braket tasks" >&2
+          exit 64
+        fi
+        export PATH="${wire-quantum-runner-braket}/bin:${wire-quantum-braket}/bin:$PATH"
         exec ${config.packages.wire}/bin/wire run examples/wire/quantum-eraser-experiment.wire
       '';
     };
   in {
     packages =
       {
+        wire-quantum-braket = wire-quantum-braket;
         wire-quantum-ibm-rest = wire-quantum-ibm-rest;
+        wire-quantum-eraser-braket = wire-quantum-eraser-braket;
         wire-quantum-eraser = wire-quantum-eraser;
+        wire-quantum-ipea-braket = wire-quantum-ipea-braket;
+        wire-quantum-qec-repetition-braket = wire-quantum-qec-repetition-braket;
         wire-quantum-qec-repetition = wire-quantum-qec-repetition;
       }
       // lib.optionalAttrs qiskitSupported {
@@ -92,15 +166,35 @@
           program = "${wire-quantum-ibm-rest}/bin/wire-quantum-ibm-rest";
           meta.description = "Submit Wire quantum examples to IBM Quantum Runtime REST";
         };
+        wire-quantum-braket = {
+          type = "app";
+          program = "${wire-quantum-braket}/bin/wire-quantum-braket";
+          meta.description = "Submit Wire quantum examples to Amazon Braket OpenQASM";
+        };
         wire-quantum-eraser = {
           type = "app";
           program = "${wire-quantum-eraser}/bin/wire-quantum-eraser";
           meta.description = "Run the delayed-choice quantum eraser Wire sweep on IBM Runtime REST hardware";
         };
+        wire-quantum-eraser-braket = {
+          type = "app";
+          program = "${wire-quantum-eraser-braket}/bin/wire-quantum-eraser-braket";
+          meta.description = "Run the delayed-choice quantum eraser Wire sweep on Amazon Braket";
+        };
+        wire-quantum-ipea-braket = {
+          type = "app";
+          program = "${wire-quantum-ipea-braket}/bin/wire-quantum-ipea-braket";
+          meta.description = "Run iterative phase estimation as Amazon Braket tasks";
+        };
         wire-quantum-qec-repetition = {
           type = "app";
           program = "${wire-quantum-qec-repetition}/bin/wire-quantum-qec-repetition";
           meta.description = "Run the distance-3 repetition-code QEC workbench on IBM Runtime REST hardware";
+        };
+        wire-quantum-qec-repetition-braket = {
+          type = "app";
+          program = "${wire-quantum-qec-repetition-braket}/bin/wire-quantum-qec-repetition-braket";
+          meta.description = "Run the distance-3 repetition-code QEC workbench on Amazon Braket";
         };
       }
       // lib.optionalAttrs qiskitSupported {

--- a/nix/quantum.nix
+++ b/nix/quantum.nix
@@ -50,12 +50,12 @@
       name = "wire-quantum-qec-repetition";
       text = ''
         set -euo pipefail
-        if [ "$#" -ne 0 ]; then
-          echo "usage: wire-quantum-qec-repetition" >&2
-          echo "runs the Wire-authored distance-3 repetition-code workbench through local Qiskit Aer" >&2
+        if [ "$#" -ne 1 ] || [ "$1" != "--confirm-hardware" ]; then
+          echo "usage: wire-quantum-qec-repetition --confirm-hardware" >&2
+          echo "runs four selected QEC repetition-code circuit graphs as IBM Runtime REST hardware jobs" >&2
           exit 64
         fi
-        export PATH="${wire-quantum-qiskit}/bin:$PATH"
+        export PATH="${wire-quantum-ibm-rest}/bin:$PATH"
         exec ${config.packages.wire}/bin/wire run examples/wire/qec-repetition-code-forced-errors.wire
       '';
     };
@@ -78,11 +78,11 @@
       {
         wire-quantum-ibm-rest = wire-quantum-ibm-rest;
         wire-quantum-eraser = wire-quantum-eraser;
+        wire-quantum-qec-repetition = wire-quantum-qec-repetition;
       }
       // lib.optionalAttrs qiskitSupported {
         wire-quantum-qiskit = wire-quantum-qiskit;
         wire-quantum-ipea = wire-quantum-ipea;
-        wire-quantum-qec-repetition = wire-quantum-qec-repetition;
       };
 
     apps =
@@ -97,6 +97,11 @@
           program = "${wire-quantum-eraser}/bin/wire-quantum-eraser";
           meta.description = "Run the delayed-choice quantum eraser Wire sweep on IBM Runtime REST hardware";
         };
+        wire-quantum-qec-repetition = {
+          type = "app";
+          program = "${wire-quantum-qec-repetition}/bin/wire-quantum-qec-repetition";
+          meta.description = "Run the distance-3 repetition-code QEC workbench on IBM Runtime REST hardware";
+        };
       }
       // lib.optionalAttrs qiskitSupported {
         wire-quantum-qiskit = {
@@ -108,11 +113,6 @@
           type = "app";
           program = "${wire-quantum-ipea}/bin/wire-quantum-ipea";
           meta.description = "Run iterative phase estimation as composed Wire quantum rounds";
-        };
-        wire-quantum-qec-repetition = {
-          type = "app";
-          program = "${wire-quantum-qec-repetition}/bin/wire-quantum-qec-repetition";
-          meta.description = "Run the distance-3 repetition-code QEC workbench through a local Qiskit Aer simulator";
         };
       };
   };

--- a/scripts/wire-quantum-braket.py
+++ b/scripts/wire-quantum-braket.py
@@ -1,0 +1,1146 @@
+#!/usr/bin/env python3
+"""Submit Wire-authored quantum circuits to Amazon Braket.
+
+This runner is intentionally separate from the local Qiskit Aer bridge and
+the IBM Runtime REST bridge. It uses AWS CLI v2 so the Cortex dev shell does
+not need the Amazon Braket Python SDK.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import os
+import subprocess
+import sys
+import time
+from collections import Counter
+from datetime import datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from pathlib import Path
+from typing import Any
+
+
+JSON = dict[str, Any]
+DEFAULT_DEVICE_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
+DEFAULT_REGION = "us-east-1"
+DEFAULT_PREFIX = "cortex/dev"
+DEFAULT_PROFILE = "cortex-braket"
+TERMINAL_TASK_STATUSES = {"COMPLETED", "FAILED", "CANCELLED", "CANCELED"}
+RUNNING_TASK_STATUSES = {"CREATED", "QUEUED", "RUNNING"}
+TASK_STATUS_LABELS = {
+    "COMPLETED": "Completed",
+    "FAILED": "Failed",
+    "CANCELLED": "Cancelled",
+    "CANCELED": "Cancelled",
+    "CREATED": "Created",
+    "QUEUED": "Queued",
+    "RUNNING": "Running",
+}
+MIN_SIMULATOR_BILLING_SECONDS = Decimal("3")
+QPU_TASK_PRICE_USD = Decimal("0.30000")
+QPU_SHOT_PRICES_USD = {
+    "qpu/aqt/ibex": Decimal("0.02350"),
+    "qpu/aqt/ibex-q1": Decimal("0.02350"),
+    "qpu/ionq/forte": Decimal("0.08000"),
+    "qpu/iqm/emerald": Decimal("0.00160"),
+    "qpu/iqm/garnet": Decimal("0.00145"),
+    "qpu/quera/aquila": Decimal("0.01000"),
+    "qpu/rigetti/cepheus": Decimal("0.000425"),
+}
+SIMULATOR_MINUTE_PRICES_USD = {
+    "quantum-simulator/amazon/sv1": Decimal("0.075"),
+}
+
+
+def main() -> int:
+    quantum = load_quantum_support()
+    parser = argparse.ArgumentParser(
+        description="Run a Wire quantum circuit on Amazon Braket through AWS CLI.",
+    )
+    parser.add_argument(
+        "input",
+        help="Wire source file, compiled Wire JSON artifact, or '-' for compiled JSON on stdin.",
+    )
+    parser.add_argument(
+        "--wire-bin",
+        default=os.environ.get("WIRE_BIN", "wire"),
+        help="Wire CLI to use when the input is a .wire source file.",
+    )
+    parser.add_argument(
+        "--return",
+        dest="wire_return",
+        help="Compile the named Wire file-return or graph binding from a .wire source file.",
+    )
+    parser.add_argument(
+        "--backend",
+        help="Braket backend alias or device ARN. 'sv1' is the default.",
+    )
+    parser.add_argument(
+        "--device-arn",
+        default=os.environ.get("CORTEX_BRAKET_DEVICE_ARN"),
+        help="Braket device ARN. Defaults to SV1 unless --backend is provided.",
+    )
+    parser.add_argument(
+        "--s3-bucket",
+        default=os.environ.get("CORTEX_BRAKET_BUCKET"),
+        help="S3 bucket where Braket writes task results.",
+    )
+    parser.add_argument(
+        "--s3-prefix",
+        default=os.environ.get("CORTEX_BRAKET_PREFIX", DEFAULT_PREFIX),
+        help="S3 key prefix for Braket task results.",
+    )
+    parser.add_argument(
+        "--region",
+        default=default_region(),
+        help="AWS region used for Braket API calls.",
+    )
+    parser.add_argument(
+        "--profile",
+        default=os.environ.get("AWS_PROFILE", DEFAULT_PROFILE),
+        help="AWS CLI profile. Use an empty string to rely on ambient AWS credentials.",
+    )
+    parser.add_argument(
+        "--aws-bin",
+        default=os.environ.get("AWS_BIN", "aws"),
+        help="AWS CLI executable.",
+    )
+    parser.add_argument("--shots", type=positive_int, default=100)
+    parser.add_argument(
+        "--poll-interval",
+        type=positive_int,
+        default=5,
+        help="Polling interval in seconds.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=positive_int,
+        default=900,
+        help="Polling timeout in seconds.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build the Braket task request locally without queueing a task.",
+    )
+    parser.add_argument(
+        "--emit-request",
+        action="store_true",
+        help="Include the Braket action payload in dry-run output.",
+    )
+    parser.add_argument(
+        "--submit-only",
+        action="store_true",
+        help="Submit the task and print its ARN without polling for results.",
+    )
+    parser.add_argument(
+        "--confirm-hardware",
+        action="store_true",
+        help="Required before this runner can queue a paid Braket task.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Print machine-readable JSON instead of the human summary.",
+    )
+    args = parser.parse_args()
+
+    try:
+        compiled = quantum.load_compiled_circuit(args.input, args.wire_bin, args.wire_return)
+        plan = quantum.build_quantum_plan(compiled)
+        plan["backend_family"] = "amazon_braket"
+        device_arn = resolve_device_arn(args.backend, args.device_arn)
+        qasm = build_openqasm3(plan, quantum, device_arn)
+        action = build_action_payload(qasm)
+        will_submit = not args.dry_run and not args.emit_request
+        if will_submit and not args.confirm_hardware:
+            raise quantum.WireQuantumError(
+                "refusing to submit an Amazon Braket task without "
+                "--confirm-hardware; use --dry-run to inspect the request locally"
+            )
+        if args.dry_run or args.emit_request:
+            cost_estimate = estimate_task_cost(device_arn, args.shots, task=None)
+            result = {
+                "execution": "dry_run",
+                "source": args.input,
+                "backend": device_label(device_arn),
+                "backend_family": "amazon_braket",
+                "device_arn": device_arn,
+                "region": args.region,
+                "profile": args.profile or None,
+                "s3_bucket": args.s3_bucket,
+                "s3_prefix": args.s3_prefix,
+                "shots": args.shots,
+                "plan": plan,
+                "openqasm3": qasm,
+                "estimated_cost_usd": cost_estimate["estimated_cost_usd"],
+                "cost_estimate": cost_estimate,
+                "request_payload": (
+                    request_payload(device_arn, args.s3_bucket, args.s3_prefix, args.shots, action)
+                    if args.emit_request
+                    else None
+                ),
+            }
+            if args.json_output:
+                quantum.print_json(result)
+            else:
+                print_request_summary(args.input, result, qasm, include_request=args.emit_request)
+            return 0
+
+        result = execute_braket_plan(
+            plan,
+            qasm,
+            source=args.input,
+            device_arn=device_arn,
+            s3_bucket=required_s3_bucket(args.s3_bucket, quantum),
+            s3_prefix=args.s3_prefix,
+            region=args.region,
+            profile=args.profile,
+            aws_bin=args.aws_bin,
+            shots=args.shots,
+            poll_interval=args.poll_interval,
+            timeout_seconds=args.timeout,
+            submit_only=args.submit_only,
+            quiet=args.json_output,
+            quantum=quantum,
+        )
+        if args.json_output:
+            quantum.print_json(result)
+        elif args.submit_only:
+            print_submission_summary(args.input, result)
+        else:
+            print_hardware_run_summary(args.input, result, quantum)
+        return 0
+    except quantum.WireQuantumError as exc:
+        print(f"wire-quantum-braket: {exc}", file=sys.stderr)
+        return 1
+
+
+def load_quantum_support() -> Any:
+    scripts_dir = Path(
+        os.environ.get("WIRE_QUANTUM_SCRIPTS_DIR", str(Path(__file__).resolve().parent))
+    )
+    module_path = scripts_dir / "wire-quantum-qiskit.py"
+    spec = importlib.util.spec_from_file_location("wire_quantum_qiskit_support", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load quantum support module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def positive_int(raw: str) -> int:
+    value = int(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return value
+
+
+def default_region() -> str:
+    return (
+        os.environ.get("CORTEX_BRAKET_REGION")
+        or os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or DEFAULT_REGION
+    )
+
+
+def resolve_device_arn(backend: str | None, device_arn: str | None) -> str:
+    if device_arn:
+        return device_arn
+    if backend:
+        normalized = backend.strip().lower()
+        if normalized == "sv1":
+            return DEFAULT_DEVICE_ARN
+        if normalized == "tn1":
+            return "arn:aws:braket:::device/quantum-simulator/amazon/tn1"
+        if normalized == "dm1":
+            return "arn:aws:braket:::device/quantum-simulator/amazon/dm1"
+        if backend.startswith("arn:"):
+            return backend
+    return DEFAULT_DEVICE_ARN
+
+
+def device_label(device_arn: str) -> str:
+    return device_arn.rsplit("/", maxsplit=1)[-1]
+
+
+def required_s3_bucket(bucket: str | None, quantum: Any) -> str:
+    if bucket:
+        return bucket
+    raise quantum.WireQuantumError(
+        "Amazon Braket execution needs CORTEX_BRAKET_BUCKET or --s3-bucket"
+    )
+
+
+def build_openqasm3(plan: JSON, quantum: Any, device_arn: str) -> str:
+    measurements = plan["measurements"]
+    if not measurements:
+        raise quantum.WireQuantumError("Amazon Braket execution requires at least one measurement")
+
+    last_gate_use_by_wire = last_non_measure_use_by_wire(plan["operations"])
+    lower_cnot_via_cz = uses_iqm_cz_entangler(device_arn)
+    measured_wires = {int(measurement["wire"]) for measurement in measurements}
+    extra_measurements = [
+        wire for wire in sorted(plan["qubits"]) if int(wire) not in measured_wires
+    ]
+    classical_bits = len(measurements) + len(extra_measurements)
+
+    lines = [
+        "OPENQASM 3;",
+        f"qubit[{plan['num_qubits']}] q;",
+        f"bit[{classical_bits}] c;",
+    ]
+    deferred_measurements: list[JSON] = []
+    for ix, operation in enumerate(plan["operations"]):
+        gate = operation["gate"]
+        if gate == "prepare_zero":
+            continue
+        if gate == "h":
+            lines.append(f"h q[{operation['wire']}];")
+        elif gate == "rz":
+            if not math.isclose(operation["angle"], 0.0, abs_tol=1e-15):
+                lines.append(f"rz({operation['angle']}) q[{operation['wire']}];")
+        elif gate == "sx":
+            lines.append(f"v q[{operation['wire']}];")
+        elif gate == "x":
+            lines.append(f"x q[{operation['wire']}];")
+        elif gate == "cnot":
+            append_cnot(
+                lines,
+                operation["control"],
+                operation["target"],
+                lower_cnot_via_cz,
+            )
+        elif gate == "cz":
+            lines.append(f"cz q[{operation['control']}], q[{operation['target']}];")
+        elif gate == "rzz":
+            append_rzz_decomposition(
+                lines,
+                operation["angle"],
+                operation["control"],
+                operation["target"],
+                lower_cnot_via_cz,
+            )
+        elif gate == "measure_z":
+            wire = int(operation["wire"])
+            if ix >= last_gate_use_by_wire.get(wire, -1):
+                deferred_measurements.append(operation)
+            else:
+                lines.append(measurement_line(operation))
+        else:
+            raise quantum.WireQuantumError(f"unsupported planned gate {gate}")
+
+    if can_measure_full_register(plan, deferred_measurements, extra_measurements):
+        lines.append("c = measure q;")
+    else:
+        for operation in sorted(deferred_measurements, key=lambda item: int(item["classical_bit"])):
+            lines.append(measurement_line(operation))
+
+        offset = len(measurements)
+        for ix, wire in enumerate(extra_measurements):
+            lines.append(f"c[{offset + ix}] = measure q[{wire}];")
+
+    return "\n".join(lines) + "\n"
+
+
+def uses_iqm_cz_entangler(device_arn: str) -> bool:
+    return "/qpu/iqm/" in device_arn.lower()
+
+
+def can_measure_full_register(
+    plan: JSON,
+    deferred_measurements: list[JSON],
+    extra_measurements: list[int],
+) -> bool:
+    measurements = plan["measurements"]
+    if extra_measurements:
+        return False
+    if len(deferred_measurements) != len(measurements):
+        return False
+    if len(measurements) != int(plan["num_qubits"]):
+        return False
+    for measurement in measurements:
+        if int(measurement["classical_bit"]) != int(measurement["wire"]):
+            return False
+    return True
+
+
+def last_non_measure_use_by_wire(operations: list[JSON]) -> dict[int, int]:
+    last_use: dict[int, int] = {}
+    for ix, operation in enumerate(operations):
+        gate = operation["gate"]
+        if gate == "measure_z":
+            continue
+        for wire in operation_wires(operation):
+            last_use[wire] = ix
+    return last_use
+
+
+def operation_wires(operation: JSON) -> list[int]:
+    gate = operation["gate"]
+    if gate in {"prepare_zero", "h", "rz", "sx", "x", "measure_z"}:
+        return [int(operation["wire"])]
+    if gate in {"cnot", "cz", "rzz"}:
+        return [int(operation["control"]), int(operation["target"])]
+    return []
+
+
+def measurement_line(operation: JSON) -> str:
+    return f"c[{operation['classical_bit']}] = measure q[{operation['wire']}];"
+
+
+def append_cnot(lines: list[str], control: int, target: int, via_cz: bool) -> None:
+    if not via_cz:
+        lines.append(f"cnot q[{control}], q[{target}];")
+        return
+    append_self_inverse_h(lines, target)
+    lines.append(f"cz q[{control}], q[{target}];")
+    append_self_inverse_h(lines, target)
+
+
+def append_self_inverse_h(lines: list[str], wire: int) -> None:
+    line = f"h q[{wire}];"
+    if lines and lines[-1] == line:
+        lines.pop()
+    else:
+        lines.append(line)
+
+
+def append_rzz_decomposition(
+    lines: list[str],
+    angle: float,
+    control: int,
+    target: int,
+    lower_cnot_via_cz: bool,
+) -> None:
+    append_cnot(lines, control, target, lower_cnot_via_cz)
+    lines.append(f"rz({angle}) q[{target}];")
+    append_cnot(lines, control, target, lower_cnot_via_cz)
+
+
+def build_action_payload(qasm: str) -> JSON:
+    return {
+        "braketSchemaHeader": {
+            "name": "braket.ir.openqasm.program",
+            "version": "1",
+        },
+        "source": qasm,
+    }
+
+
+def request_payload(
+    device_arn: str,
+    s3_bucket: str | None,
+    s3_prefix: str,
+    shots: int,
+    action: JSON,
+) -> JSON:
+    return {
+        "deviceArn": device_arn,
+        "shots": shots,
+        "outputS3Bucket": s3_bucket,
+        "outputS3KeyPrefix": s3_prefix,
+        "action": action,
+    }
+
+
+def execute_braket_plan(
+    plan: JSON,
+    qasm: str,
+    source: str,
+    device_arn: str,
+    s3_bucket: str,
+    s3_prefix: str,
+    region: str,
+    profile: str | None,
+    aws_bin: str,
+    shots: int,
+    poll_interval: int,
+    timeout_seconds: int,
+    submit_only: bool,
+    quiet: bool,
+    quantum: Any,
+) -> JSON:
+    action = build_action_payload(qasm)
+    run_prefix = run_s3_prefix(s3_prefix)
+    task_arn = create_quantum_task(
+        device_arn,
+        s3_bucket,
+        run_prefix,
+        shots,
+        action,
+        aws_bin,
+        profile,
+        region,
+        quantum,
+    )
+    pending_cost_estimate = estimate_task_cost(device_arn, shots, task=None)
+    if submit_only:
+        return {
+            "execution": "submitted",
+            "source": source,
+            "backend": device_label(device_arn),
+            "backend_family": "amazon_braket",
+            "device_arn": device_arn,
+            "task_arn": task_arn,
+            "region": region,
+            "profile": profile or None,
+            "s3_bucket": s3_bucket,
+            "s3_prefix": run_prefix,
+            "shots": shots,
+            "plan": plan,
+            "estimated_cost_usd": pending_cost_estimate["estimated_cost_usd"],
+            "cost_estimate": pending_cost_estimate,
+        }
+
+    task = poll_task(
+        task_arn,
+        aws_bin,
+        profile,
+        region,
+        poll_interval,
+        timeout_seconds,
+        quiet,
+        quantum,
+    )
+    result_uri = task_result_uri(task, quantum)
+    raw_result = fetch_s3_json(result_uri, aws_bin, profile, region, quantum)
+    counts = extract_counts(raw_result, plan["measurements"])
+    if counts is None:
+        raise quantum.WireQuantumError(
+            f"Braket task {task_arn} returned an unsupported result shape"
+        )
+    complete_counts = quantum.complete_counts(counts, len(plan["measurements"]))
+    cost_estimate = estimate_task_cost(device_arn, shots, task)
+    return {
+        "execution": "hardware",
+        "source": source,
+        "backend": device_label(device_arn),
+        "backend_family": "amazon_braket",
+        "device_arn": device_arn,
+        "task_arn": task_arn,
+        "status": public_task_status(task),
+        "shots": shots,
+        "plan": plan,
+        "counts": counts,
+        "complete_counts": complete_counts,
+        "labeled_counts": quantum.labeled_counts(counts, plan["measurements"]),
+        "complete_labeled_counts": quantum.labeled_counts(
+            complete_counts,
+            plan["measurements"],
+        ),
+        "output_counts": quantum.output_counts(counts, plan["measurements"]),
+        "complete_output_counts": quantum.output_counts(
+            complete_counts,
+            plan["measurements"],
+        ),
+        "region": region,
+        "profile": profile or None,
+        "s3_bucket": s3_bucket,
+        "s3_prefix": run_prefix,
+        "result_s3_uri": result_uri,
+        "qpu_usage_seconds": None,
+        "estimated_cost_usd": cost_estimate["estimated_cost_usd"],
+        "cost_estimate": cost_estimate,
+    }
+
+
+def run_s3_prefix(prefix: str) -> str:
+    clean = prefix.strip("/")
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    return f"{clean}/wire-openqasm-{stamp}" if clean else f"wire-openqasm-{stamp}"
+
+
+def estimate_task_cost(device_arn: str, shots: int, task: JSON | None) -> JSON:
+    override = override_qpu_cost_estimate(shots)
+    if override is not None:
+        return override
+
+    normalized = device_arn.lower()
+    if "device/qpu/" in normalized:
+        return estimate_qpu_task_cost(normalized, shots, task)
+    if "quantum-simulator/amazon/" in normalized:
+        return estimate_simulator_task_cost(normalized, task)
+    return unavailable_cost_estimate(
+        "unknown_device_pricing",
+        "No embedded Braket pricing rule matched this device ARN.",
+    )
+
+
+def override_qpu_cost_estimate(shots: int) -> JSON | None:
+    task_price = decimal_env("CORTEX_BRAKET_TASK_PRICE_USD")
+    shot_price = decimal_env("CORTEX_BRAKET_SHOT_PRICE_USD")
+    if task_price is None and shot_price is None:
+        return None
+    if task_price is None or shot_price is None:
+        return unavailable_cost_estimate(
+            "incomplete_price_override",
+            "Set both CORTEX_BRAKET_TASK_PRICE_USD and CORTEX_BRAKET_SHOT_PRICE_USD.",
+        )
+    return qpu_cost_estimate(
+        task_price,
+        shot_price,
+        shots,
+        "environment_override",
+        [
+            "Estimated from CORTEX_BRAKET_TASK_PRICE_USD and "
+            "CORTEX_BRAKET_SHOT_PRICE_USD.",
+            "Excludes S3, taxes, discounts, credits, reservations, and other AWS charges.",
+        ],
+    )
+
+
+def estimate_qpu_task_cost(normalized_device_arn: str, shots: int, task: JSON | None) -> JSON:
+    shot_price = None
+    for device_key, price in QPU_SHOT_PRICES_USD.items():
+        if device_key in normalized_device_arn:
+            shot_price = price
+            break
+    if shot_price is None:
+        return unavailable_cost_estimate(
+            "unknown_qpu_pricing",
+            "No embedded per-shot price is available for this QPU.",
+        )
+    successful_shots = task_successful_shots(task)
+    priced_shots = successful_shots if successful_shots is not None else shots
+    return qpu_cost_estimate(
+        QPU_TASK_PRICE_USD,
+        shot_price,
+        priced_shots,
+        "embedded_public_braket_qpu_pricing",
+        [
+            "Estimated from public Amazon Braket QPU per-task and per-shot pricing.",
+            "Excludes S3, taxes, discounts, credits, reservations, and other AWS charges.",
+        ],
+    )
+
+
+def qpu_cost_estimate(
+    task_price: Decimal,
+    shot_price: Decimal,
+    priced_shots: int,
+    pricing_source: str,
+    notes: list[str],
+) -> JSON:
+    amount = task_price + (shot_price * Decimal(priced_shots))
+    return cost_estimate_result(
+        amount,
+        "qpu_task_and_shot",
+        pricing_source,
+        {
+            "task_count": 1,
+            "priced_shots": priced_shots,
+            "task_price_usd": decimal_text(task_price),
+            "shot_price_usd": decimal_text(shot_price),
+        },
+        notes,
+    )
+
+
+def estimate_simulator_task_cost(normalized_device_arn: str, task: JSON | None) -> JSON:
+    override_rate = decimal_env("CORTEX_BRAKET_SIMULATOR_MINUTE_PRICE_USD")
+    simulator_key = None
+    minute_price = override_rate
+    for device_key, price in SIMULATOR_MINUTE_PRICES_USD.items():
+        if device_key in normalized_device_arn:
+            simulator_key = device_key.rsplit("/", maxsplit=1)[-1]
+            minute_price = minute_price if minute_price is not None else price
+            break
+    if minute_price is None:
+        return unavailable_cost_estimate(
+            "unknown_simulator_pricing",
+            "No embedded per-minute price is available for this managed simulator.",
+        )
+    if task is None:
+        return unavailable_cost_estimate(
+            "simulator_duration_unavailable_before_completion",
+            "Managed simulator estimates require task start/end metadata after completion.",
+        )
+    duration = task_wall_clock_seconds(task)
+    if duration is None:
+        return unavailable_cost_estimate(
+            "simulator_duration_unavailable",
+            "The Braket task metadata did not include parseable createdAt and endedAt values.",
+        )
+    billed_seconds = max(duration, MIN_SIMULATOR_BILLING_SECONDS)
+    amount = minute_price * billed_seconds / Decimal(60)
+    source = (
+        "environment_override"
+        if override_rate is not None
+        else f"embedded_public_braket_{simulator_key}_pricing"
+    )
+    return cost_estimate_result(
+        amount,
+        "managed_simulator_duration",
+        source,
+        {
+            "duration_seconds": decimal_text(duration),
+            "billed_duration_seconds": decimal_text(billed_seconds),
+            "minute_price_usd": decimal_text(minute_price),
+        },
+        [
+            "Estimated from task createdAt/endedAt metadata and public managed-simulator pricing.",
+            "Braket bills managed simulators by execution duration with a minimum duration; "
+            "createdAt/endedAt may include non-billable service overhead.",
+            "Excludes S3, taxes, discounts, credits, free-tier credits, and other AWS charges.",
+        ],
+    )
+
+
+def task_successful_shots(task: JSON | None) -> int | None:
+    if task is None:
+        return None
+    value = task.get("numSuccessfulShots")
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def task_wall_clock_seconds(task: JSON) -> Decimal | None:
+    created = parse_task_time(task.get("createdAt"))
+    ended = parse_task_time(task.get("endedAt"))
+    if created is None or ended is None:
+        return None
+    seconds = Decimal(str((ended - created).total_seconds()))
+    return seconds if seconds > 0 else None
+
+
+def parse_task_time(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def decimal_env(name: str) -> Decimal | None:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return None
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation:
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def cost_estimate_result(
+    amount: Decimal,
+    pricing_model: str,
+    pricing_source: str,
+    detail: JSON,
+    notes: list[str],
+) -> JSON:
+    rounded = amount.quantize(Decimal("0.0000000001"), rounding=ROUND_HALF_UP)
+    return {
+        "status": "estimated",
+        "currency": "USD",
+        "estimated_cost_usd": float(rounded),
+        "estimated_cost_usd_text": decimal_text(rounded),
+        "pricing_model": pricing_model,
+        "pricing_source": pricing_source,
+        **detail,
+        "notes": notes,
+    }
+
+
+def unavailable_cost_estimate(reason: str, note: str) -> JSON:
+    return {
+        "status": "unavailable",
+        "currency": "USD",
+        "estimated_cost_usd": None,
+        "estimated_cost_usd_text": None,
+        "pricing_model": None,
+        "pricing_source": None,
+        "reason": reason,
+        "notes": [note],
+    }
+
+
+def decimal_text(value: Decimal) -> str:
+    return format(value.normalize(), "f")
+
+
+def create_quantum_task(
+    device_arn: str,
+    s3_bucket: str,
+    s3_prefix: str,
+    shots: int,
+    action: JSON,
+    aws_bin: str,
+    profile: str | None,
+    region: str,
+    quantum: Any,
+) -> str:
+    command = aws_command(
+        aws_bin,
+        profile,
+        region,
+        [
+            "braket",
+            "create-quantum-task",
+            "--device-arn",
+            device_arn,
+            "--shots",
+            str(shots),
+            "--output-s3-bucket",
+            s3_bucket,
+            "--output-s3-key-prefix",
+            s3_prefix,
+            "--action",
+            json.dumps(action),
+            "--query",
+            "quantumTaskArn",
+            "--output",
+            "text",
+        ],
+    )
+    task_arn = run_text(command, quantum).strip()
+    if not task_arn.startswith("arn:aws:braket:"):
+        raise quantum.WireQuantumError("Braket task creation did not return a task ARN")
+    return task_arn
+
+
+def poll_task(
+    task_arn: str,
+    aws_bin: str,
+    profile: str | None,
+    region: str,
+    poll_interval: int,
+    timeout_seconds: int,
+    quiet: bool,
+    quantum: Any,
+) -> JSON:
+    deadline = time.monotonic() + timeout_seconds
+    last_task: JSON | None = None
+    while True:
+        task = get_quantum_task(task_arn, aws_bin, profile, region, quantum)
+        last_task = task
+        status = str(task.get("status", "UNKNOWN"))
+        if status in TERMINAL_TASK_STATUSES:
+            if status != "COMPLETED":
+                detail = task_failure_detail(task)
+                suffix = f": {detail}" if detail else ""
+                raise quantum.WireQuantumError(
+                    f"Braket task {task_arn} ended with status {status}{suffix}"
+                )
+            return task
+        if status not in RUNNING_TASK_STATUSES:
+            raise quantum.WireQuantumError(
+                f"Braket task {task_arn} returned unexpected status {status}"
+            )
+        if time.monotonic() >= deadline:
+            last_status = last_task.get("status", "UNKNOWN") if last_task else "UNKNOWN"
+            raise quantum.WireQuantumError(
+                f"timed out waiting for Braket task {task_arn}; "
+                f"last status was {last_status}"
+            )
+        if not quiet:
+            sys.stderr.write(f"Braket task status={status}; polling again.\n")
+        time.sleep(poll_interval)
+
+
+def get_quantum_task(
+    task_arn: str,
+    aws_bin: str,
+    profile: str | None,
+    region: str,
+    quantum: Any,
+) -> JSON:
+    command = aws_command(
+        aws_bin,
+        profile,
+        region,
+        [
+            "braket",
+            "get-quantum-task",
+            "--quantum-task-arn",
+            task_arn,
+            "--output",
+            "json",
+        ],
+    )
+    return run_json(command, quantum)
+
+
+def task_result_uri(task: JSON, quantum: Any) -> str:
+    bucket = task.get("outputS3Bucket")
+    directory = task.get("outputS3Directory")
+    if not isinstance(bucket, str) or not bucket:
+        raise quantum.WireQuantumError("Braket task metadata did not include outputS3Bucket")
+    if not isinstance(directory, str) or not directory:
+        raise quantum.WireQuantumError("Braket task metadata did not include outputS3Directory")
+    return f"s3://{bucket}/{directory.rstrip('/')}/results.json"
+
+
+def fetch_s3_json(
+    uri: str,
+    aws_bin: str,
+    profile: str | None,
+    region: str,
+    quantum: Any,
+) -> Any:
+    command = aws_command(aws_bin, profile, region, ["s3", "cp", uri, "-"])
+    return json.loads(run_text(command, quantum))
+
+
+def aws_command(
+    aws_bin: str,
+    profile: str | None,
+    region: str,
+    args: list[str],
+) -> list[str]:
+    command = [aws_bin, *args]
+    if profile:
+        command.extend(["--profile", profile])
+    if region:
+        command.extend(["--region", region])
+    return command
+
+
+def run_json(command: list[str], quantum: Any) -> JSON:
+    text = run_text(command, quantum)
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise quantum.WireQuantumError(
+            f"command returned non-JSON output: {display_command(command)}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise quantum.WireQuantumError(
+            f"command did not return a JSON object: {display_command(command)}"
+        )
+    return value
+
+
+def run_text(command: list[str], quantum: Any) -> str:
+    proc = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip()
+        suffix = f": {detail}" if detail else ""
+        raise quantum.WireQuantumError(
+            f"command failed ({proc.returncode}): {display_command(command)}{suffix}"
+        )
+    return proc.stdout
+
+
+def display_command(command: list[str]) -> str:
+    return " ".join(command[:4] + (["..."] if len(command) > 4 else []))
+
+
+def public_task_status(task: JSON) -> str:
+    status = str(task.get("status", "UNKNOWN"))
+    return TASK_STATUS_LABELS.get(status, "Unknown")
+
+
+def task_failure_detail(task: JSON) -> str | None:
+    value = task.get("failureReason")
+    if isinstance(value, str) and value:
+        return " ".join(value.split())[:500]
+    return None
+
+
+def extract_counts(raw_result: Any, measurements: list[JSON]) -> dict[str, int] | None:
+    width = len(measurements)
+    rows = find_measurement_rows(raw_result)
+    if rows is not None:
+        return counts_from_rows(rows, measurements)
+    direct = find_direct_counts(raw_result, width)
+    if direct is not None:
+        return direct
+    return None
+
+
+def find_measurement_rows(value: Any) -> list[Any] | None:
+    if isinstance(value, dict):
+        measurements = value.get("measurements")
+        if isinstance(measurements, list):
+            return measurements
+        for child in value.values():
+            found = find_measurement_rows(child)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for child in value:
+            found = find_measurement_rows(child)
+            if found is not None:
+                return found
+    return None
+
+
+def counts_from_rows(rows: list[Any], measurements: list[JSON]) -> dict[str, int] | None:
+    width = len(measurements)
+    if width <= 0:
+        return None
+    counter: Counter[str] = Counter()
+    classical_bits = [int(measurement["classical_bit"]) for measurement in measurements]
+    for row in rows:
+        if not isinstance(row, list):
+            return None
+        if any(bit_index >= len(row) for bit_index in classical_bits):
+            return None
+        try:
+            selected = [int(row[bit_index]) for bit_index in classical_bits]
+        except (TypeError, ValueError):
+            return None
+        if any(bit not in (0, 1) for bit in selected):
+            return None
+        counter["".join(str(bit) for bit in selected)[::-1]] += 1
+    return dict(sorted(counter.items()))
+
+
+def find_direct_counts(value: Any, width: int) -> dict[str, int] | None:
+    if isinstance(value, dict):
+        for key in ("measurementCounts", "measurement_counts", "counts"):
+            candidate = normalize_counts(value.get(key), width)
+            if candidate is not None:
+                return candidate
+        for child in value.values():
+            found = find_direct_counts(child, width)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for child in value:
+            found = find_direct_counts(child, width)
+            if found is not None:
+                return found
+    return None
+
+
+def normalize_counts(value: Any, width: int) -> dict[str, int] | None:
+    if not isinstance(value, dict) or not value:
+        return None
+    counts: dict[str, int] = {}
+    for raw_bits, raw_count in value.items():
+        if not isinstance(raw_bits, str):
+            return None
+        bits = raw_bits.replace(" ", "")
+        if len(bits) != width or set(bits) - {"0", "1"}:
+            return None
+        if isinstance(raw_count, bool) or not isinstance(raw_count, (int, float)):
+            return None
+        if isinstance(raw_count, float) and not raw_count.is_integer():
+            return None
+        counts[bits] = int(raw_count)
+    return dict(sorted(counts.items()))
+
+
+def print_request_summary(
+    source: str,
+    result: JSON,
+    openqasm3: str,
+    include_request: bool,
+) -> None:
+    print("Wire Amazon Braket request")
+    emit_field("source", source)
+    print("execution: dry run (not submitted)")
+    emit_field("device", result["device_arn"])
+    emit_field("region", result["region"])
+    emit_field("profile", result["profile"] or "ambient")
+    emit_field("s3", f"s3://{result['s3_bucket']}/{result['s3_prefix']}")
+    emit_field("shots", result["shots"])
+    emit_cost_estimate(result["cost_estimate"])
+    emit_field("qubits", result["plan"]["num_qubits"])
+    emit_field("measurements", format_measurements(result["plan"]))
+    print()
+    print("What would happen:")
+    print("Wire compiles the graph into typed quantum executor nodes.")
+    print("This runner lowers those nodes into one Braket OpenQASM 3 task.")
+    print("No Braket task was queued.")
+    print()
+    print("OpenQASM 3:")
+    emit_block(openqasm3)
+    if include_request:
+        print()
+        print("Braket payload:")
+        emit_line(json.dumps(result["request_payload"], indent=2, sort_keys=True))
+
+
+def print_submission_summary(source: str, result: JSON) -> None:
+    print("Wire Amazon Braket task")
+    emit_field("source", source)
+    print("execution: submitted (not polled)")
+    emit_field("device", result["device_arn"])
+    emit_field("task", result["task_arn"])
+    emit_field("region", result["region"])
+    emit_field("s3", f"s3://{result['s3_bucket']}/{result['s3_prefix']}")
+    emit_field("shots", result["shots"])
+    emit_cost_estimate(result["cost_estimate"])
+    print()
+    print("The task is now queued with Amazon Braket.")
+
+
+def print_hardware_run_summary(source: str, result: JSON, quantum: Any) -> None:
+    plan = result["plan"]
+    print("Wire Amazon Braket run")
+    emit_field("source", source)
+    print("execution: Amazon Braket OpenQASM")
+    emit_field("device", result["device_arn"])
+    emit_field("task", result["task_arn"])
+    emit_field("status", result["status"])
+    emit_field("region", result["region"])
+    emit_field("result", result["result_s3_uri"])
+    emit_field("shots", result["shots"])
+    emit_cost_estimate(result["cost_estimate"])
+    emit_field("qubits", plan["num_qubits"])
+    emit_field("measurements", format_measurements(plan))
+    print()
+    print("What happened:")
+    print("Wire compiled the graph into typed quantum executor nodes.")
+    print("The runner lowered the admitted gates into Braket OpenQASM 3 and")
+    print("submitted that circuit through AWS CLI.")
+    print()
+    print("Result:")
+    emit_line(quantum.format_result_table(result["counts"], plan["measurements"], result["shots"]))
+
+
+def format_measurements(plan: JSON) -> str:
+    measurements = plan["measurements"]
+    if not measurements:
+        return "none"
+    return ", ".join(
+        f"{measurement['output']}=q[{measurement['wire']}]" for measurement in measurements
+    )
+
+
+def emit_field(label: str, value: Any) -> None:
+    emit_raw(f"{label}: {value}\n")
+
+
+def emit_cost_estimate(cost_estimate: JSON) -> None:
+    if cost_estimate.get("status") == "estimated":
+        emit_field("estimated cost", f"${cost_estimate['estimated_cost_usd_text']} USD")
+    else:
+        emit_field("estimated cost", f"unavailable ({cost_estimate.get('reason')})")
+
+
+def emit_line(value: str) -> None:
+    emit_raw(value)
+    if not value.endswith("\n"):
+        emit_raw("\n")
+
+
+def emit_block(value: str) -> None:
+    emit_raw(value)
+
+
+def emit_raw(value: str) -> None:
+    sys.stdout.flush()
+    os.write(sys.stdout.fileno(), value.encode("utf-8"))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wire-quantum-ibm-rest.py
+++ b/scripts/wire-quantum-ibm-rest.py
@@ -404,21 +404,16 @@ def build_openqasm3(plan: JSON, quantum: Any) -> str:
         if gate == "prepare_zero":
             continue
         if gate == "h":
-            raise quantum.WireQuantumError(
-                "IBM hardware runner requires primitive Wire gates; decompose "
-                "quantum.h as quantum.rz(pi/2) => quantum.sx => quantum.rz(pi/2)"
-            )
+            append_h_decomposition(lines, operation["wire"])
         elif gate == "rz":
-            lines.append(f"rz({operation['angle']}) q[{operation['wire']}];")
+            if not math.isclose(operation["angle"], 0.0, abs_tol=1e-15):
+                lines.append(f"rz({operation['angle']}) q[{operation['wire']}];")
         elif gate == "sx":
             lines.append(f"sx q[{operation['wire']}];")
         elif gate == "x":
             lines.append(f"x q[{operation['wire']}];")
         elif gate == "cnot":
-            raise quantum.WireQuantumError(
-                "IBM hardware runner requires primitive Wire gates; decompose "
-                "quantum.cnot as h(target) => quantum.cz => h(target)"
-            )
+            append_cnot_decomposition(lines, operation["control"], operation["target"])
         elif gate == "cz":
             lines.append(f"cz q[{operation['control']}], q[{operation['target']}];")
         elif gate == "rzz":

--- a/scripts/wire-quantum-ibm-rest.py
+++ b/scripts/wire-quantum-ibm-rest.py
@@ -503,12 +503,19 @@ def resolve_backend(
     if backend_request != "least_busy":
         return backend_request
 
-    response = request_json(
-        "GET",
-        api_url(config, "backends"),
-        runtime_headers(config, token),
-        quantum=quantum,
-    )
+    try:
+        response = request_json(
+            "GET",
+            api_url(config, "backends"),
+            runtime_headers(config, token),
+            quantum=quantum,
+        )
+    except quantum.WireQuantumError as exc:
+        raise quantum.WireQuantumError(
+            f"{exc}; failed while resolving backend = \"least_busy\". "
+            "Set a concrete backend in the IBM Runtime config, or pass --backend "
+            "for direct single-circuit runs, to avoid listing backends."
+        ) from exc
     devices = response.get("devices") if isinstance(response, dict) else response
     if not isinstance(devices, list):
         raise quantum.WireQuantumError("IBM backends response did not include a devices list")
@@ -627,9 +634,10 @@ def request_json(
         with urllib.request.urlopen(request, timeout=60) as response:
             body = response.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
+        detail = http_error_detail(exc)
+        suffix = f"; response: {detail}" if detail else "; response body omitted"
         raise quantum.WireQuantumError(
-            f"IBM Runtime REST {method} {url} failed with HTTP {exc.code}; "
-            "response body omitted"
+            f"IBM Runtime REST {method} {url} failed with HTTP {exc.code}{suffix}"
         ) from exc
     except urllib.error.URLError as exc:
         raise quantum.WireQuantumError(
@@ -643,6 +651,18 @@ def request_json(
         raise quantum.WireQuantumError(
             f"IBM Runtime REST {method} {url} returned non-JSON response"
         ) from exc
+
+
+def http_error_detail(exc: urllib.error.HTTPError) -> str | None:
+    try:
+        raw = exc.read(2048)
+    except Exception:
+        return None
+    if not raw:
+        return None
+    text = raw.decode("utf-8", errors="replace")
+    compact = " ".join(text.split())
+    return compact[:500] if compact else None
 
 
 def api_url(config: JSON, path: str) -> str:

--- a/scripts/wire-quantum-ibm-rest.py
+++ b/scripts/wire-quantum-ibm-rest.py
@@ -224,6 +224,14 @@ def main() -> int:
                 if complete_counts
                 else None
             ),
+            "output_counts": (
+                quantum.output_counts(counts, plan["measurements"]) if counts else None
+            ),
+            "complete_output_counts": (
+                quantum.output_counts(complete_counts, plan["measurements"])
+                if complete_counts
+                else None
+            ),
             "qpu_usage_seconds": qpu_usage_seconds(metrics),
         }
         if args.json_output:

--- a/scripts/wire-quantum-ipea.py
+++ b/scripts/wire-quantum-ipea.py
@@ -45,7 +45,13 @@ def main() -> int:
     parser.add_argument(
         "--hardware",
         action="store_true",
-        help="Run on IBM Quantum hardware instead of the local Aer simulator.",
+        help="Run on a provider backend instead of the local Aer simulator.",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=["ibm", "braket"],
+        default="ibm",
+        help="Hardware provider used with --hardware.",
     )
     parser.add_argument(
         "--config",
@@ -54,7 +60,42 @@ def main() -> int:
     )
     parser.add_argument(
         "--backend",
-        help="IBM backend override. Use 'least_busy' to auto-select online hardware.",
+        help="IBM backend override or Braket backend alias/device ARN.",
+    )
+    parser.add_argument(
+        "--device-arn",
+        default=os.environ.get("CORTEX_BRAKET_DEVICE_ARN"),
+        help="Braket device ARN used with --provider braket.",
+    )
+    parser.add_argument(
+        "--s3-bucket",
+        default=os.environ.get("CORTEX_BRAKET_BUCKET"),
+        help="Braket result bucket used with --provider braket.",
+    )
+    parser.add_argument(
+        "--s3-prefix",
+        default=os.environ.get("CORTEX_BRAKET_PREFIX", "cortex/dev"),
+        help="Braket result prefix used with --provider braket.",
+    )
+    parser.add_argument(
+        "--region",
+        default=(
+            os.environ.get("CORTEX_BRAKET_REGION")
+            or os.environ.get("AWS_REGION")
+            or os.environ.get("AWS_DEFAULT_REGION")
+            or "us-east-1"
+        ),
+        help="AWS region used with --provider braket.",
+    )
+    parser.add_argument(
+        "--profile",
+        default=os.environ.get("AWS_PROFILE", "cortex-braket"),
+        help="AWS profile used with --provider braket.",
+    )
+    parser.add_argument(
+        "--aws-bin",
+        default=os.environ.get("AWS_BIN", "aws"),
+        help="AWS CLI executable used with --provider braket.",
     )
     parser.add_argument(
         "--confirm-hardware",
@@ -94,10 +135,11 @@ def main() -> int:
         )
         quantum = load_module(scripts_dir / "wire-quantum-qiskit.py", "wire_quantum_qiskit")
         ibm = load_module(scripts_dir / "wire-quantum-ibm-rest.py", "wire_quantum_ibm_rest")
+        braket = load_module(scripts_dir / "wire-quantum-braket.py", "wire_quantum_braket")
         phase = normalize_phase(parse_phase(args.phase))
         if args.hardware and not args.dry_run and not args.confirm_hardware:
             raise IpeaError(
-                "refusing to submit IBM Quantum jobs without --confirm-hardware; "
+                f"refusing to submit {args.provider} quantum jobs without --confirm-hardware; "
                 "use --dry-run to inspect generated rounds"
             )
 
@@ -105,8 +147,12 @@ def main() -> int:
         if emit_dir is not None:
             emit_dir.mkdir(parents=True, exist_ok=True)
 
-        hardware = prepare_hardware(args, ibm, quantum) if args.hardware and not args.dry_run else None
-        result = run_ipea(args, phase, quantum, ibm, emit_dir, hardware)
+        hardware = (
+            prepare_hardware(args, ibm, braket, quantum)
+            if args.hardware and not args.dry_run
+            else None
+        )
+        result = run_ipea(args, phase, quantum, ibm, braket, emit_dir, hardware)
         if args.json_output:
             print(json.dumps(result, indent=2, sort_keys=True))
         else:
@@ -153,11 +199,30 @@ def normalize_phase(phase: Fraction) -> Fraction:
     return phase % 1
 
 
-def prepare_hardware(args: argparse.Namespace, ibm: Any, quantum: Any) -> JSON:
+def prepare_hardware(args: argparse.Namespace, ibm: Any, braket: Any, quantum: Any) -> JSON:
+    if args.provider == "braket":
+        device_arn = braket.resolve_device_arn(args.backend, args.device_arn)
+        return {
+            "provider": "braket",
+            "device_arn": device_arn,
+            "backend": braket.device_label(device_arn),
+            "s3_bucket": braket.required_s3_bucket(args.s3_bucket, quantum),
+            "s3_prefix": args.s3_prefix,
+            "region": args.region,
+            "profile": args.profile,
+            "aws_bin": args.aws_bin,
+        }
+
     config_path = Path(args.config).expanduser().resolve()
     config = ibm.load_runtime_config(config_path, require_credentials=True, quantum=quantum)
     token = ibm.fetch_iam_token(config, quantum)
-    return {"config_path": config_path, "config": config, "token": token, "backend": None}
+    return {
+        "provider": "ibm",
+        "config_path": config_path,
+        "config": config,
+        "token": token,
+        "backend": None,
+    }
 
 
 def run_ipea(
@@ -165,12 +230,14 @@ def run_ipea(
     phase: Fraction,
     quantum: Any,
     ibm: Any,
+    braket: Any,
     emit_dir: Path | None,
     hardware: JSON | None,
 ) -> JSON:
     rounds: list[JSON] = []
     measured_bits: dict[int, int] = {}
     total_qpu_usage = 0.0
+    total_estimated_cost = 0.0
     config_path = Path(args.config).expanduser().resolve()
 
     with tempfile.TemporaryDirectory(prefix="wire-ipea-") as tmpdir:
@@ -191,7 +258,7 @@ def run_ipea(
             round_path = write_round_source(wire_source, tmp_path, emit_dir, ix, bit_position)
             compiled = quantum.load_compiled_circuit(str(round_path), args.wire_bin)
             plan = quantum.build_quantum_plan(compiled)
-            qasm = ibm.build_openqasm3(plan, quantum)
+            qasm = build_round_openqasm(args, hardware, ibm, braket, plan, quantum)
 
             round_result: JSON = {
                 "round": ix,
@@ -217,14 +284,20 @@ def run_ipea(
                 hw_result = execute_hardware_round(
                     args,
                     ibm,
+                    braket,
                     quantum,
                     hardware,
                     plan,
                     qasm,
+                    round_path,
                 )
                 bit = choose_majority_bit(hw_result["counts"])
-                usage = hw_result["qpu_usage_seconds"]
-                total_qpu_usage += usage
+                usage = hw_result.get("qpu_usage_seconds")
+                if isinstance(usage, (int, float)):
+                    total_qpu_usage += usage
+                estimated_cost = hw_result.get("estimated_cost_usd")
+                if isinstance(estimated_cost, (int, float)):
+                    total_estimated_cost += float(estimated_cost)
                 round_result.update(hw_result)
                 round_result.update({"chosen_bit": bit})
             else:
@@ -263,18 +336,39 @@ def run_ipea(
         "estimated_phase_decimal": float(estimated),
         "absolute_error": abs(float(phase) - float(estimated)),
         "rounds": rounds,
-        "qpu_usage_seconds": total_qpu_usage if hardware is not None else None,
+        "qpu_usage_seconds": total_qpu_usage if total_qpu_usage > 0 else None,
+        "estimated_cost_usd": (
+            total_estimated_cost if total_estimated_cost > 0 else None
+        ),
     }
+
+
+def build_round_openqasm(
+    args: argparse.Namespace,
+    hardware: JSON | None,
+    ibm: Any,
+    braket: Any,
+    plan: JSON,
+    quantum: Any,
+) -> str:
+    if args.hardware and args.provider == "braket":
+        return braket.build_openqasm3(plan, quantum)
+    return ibm.build_openqasm3(plan, quantum)
 
 
 def execute_hardware_round(
     args: argparse.Namespace,
     ibm: Any,
+    braket: Any,
     quantum: Any,
     hardware: JSON,
     plan: JSON,
     qasm: str,
+    round_path: Path,
 ) -> JSON:
+    if hardware["provider"] == "braket":
+        return execute_braket_round(args, braket, quantum, hardware, plan, qasm, round_path)
+
     config = hardware["config"]
     token = hardware["token"]
     if hardware["backend"] is None:
@@ -305,6 +399,49 @@ def execute_hardware_round(
         "counts": counts,
         "labeled_counts": quantum.labeled_counts(counts, plan["measurements"]),
         "qpu_usage_seconds": qpu_usage_seconds(ibm, metrics),
+    }
+
+
+def execute_braket_round(
+    args: argparse.Namespace,
+    braket: Any,
+    quantum: Any,
+    hardware: JSON,
+    plan: JSON,
+    qasm: str,
+    round_path: Path,
+) -> JSON:
+    result = braket.execute_braket_plan(
+        plan,
+        qasm,
+        source=str(round_path),
+        device_arn=hardware["device_arn"],
+        s3_bucket=hardware["s3_bucket"],
+        s3_prefix=hardware["s3_prefix"],
+        region=hardware["region"],
+        profile=hardware["profile"],
+        aws_bin=hardware["aws_bin"],
+        shots=args.shots,
+        poll_interval=args.poll_interval or 5,
+        timeout_seconds=args.timeout or 900,
+        submit_only=False,
+        quiet=args.json_output,
+        quantum=quantum,
+    )
+    return {
+        "execution": "amazon_braket",
+        "backend": result["backend"],
+        "backend_family": result["backend_family"],
+        "device_arn": result["device_arn"],
+        "task_arn": result["task_arn"],
+        "status": result["status"],
+        "counts": result["counts"],
+        "complete_counts": result["complete_counts"],
+        "labeled_counts": result["labeled_counts"],
+        "result_s3_uri": result["result_s3_uri"],
+        "qpu_usage_seconds": result["qpu_usage_seconds"],
+        "estimated_cost_usd": result["estimated_cost_usd"],
+        "cost_estimate": result["cost_estimate"],
     }
 
 
@@ -430,18 +567,12 @@ let feedback_and_readout =
 
 ibm_runtime_config
   => (
-    (
-      prepare_control
-        => h_control
-        => controlled_phase
-        => feedback_and_readout
-    )
-    <>
-    (
-      prepare_eigenstate
-        => controlled_phase
-    )
-)
+    (prepare_control
+      => h_control)
+    <> prepare_eigenstate
+  )
+  => controlled_phase
+  => feedback_and_readout
 """
 
 
@@ -494,7 +625,7 @@ def execution_label(args: argparse.Namespace) -> str:
     if args.dry_run:
         return "dry_run"
     if args.hardware:
-        return "ibm_quantum_hardware"
+        return "amazon_braket" if args.provider == "braket" else "ibm_quantum_hardware"
     return "local_simulation"
 
 
@@ -506,6 +637,8 @@ def print_summary(result: JSON) -> None:
     print(f"shots per round: {result['shots']}")
     if result.get("qpu_usage_seconds") is not None:
         print(f"qpu usage: {result['qpu_usage_seconds']:.3f}s")
+    if result.get("estimated_cost_usd") is not None:
+        print(f"estimated cost: ${result['estimated_cost_usd']:.6f} USD")
     print()
     print("Rounds:")
     rows = []

--- a/scripts/wire-quantum-qiskit.py
+++ b/scripts/wire-quantum-qiskit.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import heapq
 import json
+import math
 import os
 import subprocess
 import sys
@@ -807,7 +808,8 @@ def execute_qiskit_plan(plan: JSON, backend_name: str, shots: int, seed: int | N
         if gate == "h":
             circuit.h(operation["wire"])
         elif gate == "rz":
-            circuit.rz(operation["angle"], operation["wire"])
+            if not math.isclose(operation["angle"], 0.0, abs_tol=1e-15):
+                circuit.rz(operation["angle"], operation["wire"])
         elif gate == "sx":
             circuit.sx(operation["wire"])
         elif gate == "x":
@@ -845,6 +847,8 @@ def execute_qiskit_plan(plan: JSON, backend_name: str, shots: int, seed: int | N
         "complete_counts": complete,
         "labeled_counts": labeled_counts(counts, measurements),
         "complete_labeled_counts": labeled_counts(complete, measurements),
+        "output_counts": output_counts(counts, measurements),
+        "complete_output_counts": output_counts(complete, measurements),
     }
 
 
@@ -859,6 +863,22 @@ def labeled_counts(counts: dict[str, int], measurements: list[JSON]) -> dict[str
     labeled: dict[str, int] = {}
     for raw_bits, count in counts.items():
         labeled[label_bits(raw_bits, measurements)] = count
+    return dict(sorted(labeled.items()))
+
+
+def output_counts(counts: dict[str, int], measurements: list[JSON]) -> dict[str, dict[str, int]]:
+    labeled: dict[str, dict[str, int]] = {
+        measurement["output"]: {"0": 0, "1": 0} for measurement in measurements
+    }
+    width = len(measurements)
+    for raw_bits, count in counts.items():
+        bits = raw_bits.replace(" ", "")
+        if len(bits) != width:
+            raise WireQuantumError(f"unexpected Qiskit bitstring width: {raw_bits}")
+        for measurement in measurements:
+            classical_bit = measurement["classical_bit"]
+            bit = bits[width - classical_bit - 1]
+            labeled[measurement["output"]][bit] += count
     return dict(sorted(labeled.items()))
 
 

--- a/src/Cortex/Capability/BindingPack.hs
+++ b/src/Cortex/Capability/BindingPack.hs
@@ -1,0 +1,46 @@
+{- |
+Module      : Cortex.Capability.BindingPack
+Description : ADR 0054 host runtime binding pack — the only artifact with runtime authority.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+A host runtime binding pack (ADR 0054) is the sole artifact that carries runtime
+authority. It depends on one or more Wire packages (never the reverse), resolves
+their declared executor requirements against concrete host authority, and mints the
+ADR 0053 runtime binding records a runnable Circuit carries into Pulse dispatch.
+
+This module defines the inert descriptor; a concrete pack (e.g. the Braket pack,
+ADR 0059 phase P7) supplies the runnable @StageAction@s the records reference.
+-}
+module Cortex.Capability.BindingPack
+  ( HostBindingPack (..)
+  , lookupBinding
+  )
+where
+
+import Data.List (find)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Cortex.Capability.Catalog.RuntimeBindingRecord (RuntimeBindingRecord (..))
+import Cortex.Wire.Executor (WireExecutorId)
+
+data HostBindingPack = HostBindingPack
+  { hbpIdentity :: !Text
+  -- ^ The pack's identity (e.g. @braket-pack@).
+  , hbpWirePackageDeps :: ![Text]
+  -- ^ Ids of the Wire packages this pack binds (dependency is one-way: pack → package).
+  , hbpRuntimeBindings :: ![RuntimeBindingRecord]
+  -- ^ The minted binding records, one per executor id this pack resolves.
+  }
+  deriving stock (Eq, Show, Generic)
+
+{- | Resolve an executor id to its minted runtime binding record, if this pack binds it.
+A missing result is the @missing runtime binding@ condition (ADR 0054): compile
+succeeds without a pack; only runnable Pulse lowering fails.
+-}
+lookupBinding :: WireExecutorId -> HostBindingPack -> Maybe RuntimeBindingRecord
+lookupBinding executorId pack =
+  find ((== executorId) . rbrExecutorId) (hbpRuntimeBindings pack)

--- a/src/Cortex/Capability/BindingPack/Braket.hs
+++ b/src/Cortex/Capability/BindingPack/Braket.hs
@@ -1,0 +1,89 @@
+{- |
+Module      : Cortex.Capability.BindingPack.Braket
+Description : The Braket host runtime binding pack for quantum.realize (ADR 0059 / 0054).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The Braket host binding pack (ADR 0054) is the artifact that carries AWS runtime
+authority: it depends on the @quantum.braket@ Wire package and mints the ADR 0053
+runtime binding record that resolves @quantum.realize@ to a @submit_park_resume@
+external-call stage (ADR 0059 §3). The runnable driver — OpenQASM lowering + Braket
+submit/poll over @scripts/wire-quantum-braket.py@ — is supplied at the Pulse layer
+when the CLI runs; this module owns the inert, authority-bearing binding descriptor
+and the config that parameterises it.
+-}
+module Cortex.Capability.BindingPack.Braket
+  ( BraketConfig (..)
+  , braketBindingPack
+  )
+where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Cortex.Capability.BindingPack (HostBindingPack (..))
+import Cortex.Capability.Catalog.AdmissionProjection (ContentDigest (..), ProjectionVersion (..))
+import Cortex.Capability.Catalog.AwaitStrategy
+  ( AwaitStrategy (..)
+  , IsolationExpectation (..)
+  , ReplayClass (..)
+  )
+import Cortex.Capability.Catalog.ExecutorManifest (AbiKind (..), ContentAddress (..))
+import Cortex.Capability.Catalog.RuntimeBindingRecord
+import Cortex.Wire.Executor (WireExecutorId (..))
+import Cortex.Wire.Quantum (realizeExecutorId)
+
+{- | AWS Braket binding configuration, loaded from @--config@. Inert until the
+runnable driver consumes it.
+-}
+data BraketConfig = BraketConfig
+  { braketRegion :: !Text
+  , braketDeviceArn :: !Text
+  , braketS3Bucket :: !Text
+  , braketProfile :: !(Maybe Text)
+  }
+  deriving stock (Eq, Show, Generic)
+
+{- | Mint the Braket binding pack: a single runtime binding record resolving
+@quantum.realize@ to a @submit_park_resume@ external-call stage driven through the
+subprocess JSONL ABI, isolated in a subprocess sandbox, with an idempotency-keyed
+replay class (required for the crash-safe submit protocol). The resolved device ARN
+and region are recorded as authority fingerprints for provenance.
+-}
+braketBindingPack :: BraketConfig -> HostBindingPack
+braketBindingPack config =
+  HostBindingPack
+    { hbpIdentity = "braket-pack"
+    , hbpWirePackageDeps = ["quantum.braket"]
+    , hbpRuntimeBindings =
+        [ RuntimeBindingRecord
+            { rbrBindingId = "braket-pack/" <> realizeExecutorId
+            , rbrBindingVersion = "1"
+            , rbrExecutorId = WireExecutorId realizeExecutorId
+            , rbrProjectionVersion = ProjectionVersion "1"
+            , rbrStageActionRef = RuntimeStageActionRef "quantum.realize.braket"
+            , rbrManifestContentAddress = ContentAddress "wire-quantum-braket.py"
+            , rbrArtifactDigest = ContentDigest "braket-driver"
+            , rbrAbiKind = AbiSubprocessJsonl
+            , rbrAbiVersion = "1"
+            , rbrAbiDriverDigest = ContentDigest "braket-driver"
+            , rbrBindingPackIdentity = "braket-pack"
+            , rbrResolvedAuthorities =
+                [ ResolvedAuthorityFingerprint
+                    "aws.braket.device"
+                    (braketDeviceArn config)
+                    (ContentDigest (braketDeviceArn config))
+                , ResolvedAuthorityFingerprint
+                    "aws.region"
+                    (braketRegion config)
+                    (ContentDigest (braketRegion config))
+                ]
+            , rbrIsolation = SubprocessSandbox
+            , rbrAcceptedReplayClass = IdempotentWithKey
+            , rbrAcceptedAwaitStrategy = SubmitParkResume
+            , rbrCompatibilityDigest = ContentDigest "braket-1"
+            }
+        ]
+    }

--- a/src/Cortex/Capability/Catalog/AdmissionProjection.hs
+++ b/src/Cortex/Capability/Catalog/AdmissionProjection.hs
@@ -1,0 +1,208 @@
+{- |
+Module      : Cortex.Capability.Catalog.AdmissionProjection
+Description : ADR 0053 admission projection — the inert public surface of an executor.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The admission projection is the compile-time, authority-free description of an
+executor that Wire and Capability check against (ADR 0053): identity, a projection
+version, a content digest, typed ports, a config schema reference, declared
+requirement slots, and the replay / isolation / effect / await-strategy metadata
+the runtime binding later honours. It carries no runnable action and no credentials.
+
+The registry invariant is @(executor id, projection version)@ uniquely identifies
+projection content; two manifests claiming the same pair must agree on the digest.
+
+JSON is hand-written because the reused Wire port types do not round-trip through
+their derived instances; the digest is taken over a canonical field tuple so it is
+stable regardless of JSON object ordering (mirrors 'Cortex.Pulse.Materialization.computeTopologyHash').
+-}
+module Cortex.Capability.Catalog.AdmissionProjection
+  ( AdmissionProjection (..)
+  , ProjectionVersion (..)
+  , ContentDigest (..)
+  , ConfigSchemaRef (..)
+  , RequirementSlot (..)
+  , admissionProjectionDigest
+  , encodeWirePorts
+  , decodeWirePorts
+  )
+where
+
+import Crypto.Hash (SHA256, hashlazy)
+import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.!=), (.:), (.:?), (.=))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.Types (Parser)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHC.Generics (Generic)
+
+import Cortex.Capability.Catalog.AwaitStrategy
+  ( AwaitStrategy
+  , IsolationExpectation
+  , ReplayClass
+  )
+import Cortex.Wire.AST
+  ( WireInputCardinality (..)
+  , WireInputPort (..)
+  , WireOutputPort (..)
+  , WirePorts (..)
+  )
+import Cortex.Wire.Executor
+  ( WireExecutorEffect (..)
+  , WireExecutorId (..)
+  )
+
+newtype ProjectionVersion = ProjectionVersion {unProjectionVersion :: Text}
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (ToJSON, FromJSON)
+
+newtype ContentDigest = ContentDigest {unContentDigest :: Text}
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (ToJSON, FromJSON)
+
+{- | A reference to the executor's config schema (digest or named decoder), never
+the config itself (ADR 0053 keeps config data pure and out of the projection).
+-}
+data ConfigSchemaRef
+  = ConfigSchemaNone
+  | ConfigSchemaDigest ContentDigest
+  | ConfigSchemaName Text
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+{- | A declared requirement the binding layer must satisfy: a capability kind, the
+local binding name the host resolves, an optional config selector path, and the
+required permission class. Inert — declaring a requirement does not grant it.
+-}
+data RequirementSlot = RequirementSlot
+  { rsCapabilityKind :: !Text
+  , rsBindingName :: !Text
+  , rsConfigSelector :: !(Maybe Text)
+  , rsPermissionClass :: !(Maybe Text)
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+data AdmissionProjection = AdmissionProjection
+  { apExecutorId :: !WireExecutorId
+  , apProjectionVersion :: !ProjectionVersion
+  , apPorts :: !WirePorts
+  , apConfigSchemaRef :: !ConfigSchemaRef
+  , apRequirementSlots :: ![RequirementSlot]
+  , apReplayClass :: !ReplayClass
+  , apIsolationExpectation :: !IsolationExpectation
+  , apEffect :: !WireExecutorEffect
+  , apAwaitStrategy :: !AwaitStrategy
+  }
+  deriving stock (Eq, Show, Generic)
+
+instance ToJSON AdmissionProjection where
+  toJSON p =
+    object
+      [ "executorId" .= unWireExecutorId (apExecutorId p)
+      , "projectionVersion" .= apProjectionVersion p
+      , "ports" .= encodeWirePorts (apPorts p)
+      , "configSchemaRef" .= apConfigSchemaRef p
+      , "requirementSlots" .= apRequirementSlots p
+      , "replayClass" .= apReplayClass p
+      , "isolationExpectation" .= apIsolationExpectation p
+      , "effect" .= effectText (apEffect p)
+      , "awaitStrategy" .= apAwaitStrategy p
+      ]
+
+instance FromJSON AdmissionProjection where
+  parseJSON = withObject "AdmissionProjection" $ \o ->
+    AdmissionProjection . WireExecutorId
+      <$> o .: "executorId"
+      <*> o .: "projectionVersion"
+      <*> (o .: "ports" >>= decodeWirePorts)
+      <*> o .: "configSchemaRef"
+      <*> o .:? "requirementSlots" .!= []
+      <*> o .: "replayClass"
+      <*> o .: "isolationExpectation"
+      <*> (o .: "effect" >>= parseEffect)
+      <*> o .: "awaitStrategy"
+
+{- | Deterministic content digest over the projection's defining fields. Taken over
+a canonical tuple (not the JSON object) so object key ordering cannot perturb it.
+-}
+admissionProjectionDigest :: AdmissionProjection -> ContentDigest
+admissionProjectionDigest p =
+  let canonical =
+        Aeson.encode
+          ( unWireExecutorId (apExecutorId p)
+          , unProjectionVersion (apProjectionVersion p)
+          , canonicalPorts (apPorts p)
+          , toJSON (apConfigSchemaRef p)
+          , toJSON (apRequirementSlots p)
+          , toJSON (apReplayClass p)
+          , toJSON (apIsolationExpectation p)
+          , effectText (apEffect p)
+          , toJSON (apAwaitStrategy p)
+          )
+      digest = hashlazy @SHA256 canonical
+   in ContentDigest (T.pack (show digest))
+
+-- Canonical, order-stable encoding of ports for the digest: sorted association
+-- lists rather than a map/object.
+canonicalPorts :: WirePorts -> Aeson.Value
+canonicalPorts ports =
+  toJSON
+    ( [ (name, p.wireInputPortAccepts, cardinalityText p.wireInputPortCardinality, p.wireInputPortRequired)
+      | (name, p) <- Map.toAscList ports.wirePortsInputs
+      ]
+    , [ (name, p.wireOutputPortContract)
+      | (name, p) <- Map.toAscList ports.wirePortsOutputs
+      ]
+    )
+
+{- | Encode ports in the shape 'FromJSON' 'WirePorts' reads (object form with
+@inputs@/@outputs@ maps and @accepts@/@cardinality@/@required@/@contract@ fields).
+-}
+encodeWirePorts :: WirePorts -> Aeson.Value
+encodeWirePorts ports =
+  object
+    [ "inputs"
+        .= object
+          [ Key.fromText name
+              .= object
+                [ "accepts" .= p.wireInputPortAccepts
+                , "cardinality" .= cardinalityText p.wireInputPortCardinality
+                , "required" .= p.wireInputPortRequired
+                ]
+          | (name, p) <- Map.toList ports.wirePortsInputs
+          ]
+    , "outputs"
+        .= object
+          [ Key.fromText name .= object ["contract" .= p.wireOutputPortContract]
+          | (name, p) <- Map.toList ports.wirePortsOutputs
+          ]
+    ]
+
+decodeWirePorts :: Aeson.Value -> Parser WirePorts
+decodeWirePorts = parseJSON
+
+cardinalityText :: WireInputCardinality -> Text
+cardinalityText = \case
+  WireInputCardinalityOne -> "one"
+  WireInputCardinalityMany -> "many"
+
+effectText :: WireExecutorEffect -> Text
+effectText = \case
+  WireExecutorPure -> "pure"
+  WireExecutorModel -> "model"
+  WireExecutorHostEffect -> "host_effect"
+  WireExecutorImpure -> "impure"
+
+parseEffect :: Text -> Parser WireExecutorEffect
+parseEffect = \case
+  "pure" -> pure WireExecutorPure
+  "model" -> pure WireExecutorModel
+  "host_effect" -> pure WireExecutorHostEffect
+  "impure" -> pure WireExecutorImpure
+  other -> fail ("unknown executor effect: " <> T.unpack other)

--- a/src/Cortex/Capability/Catalog/AwaitStrategy.hs
+++ b/src/Cortex/Capability/Catalog/AwaitStrategy.hs
@@ -1,0 +1,134 @@
+{- |
+Module      : Cortex.Capability.Catalog.AwaitStrategy
+Description : Executor await strategy, replay class, and isolation expectation.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Small shared enumerations that ride the ADR 0053 admission projection and runtime
+binding record. They are inert catalog metadata: the host binding declares them,
+and Pulse never interprets them — it dispatches an opaque @StageAction@ and reacts
+only to complete-or-suspend (ADR 0059 §3).
+
+These types stay consumer-neutral; they classify executor authority, not product policy.
+-}
+module Cortex.Capability.Catalog.AwaitStrategy
+  ( AwaitStrategy (..)
+  , awaitStrategyText
+  , parseAwaitStrategy
+  , ReplayClass (..)
+  , replayClassText
+  , parseReplayClass
+  , IsolationExpectation (..)
+  , isolationExpectationText
+  , parseIsolationExpectation
+  )
+where
+
+import Data.Aeson (FromJSON (..), ToJSON (..), withText)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+{- | Whether a bound stage returns its result inline or submits, suspends, and
+resumes on an ordinary durable signal (ADR 0059 §3). The field is declared at the
+executor level so it applies equally to a long-running @ModelExecutor@.
+-}
+data AwaitStrategy
+  = -- | The bound action runs the effect inline and completes in one transaction.
+    Synchronous
+  | {- | The bound action submits, returns a job handle, and suspends until a
+    durable completion signal wakes it.
+    -}
+    SubmitParkResume
+  deriving stock (Eq, Show, Generic)
+
+awaitStrategyText :: AwaitStrategy -> Text
+awaitStrategyText = \case
+  Synchronous -> "synchronous"
+  SubmitParkResume -> "submit_park_resume"
+
+parseAwaitStrategy :: Text -> Either Text AwaitStrategy
+parseAwaitStrategy = \case
+  "synchronous" -> Right Synchronous
+  "submit_park_resume" -> Right SubmitParkResume
+  other -> Left ("unknown await strategy: " <> other)
+
+instance ToJSON AwaitStrategy where
+  toJSON = toJSON . awaitStrategyText
+
+instance FromJSON AwaitStrategy where
+  parseJSON = withText "AwaitStrategy" (either (fail . show) pure . parseAwaitStrategy)
+
+{- | How an executor's output is reproduced across a replay (ADR 0053). Recorded
+as catalog metadata; the @submit_park_resume@ external-call path requires an
+idempotency-keyed or exactly-once class to be admissible (ADR 0059 §3).
+-}
+data ReplayClass
+  = Deterministic
+  | ReplayByRerun
+  | ReplayByReusingRecordedOutputs
+  | IdempotentWithKey
+  | ExactlyOnceViaCommitLog
+  | NonReplayable
+  deriving stock (Eq, Show, Generic)
+
+replayClassText :: ReplayClass -> Text
+replayClassText = \case
+  Deterministic -> "deterministic"
+  ReplayByRerun -> "replay_by_rerun"
+  ReplayByReusingRecordedOutputs -> "replay_by_reusing_recorded_outputs"
+  IdempotentWithKey -> "idempotent_with_key"
+  ExactlyOnceViaCommitLog -> "exactly_once_via_commit_log"
+  NonReplayable -> "non_replayable"
+
+parseReplayClass :: Text -> Either Text ReplayClass
+parseReplayClass = \case
+  "deterministic" -> Right Deterministic
+  "replay_by_rerun" -> Right ReplayByRerun
+  "replay_by_reusing_recorded_outputs" -> Right ReplayByReusingRecordedOutputs
+  "idempotent_with_key" -> Right IdempotentWithKey
+  "exactly_once_via_commit_log" -> Right ExactlyOnceViaCommitLog
+  "non_replayable" -> Right NonReplayable
+  other -> Left ("unknown replay class: " <> other)
+
+instance ToJSON ReplayClass where
+  toJSON = toJSON . replayClassText
+
+instance FromJSON ReplayClass where
+  parseJSON = withText "ReplayClass" (either (fail . show) pure . parseReplayClass)
+
+{- | The minimum isolation an executor package requests at runtime (ADR 0053).
+Inert until a host binding pack honours it.
+-}
+data IsolationExpectation
+  = InProcess
+  | WasmSandbox
+  | SubprocessSandbox
+  | Container
+  | BrokeredProcess
+  deriving stock (Eq, Show, Generic)
+
+isolationExpectationText :: IsolationExpectation -> Text
+isolationExpectationText = \case
+  InProcess -> "in_process"
+  WasmSandbox -> "wasm_sandbox"
+  SubprocessSandbox -> "subprocess_sandbox"
+  Container -> "container"
+  BrokeredProcess -> "brokered_process"
+
+parseIsolationExpectation :: Text -> Either Text IsolationExpectation
+parseIsolationExpectation = \case
+  "in_process" -> Right InProcess
+  "wasm_sandbox" -> Right WasmSandbox
+  "subprocess_sandbox" -> Right SubprocessSandbox
+  "container" -> Right Container
+  "brokered_process" -> Right BrokeredProcess
+  other -> Left ("unknown isolation expectation: " <> other)
+
+instance ToJSON IsolationExpectation where
+  toJSON = toJSON . isolationExpectationText
+
+instance FromJSON IsolationExpectation where
+  parseJSON =
+    withText "IsolationExpectation" (either (fail . show) pure . parseIsolationExpectation)

--- a/src/Cortex/Capability/Catalog/ExecutorManifest.hs
+++ b/src/Cortex/Capability/Catalog/ExecutorManifest.hs
@@ -1,0 +1,78 @@
+{- |
+Module      : Cortex.Capability.Catalog.ExecutorManifest
+Description : ADR 0053 executor manifest — the runnable-artifact descriptor.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The executor manifest is produced by an executor package and consumed by the build
+system and host runtime binding (ADR 0053). It is still inert: it names an artifact,
+its ABI, its provenance, and the projection it implements, but it grants no authority
+on its own — only a host binding pack turns a manifest into a runtime binding record.
+
+Pulse never consumes manifests directly.
+-}
+module Cortex.Capability.Catalog.ExecutorManifest
+  ( ExecutorManifest (..)
+  , AbiKind (..)
+  , ContentAddress (..)
+  , OutputCommitPolicy (..)
+  )
+where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Cortex.Capability.Catalog.AdmissionProjection
+  ( ContentDigest
+  , ProjectionVersion
+  )
+import Cortex.Capability.Catalog.AwaitStrategy (IsolationExpectation, ReplayClass)
+import Cortex.Wire.Executor (WireExecutorId)
+
+newtype ContentAddress = ContentAddress {unContentAddress :: Text}
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (ToJSON, FromJSON)
+
+{- | The driver/ABI kind through which the host invokes the artifact. @host-action-v1@
+is one option, not the required mechanism (ADR 0059 §3).
+-}
+data AbiKind
+  = AbiHostActionV1
+  | AbiSubprocessJsonl
+  | AbiInProcessNative
+  | AbiWasmComponent
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+{- | How the executor's outputs are committed relative to its effect (informs the
+replay class for @submit_park_resume@ external calls).
+-}
+data OutputCommitPolicy
+  = CommitOnComplete
+  | CommitViaAttemptRecord
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+data ExecutorManifest = ExecutorManifest
+  { emSchemaVersion :: !Text
+  , emContentAddress :: !ContentAddress
+  , emSignature :: !(Maybe Text)
+  , emExecutorId :: !WireExecutorId
+  , emProjectionVersion :: !ProjectionVersion
+  , emProjectionDigest :: !ContentDigest
+  , emArtifactRef :: !ContentAddress
+  , emArtifactDigest :: !ContentDigest
+  , emAbiKind :: !AbiKind
+  , emAbiVersion :: !Text
+  , emAbiDriverIdentity :: !Text
+  , emProvenance :: !(Maybe Text)
+  , emPermissions :: ![Text]
+  , emIsolationExpectation :: !IsolationExpectation
+  , emReplayClass :: !ReplayClass
+  , emOutputCommitPolicy :: !OutputCommitPolicy
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)

--- a/src/Cortex/Capability/Catalog/RuntimeBindingRecord.hs
+++ b/src/Cortex/Capability/Catalog/RuntimeBindingRecord.hs
@@ -1,0 +1,72 @@
+{- |
+Module      : Cortex.Capability.Catalog.RuntimeBindingRecord
+Description : ADR 0053 runtime binding record — the minted, authority-bearing binding.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+A runtime binding record is what a host runtime binding pack mints (ADR 0053/0054)
+when it resolves an executor manifest against concrete host authority. It is the
+record a runnable Circuit carries into Pulse dispatch. Pulse reads only the opaque
+action reference and the accepted replay/await metadata; it does not interpret the
+backend (ADR 0059 §3).
+
+This module stays Pulse-free: the bound action is named by an opaque text reference
+('RuntimeStageActionRef'), so the catalog layer does not depend on the Pulse runtime.
+-}
+module Cortex.Capability.Catalog.RuntimeBindingRecord
+  ( RuntimeBindingRecord (..)
+  , RuntimeStageActionRef (..)
+  , ResolvedAuthorityFingerprint (..)
+  )
+where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Cortex.Capability.Catalog.AdmissionProjection (ContentDigest, ProjectionVersion)
+import Cortex.Capability.Catalog.AwaitStrategy (AwaitStrategy, IsolationExpectation, ReplayClass)
+import Cortex.Capability.Catalog.ExecutorManifest (AbiKind, ContentAddress)
+import Cortex.Wire.Executor (WireExecutorId)
+
+{- | Opaque reference to the bound Pulse stage action. Kept as text so the catalog
+layer does not import the Pulse runtime; the host resolves it to a @StageAction@.
+-}
+newtype RuntimeStageActionRef = RuntimeStageActionRef {unRuntimeStageActionRef :: Text}
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (ToJSON, FromJSON)
+
+{- | A fingerprint of a resolved authority (provider, tool, model policy, secret
+handle) the binding depends on, recorded for provenance without embedding the
+authority itself.
+-}
+data ResolvedAuthorityFingerprint = ResolvedAuthorityFingerprint
+  { rafKind :: !Text
+  , rafName :: !Text
+  , rafDigest :: !ContentDigest
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+data RuntimeBindingRecord = RuntimeBindingRecord
+  { rbrBindingId :: !Text
+  , rbrBindingVersion :: !Text
+  , rbrExecutorId :: !WireExecutorId
+  , rbrProjectionVersion :: !ProjectionVersion
+  , rbrStageActionRef :: !RuntimeStageActionRef
+  , rbrManifestContentAddress :: !ContentAddress
+  , rbrArtifactDigest :: !ContentDigest
+  , rbrAbiKind :: !AbiKind
+  , rbrAbiVersion :: !Text
+  , rbrAbiDriverDigest :: !ContentDigest
+  , rbrBindingPackIdentity :: !Text
+  , rbrResolvedAuthorities :: ![ResolvedAuthorityFingerprint]
+  , rbrIsolation :: !IsolationExpectation
+  , rbrAcceptedReplayClass :: !ReplayClass
+  , rbrAcceptedAwaitStrategy :: !AwaitStrategy
+  , rbrCompatibilityDigest :: !ContentDigest
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)

--- a/src/Cortex/Pulse/Executor/ExternalCall.hs
+++ b/src/Cortex/Pulse/Executor/ExternalCall.hs
@@ -1,0 +1,126 @@
+{- |
+Module      : Cortex.Pulse.Executor.ExternalCall
+Description : The submit/park/resume external-call protocol (ADR 0059 §3).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The crash-safe state machine a bound external-call stage runs (ADR 0059 §3),
+parameterised over the host-supplied driver and an abstract attempt store so it is
+testable without a database or the Pulse executor. P6 instantiates the store with
+the 'Cortex.Pulse.Query.ExternalCall' CRUD and maps the outcome onto Pulse's
+@StageResult@ (suspend ↔ @StageSuspend@, complete ↔ @StageComplete@, fail ↔ the
+ADR 0026 failure closure).
+
+Two await strategies (ADR 0053 binding metadata):
+
+* __synchronous__ — run the fused plan inline and complete;
+* __submit/park/resume__ — first entry reserves the attempt, submits to the
+  provider under an idempotency key, persists the job handle, and suspends; resume
+  (the attempt already carries a handle) fetches the provider result and completes.
+
+Reserve is idempotent on the key, so a crash that re-enters before the handle is
+recorded re-submits with the same key rather than creating a duplicate task.
+-}
+module Cortex.Pulse.Executor.ExternalCall
+  ( ExternalCallDriver (..)
+  , AttemptStore (..)
+  , AttemptView (..)
+  , ExternalCallOutcome (..)
+  , runExternalCall
+  )
+where
+
+import Data.Aeson (Value)
+import Data.Text (Text)
+
+import Cortex.Capability.Catalog.AwaitStrategy (AwaitStrategy (..))
+import Cortex.Pulse.Query.ExternalCall (ExternalCallAttemptKey)
+
+-- | Host-supplied, backend-specific operations. Opaque to Pulse (ADR 0053).
+data ExternalCallDriver m = ExternalCallDriver
+  { driverRunSync :: Value -> m (Either Text [(Text, Value)])
+  -- ^ Run the fused plan inline (synchronous strategy) → named measurement outputs.
+  , driverSubmit :: Text -> Value -> m (Either Text Value)
+  -- ^ Submit under an idempotency key (arg 1) → an opaque provider job handle.
+  , driverFetch :: Value -> m (Either Text [(Text, Value)])
+  -- ^ Fetch/validate a completed provider job → named measurement outputs.
+  , driverIdempotencyKey :: Value -> Text
+  -- ^ Derive a deterministic idempotency key from the frozen plan.
+  , driverSignalName :: ExternalCallAttemptKey -> Text
+  -- ^ The ordinary durable signal woken on completion (never the run-terminal family).
+  }
+
+-- | What the executor reads back about an in-flight attempt.
+data AttemptView = AttemptView
+  { avJobHandle :: !(Maybe Value)
+  , avStatus :: !Text
+  }
+  deriving stock (Eq, Show)
+
+{- | The durable attempt store, abstracted so the protocol is testable. P6 binds it
+to the 'Cortex.Pulse.Query.ExternalCall' transactions (reserve and link committed
+atomically with ADR 0058 suspend settlement).
+-}
+data AttemptStore m = AttemptStore
+  { storeLoad :: ExternalCallAttemptKey -> m (Maybe AttemptView)
+  , storeReserve :: ExternalCallAttemptKey -> Text -> Value -> m ()
+  , storePersistHandle :: ExternalCallAttemptKey -> Value -> Text -> m ()
+  , storeSettle :: ExternalCallAttemptKey -> m ()
+  , storeFail :: ExternalCallAttemptKey -> m ()
+  }
+
+-- | The outcome the executor maps onto a Pulse @StageResult@.
+data ExternalCallOutcome
+  = -- | Completed with named measurement outputs.
+    ExternalCallCompleted ![(Text, Value)]
+  | -- | Suspended; the run parks on this durable signal until the job completes.
+    ExternalCallSuspended !Text
+  | -- | Failed with a typed reason (routed through the ADR 0026 closure in P6).
+    ExternalCallFailed !Text
+  deriving stock (Eq, Show)
+
+{- | Run the external-call protocol for one stage entry. The same action runs on
+first entry and on resume; it distinguishes them by the durable attempt state.
+-}
+runExternalCall
+  :: Monad m
+  => AwaitStrategy
+  -> ExternalCallDriver m
+  -> AttemptStore m
+  -> ExternalCallAttemptKey
+  -> Value
+  -- ^ frozen fused plan
+  -> m ExternalCallOutcome
+runExternalCall Synchronous driver _ _ frozenPlan = do
+  result <- driverRunSync driver frozenPlan
+  pure (either ExternalCallFailed ExternalCallCompleted result)
+runExternalCall SubmitParkResume driver store key frozenPlan = do
+  existing <- storeLoad store key
+  case existing of
+    Just view | Just handle <- avJobHandle view -> resume handle
+    _ -> firstEntry
+  where
+    resume handle = do
+      fetched <- driverFetch driver handle
+      case fetched of
+        Right outputs -> do
+          storeSettle store key
+          pure (ExternalCallCompleted outputs)
+        Left reason -> do
+          storeFail store key
+          pure (ExternalCallFailed reason)
+
+    firstEntry = do
+      let idempotencyKey = driverIdempotencyKey driver frozenPlan
+      storeReserve store key idempotencyKey frozenPlan
+      submitted <- driverSubmit driver idempotencyKey frozenPlan
+      case submitted of
+        Right handle -> do
+          let signalName = driverSignalName driver key
+          storePersistHandle store key handle signalName
+          pure (ExternalCallSuspended signalName)
+        Left reason -> do
+          storeFail store key
+          pure (ExternalCallFailed reason)

--- a/src/Cortex/Pulse/Lowering/Circuit.hs
+++ b/src/Cortex/Pulse/Lowering/Circuit.hs
@@ -1,0 +1,91 @@
+{- |
+Module      : Cortex.Pulse.Lowering.Circuit
+Description : Lower a realize frontier to a bound, durable stage (ADR 0059 §2/§3).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The decision core of the Wire→Pulse lowering: given a realize node's collected
+upstream frontier (classified by backend authority and await strategy), the fused
+operation/measurement list, and the host binding pack, it
+
+1. admits the contraction (ADR 0059 §2, 'admitFrontierContraction') — rejecting a
+   mixed or non-backend frontier rather than splitting it;
+2. resolves the realize executor through the binding pack, failing with the typed
+   @missing runtime binding@ (the ADR 0054 invariant: compile succeeds without a
+   pack; only runnable lowering fails);
+3. builds the canonical fused plan (P6a) and its digest (the idempotency key).
+
+The result is a 'LoweredRealize' the executor runs via
+'Cortex.Pulse.Executor.ExternalCall.runExternalCall'. Walking the compiled-circuit
+artifact to produce the inputs, and the @wire pulse run@ CLI, sit on top of this
+core; this module keeps the admission/binding/plan decision pure and testable.
+-}
+module Cortex.Pulse.Lowering.Circuit
+  ( LoweringError (..)
+  , LoweredRealize (..)
+  , lowerRealizeFrontier
+  )
+where
+
+import Data.Text (Text)
+
+import Cortex.Capability.BindingPack (HostBindingPack, lookupBinding)
+import Cortex.Capability.Catalog.AwaitStrategy (AwaitStrategy)
+import Cortex.Capability.Catalog.RuntimeBindingRecord
+  ( RuntimeBindingRecord (..)
+  )
+import Cortex.Pulse.Lowering.FusedPlan
+  ( FusedMeasurement
+  , FusedOp
+  , FusedPlan
+  , fusedPlan
+  , fusedPlanDigest
+  )
+import Cortex.Pulse.Rewrite.Contract
+  ( CollectedNode
+  , FrontierAdmissionError
+  , admitFrontierContraction
+  )
+import Cortex.Wire.Executor (WireExecutorId)
+
+data LoweringError
+  = -- | The collected frontier is inadmissible (ADR 0059 §2).
+    LoweringInadmissibleFrontier !(FrontierAdmissionError Text)
+  | -- | No host binding pack resolves the realize executor (ADR 0054).
+    LoweringMissingRuntimeBinding !WireExecutorId
+  deriving stock (Eq, Show)
+
+data LoweredRealize = LoweredRealize
+  { lrBinding :: !RuntimeBindingRecord
+  , lrAwaitStrategy :: !AwaitStrategy
+  , lrFusedPlan :: !FusedPlan
+  , lrIdempotencyKey :: !Text
+  }
+  deriving stock (Eq, Show)
+
+{- | Lower a realize node's collected frontier to a bound, durable stage. The
+collected nodes are classified by @(authority, await strategy)@ (a non-backend node
+classifies as @Nothing@); ops/measurements are the fused sub-plan in topological
+order.
+-}
+lowerRealizeFrontier
+  :: HostBindingPack
+  -> WireExecutorId
+  -> [CollectedNode Text WireExecutorId AwaitStrategy]
+  -> [FusedOp]
+  -> [FusedMeasurement]
+  -> Either LoweringError LoweredRealize
+lowerRealizeFrontier pack realizeId collected ops measurements = do
+  either (Left . LoweringInadmissibleFrontier) Right (admitFrontierContraction collected)
+  binding <-
+    maybe (Left (LoweringMissingRuntimeBinding realizeId)) Right (lookupBinding realizeId pack)
+  let plan = fusedPlan ops measurements
+  Right
+    LoweredRealize
+      { lrBinding = binding
+      , lrAwaitStrategy = rbrAcceptedAwaitStrategy binding
+      , lrFusedPlan = plan
+      , lrIdempotencyKey = fusedPlanDigest plan
+      }

--- a/src/Cortex/Pulse/Lowering/FusedPlan.hs
+++ b/src/Cortex/Pulse/Lowering/FusedPlan.hs
@@ -1,0 +1,100 @@
+{- |
+Module      : Cortex.Pulse.Lowering.FusedPlan
+Description : Canonical fused sub-plan + idempotency key for a realize frontier (ADR 0059 §2/§3).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The fused sub-plan is the backend-neutral payload a realize stage carries (the
+operation/measurement list the standalone bridge's @build_quantum_plan@ builds
+today). ADR 0059 §2 requires its emission to be a __deterministic, canonical__
+function of the frozen frontier: the lowering supplies operations in topological
+order, and this module serialises them and the measurements (sorted by output name)
+so the same topology yields the same JSON and the same SHA-256 digest across
+replays. The digest is the stable idempotency key the crash-safe submit protocol
+(§3) keys on, so it must not drift between attempts.
+-}
+module Cortex.Pulse.Lowering.FusedPlan
+  ( FusedOp (..)
+  , FusedMeasurement (..)
+  , FusedPlan (..)
+  , fusedPlan
+  , fusedPlanValue
+  , fusedPlanDigest
+  )
+where
+
+import Crypto.Hash (SHA256, hashlazy)
+import Data.Aeson (Value, object, (.=))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.List (sortOn)
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHC.Generics (Generic)
+
+{- | One backend-neutral operation: a gate name, its qubit wire indices in order,
+and named scalar parameters (e.g. a rotation angle).
+-}
+data FusedOp = FusedOp
+  { foGate :: !Text
+  , foWires :: ![Int]
+  , foParams :: ![(Text, Value)]
+  }
+  deriving stock (Eq, Show, Generic)
+
+-- | A terminal measurement: the qubit wire and the output port name it produces.
+data FusedMeasurement = FusedMeasurement
+  { fmWire :: !Int
+  , fmOutput :: !Text
+  }
+  deriving stock (Eq, Show, Generic)
+
+{- | The canonical fused plan: operations in topological order, measurements sorted
+by output name so the encoding is order-stable.
+-}
+data FusedPlan = FusedPlan
+  { fpOperations :: ![FusedOp]
+  , fpMeasurements :: ![FusedMeasurement]
+  }
+  deriving stock (Eq, Show, Generic)
+
+{- | Build the canonical plan: operations are kept in the supplied (topological)
+order; measurements are sorted by output name.
+-}
+fusedPlan :: [FusedOp] -> [FusedMeasurement] -> FusedPlan
+fusedPlan operations measurements =
+  FusedPlan
+    { fpOperations = operations
+    , fpMeasurements = sortOn fmOutput measurements
+    }
+
+-- | The canonical JSON payload the realize stage carries.
+fusedPlanValue :: FusedPlan -> Value
+fusedPlanValue plan =
+  object
+    [ "operations" .= fmap opValue (fpOperations plan)
+    , "measurements" .= fmap measurementValue (fpMeasurements plan)
+    ]
+  where
+    opValue op =
+      object
+        [ "gate" .= foGate op
+        , "wires" .= foWires op
+        , "params" .= object [Key.fromText k .= v | (k, v) <- foParams op]
+        ]
+    measurementValue m = object ["wire" .= fmWire m, "output" .= fmOutput m]
+
+{- | The deterministic SHA-256 digest of the canonical plan — the idempotency key
+the submit/park/resume protocol keys on. Taken over a canonical tuple (not the JSON
+object) so object key ordering cannot perturb it.
+-}
+fusedPlanDigest :: FusedPlan -> Text
+fusedPlanDigest plan =
+  let canonical =
+        Aeson.encode
+          ( [(foGate op, foWires op, [(k, v) | (k, v) <- foParams op]) | op <- fpOperations plan]
+          , [(fmWire m, fmOutput m) | m <- fpMeasurements plan]
+          )
+   in T.pack (show (hashlazy @SHA256 canonical))

--- a/src/Cortex/Pulse/Query/ExternalCall.hs
+++ b/src/Cortex/Pulse/Query/ExternalCall.hs
@@ -1,0 +1,200 @@
+{- |
+Module      : Cortex.Pulse.Query.ExternalCall
+Description : Durable external-call attempt record CRUD (ADR 0059 §3).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The external-call attempt record is the Pulse-owned durable home for a
+@submit_park_resume@ external call's @{idempotency key, frozen fused plan, job
+handle, completion signal}@, keyed by @(run, node, runtime binding, frontier)@
+(ADR 0059 §3). ADR 0058 settlement commits only graph state, signal wait rows, and
+run status, so executor metadata lives here, not on the signal rows.
+
+The crash-safe protocol is: reserve (before provider submit), persist the handle
+(after submit, before suspend), then settle on completion. Reserve is idempotent on
+the key so recovery re-entry never creates a duplicate provider task. Provider
+fields are opaque JSON; Pulse does not interpret the backend.
+-}
+module Cortex.Pulse.Query.ExternalCall
+  ( ExternalCallAttemptKey (..)
+  , ExternalCallAttemptStatus (..)
+  , externalCallStatusText
+  , parseExternalCallStatus
+  , ExternalCallAttempt (..)
+  , reserveExternalCallAttempt
+  , persistExternalCallHandle
+  , settleExternalCallAttempt
+  , failExternalCallAttempt
+  , loadExternalCallAttempt
+  )
+where
+
+import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+import Data.Time (UTCTime)
+import Data.UUID (UUID)
+import Hasql.Decoders qualified as D
+import Hasql.Statement (Statement (..))
+import Hasql.Transaction (Transaction)
+import Hasql.Transaction qualified as Tx
+
+import Platform.Database.Encode qualified as Enc
+
+{- | Identity of an external-call attempt: the realize stage's node within a run,
+the runtime binding that owns it, and the canonical frontier hash.
+-}
+data ExternalCallAttemptKey = ExternalCallAttemptKey
+  { ecaRunId :: !UUID
+  , ecaNodeId :: !Text
+  , ecaRuntimeBindingId :: !Text
+  , ecaFrontierId :: !Text
+  }
+  deriving stock (Eq, Show)
+
+data ExternalCallAttemptStatus
+  = AttemptReserved
+  | AttemptSubmitted
+  | AttemptSettled
+  | AttemptFailed
+  deriving stock (Eq, Show)
+
+externalCallStatusText :: ExternalCallAttemptStatus -> Text
+externalCallStatusText = \case
+  AttemptReserved -> "reserved"
+  AttemptSubmitted -> "submitted"
+  AttemptSettled -> "settled"
+  AttemptFailed -> "failed"
+
+parseExternalCallStatus :: Text -> Maybe ExternalCallAttemptStatus
+parseExternalCallStatus = \case
+  "reserved" -> Just AttemptReserved
+  "submitted" -> Just AttemptSubmitted
+  "settled" -> Just AttemptSettled
+  "failed" -> Just AttemptFailed
+  _ -> Nothing
+
+data ExternalCallAttempt = ExternalCallAttempt
+  { ecaKey :: !ExternalCallAttemptKey
+  , ecaIdempotencyKey :: !Text
+  , ecaFrozenPlan :: !Aeson.Value
+  , ecaJobHandle :: !(Maybe Aeson.Value)
+  , ecaSignalName :: !(Maybe Text)
+  , ecaStatus :: !Text
+  }
+  deriving stock (Eq, Show)
+
+{- | Reserve the attempt before provider submission. Idempotent on the key: a
+recovery re-entry with the same key is a no-op (@ON CONFLICT DO NOTHING@), so the
+frozen plan and idempotency key written on first reservation are authoritative.
+-}
+reserveExternalCallAttempt
+  :: ExternalCallAttemptKey -> Text -> Aeson.Value -> UTCTime -> Transaction ()
+reserveExternalCallAttempt key idempotencyKey frozenPlan now =
+  Tx.statement
+    ( key.ecaRunId
+    , key.ecaNodeId
+    , key.ecaRuntimeBindingId
+    , key.ecaFrontierId
+    , idempotencyKey
+    , frozenPlan
+    , now
+    )
+    $ Statement
+      "INSERT INTO pulse.external_call_attempts \
+      \(run_id, node_id, runtime_binding_id, frontier_id, idempotency_key, frozen_plan, status, created_at) \
+      \VALUES ($1, $2, $3, $4, $5, $6, 'reserved', $7) \
+      \ON CONFLICT (run_id, node_id, runtime_binding_id, frontier_id) DO NOTHING"
+      ( Enc.encode7
+          ((\(a, _, _, _, _, _, _) -> a), Enc.nonNullable Enc.uuid)
+          ((\(_, b, _, _, _, _, _) -> b), Enc.nonNullable Enc.text)
+          ((\(_, _, c, _, _, _, _) -> c), Enc.nonNullable Enc.text)
+          ((\(_, _, _, d, _, _, _) -> d), Enc.nonNullable Enc.text)
+          ((\(_, _, _, _, e, _, _) -> e), Enc.nonNullable Enc.text)
+          ((\(_, _, _, _, _, f, _) -> f), Enc.nonNullable Enc.jsonb)
+          ((\(_, _, _, _, _, _, g) -> g), Enc.nonNullable Enc.timestamptz)
+      )
+      D.noResult
+      False
+
+{- | Persist the provider job handle and completion signal name, marking the attempt
+submitted. Called after provider submit, before the stage returns @StageSuspend@.
+-}
+persistExternalCallHandle
+  :: ExternalCallAttemptKey -> Aeson.Value -> Text -> UTCTime -> Transaction ()
+persistExternalCallHandle key jobHandle signalName now =
+  Tx.statement
+    ( jobHandle
+    , signalName
+    , now
+    , key.ecaRunId
+    , key.ecaNodeId
+    , key.ecaRuntimeBindingId
+    , key.ecaFrontierId
+    )
+    $ Statement
+      "UPDATE pulse.external_call_attempts \
+      \SET job_handle = $1, signal_name = $2, status = 'submitted', submitted_at = $3 \
+      \WHERE run_id = $4 AND node_id = $5 AND runtime_binding_id = $6 AND frontier_id = $7"
+      ( Enc.encode7
+          ((\(a, _, _, _, _, _, _) -> a), Enc.nonNullable Enc.jsonb)
+          ((\(_, b, _, _, _, _, _) -> b), Enc.nonNullable Enc.text)
+          ((\(_, _, c, _, _, _, _) -> c), Enc.nonNullable Enc.timestamptz)
+          ((\(_, _, _, d, _, _, _) -> d), Enc.nonNullable Enc.uuid)
+          ((\(_, _, _, _, e, _, _) -> e), Enc.nonNullable Enc.text)
+          ((\(_, _, _, _, _, f, _) -> f), Enc.nonNullable Enc.text)
+          ((\(_, _, _, _, _, _, g) -> g), Enc.nonNullable Enc.text)
+      )
+      D.noResult
+      False
+
+settleExternalCallAttempt :: ExternalCallAttemptKey -> UTCTime -> Transaction ()
+settleExternalCallAttempt = updateStatus "settled"
+
+failExternalCallAttempt :: ExternalCallAttemptKey -> UTCTime -> Transaction ()
+failExternalCallAttempt = updateStatus "failed"
+
+updateStatus :: Text -> ExternalCallAttemptKey -> UTCTime -> Transaction ()
+updateStatus status key now =
+  Tx.statement
+    (status, now, key.ecaRunId, key.ecaNodeId, key.ecaRuntimeBindingId, key.ecaFrontierId)
+    $ Statement
+      "UPDATE pulse.external_call_attempts \
+      \SET status = $1, settled_at = $2 \
+      \WHERE run_id = $3 AND node_id = $4 AND runtime_binding_id = $5 AND frontier_id = $6"
+      ( Enc.encode6
+          ((\(a, _, _, _, _, _) -> a), Enc.nonNullable Enc.text)
+          ((\(_, b, _, _, _, _) -> b), Enc.nonNullable Enc.timestamptz)
+          ((\(_, _, c, _, _, _) -> c), Enc.nonNullable Enc.uuid)
+          ((\(_, _, _, d, _, _) -> d), Enc.nonNullable Enc.text)
+          ((\(_, _, _, _, e, _) -> e), Enc.nonNullable Enc.text)
+          ((\(_, _, _, _, _, f) -> f), Enc.nonNullable Enc.text)
+      )
+      D.noResult
+      False
+
+loadExternalCallAttempt :: ExternalCallAttemptKey -> Transaction (Maybe ExternalCallAttempt)
+loadExternalCallAttempt key =
+  Tx.statement
+    (key.ecaRunId, key.ecaNodeId, key.ecaRuntimeBindingId, key.ecaFrontierId)
+    $ Statement
+      "SELECT idempotency_key, frozen_plan, job_handle, signal_name, status \
+      \FROM pulse.external_call_attempts \
+      \WHERE run_id = $1 AND node_id = $2 AND runtime_binding_id = $3 AND frontier_id = $4"
+      ( Enc.encode4
+          ((\(a, _, _, _) -> a), Enc.nonNullable Enc.uuid)
+          ((\(_, b, _, _) -> b), Enc.nonNullable Enc.text)
+          ((\(_, _, c, _) -> c), Enc.nonNullable Enc.text)
+          ((\(_, _, _, d) -> d), Enc.nonNullable Enc.text)
+      )
+      (D.rowMaybe row)
+      False
+  where
+    row =
+      ExternalCallAttempt key
+        <$> D.column (D.nonNullable D.text)
+        <*> D.column (D.nonNullable D.jsonb)
+        <*> D.column (D.nullable D.jsonb)
+        <*> D.column (D.nullable D.text)
+        <*> D.column (D.nonNullable D.text)

--- a/src/Cortex/Pulse/Rewrite/Contract.hs
+++ b/src/Cortex/Pulse/Rewrite/Contract.hs
@@ -1,0 +1,82 @@
+{- |
+Module      : Cortex.Pulse.Rewrite.Contract
+Description : Decidable admission check for a realize-node frontier contraction (ADR 0059 §2).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Sinking the set of upstream backend nodes feeding a realize node into one durable
+stage is a contraction. ADR 0059 §2 requires a /decidable/ admission check that
+runs in the @validatorReady@ lineage rather than host-side guesswork: every node in
+the collected set must share one external-call authority and one await strategy, and
+no non-backend node may sit inside the set. A set that violates this is __rejected__
+(the author/materializer must place separate realize nodes); the validator never
+silently splits it.
+
+The check is on the /collected set/ only. Frozen classical boundary inputs to the
+realize node (shot count, rotation angles, backend config) are legitimate inbound
+edges, not members of the collected set, so they are not authority violations — they
+are excluded by the lowering's collection traversal, not by this check.
+
+This module is pure and polymorphic over the node, authority, and strategy types so
+it carries no runtime dependency; call sites instantiate it with the concrete
+'Cortex.Wire.Executor.WireExecutorId' and
+'Cortex.Capability.Catalog.AwaitStrategy.AwaitStrategy'.
+-}
+module Cortex.Pulse.Rewrite.Contract
+  ( FrontierAdmissionError (..)
+  , CollectedNode (..)
+  , admitFrontierContraction
+  )
+where
+
+import Data.List (nub)
+import Data.Maybe (isNothing)
+
+{- | A node collected into a realize frontier, paired with its backend classification:
+@Just (authority, strategy)@ for a backend node, @Nothing@ for a non-backend node
+that must not appear inside the collected set.
+-}
+data CollectedNode node authority strategy = CollectedNode
+  { cnNode :: !node
+  , cnClassification :: !(Maybe (authority, strategy))
+  }
+  deriving stock (Eq, Show)
+
+{- | Why a collected frontier is inadmissible. Carries the offending nodes so the
+caller can report a precise rejection rather than silently splitting.
+-}
+data FrontierAdmissionError node
+  = -- | The collected set spans more than one external-call authority.
+    FrontierMixedAuthority ![node]
+  | -- | The collected set spans more than one await strategy.
+    FrontierMixedAwaitStrategy ![node]
+  | -- | A non-backend node sits inside the collected set.
+    FrontierNonBackendIntervening !node
+  | -- | The collected set is empty; there is no frontier to realize.
+    FrontierEmpty
+  deriving stock (Eq, Show)
+
+{- | Decide whether a collected frontier may contract into one realize stage. Rejects
+(never splits) on a mixed authority, a mixed await strategy, an intervening
+non-backend node, or an empty set.
+-}
+admitFrontierContraction
+  :: (Eq authority, Eq strategy)
+  => [CollectedNode node authority strategy]
+  -> Either (FrontierAdmissionError node) ()
+admitFrontierContraction [] = Left FrontierEmpty
+admitFrontierContraction collected =
+  case [cnNode n | n <- collected, isNothing (cnClassification n)] of
+    (nonBackend : _) -> Left (FrontierNonBackendIntervening nonBackend)
+    [] ->
+      let classified = [(a, s) | CollectedNode _ (Just (a, s)) <- collected]
+          authorities = nub (fmap fst classified)
+          strategies = nub (fmap snd classified)
+       in if length authorities > 1
+            then Left (FrontierMixedAuthority (fmap cnNode collected))
+            else
+              if length strategies > 1
+                then Left (FrontierMixedAwaitStrategy (fmap cnNode collected))
+                else Right ()

--- a/src/Cortex/Wire/Compile.hs
+++ b/src/Cortex/Wire/Compile.hs
@@ -154,6 +154,7 @@ import Cortex.Wire.Pure
   , renderPureEvalError
   , validatePureTaskConfig
   )
+import Cortex.Wire.Quantum qualified as Quantum
 import Cortex.Wire.Std
   ( stdIoCommandExecutorId
   , stdIoCommandShapeMessage
@@ -1399,7 +1400,11 @@ lowerUseSpec :: LoweringState -> UseSpec -> Either WireCore.WireError LoweringSt
 lowerUseSpec st useSpec = do
   useScope <-
     mapLeft wireUseErrorToWireError $
-      applyWireUseSpec Package.stdOnlyRegistry (topLevelBindingNameTaken st) st.lsUseScope useSpec
+      applyWireUseSpec
+        (Package.packageNamespaceRegistry Quantum.quantumPackages)
+        (topLevelBindingNameTaken st)
+        st.lsUseScope
+        useSpec
   Right
     st
       { lsUseScope = useScope

--- a/src/Cortex/Wire/Compile.hs
+++ b/src/Cortex/Wire/Compile.hs
@@ -138,6 +138,7 @@ import Cortex.Wire.NodeBoundary
   , signalNodeBoundaryNormalForm
   , validateNodeBoundaryNormalForm
   )
+import Cortex.Wire.Package qualified as Package
 import Cortex.Wire.Parser
   ( GeneratedFamilyChild (..)
   , GeneratedFamilyKind (..)
@@ -1398,7 +1399,7 @@ lowerUseSpec :: LoweringState -> UseSpec -> Either WireCore.WireError LoweringSt
 lowerUseSpec st useSpec = do
   useScope <-
     mapLeft wireUseErrorToWireError $
-      applyWireUseSpec (topLevelBindingNameTaken st) st.lsUseScope useSpec
+      applyWireUseSpec Package.stdOnlyRegistry (topLevelBindingNameTaken st) st.lsUseScope useSpec
   Right
     st
       { lsUseScope = useScope

--- a/src/Cortex/Wire/Executor.hs
+++ b/src/Cortex/Wire/Executor.hs
@@ -48,6 +48,7 @@ import Cortex.Wire.AST
 
 newtype WireExecutorId = WireExecutorId {unWireExecutorId :: Text}
   deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
 
 wireExecutorIdToText :: WireExecutorId -> Text
 wireExecutorIdToText = unWireExecutorId

--- a/src/Cortex/Wire/Package.hs
+++ b/src/Cortex/Wire/Package.hs
@@ -1,0 +1,95 @@
+{- |
+Module      : Cortex.Wire.Package
+Description : ADR 0054 Wire packages and the namespace registry `use` resolves against.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+A Wire package is inert compile-time vocabulary (ADR 0054): it exports namespaces
+that resolve @use@ leaves to canonical executor and contract ids, plus the executor
+projections and contract specs the compiler checks against. Importing a Wire package
+never grants runtime authority — only a host binding pack (Capability layer) does.
+
+The 'NamespaceRegistry' is the composition @use@ resolves against. @std.io@ is just
+the first namespace in it, not a special case (it is wrapped as a 'NamespaceEntry'
+over the existing 'Cortex.Wire.Std' lookups). This module stays in the Wire layer:
+it carries 'WireExecutorProjection', not the richer Capability catalog projection.
+-}
+module Cortex.Wire.Package
+  ( NamespaceEntry (..)
+  , NamespaceRegistry
+  , namespaceRegistryFromEntries
+  , lookupNamespace
+  , namespaceRegistryNamespaces
+  , stdNamespaceEntry
+  , stdOnlyRegistry
+  , WirePackage (..)
+  , packageNamespaceRegistry
+  )
+where
+
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+
+import Cortex.Wire.Contract (WireContractSpec)
+import Cortex.Wire.Executor (WireExecutorProjection)
+import Cortex.Wire.Std (stdIoContractIdForName, stdIoExecutorIdForLeaf, stdIoNamespace)
+
+{- | One importable namespace. Resolution is by function so an entry can be backed
+by the hardcoded @std.io@ lookups or by a package's maps without enumeration.
+-}
+data NamespaceEntry = NamespaceEntry
+  { nsNamespace :: !Text
+  , nsResolveExecutorLeaf :: !(Text -> Maybe Text)
+  -- ^ @use ns.{@leaf}@ → canonical executor id.
+  , nsResolveContract :: !(Text -> Maybe Text)
+  -- ^ @use ns.{Name}@ → canonical contract id.
+  }
+
+{- | The set of importable namespaces, keyed by namespace text (e.g. @std.io@,
+@quantum.core@). Later entries do not override earlier ones.
+-}
+newtype NamespaceRegistry = NamespaceRegistry (Map Text NamespaceEntry)
+
+namespaceRegistryFromEntries :: [NamespaceEntry] -> NamespaceRegistry
+namespaceRegistryFromEntries entries =
+  NamespaceRegistry (Map.fromList [(nsNamespace e, e) | e <- entries])
+
+lookupNamespace :: Text -> NamespaceRegistry -> Maybe NamespaceEntry
+lookupNamespace ns (NamespaceRegistry m) = Map.lookup ns m
+
+namespaceRegistryNamespaces :: NamespaceRegistry -> [Text]
+namespaceRegistryNamespaces (NamespaceRegistry m) = Map.keys m
+
+-- | @std.io@ as a namespace entry, wrapping the existing 'Cortex.Wire.Std' lookups.
+stdNamespaceEntry :: NamespaceEntry
+stdNamespaceEntry =
+  NamespaceEntry
+    { nsNamespace = stdIoNamespace
+    , nsResolveExecutorLeaf = stdIoExecutorIdForLeaf
+    , nsResolveContract = stdIoContractIdForName
+    }
+
+{- | The registry containing only @std.io@ — today's compile-time default before any
+downstream Wire package is composed in (ADR 0059 phase P6 threads packages in).
+-}
+stdOnlyRegistry :: NamespaceRegistry
+stdOnlyRegistry = namespaceRegistryFromEntries [stdNamespaceEntry]
+
+{- | An inert downstream Wire package (ADR 0054): the namespaces it exports for
+@use@, the executor projections, and the contract specs the compiler checks against.
+No credentials, no runnable action.
+-}
+data WirePackage = WirePackage
+  { wpId :: !Text
+  , wpNamespaceEntries :: ![NamespaceEntry]
+  , wpExecutorProjections :: ![WireExecutorProjection]
+  , wpContractSpecs :: ![WireContractSpec]
+  }
+
+-- | Compose @std.io@ with the given Wire packages into one registry.
+packageNamespaceRegistry :: [WirePackage] -> NamespaceRegistry
+packageNamespaceRegistry packages =
+  namespaceRegistryFromEntries (stdNamespaceEntry : concatMap wpNamespaceEntries packages)

--- a/src/Cortex/Wire/Quantum.hs
+++ b/src/Cortex/Wire/Quantum.hs
@@ -1,0 +1,149 @@
+{- |
+Module      : Cortex.Wire.Quantum
+Description : The quantum Wire packages (ADR 0059 first downstream consumer of ADR 0054).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The quantum surface as inert Wire packages (ADR 0054): @quantum.core@ (generic
+circuit vocabulary — prepare_zero / x / cnot / measure_z and the data contracts),
+@quantum.qec@ (reusable QEC contracts), and @quantum.braket@ (the @realize@
+collect-node projection). These carry no runtime authority; a host binding pack
+(Capability layer, e.g. the Braket pack) resolves @quantum.realize@ to a runnable
+stage. Canonical executor ids match the structurally-admitted @\@quantum.*@ surface
+the existing examples use (namespace @quantum.core@, leaf @prepare_zero@ →
+@quantum.prepare_zero@), so packaging is additive, not a rename.
+-}
+module Cortex.Wire.Quantum
+  ( quantumCorePackage
+  , quantumQecPackage
+  , quantumBraketPackage
+  , quantumPackages
+  , realizeExecutorId
+  )
+where
+
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text (Text)
+
+import Cortex.Wire.AST (WirePorts (..))
+import Cortex.Wire.Contract (WireContractSpec (..))
+import Cortex.Wire.Executor
+  ( WireExecutorConfigShape (..)
+  , WireExecutorEffect (..)
+  , WireExecutorId (..)
+  , WireExecutorPortPolicy (..)
+  , WireExecutorProjection (..)
+  )
+import Cortex.Wire.Package (NamespaceEntry (..), WirePackage (..))
+import Cortex.Wire.Value (WirePayloadKind (..))
+
+-- | The canonical id of the realize collect node (ADR 0059 §2).
+realizeExecutorId :: Text
+realizeExecutorId = "quantum.realize"
+
+coreExecutors :: Map Text Text
+coreExecutors =
+  Map.fromList
+    [ ("prepare_zero", "quantum.prepare_zero")
+    , ("x", "quantum.x")
+    , ("cnot", "quantum.cnot")
+    , ("measure_z", "quantum.measure_z")
+    , ("rz", "quantum.rz")
+    , ("h", "quantum.h")
+    ]
+
+coreContracts :: Map Text Text
+coreContracts =
+  Map.fromList
+    [ ("Qubit", "quantum.Qubit")
+    , ("Bit", "quantum.Bit")
+    , ("QuantumResult", "quantum.QuantumResult")
+    , ("MeasurementCounts", "quantum.MeasurementCounts")
+    , ("ShotCount", "quantum.ShotCount")
+    , ("BackendConfig", "quantum.BackendConfig")
+    ]
+
+qecContracts :: Map Text Text
+qecContracts =
+  Map.fromList
+    [ ("RepetitionResult", "quantum.RepetitionResult")
+    , ("Syndrome", "quantum.Syndrome")
+    ]
+
+braketExecutors :: Map Text Text
+braketExecutors = Map.fromList [("realize", realizeExecutorId)]
+
+mapEntry :: Text -> Map Text Text -> Map Text Text -> NamespaceEntry
+mapEntry namespace execs contracts =
+  NamespaceEntry
+    { nsNamespace = namespace
+    , nsResolveExecutorLeaf = (`Map.lookup` execs)
+    , nsResolveContract = (`Map.lookup` contracts)
+    }
+
+{- | An author-declared-ports, host-effecting executor projection over the quantum
+contract vocabulary. The author declares concrete ports per node (gates are
+single-qubit/two-qubit; @realize@ declares one output per named measurement).
+-}
+quantumProjection :: Text -> WireExecutorProjection
+quantumProjection executorId =
+  WireExecutorProjection
+    { wireExecutorProjectionId = WireExecutorId executorId
+    , wireExecutorProjectionPorts = WirePorts Map.empty Map.empty
+    , wireExecutorProjectionVocabulary = Set.fromList (Map.elems coreContracts)
+    , wireExecutorProjectionEffect = WireExecutorHostEffect
+    , wireExecutorProjectionConfigShape = WireExecutorConfigUnchecked
+    , wireExecutorProjectionPortPolicy = WireExecutorAuthorDeclaredPorts
+    }
+
+contractSpec :: Text -> Text -> WireContractSpec
+contractSpec contractId description =
+  WireContractSpec
+    { wireContractSpecId = contractId
+    , wireContractSpecPayloadKind = WirePayloadJson
+    , wireContractSpecDescription = description
+    , wireContractSpecRecordFields = Nothing
+    , wireContractSpecSchema = Nothing
+    , wireContractSpecExamples = []
+    }
+
+quantumCorePackage :: WirePackage
+quantumCorePackage =
+  WirePackage
+    { wpId = "quantum.core"
+    , wpNamespaceEntries = [mapEntry "quantum.core" coreExecutors coreContracts]
+    , wpExecutorProjections = fmap quantumProjection (Map.elems coreExecutors)
+    , wpContractSpecs =
+        [ contractSpec cid ("Quantum core contract " <> cid)
+        | cid <- Map.elems coreContracts
+        ]
+    }
+
+quantumQecPackage :: WirePackage
+quantumQecPackage =
+  WirePackage
+    { wpId = "quantum.qec"
+    , wpNamespaceEntries = [mapEntry "quantum.qec" Map.empty qecContracts]
+    , wpExecutorProjections = []
+    , wpContractSpecs =
+        [ contractSpec cid ("Quantum QEC contract " <> cid)
+        | cid <- Map.elems qecContracts
+        ]
+    }
+
+quantumBraketPackage :: WirePackage
+quantumBraketPackage =
+  WirePackage
+    { wpId = "quantum.braket"
+    , wpNamespaceEntries = [mapEntry "quantum.braket" braketExecutors Map.empty]
+    , wpExecutorProjections = [quantumProjection realizeExecutorId]
+    , wpContractSpecs = []
+    }
+
+-- | All quantum Wire packages, composed by a host's package set (ADR 0054).
+quantumPackages :: [WirePackage]
+quantumPackages = [quantumCorePackage, quantumQecPackage, quantumBraketPackage]

--- a/src/Cortex/Wire/Use.hs
+++ b/src/Cortex/Wire/Use.hs
@@ -33,12 +33,14 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
 
+import Cortex.Wire.Package
+  ( NamespaceEntry (..)
+  , NamespaceRegistry
+  , lookupNamespace
+  )
 import Cortex.Wire.Std
-  ( stdIoContractIdForName
-  , stdIoExecutorIdForLeaf
-  , stdIoExecutorIds
+  ( stdIoExecutorIds
   , stdIoExecutorLeaves
-  , stdIoNamespace
   )
 import Cortex.Wire.Syntax
   ( QName (..)
@@ -68,20 +70,31 @@ emptyWireUseScope =
     , wireUseStdExecutorsInScope = Set.empty
     }
 
-applyWireUseSpecs :: (Text -> Bool) -> [UseSpec] -> Either WireUseError WireUseScope
-applyWireUseSpecs externalNameTaken =
-  foldM (applyWireUseSpec externalNameTaken) emptyWireUseScope
+applyWireUseSpecs
+  :: NamespaceRegistry -> (Text -> Bool) -> [UseSpec] -> Either WireUseError WireUseScope
+applyWireUseSpecs registry externalNameTaken =
+  foldM (applyWireUseSpec registry externalNameTaken) emptyWireUseScope
 
 applyWireUseSpec
-  :: (Text -> Bool) -> WireUseScope -> UseSpec -> Either WireUseError WireUseScope
-applyWireUseSpec externalNameTaken scope useSpec = do
-  when (renderQName useSpec.useSpecNamespace /= stdIoNamespace) $
-    Left (WireUseUnknownNamespace (renderQName useSpec.useSpecNamespace))
-  foldM lowerUseItem scope (NE.toList useSpec.useSpecItems)
+  :: NamespaceRegistry
+  -> (Text -> Bool)
+  -> WireUseScope
+  -> UseSpec
+  -> Either WireUseError WireUseScope
+applyWireUseSpec registry externalNameTaken scope useSpec = do
+  entry <-
+    maybe (Left (WireUseUnknownNamespace namespace)) Right (lookupNamespace namespace registry)
+  foldM (lowerUseItem entry) scope (NE.toList useSpec.useSpecItems)
   where
-    lowerUseItem state = \case
+    namespace = renderQName useSpec.useSpecNamespace
+
+    lowerUseItem entry state = \case
       UseExecutor itemName maybeAlias -> do
-        canonical <- stdIoExecutorId itemName
+        canonical <-
+          maybe
+            (Left (WireUseUnknownItem namespace ("@" <> itemName)))
+            Right
+            (nsResolveExecutorLeaf entry itemName)
         let localName = fromMaybe itemName maybeAlias
         ensureUseNameFresh localName state
         Right
@@ -91,7 +104,11 @@ applyWireUseSpec externalNameTaken scope useSpec = do
                 Set.insert canonical state.wireUseStdExecutorsInScope
             }
       UseContract itemName maybeAlias -> do
-        canonical <- stdIoContractId itemName
+        canonical <-
+          maybe
+            (Left (WireUseUnknownItem namespace itemName))
+            Right
+            (nsResolveContract entry itemName)
         let localName = fromMaybe itemName maybeAlias
         ensureUseNameFresh localName state
         Right
@@ -108,20 +125,6 @@ wireUseLocalNameTaken externalNameTaken scope localName =
   externalNameTaken localName
     || Map.member localName scope.wireUseExecutors
     || Map.member localName scope.wireUseContracts
-
-stdIoExecutorId :: Text -> Either WireUseError Text
-stdIoExecutorId itemName =
-  maybe
-    (Left (WireUseUnknownItem stdIoNamespace ("@" <> itemName)))
-    Right
-    (stdIoExecutorIdForLeaf itemName)
-
-stdIoContractId :: Text -> Either WireUseError Text
-stdIoContractId itemName =
-  maybe
-    (Left (WireUseUnknownItem stdIoNamespace itemName))
-    Right
-    (stdIoContractIdForName itemName)
 
 wireUseDeclaredContracts :: WireUseScope -> Set Text
 wireUseDeclaredContracts scope =

--- a/test/Cortex/Capability/BindingPack/BraketSpec.hs
+++ b/test/Cortex/Capability/BindingPack/BraketSpec.hs
@@ -1,0 +1,60 @@
+{- |
+Module      : Cortex.Capability.BindingPack.BraketSpec
+Description : Tests for the Braket host binding pack (ADR 0059 / 0054).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The minted pack resolves quantum.realize to a submit/park/resume binding carrying
+the configured device authority — the ADR 0054 host-binding contract.
+-}
+module Cortex.Capability.BindingPack.BraketSpec (spec) where
+
+import Data.Text (Text)
+import Test.Hspec
+
+import Cortex.Capability.BindingPack (HostBindingPack (..), lookupBinding)
+import Cortex.Capability.BindingPack.Braket
+import Cortex.Capability.Catalog.AwaitStrategy (AwaitStrategy (..))
+import Cortex.Capability.Catalog.ExecutorManifest (AbiKind (..))
+import Cortex.Capability.Catalog.RuntimeBindingRecord
+import Cortex.Wire.Executor (WireExecutorId (..))
+
+config :: BraketConfig
+config =
+  BraketConfig
+    { braketRegion = "us-east-1"
+    , braketDeviceArn = "arn:aws:braket:::device/qpu/ionq/Aria-1"
+    , braketS3Bucket = "amazon-braket-results"
+    , braketProfile = Just "research"
+    }
+
+realizeId :: WireExecutorId
+realizeId = WireExecutorId "quantum.realize"
+
+deviceArn :: Text
+deviceArn = "arn:aws:braket:::device/qpu/ionq/Aria-1"
+
+spec :: Spec
+spec = describe "braketBindingPack" $ do
+  it "declares a one-way dependency on the quantum.braket Wire package" $
+    hbpWirePackageDeps (braketBindingPack config) `shouldBe` ["quantum.braket"]
+
+  it "resolves quantum.realize to a submit/park/resume binding" $
+    case lookupBinding realizeId (braketBindingPack config) of
+      Nothing -> expectationFailure "expected a binding for quantum.realize"
+      Just record -> do
+        rbrAcceptedAwaitStrategy record `shouldBe` SubmitParkResume
+        rbrAbiKind record `shouldBe` AbiSubprocessJsonl
+        rbrStageActionRef record `shouldBe` RuntimeStageActionRef "quantum.realize.braket"
+
+  it "records the configured device as a resolved authority fingerprint" $
+    case lookupBinding realizeId (braketBindingPack config) of
+      Nothing -> expectationFailure "expected a binding"
+      Just record ->
+        fmap rafName (rbrResolvedAuthorities record) `shouldContain` [deviceArn]
+
+  it "does not resolve an unrelated executor" $
+    lookupBinding (WireExecutorId "quantum.prepare_zero") (braketBindingPack config)
+      `shouldBe` Nothing

--- a/test/Cortex/Capability/CatalogSpec.hs
+++ b/test/Cortex/Capability/CatalogSpec.hs
@@ -1,0 +1,89 @@
+{- |
+Module      : Cortex.Capability.CatalogSpec
+Description : Tests for the ADR 0053 executor catalog types.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+JSON round-trips (including the hand-written port codec), content-digest
+determinism, and the runtime binding record.
+-}
+module Cortex.Capability.CatalogSpec (spec) where
+
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy (ByteString)
+import Test.Hspec
+
+import Cortex.Capability.Catalog.AdmissionProjection
+import Cortex.Capability.Catalog.AwaitStrategy
+import Cortex.Capability.Catalog.ExecutorManifest (AbiKind (..), ContentAddress (..))
+import Cortex.Capability.Catalog.RuntimeBindingRecord
+import Cortex.Wire.Executor (WireExecutorId (..))
+
+-- A realize-style projection authored as JSON (the port constructors live in the
+-- library-internal Cortex.Wire.AST, so the test exercises the public FromJSON path
+-- rather than importing hidden modules — this also covers the port codec directly).
+sampleProjectionJSON :: ByteString
+sampleProjectionJSON =
+  "{\"executorId\":\"quantum.realize\"\
+  \,\"projectionVersion\":\"1\"\
+  \,\"ports\":{\"inputs\":{\"shots\":{\"accepts\":[\"ShotCount\"],\"cardinality\":\"one\",\"required\":true}}\
+  \,\"outputs\":{\"s01\":{\"contract\":\"MeasurementResult\"},\"s12\":{\"contract\":\"MeasurementResult\"}}}\
+  \,\"configSchemaRef\":{\"tag\":\"ConfigSchemaName\",\"contents\":\"braket-config\"}\
+  \,\"requirementSlots\":[{\"rsCapabilityKind\":\"provider\",\"rsBindingName\":\"braket\"\
+  \,\"rsConfigSelector\":\"config.device\",\"rsPermissionClass\":\"aws.braket\"}]\
+  \,\"replayClass\":\"idempotent_with_key\"\
+  \,\"isolationExpectation\":\"subprocess_sandbox\"\
+  \,\"effect\":\"host_effect\"\
+  \,\"awaitStrategy\":\"submit_park_resume\"}"
+
+sampleProjection :: AdmissionProjection
+sampleProjection =
+  either (error . ("sampleProjection decode: " <>)) id (Aeson.eitherDecode sampleProjectionJSON)
+
+roundTrips :: (Eq a, Show a, Aeson.ToJSON a, Aeson.FromJSON a) => a -> Expectation
+roundTrips x = Aeson.eitherDecode (Aeson.encode x) `shouldBe` Right x
+
+sampleBinding :: RuntimeBindingRecord
+sampleBinding =
+  RuntimeBindingRecord
+    { rbrBindingId = "braket-pack/quantum.realize"
+    , rbrBindingVersion = "1"
+    , rbrExecutorId = WireExecutorId "quantum.realize"
+    , rbrProjectionVersion = ProjectionVersion "1"
+    , rbrStageActionRef = RuntimeStageActionRef "quantum.realize.braket"
+    , rbrManifestContentAddress = ContentAddress "sha256:manifest"
+    , rbrArtifactDigest = ContentDigest "d"
+    , rbrAbiKind = AbiSubprocessJsonl
+    , rbrAbiVersion = "1"
+    , rbrAbiDriverDigest = ContentDigest "dd"
+    , rbrBindingPackIdentity = "braket-pack"
+    , rbrResolvedAuthorities = []
+    , rbrIsolation = SubprocessSandbox
+    , rbrAcceptedReplayClass = IdempotentWithKey
+    , rbrAcceptedAwaitStrategy = SubmitParkResume
+    , rbrCompatibilityDigest = ContentDigest "c"
+    }
+
+spec :: Spec
+spec = do
+  describe "AdmissionProjection JSON" $ do
+    it "round-trips through JSON, including ports" $
+      roundTrips sampleProjection
+    it "round-trips the await strategy / replay / isolation enums" $ do
+      roundTrips Synchronous
+      roundTrips SubmitParkResume
+      roundTrips IdempotentWithKey
+      roundTrips SubprocessSandbox
+
+  describe "admissionProjectionDigest" $ do
+    it "is deterministic for the same projection" $
+      admissionProjectionDigest sampleProjection
+        `shouldBe` admissionProjectionDigest sampleProjection
+    it "changes when a defining field changes" $
+      admissionProjectionDigest sampleProjection
+        `shouldNotBe` admissionProjectionDigest sampleProjection {apAwaitStrategy = Synchronous}
+
+  describe "RuntimeBindingRecord JSON" $
+    it "round-trips" (roundTrips sampleBinding)

--- a/test/Cortex/Pulse/Executor/ExternalCallAttemptSpec.hs
+++ b/test/Cortex/Pulse/Executor/ExternalCallAttemptSpec.hs
@@ -1,0 +1,93 @@
+{- |
+Module      : Cortex.Pulse.Executor.ExternalCallAttemptSpec
+Description : DB tests for the ADR 0059 external-call attempt record CRUD.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Reserve → persist-handle → settle lifecycle, and the crash-safety property that
+reserve is idempotent on the key (a recovery re-entry never overwrites the
+authoritative first reservation). Self-skips when PGHOST is unset.
+-}
+module Cortex.Pulse.Executor.ExternalCallAttemptSpec (spec) where
+
+import Control.Exception (SomeException, try)
+import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+import Data.Time (getCurrentTime)
+import Data.UUID qualified as UUID
+import System.Environment (lookupEnv)
+import Test.Hspec
+
+import Cortex.Pulse.Query.ExternalCall
+import Cortex.TestSupport.Database (TestDB, createTestDB, runTx)
+
+setupTestDb :: IO (Maybe TestDB)
+setupTestDb = do
+  mHost <- lookupEnv "PGHOST"
+  case mHost of
+    Nothing -> pure Nothing
+    Just _ -> do
+      result <- try createTestDB :: IO (Either SomeException TestDB)
+      either (\e -> error ("PGHOST set but DB setup failed: " <> show e)) (pure . Just) result
+
+withDb :: Maybe TestDB -> (TestDB -> IO ()) -> IO ()
+withDb Nothing _ = pendingWith "PGHOST not set - database not available"
+withDb (Just db) action = action db
+
+mkKey :: Text -> ExternalCallAttemptKey
+mkKey frontier =
+  ExternalCallAttemptKey
+    { ecaRunId = UUID.nil
+    , ecaNodeId = "realize"
+    , ecaRuntimeBindingId = "braket-pack/quantum.realize"
+    , ecaFrontierId = frontier
+    }
+
+plan :: Aeson.Value
+plan = Aeson.object ["operations" Aeson..= ([Aeson.object ["gate" Aeson..= ("cnot" :: Text)]])]
+
+spec :: Spec
+spec = beforeAll setupTestDb . describe "external-call attempt CRUD" $ do
+  it "reserve then load yields a reserved attempt with the frozen plan" $ \mdb -> withDb mdb $ \db -> do
+    now <- getCurrentTime
+    let key = mkKey "f-reserve"
+    runTx db (reserveExternalCallAttempt key "idem-1" plan now)
+    loaded <- runTx db (loadExternalCallAttempt key)
+    fmap ecaStatus loaded `shouldBe` Just "reserved"
+    fmap ecaIdempotencyKey loaded `shouldBe` Just "idem-1"
+    fmap ecaFrozenPlan loaded `shouldBe` Just plan
+    (ecaJobHandle =<< loaded) `shouldBe` Nothing
+
+  it "reserve is idempotent on the key (recovery re-entry does not overwrite)" $ \mdb -> withDb mdb $ \db -> do
+    now <- getCurrentTime
+    let key = mkKey "f-idem"
+    runTx db (reserveExternalCallAttempt key "idem-first" plan now)
+    runTx db (reserveExternalCallAttempt key "idem-second" (Aeson.object ["x" Aeson..= (1 :: Int)]) now)
+    loaded <- runTx db (loadExternalCallAttempt key)
+    fmap ecaIdempotencyKey loaded `shouldBe` Just "idem-first"
+    fmap ecaFrozenPlan loaded `shouldBe` Just plan
+
+  it "persist handle marks the attempt submitted with the job handle and signal" $ \mdb -> withDb mdb $ \db -> do
+    now <- getCurrentTime
+    let key = mkKey "f-submit"
+        handle = Aeson.object ["jobArn" Aeson..= ("arn:aws:braket:job/abc" :: Text)]
+    runTx db (reserveExternalCallAttempt key "idem-s" plan now)
+    runTx db (persistExternalCallHandle key handle "ext:job-abc" now)
+    loaded <- runTx db (loadExternalCallAttempt key)
+    fmap ecaStatus loaded `shouldBe` Just "submitted"
+    (ecaJobHandle =<< loaded) `shouldBe` Just handle
+    (ecaSignalName =<< loaded) `shouldBe` Just "ext:job-abc"
+
+  it "settle marks the attempt settled" $ \mdb -> withDb mdb $ \db -> do
+    now <- getCurrentTime
+    let key = mkKey "f-settle"
+    runTx db (reserveExternalCallAttempt key "idem-x" plan now)
+    runTx db (settleExternalCallAttempt key now)
+    loaded <- runTx db (loadExternalCallAttempt key)
+    fmap ecaStatus loaded `shouldBe` Just "settled"
+
+  it "load of an absent key is Nothing" $ \mdb -> withDb mdb $ \db -> do
+    loaded <- runTx db (loadExternalCallAttempt (mkKey "f-absent"))
+    loaded `shouldBe` Nothing

--- a/test/Cortex/Pulse/Executor/ExternalCallSpec.hs
+++ b/test/Cortex/Pulse/Executor/ExternalCallSpec.hs
@@ -1,0 +1,112 @@
+{- |
+Module      : Cortex.Pulse.Executor.ExternalCallSpec
+Description : Tests for the ADR 0059 §3 submit/park/resume protocol.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Drives the protocol state machine over IORef-backed fakes: synchronous complete and
+fail, submit→suspend, resume→complete, submit-failure→fail, and the crash-safety
+property that a re-entry before the handle is recorded re-submits with the same
+idempotency key (no duplicate provider task).
+-}
+module Cortex.Pulse.Executor.ExternalCallSpec (spec) where
+
+import Data.Aeson (Value)
+import Data.Aeson qualified as Aeson
+import Data.IORef
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.UUID qualified as UUID
+import Test.Hspec
+
+import Cortex.Capability.Catalog.AwaitStrategy (AwaitStrategy (..))
+import Cortex.Pulse.Executor.ExternalCall
+import Cortex.Pulse.Query.ExternalCall (ExternalCallAttemptKey (..))
+
+key :: Text -> ExternalCallAttemptKey
+key = ExternalCallAttemptKey UUID.nil "realize" "pack"
+
+-- The IORef store is keyed by frontier id (distinct per test).
+newStore :: IO (IORef (Map Text AttemptView), AttemptStore IO)
+newStore = do
+  ref <- newIORef Map.empty
+  let setStatus s = modifyIORef' ref . Map.adjust (\v -> v {avStatus = s}) . ecaFrontierId
+      store =
+        AttemptStore
+          { storeLoad = \k -> Map.lookup (ecaFrontierId k) <$> readIORef ref
+          , storeReserve = \k _ _ ->
+              modifyIORef' ref (Map.insertWith (\_ old -> old) (ecaFrontierId k) (AttemptView Nothing "reserved"))
+          , storePersistHandle = \k h _ ->
+              modifyIORef' ref (Map.insert (ecaFrontierId k) (AttemptView (Just h) "submitted"))
+          , storeSettle = setStatus "settled"
+          , storeFail = setStatus "failed"
+          }
+  pure (ref, store)
+
+plan :: Value
+plan = Aeson.object ["op" Aeson..= ("cnot" :: Text)]
+
+outputs :: [(Text, Value)]
+outputs = [("s01", Aeson.toJSON (1 :: Int)), ("s12", Aeson.toJSON (0 :: Int))]
+
+baseDriver :: ExternalCallDriver IO
+baseDriver =
+  ExternalCallDriver
+    { driverRunSync = \_ -> pure (Right outputs)
+    , driverSubmit = \_ _ -> pure (Right (Aeson.toJSON ("job-1" :: Text)))
+    , driverFetch = \_ -> pure (Right outputs)
+    , driverIdempotencyKey = const "idem-fixed"
+    , driverSignalName = \k -> "ext:" <> ecaFrontierId k
+    }
+
+spec :: Spec
+spec = describe "runExternalCall" $ do
+  it "synchronous: runs inline and completes" $ do
+    (_, store) <- newStore
+    r <- runExternalCall Synchronous baseDriver store (key "sync") plan
+    r `shouldBe` ExternalCallCompleted outputs
+
+  it "synchronous: a driver error fails" $ do
+    (_, store) <- newStore
+    let driver = baseDriver {driverRunSync = \_ -> pure (Left "device offline")}
+    r <- runExternalCall Synchronous driver store (key "sync-fail") plan
+    r `shouldBe` ExternalCallFailed "device offline"
+
+  it "submit/park/resume: first entry submits and suspends, recording the handle" $ do
+    (ref, store) <- newStore
+    r <- runExternalCall SubmitParkResume baseDriver store (key "spr") plan
+    r `shouldBe` ExternalCallSuspended "ext:spr"
+    m <- readIORef ref
+    fmap avStatus (Map.lookup "spr" m) `shouldBe` Just "submitted"
+    (avJobHandle =<< Map.lookup "spr" m) `shouldBe` Just (Aeson.toJSON ("job-1" :: Text))
+
+  it "submit/park/resume: resume with a recorded handle fetches and completes" $ do
+    (ref, store) <- newStore
+    _ <- runExternalCall SubmitParkResume baseDriver store (key "spr2") plan
+    r <- runExternalCall SubmitParkResume baseDriver store (key "spr2") plan
+    r `shouldBe` ExternalCallCompleted outputs
+    m <- readIORef ref
+    fmap avStatus (Map.lookup "spr2" m) `shouldBe` Just "settled"
+
+  it "submit/park/resume: a submit failure fails" $ do
+    (_, store) <- newStore
+    let driver = baseDriver {driverSubmit = \_ _ -> pure (Left "queue rejected")}
+    r <- runExternalCall SubmitParkResume driver store (key "spr-fail") plan
+    r `shouldBe` ExternalCallFailed "queue rejected"
+
+  it "submit/park/resume: re-entry before the handle is recorded re-submits with the same key" $ do
+    (_, store) <- newStore
+    submittedKeys <- newIORef ([] :: [Text])
+    -- A store that loses the handle (simulating a crash before persist): persistHandle is a no-op.
+    let losingStore = store {storePersistHandle = \_ _ _ -> pure ()}
+        driver =
+          baseDriver
+            { driverSubmit = \idem _ -> modifyIORef' submittedKeys (idem :) >> pure (Right (Aeson.toJSON ("job" :: Text)))
+            }
+    _ <- runExternalCall SubmitParkResume driver losingStore (key "spr-crash") plan
+    _ <- runExternalCall SubmitParkResume driver losingStore (key "spr-crash") plan
+    ks <- readIORef submittedKeys
+    ks `shouldBe` ["idem-fixed", "idem-fixed"]

--- a/test/Cortex/Pulse/FrontierContractionSpec.hs
+++ b/test/Cortex/Pulse/FrontierContractionSpec.hs
@@ -1,0 +1,59 @@
+{- |
+Module      : Cortex.Pulse.FrontierContractionSpec
+Description : Tests for the ADR 0059 §2 decidable frontier-contraction admission check.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Admits a homogeneous backend frontier; rejects (never splits) a mixed authority, a
+mixed await strategy, an intervening non-backend node, and an empty set.
+-}
+module Cortex.Pulse.FrontierContractionSpec (spec) where
+
+import Data.Text (Text)
+import Test.Hspec
+
+import Cortex.Capability.Catalog.AwaitStrategy (AwaitStrategy (..))
+import Cortex.Pulse.Rewrite.Contract
+
+backend :: Text -> Text -> AwaitStrategy -> CollectedNode Text Text AwaitStrategy
+backend node authority strat = CollectedNode node (Just (authority, strat))
+
+classical :: Text -> CollectedNode Text Text AwaitStrategy
+classical node = CollectedNode node Nothing
+
+spec :: Spec
+spec = describe "admitFrontierContraction" $ do
+  it "admits a homogeneous same-authority, same-strategy frontier" $
+    admitFrontierContraction
+      [ backend "g0" "quantum.braket" SubmitParkResume
+      , backend "g1" "quantum.braket" SubmitParkResume
+      , backend "m0" "quantum.braket" SubmitParkResume
+      ]
+      `shouldBe` Right ()
+
+  it "rejects a mixed-authority frontier (does not split)" $
+    admitFrontierContraction
+      [ backend "g0" "quantum.braket" SubmitParkResume
+      , backend "g1" "quantum.iqm" SubmitParkResume
+      ]
+      `shouldBe` Left (FrontierMixedAuthority ["g0", "g1"])
+
+  it "rejects a mixed await-strategy frontier" $
+    admitFrontierContraction
+      [ backend "g0" "quantum.braket" SubmitParkResume
+      , backend "g1" "quantum.braket" Synchronous
+      ]
+      `shouldBe` Left (FrontierMixedAwaitStrategy ["g0", "g1"])
+
+  it "rejects an intervening non-backend node" $
+    admitFrontierContraction
+      [ backend "g0" "quantum.braket" SubmitParkResume
+      , classical "decode"
+      ]
+      `shouldBe` Left (FrontierNonBackendIntervening "decode")
+
+  it "rejects an empty collected set" $
+    admitFrontierContraction ([] :: [CollectedNode Text Text AwaitStrategy])
+      `shouldBe` Left FrontierEmpty

--- a/test/Cortex/Pulse/Lowering/CircuitSpec.hs
+++ b/test/Cortex/Pulse/Lowering/CircuitSpec.hs
@@ -1,0 +1,97 @@
+{- |
+Module      : Cortex.Pulse.Lowering.CircuitSpec
+Description : Tests for the realize-frontier lowering decision core (ADR 0059 §2/§3).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Lowering admits the frontier, resolves the binding pack (typed @missing runtime
+binding@ when absent — the ADR 0054 invariant), and produces a deterministic fused
+plan + idempotency key carrying the binding's await strategy.
+-}
+module Cortex.Pulse.Lowering.CircuitSpec (spec) where
+
+import Data.Text (Text)
+import Test.Hspec
+
+import Cortex.Capability.BindingPack (HostBindingPack (..))
+import Cortex.Capability.Catalog.AdmissionProjection (ContentDigest (..), ProjectionVersion (..))
+import Cortex.Capability.Catalog.AwaitStrategy
+  ( AwaitStrategy (..)
+  , IsolationExpectation (..)
+  , ReplayClass (..)
+  )
+import Cortex.Capability.Catalog.ExecutorManifest (AbiKind (..), ContentAddress (..))
+import Cortex.Capability.Catalog.RuntimeBindingRecord
+import Cortex.Pulse.Lowering.Circuit
+import Cortex.Pulse.Lowering.FusedPlan
+  ( FusedMeasurement (..)
+  , FusedOp (..)
+  , fusedPlan
+  , fusedPlanDigest
+  )
+import Cortex.Pulse.Rewrite.Contract (CollectedNode (..))
+import Cortex.Wire.Executor (WireExecutorId (..))
+
+realizeId :: WireExecutorId
+realizeId = WireExecutorId "quantum.realize"
+
+binding :: RuntimeBindingRecord
+binding =
+  RuntimeBindingRecord
+    { rbrBindingId = "braket-pack/quantum.realize"
+    , rbrBindingVersion = "1"
+    , rbrExecutorId = realizeId
+    , rbrProjectionVersion = ProjectionVersion "1"
+    , rbrStageActionRef = RuntimeStageActionRef "quantum.realize.braket"
+    , rbrManifestContentAddress = ContentAddress "sha256:m"
+    , rbrArtifactDigest = ContentDigest "d"
+    , rbrAbiKind = AbiSubprocessJsonl
+    , rbrAbiVersion = "1"
+    , rbrAbiDriverDigest = ContentDigest "dd"
+    , rbrBindingPackIdentity = "braket-pack"
+    , rbrResolvedAuthorities = []
+    , rbrIsolation = SubprocessSandbox
+    , rbrAcceptedReplayClass = IdempotentWithKey
+    , rbrAcceptedAwaitStrategy = SubmitParkResume
+    , rbrCompatibilityDigest = ContentDigest "c"
+    }
+
+braketPack :: HostBindingPack
+braketPack = HostBindingPack "braket-pack" ["quantum.braket"] [binding]
+
+emptyPack :: HostBindingPack
+emptyPack = HostBindingPack "empty" [] []
+
+node :: Text -> CollectedNode Text WireExecutorId AwaitStrategy
+node n = CollectedNode n (Just (WireExecutorId "quantum.braket", SubmitParkResume))
+
+ops :: [FusedOp]
+ops = [FusedOp "cnot" [0, 1] [], FusedOp "measure_z" [0] []]
+
+measurements :: [FusedMeasurement]
+measurements = [FusedMeasurement 0 "s01"]
+
+spec :: Spec
+spec = describe "lowerRealizeFrontier" $ do
+  it "fails with missing runtime binding when no pack resolves the realize executor" $
+    lowerRealizeFrontier emptyPack realizeId [node "g0"] ops measurements
+      `shouldBe` Left (LoweringMissingRuntimeBinding realizeId)
+
+  it "rejects an inadmissible (mixed-authority) frontier" $ do
+    let mixed =
+          [ node "g0"
+          , CollectedNode "g1" (Just (WireExecutorId "quantum.iqm", SubmitParkResume))
+          ]
+    case lowerRealizeFrontier braketPack realizeId mixed ops measurements of
+      Left (LoweringInadmissibleFrontier _) -> pure ()
+      other -> expectationFailure ("expected inadmissible frontier, got " <> show other)
+
+  it "lowers an admissible bound frontier to a deterministic plan carrying the await strategy" $
+    case lowerRealizeFrontier braketPack realizeId [node "g0", node "g1"] ops measurements of
+      Left err -> expectationFailure (show err)
+      Right lowered -> do
+        lrAwaitStrategy lowered `shouldBe` SubmitParkResume
+        lrIdempotencyKey lowered `shouldBe` fusedPlanDigest (fusedPlan ops measurements)
+        rbrStageActionRef (lrBinding lowered) `shouldBe` RuntimeStageActionRef "quantum.realize.braket"

--- a/test/Cortex/Pulse/Lowering/FusedPlanSpec.hs
+++ b/test/Cortex/Pulse/Lowering/FusedPlanSpec.hs
@@ -1,0 +1,44 @@
+{- |
+Module      : Cortex.Pulse.Lowering.FusedPlanSpec
+Description : Tests for the canonical fused-plan serializer (ADR 0059 §2/§3).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The digest is deterministic, independent of measurement input order (sorted), and
+sensitive to operation order (gate order is physically meaningful). This is the
+idempotency-key stability property the submit/park/resume protocol relies on.
+-}
+module Cortex.Pulse.Lowering.FusedPlanSpec (spec) where
+
+import Test.Hspec
+
+import Cortex.Pulse.Lowering.FusedPlan
+
+ops :: [FusedOp]
+ops =
+  [ FusedOp "prepare_zero" [0] []
+  , FusedOp "x" [0] []
+  , FusedOp "cnot" [0, 1] []
+  ]
+
+measurements :: [FusedMeasurement]
+measurements = [FusedMeasurement 1 "s12", FusedMeasurement 0 "s01"]
+
+spec :: Spec
+spec = describe "fusedPlanDigest" $ do
+  it "is deterministic for the same plan" $
+    fusedPlanDigest (fusedPlan ops measurements)
+      `shouldBe` fusedPlanDigest (fusedPlan ops measurements)
+
+  it "is independent of measurement input order (measurements are sorted)" $
+    fusedPlanDigest (fusedPlan ops measurements)
+      `shouldBe` fusedPlanDigest (fusedPlan ops (reverse measurements))
+
+  it "is sensitive to operation order (gate order is physical)" $
+    fusedPlanDigest (fusedPlan ops measurements)
+      `shouldNotBe` fusedPlanDigest (fusedPlan (reverse ops) measurements)
+
+  it "sorts measurements canonically in the payload" $
+    fmap fmOutput (fpMeasurements (fusedPlan ops measurements)) `shouldBe` ["s01", "s12"]

--- a/test/Cortex/Wire/CompileSpec.hs
+++ b/test/Cortex/Wire/CompileSpec.hs
@@ -3675,6 +3675,55 @@ spec = describe "Cortex.Wire.Compile" $ do
       successors compiled.compiledCircuitTopology (CircuitNodeRef "render_experiment_report")
         `shouldBe` Set.fromList [CircuitNodeRef "print_report", CircuitNodeRef "write_report"]
 
+    it "compiles the QEC repetition-code experiment scaffold" $ do
+      source <- TIO.readFile "examples/wire/qec-repetition-code-forced-errors.wire"
+      compiled <- requireRight (compileWireText source)
+      Set.fromList compiled.compiledCircuitEntryNodes
+        `shouldBe` Set.fromList [CircuitNodeRef "start_experiment"]
+      Set.fromList compiled.compiledCircuitExitNodes
+        `shouldBe` Set.fromList [CircuitNodeRef "print_report", CircuitNodeRef "write_report"]
+      let phantomRefs =
+            Set.filter
+              (("__star:gather:" `T.isPrefixOf`) . (.unCircuitNodeRef))
+              (Map.keysSet compiled.compiledCircuitNodes)
+      Set.size phantomRefs `shouldBe` 1
+      let resultsPhantom = Set.findMin phantomRefs
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "run_none/run")
+        `shouldBe` Set.singleton (CircuitNodeRef "run_x0/gate")
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "run_x0/gate")
+        `shouldBe` Set.fromList [resultsPhantom, CircuitNodeRef "run_x0/run"]
+      successors compiled.compiledCircuitTopology resultsPhantom
+        `shouldBe` Set.singleton (CircuitNodeRef "analyze_qec")
+      successors compiled.compiledCircuitTopology (CircuitNodeRef "render_qec_report")
+        `shouldBe` Set.fromList [CircuitNodeRef "print_report", CircuitNodeRef "write_report"]
+
+    it "compiles each selected QEC repetition-code circuit export" $ do
+      source <- TIO.readFile "examples/wire/qec-repetition-code-forced-errors.wire"
+      Foldable.for_
+        [ "qec_repetition_none"
+        , "qec_repetition_x0"
+        , "qec_repetition_x1"
+        , "qec_repetition_x2"
+        ]
+        $ \selected -> do
+          compiled <- requireRight (compileWireTextWithReturn selected source)
+          Set.fromList compiled.compiledCircuitEntryNodes
+            `shouldBe` Set.fromList
+              [ CircuitNodeRef (selected <> "/encode/prepare_d0")
+              , CircuitNodeRef (selected <> "/encode/prepare_d1")
+              , CircuitNodeRef (selected <> "/encode/prepare_d2")
+              , CircuitNodeRef (selected <> "/encode/prepare_a01")
+              , CircuitNodeRef (selected <> "/encode/prepare_a12")
+              ]
+          Set.fromList compiled.compiledCircuitExitNodes
+            `shouldBe` Set.fromList
+              [ CircuitNodeRef (selected <> "/readout/measure_s01")
+              , CircuitNodeRef (selected <> "/readout/measure_s12")
+              , CircuitNodeRef (selected <> "/readout/measure_d0")
+              , CircuitNodeRef (selected <> "/readout/measure_d1")
+              , CircuitNodeRef (selected <> "/readout/measure_d2")
+              ]
+
     it "compiles the quantum eraser sweep circuit examples with primitive executors" $
       mapM_ compileQuantumEraserFixture quantumEraserSweepFixtures
 

--- a/test/Cortex/Wire/CompileSpec.hs
+++ b/test/Cortex/Wire/CompileSpec.hs
@@ -3709,7 +3709,7 @@ spec = describe "Cortex.Wire.Compile" $ do
           compiled <- requireRight (compileWireTextWithReturn selected source)
           Set.fromList compiled.compiledCircuitEntryNodes
             `shouldBe` Set.fromList
-              [ CircuitNodeRef (selected <> "/encode/prepare_d0")
+              [ CircuitNodeRef (selected <> "/encode/ibm_runtime_config")
               , CircuitNodeRef (selected <> "/encode/prepare_d1")
               , CircuitNodeRef (selected <> "/encode/prepare_d2")
               , CircuitNodeRef (selected <> "/encode/prepare_a01")

--- a/test/Cortex/Wire/PackageSpec.hs
+++ b/test/Cortex/Wire/PackageSpec.hs
@@ -1,0 +1,83 @@
+{- |
+Module      : Cortex.Wire.PackageSpec
+Description : Tests for ADR 0054 Wire packages and namespace `use` resolution.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Resolving @use@ against a composed namespace registry: a non-@std.io@ package
+namespace resolves leaves and contracts, unknown namespaces and items are rejected,
+and @std.io@ still resolves as one entry among others.
+-}
+module Cortex.Wire.PackageSpec (spec) where
+
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Test.Hspec
+
+import Cortex.Wire.Package
+import Cortex.Wire.Syntax (QName (..), UseItem (..), UseSpec (..))
+import Cortex.Wire.Use
+
+quantumCore :: NamespaceEntry
+quantumCore =
+  NamespaceEntry
+    { nsNamespace = "quantum.core"
+    , nsResolveExecutorLeaf = \leaf ->
+        if leaf == "realize" then Just "quantum.realize" else Nothing
+    , nsResolveContract = \name ->
+        if name == "QuantumResult" then Just "quantum.QuantumResult" else Nothing
+    }
+
+registry :: NamespaceRegistry
+registry = namespaceRegistryFromEntries [stdNamespaceEntry, quantumCore]
+
+useQuantum :: UseSpec
+useQuantum =
+  UseSpec
+    { useSpecNamespace = QName ("quantum" :| ["core"])
+    , useSpecItems = UseExecutor "realize" Nothing :| [UseContract "QuantumResult" Nothing]
+    }
+
+useStdOut :: UseSpec
+useStdOut =
+  UseSpec
+    { useSpecNamespace = QName ("std" :| ["io"])
+    , useSpecItems = UseExecutor "stdout" Nothing :| []
+    }
+
+notTaken :: Text -> Bool
+notTaken = const False
+
+spec :: Spec
+spec = do
+  describe "applyWireUseSpecs against a composed registry" $ do
+    it "resolves a non-std package namespace's executor and contract leaves" $
+      case applyWireUseSpecs registry notTaken [useQuantum] of
+        Left err -> expectationFailure ("unexpected: " <> show err)
+        Right scope -> do
+          Map.lookup "realize" (wireUseExecutors scope) `shouldBe` Just "quantum.realize"
+          Map.lookup "QuantumResult" (wireUseContracts scope) `shouldBe` Just "quantum.QuantumResult"
+
+    it "still resolves std.io as one entry among others" $
+      case applyWireUseSpecs registry notTaken [useStdOut] of
+        Left err -> expectationFailure ("unexpected: " <> show err)
+        Right scope ->
+          Map.lookup "stdout" (wireUseExecutors scope) `shouldBe` Just "std.io.stdout"
+
+    it "rejects an unknown namespace" $
+      applyWireUseSpecs registry notTaken [useQuantum {useSpecNamespace = QName ("nope" :| [])}]
+        `shouldBe` Left (WireUseUnknownNamespace "nope")
+
+    it "rejects an unknown item in a known namespace" $
+      applyWireUseSpecs
+        registry
+        notTaken
+        [useQuantum {useSpecItems = UseExecutor "teleport" Nothing :| []}]
+        `shouldBe` Left (WireUseUnknownItem "quantum.core" "@teleport")
+
+  describe "packageNamespaceRegistry" . it "composes std.io with package namespaces" $ do
+    let reg = packageNamespaceRegistry [WirePackage "quantum" [quantumCore] [] []]
+    namespaceRegistryNamespaces reg `shouldMatchList` ["std.io", "quantum.core"]

--- a/test/Cortex/Wire/ParserSpec.hs
+++ b/test/Cortex/Wire/ParserSpec.hs
@@ -115,6 +115,9 @@ spec = describe "Cortex.Wire.Parser" $ do
     it "parses the full quantum eraser experiment scaffold" $
       parseWireFixture "examples/wire/quantum-eraser-experiment.wire"
 
+    it "parses the QEC repetition-code experiment scaffold" $
+      parseWireFixture "examples/wire/qec-repetition-code-forced-errors.wire"
+
     it "parses the quantum eraser sweep circuit examples" $
       mapM_ parseWireFixture quantumEraserSweepFixtures
 

--- a/test/Cortex/Wire/QuantumPackageSpec.hs
+++ b/test/Cortex/Wire/QuantumPackageSpec.hs
@@ -1,0 +1,68 @@
+{- |
+Module      : Cortex.Wire.QuantumPackageSpec
+Description : Tests for the quantum Wire packages (ADR 0059 / ADR 0054).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The composed quantum package registry resolves @use quantum.core/qec/braket@ leaves
+and contracts to their canonical ids, and exposes the @quantum.realize@ projection —
+all inert, with no host binding pack present (the ADR 0054 invariant).
+-}
+module Cortex.Wire.QuantumPackageSpec (spec) where
+
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Test.Hspec
+
+import Cortex.Wire.Executor (WireExecutorId (..), WireExecutorProjection (..))
+import Cortex.Wire.Package (WirePackage (..), packageNamespaceRegistry)
+import Cortex.Wire.Quantum
+import Cortex.Wire.Syntax (QName (..), UseItem (..), UseSpec (..))
+import Cortex.Wire.Use
+
+notTaken :: Text -> Bool
+notTaken = const False
+
+useSpec :: [Text] -> [UseItem] -> UseSpec
+useSpec ns (i : is) = UseSpec {useSpecNamespace = qn ns, useSpecItems = i :| is}
+  where
+    qn (x : xs) = QName (x :| xs)
+    qn [] = error "empty namespace"
+useSpec _ [] = error "empty items"
+
+spec :: Spec
+spec = describe "quantum Wire packages" $ do
+  let registry = packageNamespaceRegistry quantumPackages
+
+  it "resolves quantum.core gate leaves and contracts" $
+    case applyWireUseSpecs
+      registry
+      notTaken
+      [ useSpec
+          ["quantum", "core"]
+          [UseExecutor "prepare_zero" Nothing, UseExecutor "cnot" Nothing, UseContract "Qubit" Nothing]
+      ] of
+      Left err -> expectationFailure (show err)
+      Right scope -> do
+        Map.lookup "prepare_zero" (wireUseExecutors scope) `shouldBe` Just "quantum.prepare_zero"
+        Map.lookup "cnot" (wireUseExecutors scope) `shouldBe` Just "quantum.cnot"
+        Map.lookup "Qubit" (wireUseContracts scope) `shouldBe` Just "quantum.Qubit"
+
+  it "resolves quantum.braket.@realize to the realize executor id" $
+    case applyWireUseSpecs registry notTaken [useSpec ["quantum", "braket"] [UseExecutor "realize" Nothing]] of
+      Left err -> expectationFailure (show err)
+      Right scope ->
+        Map.lookup "realize" (wireUseExecutors scope) `shouldBe` Just realizeExecutorId
+
+  it "resolves quantum.qec contracts" $
+    case applyWireUseSpecs registry notTaken [useSpec ["quantum", "qec"] [UseContract "Syndrome" Nothing]] of
+      Left err -> expectationFailure (show err)
+      Right scope ->
+        Map.lookup "Syndrome" (wireUseContracts scope) `shouldBe` Just "quantum.Syndrome"
+
+  it "exposes a realize executor projection in the braket package" $
+    fmap (unWireExecutorId . wireExecutorProjectionId) (wpExecutorProjections quantumBraketPackage)
+      `shouldBe` ["quantum.realize"]

--- a/test/Cortex/Wire/RealizeCompileSpec.hs
+++ b/test/Cortex/Wire/RealizeCompileSpec.hs
@@ -1,0 +1,52 @@
+{- |
+Module      : Cortex.Wire.RealizeCompileSpec
+Description : The realize collect-node compiles with the quantum Wire packages (ADR 0059 / 0054).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+A circuit authored against @use quantum.core.{…}@ / @use quantum.braket.{@realize}@,
+collecting the gate frontier into a @\@realize@ node whose outputs are the named
+measurements, compiles through the normal path — the package `use` resolves and the
+realize node is admitted. This is the ADR 0054 invariant (compile succeeds with no
+host binding pack present; only runnable lowering needs one).
+-}
+module Cortex.Wire.RealizeCompileSpec (spec) where
+
+import Data.Either (isRight)
+import Data.Text (Text)
+import Test.Hspec
+
+import Cortex.Wire.Compile (compileWireText)
+
+realizeCircuit :: Text
+realizeCircuit =
+  "use quantum.core.{@prepare_zero, @cnot};\n\
+  \use quantum.braket.{@realize};\n\
+  \\n\
+  \contract Qubit;\n\
+  \contract Bit;\n\
+  \\n\
+  \node prep_c -> control: Qubit = @prepare_zero { index = 0; } (null);\n\
+  \node prep_t -> target: Qubit = @prepare_zero { index = 1; } (null);\n\
+  \node entangle\n\
+  \  <- control: Qubit;\n\
+  \  <- target: Qubit;\n\
+  \  -> control: Qubit;\n\
+  \  -> target: Qubit;\n\
+  \  = @cnot ({ inherit control; inherit target; });\n\
+  \node collect\n\
+  \  <- control: Qubit;\n\
+  \  <- target: Qubit;\n\
+  \  -> s0: Bit;\n\
+  \  -> s1: Bit;\n\
+  \  = @realize ({ inherit control; inherit target; });\n\
+  \\n\
+  \(prep_c <> prep_t) => entangle => collect\n"
+
+spec :: Spec
+spec =
+  describe "realize collect-node compilation"
+    . it "compiles a circuit collected into @realize using the quantum packages"
+    $ compileWireText realizeCircuit `shouldSatisfy` isRight

--- a/test/sql/pulse-schema.sql
+++ b/test/sql/pulse-schema.sql
@@ -706,3 +706,29 @@ ALTER TABLE ONLY pulse.stage_log
 
 \unrestrict DOlga0R2I8dGBjDPPixbHVuE2Odt9zBedCgHJMt1barnnDbmVmzS3Nz4JmmmMgr
 
+
+
+--
+-- Name: external_call_attempts; Type: TABLE; Schema: pulse; Owner: -
+-- ADR 0059 §3: durable home for a submit/park/resume external call's idempotency
+-- key, frozen fused plan, provider job handle, and completion signal name.
+--
+
+CREATE TABLE pulse.external_call_attempts (
+    attempt_id bigserial PRIMARY KEY,
+    run_id uuid NOT NULL,
+    node_id text NOT NULL,
+    runtime_binding_id text NOT NULL,
+    frontier_id text NOT NULL,
+    idempotency_key text NOT NULL,
+    frozen_plan jsonb NOT NULL,
+    job_handle jsonb,
+    signal_name text,
+    status text DEFAULT 'reserved'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    submitted_at timestamp with time zone,
+    settled_at timestamp with time zone
+);
+
+CREATE UNIQUE INDEX idx_pulse_external_call_attempts_key
+    ON pulse.external_call_attempts USING btree (run_id, node_id, runtime_binding_id, frontier_id);

--- a/theory/README.md
+++ b/theory/README.md
@@ -236,6 +236,18 @@ Mechanized results now include:
   overlay preservation under node-and-endpoint-domain disjointness, certified single-pair and bulk
   source contraction, contraction lowering, bulk-contraction lowering, and a certified
   operation/node-port interface that exposes bundled source-linearity proofs.
+- **OPEN OBLIGATION — `realize_preserves_portLinear` (ADR 0059 §2).** The realize frontier
+  contraction (collecting a same-authority external-call frontier into one realize node, ADR 0059)
+  must preserve `PortLinear`. It does **not** reduce to `bulkContract_preserves_portLinear`:
+  `BulkContract` monotonically _erases_ exposed outputs as it consumes endpoints, whereas realize
+  erases the collected frontier's exposed outputs _and re-introduces_ one fresh exposed output per
+  named measurement on the surviving realize node. The discharge is therefore a genuinely new lemma
+  over a `realizeContract` construction
+  (`exposedOutputs := (graph.exposedOutputs \ collected) ∪ measurements`), governed by ADR 0035's
+  rewrite boundary laws with the collected external-call resource accounted under ADR 0032. Tracked,
+  not yet discharged; the decidable admission gate that makes the contraction legal is implemented
+  and tested in `Cortex.Pulse.Rewrite.Contract` (`admitFrontierContraction`). No `sorry` is
+  committed (the Lean gate is sorry-free); this entry is the obligation of record.
 - `LinearPortGraph.MakeWitness`, `LinearPortGraph.MakeWitness.toObject`,
   `LinearPortGraph.MakeWitness.make_disjoint_of_distinctBindings`,
   `LinearPortGraph.PhantomDirection`, `LinearPortGraph.ProductAdapterKind`,


### PR DESCRIPTION
## Summary

Adds a pure Wire QEC repetition-code forced-error workbench. The new Wire file is both the circuit catalog and the executable experiment graph: it exports four selected circuit graphs, runs them through the existing generic IBM Runtime REST bridge via std.io.command leaves, parses JSON with fromJson, and renders the syndrome/lookup report in Wire.

The public app now matches the existing hardware examples:

```sh
nix run .#wire-quantum-qec-repetition -- --confirm-hardware
```

The selected circuit graphs carry `@quantum.ibm_runtime_config { path = "quantum-ibm-runtime.local.json"; }`, so hardware credentials stay in the existing ignored IBM Runtime config file. Local simulator inspection remains available through `wire-quantum-qiskit` on a selected export.

Also updates the generic quantum bridges so analyzer code can consume per-output measurement counts and so IBM REST dry-runs lower h/cnot while omitting zero-angle wiring identities.

Closes #269.

## Validation

- nix run .#wire-quantum-qec-repetition  # confirms hardware usage guard exits 64 without --confirm-hardware
- nix run .#wire-quantum-qiskit -- examples/wire/qec-repetition-code-forced-errors.wire --return qec_repetition_x1 --shots 128 --seed 7 --json
- nix run .#wire-quantum-ibm-rest -- examples/wire/qec-repetition-code-forced-errors.wire --return qec_repetition_x1 --dry-run --config examples/wire/quantum-ibm-runtime.config.example.json --shots 16 --json
- just test-match QEC
- just docs-check
- just fmt-check
- just wire-style-check
- just check-commit-provenance origin/main..HEAD
