### PR TITLE
feat(wire): add catalog and package foundations

### DIFF
--- a/cortex.cabal
+++ b/cortex.cabal
@@ -139,6 +139,10 @@ library
         Cortex.Algebra.Graph.Search
         Cortex.Algebra.Graph.Validate
         Cortex.Capability
+        Cortex.Capability.Catalog.AdmissionProjection
+        Cortex.Capability.Catalog.AwaitStrategy
+        Cortex.Capability.Catalog.ExecutorManifest
+        Cortex.Capability.Catalog.RuntimeBindingRecord
         Cortex.Capability.Executor
         Cortex.Capability.Executor.Pure
         Cortex.Pulse
@@ -273,6 +277,7 @@ test-suite cortex-test
     other-modules:
         Cortex.Algebra.GraphSpec
         Cortex.CanonicalModuleTreeSpec
+        Cortex.Capability.CatalogSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -143,6 +143,7 @@ library
         Cortex.Capability.Catalog.AwaitStrategy
         Cortex.Capability.Catalog.ExecutorManifest
         Cortex.Capability.Catalog.RuntimeBindingRecord
+        Cortex.Capability.BindingPack
         Cortex.Capability.Executor
         Cortex.Capability.Executor.Pure
         Cortex.Pulse
@@ -183,6 +184,7 @@ library
         Cortex.Wire.Pure
         Cortex.Wire.Std
         Cortex.Wire.Syntax
+        Cortex.Wire.Package
         Cortex.Wire.Use
         Cortex.Wire.Circuit
         Cortex.Wire.Circuit.Artifact
@@ -278,6 +280,7 @@ test-suite cortex-test
         Cortex.Algebra.GraphSpec
         Cortex.CanonicalModuleTreeSpec
         Cortex.Capability.CatalogSpec
+        Cortex.Wire.PackageSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/src/Cortex/Capability/BindingPack.hs
+++ b/src/Cortex/Capability/BindingPack.hs
@@ -1,0 +1,46 @@
+{- |
+Module      : Cortex.Capability.BindingPack
+Description : ADR 0054 host runtime binding pack — the only artifact with runtime authority.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+A host runtime binding pack (ADR 0054) is the sole artifact that carries runtime
+authority. It depends on one or more Wire packages (never the reverse), resolves
+their declared executor requirements against concrete host authority, and mints the
+ADR 0053 runtime binding records a runnable Circuit carries into Pulse dispatch.
+
+This module defines the inert descriptor; a concrete pack (e.g. the Braket pack,
+ADR 0059 phase P7) supplies the runnable @StageAction@s the records reference.
+-}
+module Cortex.Capability.BindingPack
+  ( HostBindingPack (..)
+  , lookupBinding
+  )
+where
+
+import Data.List (find)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Cortex.Capability.Catalog.RuntimeBindingRecord (RuntimeBindingRecord (..))
+import Cortex.Wire.Executor (WireExecutorId)
+
+data HostBindingPack = HostBindingPack
+  { hbpIdentity :: !Text
+  -- ^ The pack's identity (e.g. @braket-pack@).
+  , hbpWirePackageDeps :: ![Text]
+  -- ^ Ids of the Wire packages this pack binds (dependency is one-way: pack → package).
+  , hbpRuntimeBindings :: ![RuntimeBindingRecord]
+  -- ^ The minted binding records, one per executor id this pack resolves.
+  }
+  deriving stock (Eq, Show, Generic)
+
+{- | Resolve an executor id to its minted runtime binding record, if this pack binds it.
+A missing result is the @missing runtime binding@ condition (ADR 0054): compile
+succeeds without a pack; only runnable Pulse lowering fails.
+-}
+lookupBinding :: WireExecutorId -> HostBindingPack -> Maybe RuntimeBindingRecord
+lookupBinding executorId pack =
+  find ((== executorId) . rbrExecutorId) (hbpRuntimeBindings pack)

