### PR TITLE
feat(pulse): add external-call substrate and Braket binding

### DIFF
--- a/cortex.cabal
+++ b/cortex.cabal
@@ -144,6 +144,7 @@ library
         Cortex.Capability.Catalog.ExecutorManifest
         Cortex.Capability.Catalog.RuntimeBindingRecord
         Cortex.Capability.BindingPack
+        Cortex.Capability.BindingPack.Braket
         Cortex.Capability.Executor
         Cortex.Capability.Executor.Pure
         Cortex.Pulse
@@ -286,6 +287,7 @@ test-suite cortex-test
         Cortex.Algebra.GraphSpec
         Cortex.CanonicalModuleTreeSpec
         Cortex.Capability.CatalogSpec
+        Cortex.Capability.BindingPack.BraketSpec
         Cortex.Wire.PackageSpec
         Cortex.Wire.QuantumPackageSpec
         Cortex.Wire.RealizeCompileSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -155,6 +155,7 @@ library
         Cortex.Pulse.Executor.Attempt
         Cortex.Pulse.Executor.Events
         Cortex.Pulse.Executor.Frontier
+        Cortex.Pulse.Executor.ExternalCall
         Cortex.Pulse.Executor.Loop
         Cortex.Pulse.Executor.Outcome
         Cortex.Pulse.Executor.Persistence
@@ -288,6 +289,7 @@ test-suite cortex-test
         Cortex.Wire.RealizeCompileSpec
         Cortex.Pulse.FrontierContractionSpec
         Cortex.Pulse.Executor.ExternalCallAttemptSpec
+        Cortex.Pulse.Executor.ExternalCallSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -211,6 +211,7 @@ library
         Cortex.Pulse.PlanHydration
         Cortex.Pulse.Query
         Cortex.Pulse.Rewrite
+        Cortex.Pulse.Rewrite.Contract
         Cortex.Pulse.Schema
         Cortex.Pulse.Signal
         Cortex.Pulse.Scheduler
@@ -284,6 +285,7 @@ test-suite cortex-test
         Cortex.Wire.PackageSpec
         Cortex.Wire.QuantumPackageSpec
         Cortex.Wire.RealizeCompileSpec
+        Cortex.Pulse.FrontierContractionSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -200,6 +200,7 @@ library
         Cortex.Wire.Circuit.NodeKind
         Cortex.Pulse.GraphRuntime
         Cortex.Pulse.Health
+        Cortex.Pulse.Lowering.FusedPlan
         Cortex.Pulse.Materialization
         Cortex.Pulse.Memory
         Cortex.Pulse.Memory.Query
@@ -290,6 +291,7 @@ test-suite cortex-test
         Cortex.Pulse.FrontierContractionSpec
         Cortex.Pulse.Executor.ExternalCallAttemptSpec
         Cortex.Pulse.Executor.ExternalCallSpec
+        Cortex.Pulse.Lowering.FusedPlanSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -210,6 +210,7 @@ library
         Cortex.Pulse.Plan
         Cortex.Pulse.PlanHydration
         Cortex.Pulse.Query
+        Cortex.Pulse.Query.ExternalCall
         Cortex.Pulse.Rewrite
         Cortex.Pulse.Rewrite.Contract
         Cortex.Pulse.Schema
@@ -286,6 +287,7 @@ test-suite cortex-test
         Cortex.Wire.QuantumPackageSpec
         Cortex.Wire.RealizeCompileSpec
         Cortex.Pulse.FrontierContractionSpec
+        Cortex.Pulse.Executor.ExternalCallAttemptSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/cortex.cabal
+++ b/cortex.cabal
@@ -200,6 +200,7 @@ library
         Cortex.Wire.Circuit.NodeKind
         Cortex.Pulse.GraphRuntime
         Cortex.Pulse.Health
+        Cortex.Pulse.Lowering.Circuit
         Cortex.Pulse.Lowering.FusedPlan
         Cortex.Pulse.Materialization
         Cortex.Pulse.Memory
@@ -292,6 +293,7 @@ test-suite cortex-test
         Cortex.Pulse.Executor.ExternalCallAttemptSpec
         Cortex.Pulse.Executor.ExternalCallSpec
         Cortex.Pulse.Lowering.FusedPlanSpec
+        Cortex.Pulse.Lowering.CircuitSpec
         Cortex.Capability.Executor.PureSpec
         Cortex.PublicPreludeSpec
         Cortex.Pulse.CheckpointSpec

--- a/docs/Reference/Pulse/schema.md
+++ b/docs/Reference/Pulse/schema.md
@@ -198,6 +198,31 @@ pulse.signals
 Durable external-event storage. The signal protocol, delivery semantics, and `StageSuspend`
 interaction are in [`signals.md`](./signals.md).
 
+## 10. External-call attempts
+
+```
+pulse.external_call_attempts
+  attempt_id          bigserial primary key
+  run_id              uuid not null
+  node_id             text not null            -- the realize stage node
+  runtime_binding_id  text not null
+  frontier_id         text not null            -- canonical hash of the frozen frontier
+  idempotency_key     text not null
+  frozen_plan         jsonb not null           -- the canonical fused sub-plan
+  job_handle          jsonb                     -- null until the provider submit is recorded
+  signal_name         text                      -- the ordinary durable signal woken on completion
+  status              text not null default 'reserved'   -- reserved | submitted | settled | failed
+  created_at, submitted_at, settled_at  timestamptz
+
+  unique index (run_id, node_id, runtime_binding_id, frontier_id)
+```
+
+The Pulse-owned durable home for a `submit_park_resume` external call's executor metadata (ADR 0059
+§3). ADR 0058 suspend settlement commits only graph state, signal wait rows, and run status, so this
+record — not the signal rows — carries the idempotency key, frozen fused plan, and provider job
+handle. Reserve is idempotent on the key, so crash recovery re-entry never creates a duplicate
+provider task; provider fields are opaque JSON that Pulse does not interpret.
+
 ## Appendix A — Ownership
 
 The `pulse` DB role has full ownership of every table in this schema and no access to host tables.

