### PR TITLE
fix(wire): replay select binding in variant order

### DIFF
--- a/src/Cortex/Wire/AdmissionBinding.hs
+++ b/src/Cortex/Wire/AdmissionBinding.hs
@@ -70,6 +70,7 @@ import Cortex.Wire.AST (Connection (..), EndpointRef (..))
 import Cortex.Wire.AdmissionArtifact
   ( SelectAdmissionArtifact (..)
   , SelectArmAdmissionArtifact (..)
+  , SelectVariantArtifact (..)
   , WireAdmissionArtifact (..)
   , wireAdmissionCurrentSchemaVersion
   , wireAdmissionMetadataKey
@@ -253,10 +254,19 @@ bindsSelectBodies artifact circuit =
           Nothing -> Left (BindingSelectConditionNodeMissing conditionRef)
           Just (CompiledCircuitCondition conditionNode) -> Right conditionNode
           Just _otherNode -> Left (BindingSelectConditionNodeNotCondition conditionRef)
-      -- Emitted rows are already ordered by source index; sorting makes the
-      -- replay independent of row order for artifacts that arrive decoded.
-      let orderedArms = sortOn (.selectArmSourceIndex) selectRow.selectAdmissionArms
+      let orderedArms = selectArmsInVariantOrder selectRow
       checkConditionTree conditionRef orderedArms conditionNode
+
+    selectArmsInVariantOrder selectRow =
+      sortOn armOrder selectRow.selectAdmissionArms
+      where
+        variantOrder =
+          Map.fromList
+            (zip (fmap (.selectVariantKey) selectRow.selectAdmissionVariants) [0 :: Int ..])
+        armOrder arm =
+          ( Map.findWithDefault maxBound arm.selectArmCanonicalKey variantOrder
+          , arm.selectArmSourceIndex
+          )
 
     -- Mirrors buildSelectConditionTree: the first arm forms the then group,
     -- the remaining arms the else group, recursing for nested groups.

--- a/test/Cortex/Wire/CompileSpec.hs
+++ b/test/Cortex/Wire/CompileSpec.hs
@@ -3719,6 +3719,16 @@ spec = describe "Cortex.Wire.Compile" $ do
       compiled <- requireRight (compileWireText selectSourceText)
       expectArtifactBindsCircuit compiled
 
+    it "binds source-reordered select arms with non-identity bodies" $ do
+      compiled <- requireRight (compileWireText selectReorderedNonIdentityArmsSourceText)
+      expectArtifactBindsCircuit compiled
+      artifact <- requireWireAdmissionArtifact compiled
+      case artifact.wireAdmissionSelects of
+        [selectRow] ->
+          fmap selectArmSourceKey selectRow.selectAdmissionArms `shouldBe` ["killed", "survived"]
+        otherRows ->
+          expectationFailure ("expected exactly one select row, got: " <> show otherRows)
+
     it "binds the contract-fallback select artifact to its compiled circuit" $ do
       compiled <- requireRight (compileWireText selectContractFallbackSourceText)
       expectArtifactBindsCircuit compiled
@@ -4659,6 +4669,30 @@ selectReorderedArmsSourceText =
     , "  issue: (gather_missing_constraints => repair_plan),"
     , "  ok: ()"
     , ") => publish_report"
+    ]
+
+selectReorderedNonIdentityArmsSourceText :: T.Text
+selectReorderedNonIdentityArmsSourceText =
+  T.unlines
+    [ "node decide"
+    , "  -> survived: SurvivedClaims | killed: CandidateRejection ;"
+    , "  = @demo.decide ({}) ;"
+    , "node kill_note_momentum"
+    , "  <- killed: CandidateRejection ;"
+    , "  -> out: Momentum = @demo.kill_note_momentum (killed) ;"
+    , "node themis_momentum"
+    , "  <- survived: SurvivedClaims ;"
+    , "  -> themis: ThemisMomentum = @demo.themis_momentum (survived) ;"
+    , "node techne_momentum"
+    , "  <- themis: ThemisMomentum ;"
+    , "  -> out: Momentum = @demo.techne_momentum (themis) ;"
+    , "node publish"
+    , "  <- out: Momentum ;"
+    , "  -> report: Report = @demo.publish (out) ;"
+    , "decide select("
+    , "  killed: kill_note_momentum,"
+    , "  survived: (themis_momentum => techne_momentum)"
+    , ") => publish"
     ]
 
 selectContractFallbackSourceText :: T.Text


### PR DESCRIPTION
## Summary

Fixes Wire admission artifact binding for `select(...)` clauses whose source arm order differs from the selector boundary order.

The compiler already resolves arms by label/contract and lowers the condition tree in selector variant order. The binding checker was replaying branch bodies in source order, which could produce `BindingSelectBranchBodyMismatch` for valid non-identity arms.

## Changes

- Replay select admission arms in resolved selector variant order during artifact/circuit binding.
- Preserve source-order arm rows in the persisted admission artifact for diagnostics/provenance.
- Add a regression test with non-identity reordered arms, including a two-node sequenced branch.

## Validation

- `just test-match "source-reordered select arms"`
- `just test-match "admission artifact circuit binding"`
- `just fmt-check`
- `just lint`
- `just check-commit-provenance origin/main..HEAD`

The original public `wire build` repro now succeeds.