--- a/src/Cortex/Capability/Catalog/AdmissionProjection.hs
+++ b/src/Cortex/Capability/Catalog/AdmissionProjection.hs
@@ -1,0 +1,208 @@
+{- |
+Module      : Cortex.Capability.Catalog.AdmissionProjection
+Description : ADR 0053 admission projection — the inert public surface of an executor.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The admission projection is the compile-time, authority-free description of an
+executor that Wire and Capability check against (ADR 0053): identity, a projection
+version, a content digest, typed ports, a config schema reference, declared
+requirement slots, and the replay / isolation / effect / await-strategy metadata
+the runtime binding later honours. It carries no runnable action and no credentials.
+
+The registry invariant is @(executor id, projection version)@ uniquely identifies
+projection content; two manifests claiming the same pair must agree on the digest.
+
+JSON is hand-written because the reused Wire port types do not round-trip through
+their derived instances; the digest is taken over a canonical field tuple so it is
+stable regardless of JSON object ordering (mirrors 'Cortex.Pulse.Materialization.computeTopologyHash').
+-}
+module Cortex.Capability.Catalog.AdmissionProjection
+  ( AdmissionProjection (..)
+  , ProjectionVersion (..)
+  , ContentDigest (..)
+  , ConfigSchemaRef (..)
+  , RequirementSlot (..)
+  , admissionProjectionDigest
+  , encodeWirePorts
+  , decodeWirePorts
+  )
+where
+
+import Crypto.Hash (SHA256, hashlazy)
+import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.!=), (.:), (.:?), (.=))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.Types (Parser)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHC.Generics (Generic)
+
+import Cortex.Capability.Catalog.AwaitStrategy
+  ( AwaitStrategy
+  , IsolationExpectation
+  , ReplayClass
+  )
+import Cortex.Wire.AST
+  ( WireInputCardinality (..)
+  , WireInputPort (..)
+  , WireOutputPort (..)
+  , WirePorts (..)
+  )
+import Cortex.Wire.Executor
+  ( WireExecutorEffect (..)
+  , WireExecutorId (..)
+  )
+
+newtype ProjectionVersion = ProjectionVersion {unProjectionVersion :: Text}
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (ToJSON, FromJSON)
+
+newtype ContentDigest = ContentDigest {unContentDigest :: Text}
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (ToJSON, FromJSON)
+
+{- | A reference to the executor's config schema (digest or named decoder), never
+the config itself (ADR 0053 keeps config data pure and out of the projection).
+-}
+data ConfigSchemaRef
+  = ConfigSchemaNone
+  | ConfigSchemaDigest ContentDigest
+  | ConfigSchemaName Text
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+{- | A declared requirement the binding layer must satisfy: a capability kind, the
+local binding name the host resolves, an optional config selector path, and the
+required permission class. Inert — declaring a requirement does not grant it.
+-}
+data RequirementSlot = RequirementSlot
+  { rsCapabilityKind :: !Text
+  , rsBindingName :: !Text
+  , rsConfigSelector :: !(Maybe Text)
+  , rsPermissionClass :: !(Maybe Text)
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+data AdmissionProjection = AdmissionProjection
+  { apExecutorId :: !WireExecutorId
+  , apProjectionVersion :: !ProjectionVersion
+  , apPorts :: !WirePorts
+  , apConfigSchemaRef :: !ConfigSchemaRef
+  , apRequirementSlots :: ![RequirementSlot]
+  , apReplayClass :: !ReplayClass
+  , apIsolationExpectation :: !IsolationExpectation
+  , apEffect :: !WireExecutorEffect
+  , apAwaitStrategy :: !AwaitStrategy
+  }
+  deriving stock (Eq, Show, Generic)
+
+instance ToJSON AdmissionProjection where
+  toJSON p =
+    object
+      [ "executorId" .= unWireExecutorId (apExecutorId p)
+      , "projectionVersion" .= apProjectionVersion p
+      , "ports" .= encodeWirePorts (apPorts p)
+      , "configSchemaRef" .= apConfigSchemaRef p
+      , "requirementSlots" .= apRequirementSlots p
+      , "replayClass" .= apReplayClass p
+      , "isolationExpectation" .= apIsolationExpectation p
+      , "effect" .= effectText (apEffect p)
+      , "awaitStrategy" .= apAwaitStrategy p
+      ]
+
+instance FromJSON AdmissionProjection where
+  parseJSON = withObject "AdmissionProjection" $ \o ->
+    AdmissionProjection . WireExecutorId
+      <$> o .: "executorId"
+      <*> o .: "projectionVersion"
+      <*> (o .: "ports" >>= decodeWirePorts)
+      <*> o .: "configSchemaRef"
+      <*> o .:? "requirementSlots" .!= []
+      <*> o .: "replayClass"
+      <*> o .: "isolationExpectation"
+      <*> (o .: "effect" >>= parseEffect)
+      <*> o .: "awaitStrategy"
+
+{- | Deterministic content digest over the projection's defining fields. Taken over
+a canonical tuple (not the JSON object) so object key ordering cannot perturb it.
+-}
+admissionProjectionDigest :: AdmissionProjection -> ContentDigest
+admissionProjectionDigest p =
+  let canonical =
+        Aeson.encode
+          ( unWireExecutorId (apExecutorId p)
+          , unProjectionVersion (apProjectionVersion p)
+          , canonicalPorts (apPorts p)
+          , toJSON (apConfigSchemaRef p)
+          , toJSON (apRequirementSlots p)
+          , toJSON (apReplayClass p)
+          , toJSON (apIsolationExpectation p)
+          , effectText (apEffect p)
+          , toJSON (apAwaitStrategy p)
+          )
+      digest = hashlazy @SHA256 canonical
+   in ContentDigest (T.pack (show digest))
+
+-- Canonical, order-stable encoding of ports for the digest: sorted association
+-- lists rather than a map/object.
+canonicalPorts :: WirePorts -> Aeson.Value
+canonicalPorts ports =
+  toJSON
+    ( [ (name, p.wireInputPortAccepts, cardinalityText p.wireInputPortCardinality, p.wireInputPortRequired)
+      | (name, p) <- Map.toAscList ports.wirePortsInputs
+      ]
+    , [ (name, p.wireOutputPortContract)
+      | (name, p) <- Map.toAscList ports.wirePortsOutputs
+      ]
+    )
+
+{- | Encode ports in the shape 'FromJSON' 'WirePorts' reads (object form with
+@inputs@/@outputs@ maps and @accepts@/@cardinality@/@required@/@contract@ fields).
+-}
+encodeWirePorts :: WirePorts -> Aeson.Value
+encodeWirePorts ports =
+  object
+    [ "inputs"
+        .= object
+          [ Key.fromText name
+              .= object
+                [ "accepts" .= p.wireInputPortAccepts
+                , "cardinality" .= cardinalityText p.wireInputPortCardinality
+                , "required" .= p.wireInputPortRequired
+                ]
+          | (name, p) <- Map.toList ports.wirePortsInputs
+          ]
+    , "outputs"
+        .= object
+          [ Key.fromText name .= object ["contract" .= p.wireOutputPortContract]
+          | (name, p) <- Map.toList ports.wirePortsOutputs
+          ]
+    ]
+
+decodeWirePorts :: Aeson.Value -> Parser WirePorts
+decodeWirePorts = parseJSON
+
+cardinalityText :: WireInputCardinality -> Text
+cardinalityText = \case
+  WireInputCardinalityOne -> "one"
+  WireInputCardinalityMany -> "many"
+
+effectText :: WireExecutorEffect -> Text
+effectText = \case
+  WireExecutorPure -> "pure"
+  WireExecutorModel -> "model"
+  WireExecutorHostEffect -> "host_effect"
+  WireExecutorImpure -> "impure"
+
+parseEffect :: Text -> Parser WireExecutorEffect
+parseEffect = \case
+  "pure" -> pure WireExecutorPure
+  "model" -> pure WireExecutorModel
+  "host_effect" -> pure WireExecutorHostEffect
+  "impure" -> pure WireExecutorImpure
+  other -> fail ("unknown executor effect: " <> T.unpack other)

--- a/src/Cortex/Capability/Catalog/AwaitStrategy.hs
+++ b/src/Cortex/Capability/Catalog/AwaitStrategy.hs
@@ -1,0 +1,134 @@
+{- |
+Module      : Cortex.Capability.Catalog.AwaitStrategy
+Description : Executor await strategy, replay class, and isolation expectation.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Small shared enumerations that ride the ADR 0053 admission projection and runtime
+binding record. They are inert catalog metadata: the host binding declares them,
+and Pulse never interprets them — it dispatches an opaque @StageAction@ and reacts
+only to complete-or-suspend (ADR 0059 §3).
+
+These types stay consumer-neutral; they classify executor authority, not product policy.
+-}
+module Cortex.Capability.Catalog.AwaitStrategy
+  ( AwaitStrategy (..)
+  , awaitStrategyText
+  , parseAwaitStrategy
+  , ReplayClass (..)
+  , replayClassText
+  , parseReplayClass
+  , IsolationExpectation (..)
+  , isolationExpectationText
+  , parseIsolationExpectation
+  )
+where
+
+import Data.Aeson (FromJSON (..), ToJSON (..), withText)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+{- | Whether a bound stage returns its result inline or submits, suspends, and
+resumes on an ordinary durable signal (ADR 0059 §3). The field is declared at the
+executor level so it applies equally to a long-running @ModelExecutor@.
+-}
+data AwaitStrategy
+  = -- | The bound action runs the effect inline and completes in one transaction.
+    Synchronous
+  | {- | The bound action submits, returns a job handle, and suspends until a
+    durable completion signal wakes it.
+    -}
+    SubmitParkResume
+  deriving stock (Eq, Show, Generic)
+
+awaitStrategyText :: AwaitStrategy -> Text
+awaitStrategyText = \case
+  Synchronous -> "synchronous"
+  SubmitParkResume -> "submit_park_resume"
+
+parseAwaitStrategy :: Text -> Either Text AwaitStrategy
+parseAwaitStrategy = \case
+  "synchronous" -> Right Synchronous
+  "submit_park_resume" -> Right SubmitParkResume
+  other -> Left ("unknown await strategy: " <> other)
+
+instance ToJSON AwaitStrategy where
+  toJSON = toJSON . awaitStrategyText
+
+instance FromJSON AwaitStrategy where
+  parseJSON = withText "AwaitStrategy" (either (fail . show) pure . parseAwaitStrategy)
+
+{- | How an executor's output is reproduced across a replay (ADR 0053). Recorded
+as catalog metadata; the @submit_park_resume@ external-call path requires an
+idempotency-keyed or exactly-once class to be admissible (ADR 0059 §3).
+-}
+data ReplayClass
+  = Deterministic
+  | ReplayByRerun
+  | ReplayByReusingRecordedOutputs
+  | IdempotentWithKey
+  | ExactlyOnceViaCommitLog
+  | NonReplayable
+  deriving stock (Eq, Show, Generic)
+
+replayClassText :: ReplayClass -> Text
+replayClassText = \case
+  Deterministic -> "deterministic"
+  ReplayByRerun -> "replay_by_rerun"
+  ReplayByReusingRecordedOutputs -> "replay_by_reusing_recorded_outputs"
+  IdempotentWithKey -> "idempotent_with_key"
+  ExactlyOnceViaCommitLog -> "exactly_once_via_commit_log"
+  NonReplayable -> "non_replayable"
+
+parseReplayClass :: Text -> Either Text ReplayClass
+parseReplayClass = \case
+  "deterministic" -> Right Deterministic
+  "replay_by_rerun" -> Right ReplayByRerun
+  "replay_by_reusing_recorded_outputs" -> Right ReplayByReusingRecordedOutputs
+  "idempotent_with_key" -> Right IdempotentWithKey
+  "exactly_once_via_commit_log" -> Right ExactlyOnceViaCommitLog
+  "non_replayable" -> Right NonReplayable
+  other -> Left ("unknown replay class: " <> other)
+
+instance ToJSON ReplayClass where
+  toJSON = toJSON . replayClassText
+
+instance FromJSON ReplayClass where
+  parseJSON = withText "ReplayClass" (either (fail . show) pure . parseReplayClass)
+
+{- | The minimum isolation an executor package requests at runtime (ADR 0053).
+Inert until a host binding pack honours it.
+-}
+data IsolationExpectation
+  = InProcess
+  | WasmSandbox
+  | SubprocessSandbox
+  | Container
+  | BrokeredProcess
+  deriving stock (Eq, Show, Generic)
+
+isolationExpectationText :: IsolationExpectation -> Text
+isolationExpectationText = \case
+  InProcess -> "in_process"
+  WasmSandbox -> "wasm_sandbox"
+  SubprocessSandbox -> "subprocess_sandbox"
+  Container -> "container"
+  BrokeredProcess -> "brokered_process"
+
+parseIsolationExpectation :: Text -> Either Text IsolationExpectation
+parseIsolationExpectation = \case
+  "in_process" -> Right InProcess
+  "wasm_sandbox" -> Right WasmSandbox
+  "subprocess_sandbox" -> Right SubprocessSandbox
+  "container" -> Right Container
+  "brokered_process" -> Right BrokeredProcess
+  other -> Left ("unknown isolation expectation: " <> other)
+
+instance ToJSON IsolationExpectation where
+  toJSON = toJSON . isolationExpectationText
+
+instance FromJSON IsolationExpectation where
+  parseJSON =
+    withText "IsolationExpectation" (either (fail . show) pure . parseIsolationExpectation)

--- a/src/Cortex/Capability/Catalog/ExecutorManifest.hs
+++ b/src/Cortex/Capability/Catalog/ExecutorManifest.hs
@@ -1,0 +1,78 @@
+{- |
+Module      : Cortex.Capability.Catalog.ExecutorManifest
+Description : ADR 0053 executor manifest — the runnable-artifact descriptor.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The executor manifest is produced by an executor package and consumed by the build
+system and host runtime binding (ADR 0053). It is still inert: it names an artifact,
+its ABI, its provenance, and the projection it implements, but it grants no authority
+on its own — only a host binding pack turns a manifest into a runtime binding record.
+
+Pulse never consumes manifests directly.
+-}
+module Cortex.Capability.Catalog.ExecutorManifest
+  ( ExecutorManifest (..)
+  , AbiKind (..)
+  , ContentAddress (..)
+  , OutputCommitPolicy (..)
+  )
+where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Cortex.Capability.Catalog.AdmissionProjection
+  ( ContentDigest
+  , ProjectionVersion
+  )
+import Cortex.Capability.Catalog.AwaitStrategy (IsolationExpectation, ReplayClass)
+import Cortex.Wire.Executor (WireExecutorId)
+
+newtype ContentAddress = ContentAddress {unContentAddress :: Text}
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (ToJSON, FromJSON)
+
+{- | The driver/ABI kind through which the host invokes the artifact. @host-action-v1@
+is one option, not the required mechanism (ADR 0059 §3).
+-}
+data AbiKind
+  = AbiHostActionV1
+  | AbiSubprocessJsonl
+  | AbiInProcessNative
+  | AbiWasmComponent
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+{- | How the executor's outputs are committed relative to its effect (informs the
+replay class for @submit_park_resume@ external calls).
+-}
+data OutputCommitPolicy
+  = CommitOnComplete
+  | CommitViaAttemptRecord
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+data ExecutorManifest = ExecutorManifest
+  { emSchemaVersion :: !Text
+  , emContentAddress :: !ContentAddress
+  , emSignature :: !(Maybe Text)
+  , emExecutorId :: !WireExecutorId
+  , emProjectionVersion :: !ProjectionVersion
+  , emProjectionDigest :: !ContentDigest
+  , emArtifactRef :: !ContentAddress
+  , emArtifactDigest :: !ContentDigest
+  , emAbiKind :: !AbiKind
+  , emAbiVersion :: !Text
+  , emAbiDriverIdentity :: !Text
+  , emProvenance :: !(Maybe Text)
+  , emPermissions :: ![Text]
+  , emIsolationExpectation :: !IsolationExpectation
+  , emReplayClass :: !ReplayClass
+  , emOutputCommitPolicy :: !OutputCommitPolicy
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)