--- a/src/Cortex/Capability/BindingPack/Braket.hs
+++ b/src/Cortex/Capability/BindingPack/Braket.hs
@@ -1,0 +1,89 @@
+{- |
+Module      : Cortex.Capability.BindingPack.Braket
+Description : The Braket host runtime binding pack for quantum.realize (ADR 0059 / 0054).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The Braket host binding pack (ADR 0054) is the artifact that carries AWS runtime
+authority: it depends on the @quantum.braket@ Wire package and mints the ADR 0053
+runtime binding record that resolves @quantum.realize@ to a @submit_park_resume@
+external-call stage (ADR 0059 §3). The runnable driver — OpenQASM lowering + Braket
+submit/poll over @scripts/wire-quantum-braket.py@ — is supplied at the Pulse layer
+when the CLI runs; this module owns the inert, authority-bearing binding descriptor
+and the config that parameterises it.
+-}
+module Cortex.Capability.BindingPack.Braket
+  ( BraketConfig (..)
+  , braketBindingPack
+  )
+where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Cortex.Capability.BindingPack (HostBindingPack (..))
+import Cortex.Capability.Catalog.AdmissionProjection (ContentDigest (..), ProjectionVersion (..))
+import Cortex.Capability.Catalog.AwaitStrategy
+  ( AwaitStrategy (..)
+  , IsolationExpectation (..)
+  , ReplayClass (..)
+  )
+import Cortex.Capability.Catalog.ExecutorManifest (AbiKind (..), ContentAddress (..))
+import Cortex.Capability.Catalog.RuntimeBindingRecord
+import Cortex.Wire.Executor (WireExecutorId (..))
+import Cortex.Wire.Quantum (realizeExecutorId)
+
+{- | AWS Braket binding configuration, loaded from @--config@. Inert until the
+runnable driver consumes it.
+-}
+data BraketConfig = BraketConfig
+  { braketRegion :: !Text
+  , braketDeviceArn :: !Text
+  , braketS3Bucket :: !Text
+  , braketProfile :: !(Maybe Text)
+  }
+  deriving stock (Eq, Show, Generic)
+
+{- | Mint the Braket binding pack: a single runtime binding record resolving
+@quantum.realize@ to a @submit_park_resume@ external-call stage driven through the
+subprocess JSONL ABI, isolated in a subprocess sandbox, with an idempotency-keyed
+replay class (required for the crash-safe submit protocol). The resolved device ARN
+and region are recorded as authority fingerprints for provenance.
+-}
+braketBindingPack :: BraketConfig -> HostBindingPack
+braketBindingPack config =
+  HostBindingPack
+    { hbpIdentity = "braket-pack"
+    , hbpWirePackageDeps = ["quantum.braket"]
+    , hbpRuntimeBindings =
+        [ RuntimeBindingRecord
+            { rbrBindingId = "braket-pack/" <> realizeExecutorId
+            , rbrBindingVersion = "1"
+            , rbrExecutorId = WireExecutorId realizeExecutorId
+            , rbrProjectionVersion = ProjectionVersion "1"
+            , rbrStageActionRef = RuntimeStageActionRef "quantum.realize.braket"
+            , rbrManifestContentAddress = ContentAddress "wire-quantum-braket.py"
+            , rbrArtifactDigest = ContentDigest "braket-driver"
+            , rbrAbiKind = AbiSubprocessJsonl
+            , rbrAbiVersion = "1"
+            , rbrAbiDriverDigest = ContentDigest "braket-driver"
+            , rbrBindingPackIdentity = "braket-pack"
+            , rbrResolvedAuthorities =
+                [ ResolvedAuthorityFingerprint
+                    "aws.braket.device"
+                    (braketDeviceArn config)
+                    (ContentDigest (braketDeviceArn config))
+                , ResolvedAuthorityFingerprint
+                    "aws.region"
+                    (braketRegion config)
+                    (ContentDigest (braketRegion config))
+                ]
+            , rbrIsolation = SubprocessSandbox
+            , rbrAcceptedReplayClass = IdempotentWithKey
+            , rbrAcceptedAwaitStrategy = SubmitParkResume
+            , rbrCompatibilityDigest = ContentDigest "braket-1"
+            }
+        ]
+    }

--- a/src/Cortex/Pulse/Executor/ExternalCall.hs
+++ b/src/Cortex/Pulse/Executor/ExternalCall.hs
@@ -1,0 +1,126 @@
+{- |
+Module      : Cortex.Pulse.Executor.ExternalCall
+Description : The submit/park/resume external-call protocol (ADR 0059 §3).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The crash-safe state machine a bound external-call stage runs (ADR 0059 §3),
+parameterised over the host-supplied driver and an abstract attempt store so it is
+testable without a database or the Pulse executor. P6 instantiates the store with
+the 'Cortex.Pulse.Query.ExternalCall' CRUD and maps the outcome onto Pulse's
+@StageResult@ (suspend ↔ @StageSuspend@, complete ↔ @StageComplete@, fail ↔ the
+ADR 0026 failure closure).
+
+Two await strategies (ADR 0053 binding metadata):
+
+* __synchronous__ — run the fused plan inline and complete;
+* __submit/park/resume__ — first entry reserves the attempt, submits to the
+  provider under an idempotency key, persists the job handle, and suspends; resume
+  (the attempt already carries a handle) fetches the provider result and completes.
+
+Reserve is idempotent on the key, so a crash that re-enters before the handle is
+recorded re-submits with the same key rather than creating a duplicate task.
+-}
+module Cortex.Pulse.Executor.ExternalCall
+  ( ExternalCallDriver (..)
+  , AttemptStore (..)
+  , AttemptView (..)
+  , ExternalCallOutcome (..)
+  , runExternalCall
+  )
+where
+
+import Data.Aeson (Value)
+import Data.Text (Text)
+
+import Cortex.Capability.Catalog.AwaitStrategy (AwaitStrategy (..))
+import Cortex.Pulse.Query.ExternalCall (ExternalCallAttemptKey)
+
+-- | Host-supplied, backend-specific operations. Opaque to Pulse (ADR 0053).
+data ExternalCallDriver m = ExternalCallDriver
+  { driverRunSync :: Value -> m (Either Text [(Text, Value)])
+  -- ^ Run the fused plan inline (synchronous strategy) → named measurement outputs.
+  , driverSubmit :: Text -> Value -> m (Either Text Value)
+  -- ^ Submit under an idempotency key (arg 1) → an opaque provider job handle.
+  , driverFetch :: Value -> m (Either Text [(Text, Value)])
+  -- ^ Fetch/validate a completed provider job → named measurement outputs.
+  , driverIdempotencyKey :: Value -> Text
+  -- ^ Derive a deterministic idempotency key from the frozen plan.
+  , driverSignalName :: ExternalCallAttemptKey -> Text
+  -- ^ The ordinary durable signal woken on completion (never the run-terminal family).
+  }
+
+-- | What the executor reads back about an in-flight attempt.
+data AttemptView = AttemptView
+  { avJobHandle :: !(Maybe Value)
+  , avStatus :: !Text
+  }
+  deriving stock (Eq, Show)
+
+{- | The durable attempt store, abstracted so the protocol is testable. P6 binds it
+to the 'Cortex.Pulse.Query.ExternalCall' transactions (reserve and link committed
+atomically with ADR 0058 suspend settlement).
+-}
+data AttemptStore m = AttemptStore
+  { storeLoad :: ExternalCallAttemptKey -> m (Maybe AttemptView)
+  , storeReserve :: ExternalCallAttemptKey -> Text -> Value -> m ()
+  , storePersistHandle :: ExternalCallAttemptKey -> Value -> Text -> m ()
+  , storeSettle :: ExternalCallAttemptKey -> m ()
+  , storeFail :: ExternalCallAttemptKey -> m ()
+  }
+
+-- | The outcome the executor maps onto a Pulse @StageResult@.
+data ExternalCallOutcome
+  = -- | Completed with named measurement outputs.
+    ExternalCallCompleted ![(Text, Value)]
+  | -- | Suspended; the run parks on this durable signal until the job completes.
+    ExternalCallSuspended !Text
+  | -- | Failed with a typed reason (routed through the ADR 0026 closure in P6).
+    ExternalCallFailed !Text
+  deriving stock (Eq, Show)
+
+{- | Run the external-call protocol for one stage entry. The same action runs on
+first entry and on resume; it distinguishes them by the durable attempt state.
+-}
+runExternalCall
+  :: Monad m
+  => AwaitStrategy
+  -> ExternalCallDriver m
+  -> AttemptStore m
+  -> ExternalCallAttemptKey
+  -> Value
+  -- ^ frozen fused plan
+  -> m ExternalCallOutcome
+runExternalCall Synchronous driver _ _ frozenPlan = do
+  result <- driverRunSync driver frozenPlan
+  pure (either ExternalCallFailed ExternalCallCompleted result)
+runExternalCall SubmitParkResume driver store key frozenPlan = do
+  existing <- storeLoad store key
+  case existing of
+    Just view | Just handle <- avJobHandle view -> resume handle
+    _ -> firstEntry
+  where
+    resume handle = do
+      fetched <- driverFetch driver handle
+      case fetched of
+        Right outputs -> do
+          storeSettle store key
+          pure (ExternalCallCompleted outputs)
+        Left reason -> do
+          storeFail store key
+          pure (ExternalCallFailed reason)
+
+    firstEntry = do
+      let idempotencyKey = driverIdempotencyKey driver frozenPlan
+      storeReserve store key idempotencyKey frozenPlan
+      submitted <- driverSubmit driver idempotencyKey frozenPlan
+      case submitted of
+        Right handle -> do
+          let signalName = driverSignalName driver key
+          storePersistHandle store key handle signalName
+          pure (ExternalCallSuspended signalName)
+        Left reason -> do
+          storeFail store key
+          pure (ExternalCallFailed reason)

