### PR TITLE
feat(wire): add quantum package and realize surface

### DIFF
--- a/app/wire/Main.hs
+++ b/app/wire/Main.hs
@@ -109,6 +109,8 @@ import Cortex.Wire.LeanFixture
   , renderEmittedFixtureModule
   , renderEmittedUmbrellaModule
   )
+import Cortex.Wire.Package (packageNamespaceRegistry)
+import Cortex.Wire.Quantum (quantumPackages)
 import Cortex.Wire.Use
   ( WireUseError (..)
   , WireUseScope
@@ -1019,7 +1021,7 @@ topologyLevels relation =
 
 useScopeFromWireFile :: WireFile -> Either Text WireUseScope
 useScopeFromWireFile wireFile =
-  case applyWireUseSpecs (const False) useSpecs of
+  case applyWireUseSpecs (packageNamespaceRegistry quantumPackages) (const False) useSpecs of
     Left err -> Left (renderRunUseError err)
     Right scope -> Right scope
   where

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -283,6 +283,7 @@ test-suite cortex-test
         Cortex.Capability.CatalogSpec
         Cortex.Wire.PackageSpec
         Cortex.Wire.QuantumPackageSpec
+        Cortex.Wire.RealizeCompileSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -185,6 +185,7 @@ library
         Cortex.Wire.Std
         Cortex.Wire.Syntax
         Cortex.Wire.Package
+        Cortex.Wire.Quantum
         Cortex.Wire.Use
         Cortex.Wire.Circuit
         Cortex.Wire.Circuit.Artifact
@@ -281,6 +282,7 @@ test-suite cortex-test
         Cortex.CanonicalModuleTreeSpec
         Cortex.Capability.CatalogSpec
         Cortex.Wire.PackageSpec
+        Cortex.Wire.QuantumPackageSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/examples/wire/quantum-realize-collect.wire
+++ b/examples/wire/quantum-realize-collect.wire
@@ -1,0 +1,45 @@
+# Minimal demonstration of the ADR 0059 realize collect-node on the ADR 0054
+# quantum Wire packages.
+#
+# The gate frontier is authored as native Wire topology and *collected* into a
+# single `@realize` node whose outputs are the named measurements (ADR 0059 §2).
+# `use quantum.core` / `use quantum.braket` bring the vocabulary into scope but
+# grant no runtime authority: `wire build`/check succeed with no host binding
+# pack present, and only `wire pulse run --binding-pack braket` lowers this to a
+# durable submit/park/resume stage (the ADR 0054 invariant).
+#
+# A larger crossing-qubit circuit (the distance-3 repetition code) needs the same
+# identity-threading the generator emits; this file keeps the topology linear so
+# it reads as a clean realize example. The standalone-bridge QEC workbench remains
+# qec-repetition-code-forced-errors.wire.
+
+use quantum.core.{@prepare_zero, @cnot};
+use quantum.braket.{@realize};
+
+contract Qubit;
+contract Bit;
+
+node prep_control
+  -> control: Qubit = @prepare_zero { index = 0; } (null);
+node prep_target
+  -> target: Qubit = @prepare_zero { index = 1; } (null);
+
+node entangle
+  <- control: Qubit;
+  <- target: Qubit;
+  -> control: Qubit;
+  -> target: Qubit;
+  = @cnot ({ inherit control; inherit target; });
+
+# Collect the frontier: realize consumes the final qubits and produces the named
+# measurement outputs the offline analyzer reads.
+node collect
+  <- control: Qubit;
+  <- target: Qubit;
+  -> m_control: Bit;
+  -> m_target: Bit;
+  = @realize ({ inherit control; inherit target; });
+
+(prep_control <> prep_target)
+  => entangle
+  => collect

--- a/src/Cortex/Wire/Compile.hs
+++ b/src/Cortex/Wire/Compile.hs
@@ -154,6 +154,7 @@ import Cortex.Wire.Pure
   , renderPureEvalError
   , validatePureTaskConfig
   )