--- a/src/Cortex/Capability/Catalog/RuntimeBindingRecord.hs
+++ b/src/Cortex/Capability/Catalog/RuntimeBindingRecord.hs
@@ -1,0 +1,72 @@
+{- |
+Module      : Cortex.Capability.Catalog.RuntimeBindingRecord
+Description : ADR 0053 runtime binding record — the minted, authority-bearing binding.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+A runtime binding record is what a host runtime binding pack mints (ADR 0053/0054)
+when it resolves an executor manifest against concrete host authority. It is the
+record a runnable Circuit carries into Pulse dispatch. Pulse reads only the opaque
+action reference and the accepted replay/await metadata; it does not interpret the
+backend (ADR 0059 §3).
+
+This module stays Pulse-free: the bound action is named by an opaque text reference
+('RuntimeStageActionRef'), so the catalog layer does not depend on the Pulse runtime.
+-}
+module Cortex.Capability.Catalog.RuntimeBindingRecord
+  ( RuntimeBindingRecord (..)
+  , RuntimeStageActionRef (..)
+  , ResolvedAuthorityFingerprint (..)
+  )
+where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Cortex.Capability.Catalog.AdmissionProjection (ContentDigest, ProjectionVersion)
+import Cortex.Capability.Catalog.AwaitStrategy (AwaitStrategy, IsolationExpectation, ReplayClass)
+import Cortex.Capability.Catalog.ExecutorManifest (AbiKind, ContentAddress)
+import Cortex.Wire.Executor (WireExecutorId)
+
+{- | Opaque reference to the bound Pulse stage action. Kept as text so the catalog
+layer does not import the Pulse runtime; the host resolves it to a @StageAction@.
+-}
+newtype RuntimeStageActionRef = RuntimeStageActionRef {unRuntimeStageActionRef :: Text}
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (ToJSON, FromJSON)
+
+{- | A fingerprint of a resolved authority (provider, tool, model policy, secret
+handle) the binding depends on, recorded for provenance without embedding the
+authority itself.
+-}
+data ResolvedAuthorityFingerprint = ResolvedAuthorityFingerprint
+  { rafKind :: !Text
+  , rafName :: !Text
+  , rafDigest :: !ContentDigest
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+data RuntimeBindingRecord = RuntimeBindingRecord
+  { rbrBindingId :: !Text
+  , rbrBindingVersion :: !Text
+  , rbrExecutorId :: !WireExecutorId
+  , rbrProjectionVersion :: !ProjectionVersion
+  , rbrStageActionRef :: !RuntimeStageActionRef
+  , rbrManifestContentAddress :: !ContentAddress
+  , rbrArtifactDigest :: !ContentDigest
+  , rbrAbiKind :: !AbiKind
+  , rbrAbiVersion :: !Text
+  , rbrAbiDriverDigest :: !ContentDigest
+  , rbrBindingPackIdentity :: !Text
+  , rbrResolvedAuthorities :: ![ResolvedAuthorityFingerprint]
+  , rbrIsolation :: !IsolationExpectation
+  , rbrAcceptedReplayClass :: !ReplayClass
+  , rbrAcceptedAwaitStrategy :: !AwaitStrategy
+  , rbrCompatibilityDigest :: !ContentDigest
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)

--- a/src/Cortex/Wire/Compile.hs
+++ b/src/Cortex/Wire/Compile.hs
@@ -138,6 +138,7 @@ import Cortex.Wire.NodeBoundary
   , signalNodeBoundaryNormalForm
   , validateNodeBoundaryNormalForm
   )