--- a/src/Cortex/Pulse/Lowering/Circuit.hs
+++ b/src/Cortex/Pulse/Lowering/Circuit.hs
@@ -1,0 +1,91 @@
+{- |
+Module      : Cortex.Pulse.Lowering.Circuit
+Description : Lower a realize frontier to a bound, durable stage (ADR 0059 §2/§3).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The decision core of the Wire→Pulse lowering: given a realize node's collected
+upstream frontier (classified by backend authority and await strategy), the fused
+operation/measurement list, and the host binding pack, it
+
+1. admits the contraction (ADR 0059 §2, 'admitFrontierContraction') — rejecting a
+   mixed or non-backend frontier rather than splitting it;
+2. resolves the realize executor through the binding pack, failing with the typed
+   @missing runtime binding@ (the ADR 0054 invariant: compile succeeds without a
+   pack; only runnable lowering fails);
+3. builds the canonical fused plan (P6a) and its digest (the idempotency key).
+
+The result is a 'LoweredRealize' the executor runs via
+'Cortex.Pulse.Executor.ExternalCall.runExternalCall'. Walking the compiled-circuit
+artifact to produce the inputs, and the @wire pulse run@ CLI, sit on top of this
+core; this module keeps the admission/binding/plan decision pure and testable.
+-}
+module Cortex.Pulse.Lowering.Circuit
+  ( LoweringError (..)
+  , LoweredRealize (..)
+  , lowerRealizeFrontier
+  )
+where
+
+import Data.Text (Text)
+
+import Cortex.Capability.BindingPack (HostBindingPack, lookupBinding)
+import Cortex.Capability.Catalog.AwaitStrategy (AwaitStrategy)
+import Cortex.Capability.Catalog.RuntimeBindingRecord
+  ( RuntimeBindingRecord (..)
+  )
+import Cortex.Pulse.Lowering.FusedPlan
+  ( FusedMeasurement
+  , FusedOp
+  , FusedPlan
+  , fusedPlan
+  , fusedPlanDigest
+  )
+import Cortex.Pulse.Rewrite.Contract
+  ( CollectedNode
+  , FrontierAdmissionError
+  , admitFrontierContraction
+  )
+import Cortex.Wire.Executor (WireExecutorId)
+
+data LoweringError
+  = -- | The collected frontier is inadmissible (ADR 0059 §2).
+    LoweringInadmissibleFrontier !(FrontierAdmissionError Text)
+  | -- | No host binding pack resolves the realize executor (ADR 0054).
+    LoweringMissingRuntimeBinding !WireExecutorId
+  deriving stock (Eq, Show)
+
+data LoweredRealize = LoweredRealize
+  { lrBinding :: !RuntimeBindingRecord
+  , lrAwaitStrategy :: !AwaitStrategy
+  , lrFusedPlan :: !FusedPlan
+  , lrIdempotencyKey :: !Text
+  }
+  deriving stock (Eq, Show)
+
+{- | Lower a realize node's collected frontier to a bound, durable stage. The
+collected nodes are classified by @(authority, await strategy)@ (a non-backend node
+classifies as @Nothing@); ops/measurements are the fused sub-plan in topological
+order.
+-}
+lowerRealizeFrontier
+  :: HostBindingPack
+  -> WireExecutorId
+  -> [CollectedNode Text WireExecutorId AwaitStrategy]
+  -> [FusedOp]
+  -> [FusedMeasurement]
+  -> Either LoweringError LoweredRealize
+lowerRealizeFrontier pack realizeId collected ops measurements = do
+  either (Left . LoweringInadmissibleFrontier) Right (admitFrontierContraction collected)
+  binding <-
+    maybe (Left (LoweringMissingRuntimeBinding realizeId)) Right (lookupBinding realizeId pack)
+  let plan = fusedPlan ops measurements
+  Right
+    LoweredRealize
+      { lrBinding = binding
+      , lrAwaitStrategy = rbrAcceptedAwaitStrategy binding
+      , lrFusedPlan = plan
+      , lrIdempotencyKey = fusedPlanDigest plan
+      }

--- a/src/Cortex/Pulse/Lowering/FusedPlan.hs
+++ b/src/Cortex/Pulse/Lowering/FusedPlan.hs
@@ -1,0 +1,100 @@
+{- |
+Module      : Cortex.Pulse.Lowering.FusedPlan
+Description : Canonical fused sub-plan + idempotency key for a realize frontier (ADR 0059 §2/§3).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The fused sub-plan is the backend-neutral payload a realize stage carries (the
+operation/measurement list the standalone bridge's @build_quantum_plan@ builds
+today). ADR 0059 §2 requires its emission to be a __deterministic, canonical__
+function of the frozen frontier: the lowering supplies operations in topological
+order, and this module serialises them and the measurements (sorted by output name)
+so the same topology yields the same JSON and the same SHA-256 digest across
+replays. The digest is the stable idempotency key the crash-safe submit protocol
+(§3) keys on, so it must not drift between attempts.
+-}
+module Cortex.Pulse.Lowering.FusedPlan
+  ( FusedOp (..)
+  , FusedMeasurement (..)
+  , FusedPlan (..)
+  , fusedPlan
+  , fusedPlanValue
+  , fusedPlanDigest
+  )
+where
+
+import Crypto.Hash (SHA256, hashlazy)
+import Data.Aeson (Value, object, (.=))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.List (sortOn)
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHC.Generics (Generic)
+
+{- | One backend-neutral operation: a gate name, its qubit wire indices in order,
+and named scalar parameters (e.g. a rotation angle).
+-}
+data FusedOp = FusedOp
+  { foGate :: !Text
+  , foWires :: ![Int]
+  , foParams :: ![(Text, Value)]
+  }
+  deriving stock (Eq, Show, Generic)
+
+-- | A terminal measurement: the qubit wire and the output port name it produces.
+data FusedMeasurement = FusedMeasurement
+  { fmWire :: !Int
+  , fmOutput :: !Text
+  }
+  deriving stock (Eq, Show, Generic)
+
+{- | The canonical fused plan: operations in topological order, measurements sorted
+by output name so the encoding is order-stable.
+-}
+data FusedPlan = FusedPlan
+  { fpOperations :: ![FusedOp]
+  , fpMeasurements :: ![FusedMeasurement]
+  }
+  deriving stock (Eq, Show, Generic)
+
+{- | Build the canonical plan: operations are kept in the supplied (topological)
+order; measurements are sorted by output name.
+-}
+fusedPlan :: [FusedOp] -> [FusedMeasurement] -> FusedPlan
+fusedPlan operations measurements =
+  FusedPlan
+    { fpOperations = operations
+    , fpMeasurements = sortOn fmOutput measurements
+    }
+
+-- | The canonical JSON payload the realize stage carries.
+fusedPlanValue :: FusedPlan -> Value
+fusedPlanValue plan =
+  object
+    [ "operations" .= fmap opValue (fpOperations plan)
+    , "measurements" .= fmap measurementValue (fpMeasurements plan)
+    ]
+  where
+    opValue op =
+      object
+        [ "gate" .= foGate op
+        , "wires" .= foWires op
+        , "params" .= object [Key.fromText k .= v | (k, v) <- foParams op]
+        ]
+    measurementValue m = object ["wire" .= fmWire m, "output" .= fmOutput m]
+
+{- | The deterministic SHA-256 digest of the canonical plan — the idempotency key
+the submit/park/resume protocol keys on. Taken over a canonical tuple (not the JSON
+object) so object key ordering cannot perturb it.
+-}
+fusedPlanDigest :: FusedPlan -> Text
+fusedPlanDigest plan =
+  let canonical =
+        Aeson.encode
+          ( [(foGate op, foWires op, [(k, v) | (k, v) <- foParams op]) | op <- fpOperations plan]
+          , [(fmWire m, fmOutput m) | m <- fpMeasurements plan]
+          )
+   in T.pack (show (hashlazy @SHA256 canonical))