+import Cortex.Wire.Quantum qualified as Quantum
 import Cortex.Wire.Std
   ( stdIoCommandExecutorId
   , stdIoCommandShapeMessage
@@ -1399,7 +1400,11 @@ lowerUseSpec :: LoweringState -> UseSpec -> Either WireCore.WireError LoweringSt
 lowerUseSpec st useSpec = do
   useScope <-
     mapLeft wireUseErrorToWireError $
-      applyWireUseSpec Package.stdOnlyRegistry (topLevelBindingNameTaken st) st.lsUseScope useSpec
+      applyWireUseSpec
+        (Package.packageNamespaceRegistry Quantum.quantumPackages)
+        (topLevelBindingNameTaken st)
+        st.lsUseScope
+        useSpec
   Right
     st
       { lsUseScope = useScope

--- a/src/Cortex/Wire/Quantum.hs
+++ b/src/Cortex/Wire/Quantum.hs
@@ -1,0 +1,149 @@
+{- |
+Module      : Cortex.Wire.Quantum
+Description : The quantum Wire packages (ADR 0059 first downstream consumer of ADR 0054).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The quantum surface as inert Wire packages (ADR 0054): @quantum.core@ (generic
+circuit vocabulary — prepare_zero / x / cnot / measure_z and the data contracts),
+@quantum.qec@ (reusable QEC contracts), and @quantum.braket@ (the @realize@
+collect-node projection). These carry no runtime authority; a host binding pack
+(Capability layer, e.g. the Braket pack) resolves @quantum.realize@ to a runnable
+stage. Canonical executor ids match the structurally-admitted @\@quantum.*@ surface
+the existing examples use (namespace @quantum.core@, leaf @prepare_zero@ →
+@quantum.prepare_zero@), so packaging is additive, not a rename.
+-}
+module Cortex.Wire.Quantum
+  ( quantumCorePackage
+  , quantumQecPackage
+  , quantumBraketPackage
+  , quantumPackages
+  , realizeExecutorId
+  )
+where
+
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text (Text)
+
+import Cortex.Wire.AST (WirePorts (..))
+import Cortex.Wire.Contract (WireContractSpec (..))
+import Cortex.Wire.Executor
+  ( WireExecutorConfigShape (..)
+  , WireExecutorEffect (..)
+  , WireExecutorId (..)
+  , WireExecutorPortPolicy (..)
+  , WireExecutorProjection (..)
+  )
+import Cortex.Wire.Package (NamespaceEntry (..), WirePackage (..))
+import Cortex.Wire.Value (WirePayloadKind (..))
+
+-- | The canonical id of the realize collect node (ADR 0059 §2).
+realizeExecutorId :: Text
+realizeExecutorId = "quantum.realize"
+
+coreExecutors :: Map Text Text
+coreExecutors =
+  Map.fromList
+    [ ("prepare_zero", "quantum.prepare_zero")
+    , ("x", "quantum.x")
+    , ("cnot", "quantum.cnot")
+    , ("measure_z", "quantum.measure_z")
+    , ("rz", "quantum.rz")
+    , ("h", "quantum.h")
+    ]
+
+coreContracts :: Map Text Text
+coreContracts =
+  Map.fromList
+    [ ("Qubit", "quantum.Qubit")
+    , ("Bit", "quantum.Bit")
+    , ("QuantumResult", "quantum.QuantumResult")
+    , ("MeasurementCounts", "quantum.MeasurementCounts")
+    , ("ShotCount", "quantum.ShotCount")
+    , ("BackendConfig", "quantum.BackendConfig")
+    ]
+
+qecContracts :: Map Text Text
+qecContracts =
+  Map.fromList
+    [ ("RepetitionResult", "quantum.RepetitionResult")
+    , ("Syndrome", "quantum.Syndrome")
+    ]
+
+braketExecutors :: Map Text Text
+braketExecutors = Map.fromList [("realize", realizeExecutorId)]
+
+mapEntry :: Text -> Map Text Text -> Map Text Text -> NamespaceEntry
+mapEntry namespace execs contracts =
+  NamespaceEntry
+    { nsNamespace = namespace
+    , nsResolveExecutorLeaf = (`Map.lookup` execs)
+    , nsResolveContract = (`Map.lookup` contracts)
+    }
+
+{- | An author-declared-ports, host-effecting executor projection over the quantum
+contract vocabulary. The author declares concrete ports per node (gates are
+single-qubit/two-qubit; @realize@ declares one output per named measurement).
+-}
+quantumProjection :: Text -> WireExecutorProjection
+quantumProjection executorId =
+  WireExecutorProjection
+    { wireExecutorProjectionId = WireExecutorId executorId
+    , wireExecutorProjectionPorts = WirePorts Map.empty Map.empty
+    , wireExecutorProjectionVocabulary = Set.fromList (Map.elems coreContracts)
+    , wireExecutorProjectionEffect = WireExecutorHostEffect
+    , wireExecutorProjectionConfigShape = WireExecutorConfigUnchecked
+    , wireExecutorProjectionPortPolicy = WireExecutorAuthorDeclaredPorts
+    }
+
+contractSpec :: Text -> Text -> WireContractSpec
+contractSpec contractId description =
+  WireContractSpec
+    { wireContractSpecId = contractId
+    , wireContractSpecPayloadKind = WirePayloadJson
+    , wireContractSpecDescription = description
+    , wireContractSpecRecordFields = Nothing
+    , wireContractSpecSchema = Nothing
+    , wireContractSpecExamples = []
+    }
+
+quantumCorePackage :: WirePackage
+quantumCorePackage =
+  WirePackage
+    { wpId = "quantum.core"
+    , wpNamespaceEntries = [mapEntry "quantum.core" coreExecutors coreContracts]
+    , wpExecutorProjections = fmap quantumProjection (Map.elems coreExecutors)
+    , wpContractSpecs =
+        [ contractSpec cid ("Quantum core contract " <> cid)
+        | cid <- Map.elems coreContracts
+        ]
+    }
+
+quantumQecPackage :: WirePackage
+quantumQecPackage =
+  WirePackage
+    { wpId = "quantum.qec"
+    , wpNamespaceEntries = [mapEntry "quantum.qec" Map.empty qecContracts]
+    , wpExecutorProjections = []
+    , wpContractSpecs =
+        [ contractSpec cid ("Quantum QEC contract " <> cid)
+        | cid <- Map.elems qecContracts
+        ]
+    }
+
+quantumBraketPackage :: WirePackage
+quantumBraketPackage =
+  WirePackage
+    { wpId = "quantum.braket"
+    , wpNamespaceEntries = [mapEntry "quantum.braket" braketExecutors Map.empty]
+    , wpExecutorProjections = [quantumProjection realizeExecutorId]
+    , wpContractSpecs = []
+    }
+
+-- | All quantum Wire packages, composed by a host's package set (ADR 0054).
+quantumPackages :: [WirePackage]
+quantumPackages = [quantumCorePackage, quantumQecPackage, quantumBraketPackage]

--- a/test/Cortex/Wire/QuantumPackageSpec.hs
+++ b/test/Cortex/Wire/QuantumPackageSpec.hs
@@ -1,0 +1,68 @@
+{- |
+Module      : Cortex.Wire.QuantumPackageSpec
+Description : Tests for the quantum Wire packages (ADR 0059 / ADR 0054).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The composed quantum package registry resolves @use quantum.core/qec/braket@ leaves
+and contracts to their canonical ids, and exposes the @quantum.realize@ projection —
+all inert, with no host binding pack present (the ADR 0054 invariant).
+-}
+module Cortex.Wire.QuantumPackageSpec (spec) where
+
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Test.Hspec
+
+import Cortex.Wire.Executor (WireExecutorId (..), WireExecutorProjection (..))
+import Cortex.Wire.Package (WirePackage (..), packageNamespaceRegistry)
+import Cortex.Wire.Quantum
+import Cortex.Wire.Syntax (QName (..), UseItem (..), UseSpec (..))
+import Cortex.Wire.Use
+
+notTaken :: Text -> Bool
+notTaken = const False
+
+useSpec :: [Text] -> [UseItem] -> UseSpec
+useSpec ns (i : is) = UseSpec {useSpecNamespace = qn ns, useSpecItems = i :| is}
+  where
+    qn (x : xs) = QName (x :| xs)
+    qn [] = error "empty namespace"
+useSpec _ [] = error "empty items"
+
+spec :: Spec
+spec = describe "quantum Wire packages" $ do
+  let registry = packageNamespaceRegistry quantumPackages
+
+  it "resolves quantum.core gate leaves and contracts" $
+    case applyWireUseSpecs
+      registry
+      notTaken
+      [ useSpec
+          ["quantum", "core"]
+          [UseExecutor "prepare_zero" Nothing, UseExecutor "cnot" Nothing, UseContract "Qubit" Nothing]
+      ] of
+      Left err -> expectationFailure (show err)
+      Right scope -> do
+        Map.lookup "prepare_zero" (wireUseExecutors scope) `shouldBe` Just "quantum.prepare_zero"
+        Map.lookup "cnot" (wireUseExecutors scope) `shouldBe` Just "quantum.cnot"
+        Map.lookup "Qubit" (wireUseContracts scope) `shouldBe` Just "quantum.Qubit"
+
+  it "resolves quantum.braket.@realize to the realize executor id" $
+    case applyWireUseSpecs registry notTaken [useSpec ["quantum", "braket"] [UseExecutor "realize" Nothing]] of
+      Left err -> expectationFailure (show err)
+      Right scope ->
+        Map.lookup "realize" (wireUseExecutors scope) `shouldBe` Just realizeExecutorId
+
+  it "resolves quantum.qec contracts" $
+    case applyWireUseSpecs registry notTaken [useSpec ["quantum", "qec"] [UseContract "Syndrome" Nothing]] of
+      Left err -> expectationFailure (show err)
+      Right scope ->
+        Map.lookup "Syndrome" (wireUseContracts scope) `shouldBe` Just "quantum.Syndrome"
+
+  it "exposes a realize executor projection in the braket package" $
+    fmap (unWireExecutorId . wireExecutorProjectionId) (wpExecutorProjections quantumBraketPackage)
+      `shouldBe` ["quantum.realize"]

--- a/test/Cortex/Wire/RealizeCompileSpec.hs
+++ b/test/Cortex/Wire/RealizeCompileSpec.hs
@@ -1,0 +1,52 @@
+{- |
+Module      : Cortex.Wire.RealizeCompileSpec
+Description : The realize collect-node compiles with the quantum Wire packages (ADR 0059 / 0054).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+A circuit authored against @use quantum.core.{…}@ / @use quantum.braket.{@realize}@,
+collecting the gate frontier into a @\@realize@ node whose outputs are the named
+measurements, compiles through the normal path — the package `use` resolves and the
+realize node is admitted. This is the ADR 0054 invariant (compile succeeds with no
+host binding pack present; only runnable lowering needs one).
+-}
+module Cortex.Wire.RealizeCompileSpec (spec) where
+
+import Data.Either (isRight)
+import Data.Text (Text)
+import Test.Hspec
+
+import Cortex.Wire.Compile (compileWireText)
+
+realizeCircuit :: Text
+realizeCircuit =
+  "use quantum.core.{@prepare_zero, @cnot};\n\
+  \use quantum.braket.{@realize};\n\
+  \\n\
+  \contract Qubit;\n\
+  \contract Bit;\n\
+  \\n\
+  \node prep_c -> control: Qubit = @prepare_zero { index = 0; } (null);\n\
+  \node prep_t -> target: Qubit = @prepare_zero { index = 1; } (null);\n\
+  \node entangle\n\
+  \  <- control: Qubit;\n\
+  \  <- target: Qubit;\n\
+  \  -> control: Qubit;\n\
+  \  -> target: Qubit;\n\
+  \  = @cnot ({ inherit control; inherit target; });\n\
+  \node collect\n\
+  \  <- control: Qubit;\n\
+  \  <- target: Qubit;\n\
+  \  -> s0: Bit;\n\
+  \  -> s1: Bit;\n\
+  \  = @realize ({ inherit control; inherit target; });\n\
+  \\n\
+  \(prep_c <> prep_t) => entangle => collect\n"
+
+spec :: Spec
+spec =
+  describe "realize collect-node compilation"
+    . it "compiles a circuit collected into @realize using the quantum packages"
+    $ compileWireText realizeCircuit `shouldSatisfy` isRight


### PR DESCRIPTION
Stack 3/5 for ADR 0059.

Base: #273. Backup branch/PR #270 remains open.

Scope:
- Add quantum.core, quantum.qec, and quantum.braket Wire package projections.
- Resolve `use quantum.core.{...}` / `use quantum.braket.{@realize}` through the package registry.
- Compile a minimal collect node through `@quantum.realize`.
- Add the minimal `examples/wire/quantum-realize-collect.wire` smoke example.

Validation:
- `just test` -> 810 examples, 0 failures, 119 pending.
- `nix run .#wire -- build examples/wire/quantum-realize-collect.wire` -> passed.