+import Cortex.Wire.Package qualified as Package
 import Cortex.Wire.Parser
   ( GeneratedFamilyChild (..)
   , GeneratedFamilyKind (..)
@@ -1398,7 +1399,7 @@ lowerUseSpec :: LoweringState -> UseSpec -> Either WireCore.WireError LoweringSt
 lowerUseSpec st useSpec = do
   useScope <-
     mapLeft wireUseErrorToWireError $
-      applyWireUseSpec (topLevelBindingNameTaken st) st.lsUseScope useSpec
+      applyWireUseSpec Package.stdOnlyRegistry (topLevelBindingNameTaken st) st.lsUseScope useSpec
   Right
     st
       { lsUseScope = useScope

--- a/src/Cortex/Wire/Executor.hs
+++ b/src/Cortex/Wire/Executor.hs
@@ -48,6 +48,7 @@ import Cortex.Wire.AST
 
 newtype WireExecutorId = WireExecutorId {unWireExecutorId :: Text}
   deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (Aeson.ToJSON, Aeson.FromJSON)
 
 wireExecutorIdToText :: WireExecutorId -> Text
 wireExecutorIdToText = unWireExecutorId

--- a/src/Cortex/Wire/Package.hs
+++ b/src/Cortex/Wire/Package.hs
@@ -1,0 +1,95 @@
+{- |
+Module      : Cortex.Wire.Package
+Description : ADR 0054 Wire packages and the namespace registry `use` resolves against.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+A Wire package is inert compile-time vocabulary (ADR 0054): it exports namespaces
+that resolve @use@ leaves to canonical executor and contract ids, plus the executor
+projections and contract specs the compiler checks against. Importing a Wire package
+never grants runtime authority — only a host binding pack (Capability layer) does.
+
+The 'NamespaceRegistry' is the composition @use@ resolves against. @std.io@ is just
+the first namespace in it, not a special case (it is wrapped as a 'NamespaceEntry'
+over the existing 'Cortex.Wire.Std' lookups). This module stays in the Wire layer:
+it carries 'WireExecutorProjection', not the richer Capability catalog projection.
+-}
+module Cortex.Wire.Package
+  ( NamespaceEntry (..)
+  , NamespaceRegistry
+  , namespaceRegistryFromEntries
+  , lookupNamespace
+  , namespaceRegistryNamespaces
+  , stdNamespaceEntry
+  , stdOnlyRegistry
+  , WirePackage (..)
+  , packageNamespaceRegistry
+  )
+where
+
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+
+import Cortex.Wire.Contract (WireContractSpec)
+import Cortex.Wire.Executor (WireExecutorProjection)
+import Cortex.Wire.Std (stdIoContractIdForName, stdIoExecutorIdForLeaf, stdIoNamespace)
+
+{- | One importable namespace. Resolution is by function so an entry can be backed
+by the hardcoded @std.io@ lookups or by a package's maps without enumeration.
+-}
+data NamespaceEntry = NamespaceEntry
+  { nsNamespace :: !Text
+  , nsResolveExecutorLeaf :: !(Text -> Maybe Text)
+  -- ^ @use ns.{@leaf}@ → canonical executor id.
+  , nsResolveContract :: !(Text -> Maybe Text)
+  -- ^ @use ns.{Name}@ → canonical contract id.
+  }
+
+{- | The set of importable namespaces, keyed by namespace text (e.g. @std.io@,
+@quantum.core@). Later entries do not override earlier ones.
+-}
+newtype NamespaceRegistry = NamespaceRegistry (Map Text NamespaceEntry)
+
+namespaceRegistryFromEntries :: [NamespaceEntry] -> NamespaceRegistry
+namespaceRegistryFromEntries entries =
+  NamespaceRegistry (Map.fromList [(nsNamespace e, e) | e <- entries])
+
+lookupNamespace :: Text -> NamespaceRegistry -> Maybe NamespaceEntry
+lookupNamespace ns (NamespaceRegistry m) = Map.lookup ns m
+
+namespaceRegistryNamespaces :: NamespaceRegistry -> [Text]
+namespaceRegistryNamespaces (NamespaceRegistry m) = Map.keys m
+
+-- | @std.io@ as a namespace entry, wrapping the existing 'Cortex.Wire.Std' lookups.
+stdNamespaceEntry :: NamespaceEntry
+stdNamespaceEntry =
+  NamespaceEntry
+    { nsNamespace = stdIoNamespace
+    , nsResolveExecutorLeaf = stdIoExecutorIdForLeaf
+    , nsResolveContract = stdIoContractIdForName
+    }
+
+{- | The registry containing only @std.io@ — today's compile-time default before any
+downstream Wire package is composed in (ADR 0059 phase P6 threads packages in).
+-}
+stdOnlyRegistry :: NamespaceRegistry
+stdOnlyRegistry = namespaceRegistryFromEntries [stdNamespaceEntry]
+
+{- | An inert downstream Wire package (ADR 0054): the namespaces it exports for
+@use@, the executor projections, and the contract specs the compiler checks against.
+No credentials, no runnable action.
+-}
+data WirePackage = WirePackage
+  { wpId :: !Text
+  , wpNamespaceEntries :: ![NamespaceEntry]
+  , wpExecutorProjections :: ![WireExecutorProjection]
+  , wpContractSpecs :: ![WireContractSpec]
+  }
+
+-- | Compose @std.io@ with the given Wire packages into one registry.
+packageNamespaceRegistry :: [WirePackage] -> NamespaceRegistry
+packageNamespaceRegistry packages =
+  namespaceRegistryFromEntries (stdNamespaceEntry : concatMap wpNamespaceEntries packages)

--- a/src/Cortex/Wire/Use.hs
+++ b/src/Cortex/Wire/Use.hs
@@ -33,12 +33,14 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
 
+import Cortex.Wire.Package
+  ( NamespaceEntry (..)
+  , NamespaceRegistry
+  , lookupNamespace
+  )
 import Cortex.Wire.Std
-  ( stdIoContractIdForName
-  , stdIoExecutorIdForLeaf
-  , stdIoExecutorIds
+  ( stdIoExecutorIds
   , stdIoExecutorLeaves
-  , stdIoNamespace
   )
 import Cortex.Wire.Syntax
   ( QName (..)
@@ -68,20 +70,31 @@ emptyWireUseScope =
     , wireUseStdExecutorsInScope = Set.empty
     }
 
-applyWireUseSpecs :: (Text -> Bool) -> [UseSpec] -> Either WireUseError WireUseScope
-applyWireUseSpecs externalNameTaken =
-  foldM (applyWireUseSpec externalNameTaken) emptyWireUseScope
+applyWireUseSpecs
+  :: NamespaceRegistry -> (Text -> Bool) -> [UseSpec] -> Either WireUseError WireUseScope
+applyWireUseSpecs registry externalNameTaken =
+  foldM (applyWireUseSpec registry externalNameTaken) emptyWireUseScope
 
 applyWireUseSpec
-  :: (Text -> Bool) -> WireUseScope -> UseSpec -> Either WireUseError WireUseScope
-applyWireUseSpec externalNameTaken scope useSpec = do
-  when (renderQName useSpec.useSpecNamespace /= stdIoNamespace) $
-    Left (WireUseUnknownNamespace (renderQName useSpec.useSpecNamespace))
-  foldM lowerUseItem scope (NE.toList useSpec.useSpecItems)
+  :: NamespaceRegistry
+  -> (Text -> Bool)
+  -> WireUseScope
+  -> UseSpec
+  -> Either WireUseError WireUseScope
+applyWireUseSpec registry externalNameTaken scope useSpec = do
+  entry <-
+    maybe (Left (WireUseUnknownNamespace namespace)) Right (lookupNamespace namespace registry)
+  foldM (lowerUseItem entry) scope (NE.toList useSpec.useSpecItems)
   where
-    lowerUseItem state = \case
+    namespace = renderQName useSpec.useSpecNamespace
+
+    lowerUseItem entry state = \case
       UseExecutor itemName maybeAlias -> do
-        canonical <- stdIoExecutorId itemName
+        canonical <-
+          maybe
+            (Left (WireUseUnknownItem namespace ("@" <> itemName)))
+            Right
+            (nsResolveExecutorLeaf entry itemName)
         let localName = fromMaybe itemName maybeAlias
         ensureUseNameFresh localName state
         Right
@@ -91,7 +104,11 @@ applyWireUseSpec externalNameTaken scope useSpec = do
                 Set.insert canonical state.wireUseStdExecutorsInScope
             }
       UseContract itemName maybeAlias -> do
-        canonical <- stdIoContractId itemName
+        canonical <-
+          maybe
+            (Left (WireUseUnknownItem namespace itemName))
+            Right
+            (nsResolveContract entry itemName)
         let localName = fromMaybe itemName maybeAlias
         ensureUseNameFresh localName state
         Right
@@ -108,20 +125,6 @@ wireUseLocalNameTaken externalNameTaken scope localName =
   externalNameTaken localName
     || Map.member localName scope.wireUseExecutors
     || Map.member localName scope.wireUseContracts
-
-stdIoExecutorId :: Text -> Either WireUseError Text
-stdIoExecutorId itemName =
-  maybe
-    (Left (WireUseUnknownItem stdIoNamespace ("@" <> itemName)))
-    Right
-    (stdIoExecutorIdForLeaf itemName)
-
-stdIoContractId :: Text -> Either WireUseError Text
-stdIoContractId itemName =
-  maybe
-    (Left (WireUseUnknownItem stdIoNamespace itemName))
-    Right
-    (stdIoContractIdForName itemName)
 
 wireUseDeclaredContracts :: WireUseScope -> Set Text
 wireUseDeclaredContracts scope =

--- a/test/Cortex/Capability/CatalogSpec.hs
+++ b/test/Cortex/Capability/CatalogSpec.hs
@@ -1,0 +1,89 @@
+{- |
+Module      : Cortex.Capability.CatalogSpec
+Description : Tests for the ADR 0053 executor catalog types.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+JSON round-trips (including the hand-written port codec), content-digest
+determinism, and the runtime binding record.
+-}
+module Cortex.Capability.CatalogSpec (spec) where
+
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy (ByteString)
+import Test.Hspec
+
+import Cortex.Capability.Catalog.AdmissionProjection
+import Cortex.Capability.Catalog.AwaitStrategy
+import Cortex.Capability.Catalog.ExecutorManifest (AbiKind (..), ContentAddress (..))
+import Cortex.Capability.Catalog.RuntimeBindingRecord
+import Cortex.Wire.Executor (WireExecutorId (..))
+
+-- A realize-style projection authored as JSON (the port constructors live in the
+-- library-internal Cortex.Wire.AST, so the test exercises the public FromJSON path
+-- rather than importing hidden modules — this also covers the port codec directly).
+sampleProjectionJSON :: ByteString
+sampleProjectionJSON =
+  "{\"executorId\":\"quantum.realize\"\
+  \,\"projectionVersion\":\"1\"\
+  \,\"ports\":{\"inputs\":{\"shots\":{\"accepts\":[\"ShotCount\"],\"cardinality\":\"one\",\"required\":true}}\
+  \,\"outputs\":{\"s01\":{\"contract\":\"MeasurementResult\"},\"s12\":{\"contract\":\"MeasurementResult\"}}}\
+  \,\"configSchemaRef\":{\"tag\":\"ConfigSchemaName\",\"contents\":\"braket-config\"}\
+  \,\"requirementSlots\":[{\"rsCapabilityKind\":\"provider\",\"rsBindingName\":\"braket\"\
+  \,\"rsConfigSelector\":\"config.device\",\"rsPermissionClass\":\"aws.braket\"}]\
+  \,\"replayClass\":\"idempotent_with_key\"\
+  \,\"isolationExpectation\":\"subprocess_sandbox\"\
+  \,\"effect\":\"host_effect\"\
+  \,\"awaitStrategy\":\"submit_park_resume\"}"
+
+sampleProjection :: AdmissionProjection
+sampleProjection =
+  either (error . ("sampleProjection decode: " <>)) id (Aeson.eitherDecode sampleProjectionJSON)
+
+roundTrips :: (Eq a, Show a, Aeson.ToJSON a, Aeson.FromJSON a) => a -> Expectation
+roundTrips x = Aeson.eitherDecode (Aeson.encode x) `shouldBe` Right x
+
+sampleBinding :: RuntimeBindingRecord
+sampleBinding =
+  RuntimeBindingRecord
+    { rbrBindingId = "braket-pack/quantum.realize"
+    , rbrBindingVersion = "1"
+    , rbrExecutorId = WireExecutorId "quantum.realize"
+    , rbrProjectionVersion = ProjectionVersion "1"
+    , rbrStageActionRef = RuntimeStageActionRef "quantum.realize.braket"
+    , rbrManifestContentAddress = ContentAddress "sha256:manifest"
+    , rbrArtifactDigest = ContentDigest "d"
+    , rbrAbiKind = AbiSubprocessJsonl
+    , rbrAbiVersion = "1"
+    , rbrAbiDriverDigest = ContentDigest "dd"
+    , rbrBindingPackIdentity = "braket-pack"
+    , rbrResolvedAuthorities = []
+    , rbrIsolation = SubprocessSandbox
+    , rbrAcceptedReplayClass = IdempotentWithKey
+    , rbrAcceptedAwaitStrategy = SubmitParkResume
+    , rbrCompatibilityDigest = ContentDigest "c"
+    }
+
+spec :: Spec
+spec = do
+  describe "AdmissionProjection JSON" $ do
+    it "round-trips through JSON, including ports" $
+      roundTrips sampleProjection
+    it "round-trips the await strategy / replay / isolation enums" $ do
+      roundTrips Synchronous
+      roundTrips SubmitParkResume
+      roundTrips IdempotentWithKey
+      roundTrips SubprocessSandbox
+
+  describe "admissionProjectionDigest" $ do
+    it "is deterministic for the same projection" $
+      admissionProjectionDigest sampleProjection
+        `shouldBe` admissionProjectionDigest sampleProjection
+    it "changes when a defining field changes" $
+      admissionProjectionDigest sampleProjection
+        `shouldNotBe` admissionProjectionDigest sampleProjection {apAwaitStrategy = Synchronous}
+
+  describe "RuntimeBindingRecord JSON" $
+    it "round-trips" (roundTrips sampleBinding)

--- a/test/Cortex/Wire/PackageSpec.hs
+++ b/test/Cortex/Wire/PackageSpec.hs
@@ -1,0 +1,83 @@
+{- |
+Module      : Cortex.Wire.PackageSpec
+Description : Tests for ADR 0054 Wire packages and namespace `use` resolution.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Resolving @use@ against a composed namespace registry: a non-@std.io@ package
+namespace resolves leaves and contracts, unknown namespaces and items are rejected,
+and @std.io@ still resolves as one entry among others.
+-}
+module Cortex.Wire.PackageSpec (spec) where
+
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Test.Hspec
+
+import Cortex.Wire.Package
+import Cortex.Wire.Syntax (QName (..), UseItem (..), UseSpec (..))
+import Cortex.Wire.Use
+
+quantumCore :: NamespaceEntry
+quantumCore =
+  NamespaceEntry
+    { nsNamespace = "quantum.core"
+    , nsResolveExecutorLeaf = \leaf ->
+        if leaf == "realize" then Just "quantum.realize" else Nothing
+    , nsResolveContract = \name ->
+        if name == "QuantumResult" then Just "quantum.QuantumResult" else Nothing
+    }
+
+registry :: NamespaceRegistry
+registry = namespaceRegistryFromEntries [stdNamespaceEntry, quantumCore]
+
+useQuantum :: UseSpec
+useQuantum =
+  UseSpec
+    { useSpecNamespace = QName ("quantum" :| ["core"])
+    , useSpecItems = UseExecutor "realize" Nothing :| [UseContract "QuantumResult" Nothing]
+    }
+
+useStdOut :: UseSpec
+useStdOut =
+  UseSpec
+    { useSpecNamespace = QName ("std" :| ["io"])
+    , useSpecItems = UseExecutor "stdout" Nothing :| []
+    }
+
+notTaken :: Text -> Bool
+notTaken = const False
+
+spec :: Spec
+spec = do
+  describe "applyWireUseSpecs against a composed registry" $ do
+    it "resolves a non-std package namespace's executor and contract leaves" $
+      case applyWireUseSpecs registry notTaken [useQuantum] of
+        Left err -> expectationFailure ("unexpected: " <> show err)
+        Right scope -> do
+          Map.lookup "realize" (wireUseExecutors scope) `shouldBe` Just "quantum.realize"
+          Map.lookup "QuantumResult" (wireUseContracts scope) `shouldBe` Just "quantum.QuantumResult"
+
+    it "still resolves std.io as one entry among others" $
+      case applyWireUseSpecs registry notTaken [useStdOut] of
+        Left err -> expectationFailure ("unexpected: " <> show err)
+        Right scope ->
+          Map.lookup "stdout" (wireUseExecutors scope) `shouldBe` Just "std.io.stdout"
+
+    it "rejects an unknown namespace" $
+      applyWireUseSpecs registry notTaken [useQuantum {useSpecNamespace = QName ("nope" :| [])}]
+        `shouldBe` Left (WireUseUnknownNamespace "nope")
+
+    it "rejects an unknown item in a known namespace" $
+      applyWireUseSpecs
+        registry
+        notTaken
+        [useQuantum {useSpecItems = UseExecutor "teleport" Nothing :| []}]
+        `shouldBe` Left (WireUseUnknownItem "quantum.core" "@teleport")
+
+  describe "packageNamespaceRegistry" . it "composes std.io with package namespaces" $ do
+    let reg = packageNamespaceRegistry [WirePackage "quantum" [quantumCore] [] []]
+    namespaceRegistryNamespaces reg `shouldMatchList` ["std.io", "quantum.core"]


### PR DESCRIPTION
Stack: 2/5
Base: #272 (`adr/0059-durable-external-call-frontiers`)

Adds the ADR 0053/0054 substrate foundations needed by ADR 0059:
- executor admission projection / manifest / runtime binding record types
- await/replay/isolation metadata
- Wire package registry and composed `use` namespace resolution
- host binding pack skeleton

Validation:
- `just test` (804 examples, 0 failures, 119 pending)

The backup PR #270 remains open and untouched.