--- a/src/Cortex/Pulse/Query/ExternalCall.hs
+++ b/src/Cortex/Pulse/Query/ExternalCall.hs
@@ -1,0 +1,200 @@
+{- |
+Module      : Cortex.Pulse.Query.ExternalCall
+Description : Durable external-call attempt record CRUD (ADR 0059 §3).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The external-call attempt record is the Pulse-owned durable home for a
+@submit_park_resume@ external call's @{idempotency key, frozen fused plan, job
+handle, completion signal}@, keyed by @(run, node, runtime binding, frontier)@
+(ADR 0059 §3). ADR 0058 settlement commits only graph state, signal wait rows, and
+run status, so executor metadata lives here, not on the signal rows.
+
+The crash-safe protocol is: reserve (before provider submit), persist the handle
+(after submit, before suspend), then settle on completion. Reserve is idempotent on
+the key so recovery re-entry never creates a duplicate provider task. Provider
+fields are opaque JSON; Pulse does not interpret the backend.
+-}
+module Cortex.Pulse.Query.ExternalCall
+  ( ExternalCallAttemptKey (..)
+  , ExternalCallAttemptStatus (..)
+  , externalCallStatusText
+  , parseExternalCallStatus
+  , ExternalCallAttempt (..)
+  , reserveExternalCallAttempt
+  , persistExternalCallHandle
+  , settleExternalCallAttempt
+  , failExternalCallAttempt
+  , loadExternalCallAttempt
+  )
+where
+
+import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+import Data.Time (UTCTime)
+import Data.UUID (UUID)
+import Hasql.Decoders qualified as D
+import Hasql.Statement (Statement (..))
+import Hasql.Transaction (Transaction)
+import Hasql.Transaction qualified as Tx
+
+import Platform.Database.Encode qualified as Enc
+
+{- | Identity of an external-call attempt: the realize stage's node within a run,
+the runtime binding that owns it, and the canonical frontier hash.
+-}
+data ExternalCallAttemptKey = ExternalCallAttemptKey
+  { ecaRunId :: !UUID
+  , ecaNodeId :: !Text
+  , ecaRuntimeBindingId :: !Text
+  , ecaFrontierId :: !Text
+  }
+  deriving stock (Eq, Show)
+
+data ExternalCallAttemptStatus
+  = AttemptReserved
+  | AttemptSubmitted
+  | AttemptSettled
+  | AttemptFailed
+  deriving stock (Eq, Show)
+
+externalCallStatusText :: ExternalCallAttemptStatus -> Text
+externalCallStatusText = \case
+  AttemptReserved -> "reserved"
+  AttemptSubmitted -> "submitted"
+  AttemptSettled -> "settled"
+  AttemptFailed -> "failed"
+
+parseExternalCallStatus :: Text -> Maybe ExternalCallAttemptStatus
+parseExternalCallStatus = \case
+  "reserved" -> Just AttemptReserved
+  "submitted" -> Just AttemptSubmitted
+  "settled" -> Just AttemptSettled
+  "failed" -> Just AttemptFailed
+  _ -> Nothing
+
+data ExternalCallAttempt = ExternalCallAttempt
+  { ecaKey :: !ExternalCallAttemptKey
+  , ecaIdempotencyKey :: !Text
+  , ecaFrozenPlan :: !Aeson.Value
+  , ecaJobHandle :: !(Maybe Aeson.Value)
+  , ecaSignalName :: !(Maybe Text)
+  , ecaStatus :: !Text
+  }
+  deriving stock (Eq, Show)
+
+{- | Reserve the attempt before provider submission. Idempotent on the key: a
+recovery re-entry with the same key is a no-op (@ON CONFLICT DO NOTHING@), so the
+frozen plan and idempotency key written on first reservation are authoritative.
+-}
+reserveExternalCallAttempt
+  :: ExternalCallAttemptKey -> Text -> Aeson.Value -> UTCTime -> Transaction ()
+reserveExternalCallAttempt key idempotencyKey frozenPlan now =
+  Tx.statement
+    ( key.ecaRunId
+    , key.ecaNodeId
+    , key.ecaRuntimeBindingId
+    , key.ecaFrontierId
+    , idempotencyKey
+    , frozenPlan
+    , now
+    )
+    $ Statement
+      "INSERT INTO pulse.external_call_attempts \
+      \(run_id, node_id, runtime_binding_id, frontier_id, idempotency_key, frozen_plan, status, created_at) \
+      \VALUES ($1, $2, $3, $4, $5, $6, 'reserved', $7) \
+      \ON CONFLICT (run_id, node_id, runtime_binding_id, frontier_id) DO NOTHING"
+      ( Enc.encode7
+          ((\(a, _, _, _, _, _, _) -> a), Enc.nonNullable Enc.uuid)
+          ((\(_, b, _, _, _, _, _) -> b), Enc.nonNullable Enc.text)
+          ((\(_, _, c, _, _, _, _) -> c), Enc.nonNullable Enc.text)
+          ((\(_, _, _, d, _, _, _) -> d), Enc.nonNullable Enc.text)
+          ((\(_, _, _, _, e, _, _) -> e), Enc.nonNullable Enc.text)
+          ((\(_, _, _, _, _, f, _) -> f), Enc.nonNullable Enc.jsonb)
+          ((\(_, _, _, _, _, _, g) -> g), Enc.nonNullable Enc.timestamptz)
+      )
+      D.noResult
+      False
+
+{- | Persist the provider job handle and completion signal name, marking the attempt
+submitted. Called after provider submit, before the stage returns @StageSuspend@.
+-}
+persistExternalCallHandle
+  :: ExternalCallAttemptKey -> Aeson.Value -> Text -> UTCTime -> Transaction ()
+persistExternalCallHandle key jobHandle signalName now =
+  Tx.statement
+    ( jobHandle
+    , signalName
+    , now
+    , key.ecaRunId
+    , key.ecaNodeId
+    , key.ecaRuntimeBindingId
+    , key.ecaFrontierId
+    )
+    $ Statement
+      "UPDATE pulse.external_call_attempts \
+      \SET job_handle = $1, signal_name = $2, status = 'submitted', submitted_at = $3 \
+      \WHERE run_id = $4 AND node_id = $5 AND runtime_binding_id = $6 AND frontier_id = $7"
+      ( Enc.encode7
+          ((\(a, _, _, _, _, _, _) -> a), Enc.nonNullable Enc.jsonb)
+          ((\(_, b, _, _, _, _, _) -> b), Enc.nonNullable Enc.text)
+          ((\(_, _, c, _, _, _, _) -> c), Enc.nonNullable Enc.timestamptz)
+          ((\(_, _, _, d, _, _, _) -> d), Enc.nonNullable Enc.uuid)
+          ((\(_, _, _, _, e, _, _) -> e), Enc.nonNullable Enc.text)
+          ((\(_, _, _, _, _, f, _) -> f), Enc.nonNullable Enc.text)
+          ((\(_, _, _, _, _, _, g) -> g), Enc.nonNullable Enc.text)
+      )
+      D.noResult
+      False
+
+settleExternalCallAttempt :: ExternalCallAttemptKey -> UTCTime -> Transaction ()
+settleExternalCallAttempt = updateStatus "settled"
+
+failExternalCallAttempt :: ExternalCallAttemptKey -> UTCTime -> Transaction ()
+failExternalCallAttempt = updateStatus "failed"
+
+updateStatus :: Text -> ExternalCallAttemptKey -> UTCTime -> Transaction ()
+updateStatus status key now =
+  Tx.statement
+    (status, now, key.ecaRunId, key.ecaNodeId, key.ecaRuntimeBindingId, key.ecaFrontierId)
+    $ Statement
+      "UPDATE pulse.external_call_attempts \
+      \SET status = $1, settled_at = $2 \
+      \WHERE run_id = $3 AND node_id = $4 AND runtime_binding_id = $5 AND frontier_id = $6"
+      ( Enc.encode6
+          ((\(a, _, _, _, _, _) -> a), Enc.nonNullable Enc.text)
+          ((\(_, b, _, _, _, _) -> b), Enc.nonNullable Enc.timestamptz)
+          ((\(_, _, c, _, _, _) -> c), Enc.nonNullable Enc.uuid)
+          ((\(_, _, _, d, _, _) -> d), Enc.nonNullable Enc.text)
+          ((\(_, _, _, _, e, _) -> e), Enc.nonNullable Enc.text)
+          ((\(_, _, _, _, _, f) -> f), Enc.nonNullable Enc.text)
+      )
+      D.noResult
+      False
+
+loadExternalCallAttempt :: ExternalCallAttemptKey -> Transaction (Maybe ExternalCallAttempt)
+loadExternalCallAttempt key =
+  Tx.statement
+    (key.ecaRunId, key.ecaNodeId, key.ecaRuntimeBindingId, key.ecaFrontierId)
+    $ Statement
+      "SELECT idempotency_key, frozen_plan, job_handle, signal_name, status \
+      \FROM pulse.external_call_attempts \
+      \WHERE run_id = $1 AND node_id = $2 AND runtime_binding_id = $3 AND frontier_id = $4"
+      ( Enc.encode4
+          ((\(a, _, _, _) -> a), Enc.nonNullable Enc.uuid)
+          ((\(_, b, _, _) -> b), Enc.nonNullable Enc.text)
+          ((\(_, _, c, _) -> c), Enc.nonNullable Enc.text)
+          ((\(_, _, _, d) -> d), Enc.nonNullable Enc.text)
+      )
+      (D.rowMaybe row)
+      False
+  where
+    row =
+      ExternalCallAttempt key
+        <$> D.column (D.nonNullable D.text)
+        <*> D.column (D.nonNullable D.jsonb)
+        <*> D.column (D.nullable D.jsonb)
+        <*> D.column (D.nullable D.text)
+        <*> D.column (D.nonNullable D.text)

--- a/src/Cortex/Pulse/Rewrite/Contract.hs
+++ b/src/Cortex/Pulse/Rewrite/Contract.hs
@@ -1,0 +1,82 @@
+{- |
+Module      : Cortex.Pulse.Rewrite.Contract
+Description : Decidable admission check for a realize-node frontier contraction (ADR 0059 §2).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Sinking the set of upstream backend nodes feeding a realize node into one durable
+stage is a contraction. ADR 0059 §2 requires a /decidable/ admission check that
+runs in the @validatorReady@ lineage rather than host-side guesswork: every node in
+the collected set must share one external-call authority and one await strategy, and
+no non-backend node may sit inside the set. A set that violates this is __rejected__
+(the author/materializer must place separate realize nodes); the validator never
+silently splits it.
+
+The check is on the /collected set/ only. Frozen classical boundary inputs to the
+realize node (shot count, rotation angles, backend config) are legitimate inbound
+edges, not members of the collected set, so they are not authority violations — they
+are excluded by the lowering's collection traversal, not by this check.
+
+This module is pure and polymorphic over the node, authority, and strategy types so
+it carries no runtime dependency; call sites instantiate it with the concrete
+'Cortex.Wire.Executor.WireExecutorId' and
+'Cortex.Capability.Catalog.AwaitStrategy.AwaitStrategy'.
+-}
+module Cortex.Pulse.Rewrite.Contract
+  ( FrontierAdmissionError (..)
+  , CollectedNode (..)
+  , admitFrontierContraction
+  )
+where
+
+import Data.List (nub)
+import Data.Maybe (isNothing)
+
+{- | A node collected into a realize frontier, paired with its backend classification:
+@Just (authority, strategy)@ for a backend node, @Nothing@ for a non-backend node
+that must not appear inside the collected set.
+-}
+data CollectedNode node authority strategy = CollectedNode
+  { cnNode :: !node
+  , cnClassification :: !(Maybe (authority, strategy))
+  }
+  deriving stock (Eq, Show)
+
+{- | Why a collected frontier is inadmissible. Carries the offending nodes so the
+caller can report a precise rejection rather than silently splitting.
+-}
+data FrontierAdmissionError node
+  = -- | The collected set spans more than one external-call authority.
+    FrontierMixedAuthority ![node]
+  | -- | The collected set spans more than one await strategy.
+    FrontierMixedAwaitStrategy ![node]
+  | -- | A non-backend node sits inside the collected set.
+    FrontierNonBackendIntervening !node
+  | -- | The collected set is empty; there is no frontier to realize.
+    FrontierEmpty
+  deriving stock (Eq, Show)
+
+{- | Decide whether a collected frontier may contract into one realize stage. Rejects
+(never splits) on a mixed authority, a mixed await strategy, an intervening
+non-backend node, or an empty set.
+-}
+admitFrontierContraction
+  :: (Eq authority, Eq strategy)
+  => [CollectedNode node authority strategy]
+  -> Either (FrontierAdmissionError node) ()
+admitFrontierContraction [] = Left FrontierEmpty
+admitFrontierContraction collected =
+  case [cnNode n | n <- collected, isNothing (cnClassification n)] of
+    (nonBackend : _) -> Left (FrontierNonBackendIntervening nonBackend)
+    [] ->
+      let classified = [(a, s) | CollectedNode _ (Just (a, s)) <- collected]
+          authorities = nub (fmap fst classified)
+          strategies = nub (fmap snd classified)
+       in if length authorities > 1
+            then Left (FrontierMixedAuthority (fmap cnNode collected))
+            else
+              if length strategies > 1
+                then Left (FrontierMixedAwaitStrategy (fmap cnNode collected))
+                else Right ()

--- a/test/Cortex/Capability/BindingPack/BraketSpec.hs
+++ b/test/Cortex/Capability/BindingPack/BraketSpec.hs
@@ -1,0 +1,60 @@
+{- |
+Module      : Cortex.Capability.BindingPack.BraketSpec
+Description : Tests for the Braket host binding pack (ADR 0059 / 0054).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The minted pack resolves quantum.realize to a submit/park/resume binding carrying
+the configured device authority — the ADR 0054 host-binding contract.
+-}
+module Cortex.Capability.BindingPack.BraketSpec (spec) where
+
+import Data.Text (Text)
+import Test.Hspec
+
+import Cortex.Capability.BindingPack (HostBindingPack (..), lookupBinding)
+import Cortex.Capability.BindingPack.Braket
+import Cortex.Capability.Catalog.AwaitStrategy (AwaitStrategy (..))
+import Cortex.Capability.Catalog.ExecutorManifest (AbiKind (..))
+import Cortex.Capability.Catalog.RuntimeBindingRecord
+import Cortex.Wire.Executor (WireExecutorId (..))
+
+config :: BraketConfig
+config =
+  BraketConfig
+    { braketRegion = "us-east-1"
+    , braketDeviceArn = "arn:aws:braket:::device/qpu/ionq/Aria-1"
+    , braketS3Bucket = "amazon-braket-results"
+    , braketProfile = Just "research"
+    }
+
+realizeId :: WireExecutorId
+realizeId = WireExecutorId "quantum.realize"
+
+deviceArn :: Text
+deviceArn = "arn:aws:braket:::device/qpu/ionq/Aria-1"
+
+spec :: Spec
+spec = describe "braketBindingPack" $ do
+  it "declares a one-way dependency on the quantum.braket Wire package" $
+    hbpWirePackageDeps (braketBindingPack config) `shouldBe` ["quantum.braket"]
+
+  it "resolves quantum.realize to a submit/park/resume binding" $
+    case lookupBinding realizeId (braketBindingPack config) of
+      Nothing -> expectationFailure "expected a binding for quantum.realize"
+      Just record -> do
+        rbrAcceptedAwaitStrategy record `shouldBe` SubmitParkResume
+        rbrAbiKind record `shouldBe` AbiSubprocessJsonl
+        rbrStageActionRef record `shouldBe` RuntimeStageActionRef "quantum.realize.braket"
+
+  it "records the configured device as a resolved authority fingerprint" $
+    case lookupBinding realizeId (braketBindingPack config) of
+      Nothing -> expectationFailure "expected a binding"
+      Just record ->
+        fmap rafName (rbrResolvedAuthorities record) `shouldContain` [deviceArn]
+
+  it "does not resolve an unrelated executor" $
+    lookupBinding (WireExecutorId "quantum.prepare_zero") (braketBindingPack config)
+      `shouldBe` Nothing

--- a/test/Cortex/Pulse/Executor/ExternalCallAttemptSpec.hs
+++ b/test/Cortex/Pulse/Executor/ExternalCallAttemptSpec.hs
@@ -1,0 +1,93 @@
+{- |
+Module      : Cortex.Pulse.Executor.ExternalCallAttemptSpec
+Description : DB tests for the ADR 0059 external-call attempt record CRUD.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Reserve → persist-handle → settle lifecycle, and the crash-safety property that
+reserve is idempotent on the key (a recovery re-entry never overwrites the
+authoritative first reservation). Self-skips when PGHOST is unset.
+-}
+module Cortex.Pulse.Executor.ExternalCallAttemptSpec (spec) where
+
+import Control.Exception (SomeException, try)
+import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+import Data.Time (getCurrentTime)
+import Data.UUID qualified as UUID
+import System.Environment (lookupEnv)
+import Test.Hspec
+
+import Cortex.Pulse.Query.ExternalCall
+import Cortex.TestSupport.Database (TestDB, createTestDB, runTx)
+
+setupTestDb :: IO (Maybe TestDB)
+setupTestDb = do
+  mHost <- lookupEnv "PGHOST"
+  case mHost of
+    Nothing -> pure Nothing
+    Just _ -> do
+      result <- try createTestDB :: IO (Either SomeException TestDB)
+      either (\e -> error ("PGHOST set but DB setup failed: " <> show e)) (pure . Just) result
+
+withDb :: Maybe TestDB -> (TestDB -> IO ()) -> IO ()
+withDb Nothing _ = pendingWith "PGHOST not set - database not available"
+withDb (Just db) action = action db
+
+mkKey :: Text -> ExternalCallAttemptKey
+mkKey frontier =
+  ExternalCallAttemptKey
+    { ecaRunId = UUID.nil
+    , ecaNodeId = "realize"
+    , ecaRuntimeBindingId = "braket-pack/quantum.realize"
+    , ecaFrontierId = frontier
+    }
+
+plan :: Aeson.Value
+plan = Aeson.object ["operations" Aeson..= ([Aeson.object ["gate" Aeson..= ("cnot" :: Text)]])]
+
+spec :: Spec
+spec = beforeAll setupTestDb . describe "external-call attempt CRUD" $ do
+  it "reserve then load yields a reserved attempt with the frozen plan" $ \mdb -> withDb mdb $ \db -> do
+    now <- getCurrentTime
+    let key = mkKey "f-reserve"
+    runTx db (reserveExternalCallAttempt key "idem-1" plan now)
+    loaded <- runTx db (loadExternalCallAttempt key)
+    fmap ecaStatus loaded `shouldBe` Just "reserved"
+    fmap ecaIdempotencyKey loaded `shouldBe` Just "idem-1"
+    fmap ecaFrozenPlan loaded `shouldBe` Just plan
+    (ecaJobHandle =<< loaded) `shouldBe` Nothing
+
+  it "reserve is idempotent on the key (recovery re-entry does not overwrite)" $ \mdb -> withDb mdb $ \db -> do
+    now <- getCurrentTime
+    let key = mkKey "f-idem"
+    runTx db (reserveExternalCallAttempt key "idem-first" plan now)
+    runTx db (reserveExternalCallAttempt key "idem-second" (Aeson.object ["x" Aeson..= (1 :: Int)]) now)
+    loaded <- runTx db (loadExternalCallAttempt key)
+    fmap ecaIdempotencyKey loaded `shouldBe` Just "idem-first"
+    fmap ecaFrozenPlan loaded `shouldBe` Just plan
+
+  it "persist handle marks the attempt submitted with the job handle and signal" $ \mdb -> withDb mdb $ \db -> do
+    now <- getCurrentTime
+    let key = mkKey "f-submit"
+        handle = Aeson.object ["jobArn" Aeson..= ("arn:aws:braket:job/abc" :: Text)]
+    runTx db (reserveExternalCallAttempt key "idem-s" plan now)
+    runTx db (persistExternalCallHandle key handle "ext:job-abc" now)
+    loaded <- runTx db (loadExternalCallAttempt key)
+    fmap ecaStatus loaded `shouldBe` Just "submitted"
+    (ecaJobHandle =<< loaded) `shouldBe` Just handle
+    (ecaSignalName =<< loaded) `shouldBe` Just "ext:job-abc"
+
+  it "settle marks the attempt settled" $ \mdb -> withDb mdb $ \db -> do
+    now <- getCurrentTime
+    let key = mkKey "f-settle"
+    runTx db (reserveExternalCallAttempt key "idem-x" plan now)
+    runTx db (settleExternalCallAttempt key now)
+    loaded <- runTx db (loadExternalCallAttempt key)
+    fmap ecaStatus loaded `shouldBe` Just "settled"
+
+  it "load of an absent key is Nothing" $ \mdb -> withDb mdb $ \db -> do
+    loaded <- runTx db (loadExternalCallAttempt (mkKey "f-absent"))
+    loaded `shouldBe` Nothing

--- a/test/Cortex/Pulse/Executor/ExternalCallSpec.hs
+++ b/test/Cortex/Pulse/Executor/ExternalCallSpec.hs
@@ -1,0 +1,112 @@
+{- |
+Module      : Cortex.Pulse.Executor.ExternalCallSpec
+Description : Tests for the ADR 0059 §3 submit/park/resume protocol.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Drives the protocol state machine over IORef-backed fakes: synchronous complete and
+fail, submit→suspend, resume→complete, submit-failure→fail, and the crash-safety
+property that a re-entry before the handle is recorded re-submits with the same
+idempotency key (no duplicate provider task).
+-}
+module Cortex.Pulse.Executor.ExternalCallSpec (spec) where
+
+import Data.Aeson (Value)
+import Data.Aeson qualified as Aeson
+import Data.IORef
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.UUID qualified as UUID
+import Test.Hspec
+
+import Cortex.Capability.Catalog.AwaitStrategy (AwaitStrategy (..))
+import Cortex.Pulse.Executor.ExternalCall
+import Cortex.Pulse.Query.ExternalCall (ExternalCallAttemptKey (..))
+
+key :: Text -> ExternalCallAttemptKey
+key = ExternalCallAttemptKey UUID.nil "realize" "pack"
+
+-- The IORef store is keyed by frontier id (distinct per test).
+newStore :: IO (IORef (Map Text AttemptView), AttemptStore IO)
+newStore = do
+  ref <- newIORef Map.empty
+  let setStatus s = modifyIORef' ref . Map.adjust (\v -> v {avStatus = s}) . ecaFrontierId
+      store =
+        AttemptStore
+          { storeLoad = \k -> Map.lookup (ecaFrontierId k) <$> readIORef ref
+          , storeReserve = \k _ _ ->
+              modifyIORef' ref (Map.insertWith (\_ old -> old) (ecaFrontierId k) (AttemptView Nothing "reserved"))
+          , storePersistHandle = \k h _ ->
+              modifyIORef' ref (Map.insert (ecaFrontierId k) (AttemptView (Just h) "submitted"))
+          , storeSettle = setStatus "settled"
+          , storeFail = setStatus "failed"
+          }
+  pure (ref, store)
+
+plan :: Value
+plan = Aeson.object ["op" Aeson..= ("cnot" :: Text)]
+
+outputs :: [(Text, Value)]
+outputs = [("s01", Aeson.toJSON (1 :: Int)), ("s12", Aeson.toJSON (0 :: Int))]
+
+baseDriver :: ExternalCallDriver IO
+baseDriver =
+  ExternalCallDriver
+    { driverRunSync = \_ -> pure (Right outputs)
+    , driverSubmit = \_ _ -> pure (Right (Aeson.toJSON ("job-1" :: Text)))
+    , driverFetch = \_ -> pure (Right outputs)
+    , driverIdempotencyKey = const "idem-fixed"
+    , driverSignalName = \k -> "ext:" <> ecaFrontierId k
+    }
+
+spec :: Spec
+spec = describe "runExternalCall" $ do
+  it "synchronous: runs inline and completes" $ do
+    (_, store) <- newStore
+    r <- runExternalCall Synchronous baseDriver store (key "sync") plan
+    r `shouldBe` ExternalCallCompleted outputs
+
+  it "synchronous: a driver error fails" $ do
+    (_, store) <- newStore
+    let driver = baseDriver {driverRunSync = \_ -> pure (Left "device offline")}
+    r <- runExternalCall Synchronous driver store (key "sync-fail") plan
+    r `shouldBe` ExternalCallFailed "device offline"
+
+  it "submit/park/resume: first entry submits and suspends, recording the handle" $ do
+    (ref, store) <- newStore
+    r <- runExternalCall SubmitParkResume baseDriver store (key "spr") plan
+    r `shouldBe` ExternalCallSuspended "ext:spr"
+    m <- readIORef ref
+    fmap avStatus (Map.lookup "spr" m) `shouldBe` Just "submitted"
+    (avJobHandle =<< Map.lookup "spr" m) `shouldBe` Just (Aeson.toJSON ("job-1" :: Text))
+
+  it "submit/park/resume: resume with a recorded handle fetches and completes" $ do
+    (ref, store) <- newStore
+    _ <- runExternalCall SubmitParkResume baseDriver store (key "spr2") plan
+    r <- runExternalCall SubmitParkResume baseDriver store (key "spr2") plan
+    r `shouldBe` ExternalCallCompleted outputs
+    m <- readIORef ref
+    fmap avStatus (Map.lookup "spr2" m) `shouldBe` Just "settled"
+
+  it "submit/park/resume: a submit failure fails" $ do
+    (_, store) <- newStore
+    let driver = baseDriver {driverSubmit = \_ _ -> pure (Left "queue rejected")}
+    r <- runExternalCall SubmitParkResume driver store (key "spr-fail") plan
+    r `shouldBe` ExternalCallFailed "queue rejected"
+
+  it "submit/park/resume: re-entry before the handle is recorded re-submits with the same key" $ do
+    (_, store) <- newStore
+    submittedKeys <- newIORef ([] :: [Text])
+    -- A store that loses the handle (simulating a crash before persist): persistHandle is a no-op.
+    let losingStore = store {storePersistHandle = \_ _ _ -> pure ()}
+        driver =
+          baseDriver
+            { driverSubmit = \idem _ -> modifyIORef' submittedKeys (idem :) >> pure (Right (Aeson.toJSON ("job" :: Text)))
+            }
+    _ <- runExternalCall SubmitParkResume driver losingStore (key "spr-crash") plan
+    _ <- runExternalCall SubmitParkResume driver losingStore (key "spr-crash") plan
+    ks <- readIORef submittedKeys
+    ks `shouldBe` ["idem-fixed", "idem-fixed"]

--- a/test/Cortex/Pulse/FrontierContractionSpec.hs
+++ b/test/Cortex/Pulse/FrontierContractionSpec.hs
@@ -1,0 +1,59 @@
+{- |
+Module      : Cortex.Pulse.FrontierContractionSpec
+Description : Tests for the ADR 0059 §2 decidable frontier-contraction admission check.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Admits a homogeneous backend frontier; rejects (never splits) a mixed authority, a
+mixed await strategy, an intervening non-backend node, and an empty set.
+-}
+module Cortex.Pulse.FrontierContractionSpec (spec) where
+
+import Data.Text (Text)
+import Test.Hspec
+
+import Cortex.Capability.Catalog.AwaitStrategy (AwaitStrategy (..))
+import Cortex.Pulse.Rewrite.Contract
+
+backend :: Text -> Text -> AwaitStrategy -> CollectedNode Text Text AwaitStrategy
+backend node authority strat = CollectedNode node (Just (authority, strat))
+
+classical :: Text -> CollectedNode Text Text AwaitStrategy
+classical node = CollectedNode node Nothing
+
+spec :: Spec
+spec = describe "admitFrontierContraction" $ do
+  it "admits a homogeneous same-authority, same-strategy frontier" $
+    admitFrontierContraction
+      [ backend "g0" "quantum.braket" SubmitParkResume
+      , backend "g1" "quantum.braket" SubmitParkResume
+      , backend "m0" "quantum.braket" SubmitParkResume
+      ]
+      `shouldBe` Right ()
+
+  it "rejects a mixed-authority frontier (does not split)" $
+    admitFrontierContraction
+      [ backend "g0" "quantum.braket" SubmitParkResume
+      , backend "g1" "quantum.iqm" SubmitParkResume
+      ]
+      `shouldBe` Left (FrontierMixedAuthority ["g0", "g1"])
+
+  it "rejects a mixed await-strategy frontier" $
+    admitFrontierContraction
+      [ backend "g0" "quantum.braket" SubmitParkResume
+      , backend "g1" "quantum.braket" Synchronous
+      ]
+      `shouldBe` Left (FrontierMixedAwaitStrategy ["g0", "g1"])
+
+  it "rejects an intervening non-backend node" $
+    admitFrontierContraction
+      [ backend "g0" "quantum.braket" SubmitParkResume
+      , classical "decode"
+      ]
+      `shouldBe` Left (FrontierNonBackendIntervening "decode")
+
+  it "rejects an empty collected set" $
+    admitFrontierContraction ([] :: [CollectedNode Text Text AwaitStrategy])
+      `shouldBe` Left FrontierEmpty

--- a/test/Cortex/Pulse/Lowering/CircuitSpec.hs
+++ b/test/Cortex/Pulse/Lowering/CircuitSpec.hs
@@ -1,0 +1,97 @@
+{- |
+Module      : Cortex.Pulse.Lowering.CircuitSpec
+Description : Tests for the realize-frontier lowering decision core (ADR 0059 §2/§3).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Lowering admits the frontier, resolves the binding pack (typed @missing runtime
+binding@ when absent — the ADR 0054 invariant), and produces a deterministic fused
+plan + idempotency key carrying the binding's await strategy.
+-}
+module Cortex.Pulse.Lowering.CircuitSpec (spec) where
+
+import Data.Text (Text)
+import Test.Hspec
+
+import Cortex.Capability.BindingPack (HostBindingPack (..))
+import Cortex.Capability.Catalog.AdmissionProjection (ContentDigest (..), ProjectionVersion (..))
+import Cortex.Capability.Catalog.AwaitStrategy
+  ( AwaitStrategy (..)
+  , IsolationExpectation (..)
+  , ReplayClass (..)
+  )
+import Cortex.Capability.Catalog.ExecutorManifest (AbiKind (..), ContentAddress (..))
+import Cortex.Capability.Catalog.RuntimeBindingRecord
+import Cortex.Pulse.Lowering.Circuit
+import Cortex.Pulse.Lowering.FusedPlan
+  ( FusedMeasurement (..)
+  , FusedOp (..)
+  , fusedPlan
+  , fusedPlanDigest
+  )
+import Cortex.Pulse.Rewrite.Contract (CollectedNode (..))
+import Cortex.Wire.Executor (WireExecutorId (..))
+
+realizeId :: WireExecutorId
+realizeId = WireExecutorId "quantum.realize"
+
+binding :: RuntimeBindingRecord
+binding =
+  RuntimeBindingRecord
+    { rbrBindingId = "braket-pack/quantum.realize"
+    , rbrBindingVersion = "1"
+    , rbrExecutorId = realizeId
+    , rbrProjectionVersion = ProjectionVersion "1"
+    , rbrStageActionRef = RuntimeStageActionRef "quantum.realize.braket"
+    , rbrManifestContentAddress = ContentAddress "sha256:m"
+    , rbrArtifactDigest = ContentDigest "d"
+    , rbrAbiKind = AbiSubprocessJsonl
+    , rbrAbiVersion = "1"
+    , rbrAbiDriverDigest = ContentDigest "dd"
+    , rbrBindingPackIdentity = "braket-pack"
+    , rbrResolvedAuthorities = []
+    , rbrIsolation = SubprocessSandbox
+    , rbrAcceptedReplayClass = IdempotentWithKey
+    , rbrAcceptedAwaitStrategy = SubmitParkResume
+    , rbrCompatibilityDigest = ContentDigest "c"
+    }
+
+braketPack :: HostBindingPack
+braketPack = HostBindingPack "braket-pack" ["quantum.braket"] [binding]
+
+emptyPack :: HostBindingPack
+emptyPack = HostBindingPack "empty" [] []
+
+node :: Text -> CollectedNode Text WireExecutorId AwaitStrategy
+node n = CollectedNode n (Just (WireExecutorId "quantum.braket", SubmitParkResume))
+
+ops :: [FusedOp]
+ops = [FusedOp "cnot" [0, 1] [], FusedOp "measure_z" [0] []]
+
+measurements :: [FusedMeasurement]
+measurements = [FusedMeasurement 0 "s01"]
+
+spec :: Spec
+spec = describe "lowerRealizeFrontier" $ do
+  it "fails with missing runtime binding when no pack resolves the realize executor" $
+    lowerRealizeFrontier emptyPack realizeId [node "g0"] ops measurements
+      `shouldBe` Left (LoweringMissingRuntimeBinding realizeId)
+
+  it "rejects an inadmissible (mixed-authority) frontier" $ do
+    let mixed =
+          [ node "g0"
+          , CollectedNode "g1" (Just (WireExecutorId "quantum.iqm", SubmitParkResume))
+          ]
+    case lowerRealizeFrontier braketPack realizeId mixed ops measurements of
+      Left (LoweringInadmissibleFrontier _) -> pure ()
+      other -> expectationFailure ("expected inadmissible frontier, got " <> show other)
+
+  it "lowers an admissible bound frontier to a deterministic plan carrying the await strategy" $
+    case lowerRealizeFrontier braketPack realizeId [node "g0", node "g1"] ops measurements of
+      Left err -> expectationFailure (show err)
+      Right lowered -> do
+        lrAwaitStrategy lowered `shouldBe` SubmitParkResume
+        lrIdempotencyKey lowered `shouldBe` fusedPlanDigest (fusedPlan ops measurements)
+        rbrStageActionRef (lrBinding lowered) `shouldBe` RuntimeStageActionRef "quantum.realize.braket"

--- a/test/Cortex/Pulse/Lowering/FusedPlanSpec.hs
+++ b/test/Cortex/Pulse/Lowering/FusedPlanSpec.hs
@@ -1,0 +1,44 @@
+{- |
+Module      : Cortex.Pulse.Lowering.FusedPlanSpec
+Description : Tests for the canonical fused-plan serializer (ADR 0059 §2/§3).
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The digest is deterministic, independent of measurement input order (sorted), and
+sensitive to operation order (gate order is physically meaningful). This is the
+idempotency-key stability property the submit/park/resume protocol relies on.
+-}
+module Cortex.Pulse.Lowering.FusedPlanSpec (spec) where
+
+import Test.Hspec
+
+import Cortex.Pulse.Lowering.FusedPlan
+
+ops :: [FusedOp]
+ops =
+  [ FusedOp "prepare_zero" [0] []
+  , FusedOp "x" [0] []
+  , FusedOp "cnot" [0, 1] []
+  ]
+
+measurements :: [FusedMeasurement]
+measurements = [FusedMeasurement 1 "s12", FusedMeasurement 0 "s01"]
+
+spec :: Spec
+spec = describe "fusedPlanDigest" $ do
+  it "is deterministic for the same plan" $
+    fusedPlanDigest (fusedPlan ops measurements)
+      `shouldBe` fusedPlanDigest (fusedPlan ops measurements)
+
+  it "is independent of measurement input order (measurements are sorted)" $
+    fusedPlanDigest (fusedPlan ops measurements)
+      `shouldBe` fusedPlanDigest (fusedPlan ops (reverse measurements))
+
+  it "is sensitive to operation order (gate order is physical)" $
+    fusedPlanDigest (fusedPlan ops measurements)
+      `shouldNotBe` fusedPlanDigest (fusedPlan (reverse ops) measurements)
+
+  it "sorts measurements canonically in the payload" $
+    fmap fmOutput (fpMeasurements (fusedPlan ops measurements)) `shouldBe` ["s01", "s12"]

--- a/test/sql/pulse-schema.sql
+++ b/test/sql/pulse-schema.sql
@@ -706,3 +706,29 @@ ALTER TABLE ONLY pulse.stage_log
 
 \unrestrict DOlga0R2I8dGBjDPPixbHVuE2Odt9zBedCgHJMt1barnnDbmVmzS3Nz4JmmmMgr
 
+
+
+--
+-- Name: external_call_attempts; Type: TABLE; Schema: pulse; Owner: -
+-- ADR 0059 §3: durable home for a submit/park/resume external call's idempotency
+-- key, frozen fused plan, provider job handle, and completion signal name.
+--
+
+CREATE TABLE pulse.external_call_attempts (
+    attempt_id bigserial PRIMARY KEY,
+    run_id uuid NOT NULL,
+    node_id text NOT NULL,
+    runtime_binding_id text NOT NULL,
+    frontier_id text NOT NULL,
+    idempotency_key text NOT NULL,
+    frozen_plan jsonb NOT NULL,
+    job_handle jsonb,
+    signal_name text,
+    status text DEFAULT 'reserved'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    submitted_at timestamp with time zone,
+    settled_at timestamp with time zone
+);
+
+CREATE UNIQUE INDEX idx_pulse_external_call_attempts_key
+    ON pulse.external_call_attempts USING btree (run_id, node_id, runtime_binding_id, frontier_id);

--- a/theory/README.md
+++ b/theory/README.md
@@ -236,6 +236,18 @@ Mechanized results now include:
   overlay preservation under node-and-endpoint-domain disjointness, certified single-pair and bulk
   source contraction, contraction lowering, bulk-contraction lowering, and a certified
   operation/node-port interface that exposes bundled source-linearity proofs.
+- **OPEN OBLIGATION — `realize_preserves_portLinear` (ADR 0059 §2).** The realize frontier
+  contraction (collecting a same-authority external-call frontier into one realize node, ADR 0059)
+  must preserve `PortLinear`. It does **not** reduce to `bulkContract_preserves_portLinear`:
+  `BulkContract` monotonically _erases_ exposed outputs as it consumes endpoints, whereas realize
+  erases the collected frontier's exposed outputs _and re-introduces_ one fresh exposed output per
+  named measurement on the surviving realize node. The discharge is therefore a genuinely new lemma
+  over a `realizeContract` construction
+  (`exposedOutputs := (graph.exposedOutputs \ collected) ∪ measurements`), governed by ADR 0035's
+  rewrite boundary laws with the collected external-call resource accounted under ADR 0032. Tracked,
+  not yet discharged; the decidable admission gate that makes the contraction legal is implemented
+  and tested in `Cortex.Pulse.Rewrite.Contract` (`admitFrontierContraction`). No `sorry` is
+  committed (the Lean gate is sorry-free); this entry is the obligation of record.
 - `LinearPortGraph.MakeWitness`, `LinearPortGraph.MakeWitness.toObject`,
   `LinearPortGraph.MakeWitness.make_disjoint_of_distinctBindings`,
   `LinearPortGraph.PhantomDirection`, `LinearPortGraph.ProductAdapterKind`,


### PR DESCRIPTION
Stack 4/5 for ADR 0059.

Base: #274. Backup branch/PR #270 remains open.

Scope:
- Add decidable frontier-contraction admission for realize frontiers.
- Add external-call attempt records and schema/docs support.
- Add submit/park/resume protocol types for durable external calls.
- Add canonical fused-plan serialization and idempotency-key inputs.
- Add realize-frontier lowering decision core.
- Add the Braket host runtime binding pack.
- Track the Lean port-linearity obligation in the theory ledger.

Validation:
- `just test` -> 837 examples, 0 failures, 124 pending.
- `just docs-check` -> passed.