### PR TITLE
fix(pulse): repair rewrite resume hydration

### DIFF
--- a/src/Cortex/Pulse/Executor/Frontier.hs
+++ b/src/Cortex/Pulse/Executor/Frontier.hs
@@ -336,8 +336,8 @@ runFrontierSequential env task stagePlan gsVar (nid : rest) = do
       runFrontierSequential env task stagePlan gsVar rest
 
 {- | Spawn a semaphore-bounded async worker for a single node.  The worker
-checks the terminal flag before running and sets it when the node produces
-a terminal outcome (failed, timed-out, shutdown, cancelled).
+checks the start gate before running and closes it before releasing the
+semaphore when the node produces a terminal outcome.
 -}
 spawnNodeWorker
   :: StableStageId stageId
@@ -351,7 +351,7 @@ spawnNodeWorker
   -> Map NodeId (Map NodeId Aeson.Value)
   -> NodeId
   -> IO (WorkerHandle stageId)
-spawnNodeWorker env task stagePlan rewriteAdmission budget terminalFlag sem inputsMap nid = do
+spawnNodeWorker env task stagePlan rewriteAdmission budget startGateFlag sem inputsMap nid = do
   let nodeInputs' = Map.findWithDefault Map.empty nid inputsMap
   -- Mask startup so cancellation cannot land before the outer try is installed.
   -- That keeps worker exceptions reified as node results even when cancel races
@@ -362,22 +362,23 @@ spawnNodeWorker env task stagePlan rewriteAdmission budget terminalFlag sem inpu
           outerResult <-
             (try . restore)
               ( bracket_ (waitQSem sem) (signalQSem sem) $ do
-                  cancelled <- readTVarIO terminalFlag
+                  cancelled <- readTVarIO startGateFlag
                   if cancelled
                     then pure (NodeResult nid OutcomeNodeCancelled, Nothing)
                     else do
                       result <- try (executeNodeWorker env task stagePlan rewriteAdmission budget nid nodeInputs')
-                      pure $
-                        case result of
-                          Left (e :: SomeException) -> workerExceptionResult nid e
-                          Right r -> r
+                      let workerResult =
+                            case result of
+                              Left (e :: SomeException) -> workerExceptionResult nid e
+                              Right r -> r
+                          (nr, _) = workerResult
+                      markTerminalOutcome startGateFlag nr.nrOutcome
+                      pure workerResult
               )
           let workerResult =
                 case outerResult of
                   Right r -> r
                   Left (e :: SomeException) -> workerExceptionResult nid e
-              (nr, _) = workerResult
-          markTerminalOutcome terminalFlag nr.nrOutcome
           pure workerResult
       )
   pure WorkerHandle {whNodeId = nid, whAsync = workerAsync}
@@ -393,12 +394,13 @@ collectWorkerResults
   :: StageEnv
   -> TVar PersistedGraphState
   -> TVar Bool
+  -> TVar Bool
   -> TVar (Maybe GraphStatePersistError)
   -> [WorkerHandle stageId]
   -> [(NodeResult, Maybe (PersistedRewrite stageId))]
   -> IO [(NodeResult, Maybe (PersistedRewrite stageId))]
-collectWorkerResults _ _ _ _ [] acc = pure (reverse acc)
-collectWorkerResults env gsVar terminalFlag persistFailRef remaining acc = do
+collectWorkerResults _ _ _ _ _ [] acc = pure (reverse acc)
+collectWorkerResults env gsVar startGateFlag cancelRunningFlag persistFailRef remaining acc = do
   (completed, result) <- waitAnyCatch (fmap whAsync remaining)
   let (mCompletedWorker, remaining') = takeCompletedWorker completed remaining
   case result of
@@ -411,9 +413,19 @@ collectWorkerResults env gsVar terminalFlag persistFailRef remaining acc = do
       case persistResult of
         Left err -> do
           atomically $ writeTVar persistFailRef (Just err)
-          atomically $ writeTVar terminalFlag True
-        Right persistedState -> atomically $ writeTVar gsVar persistedState
-      collectWorkerResults env gsVar terminalFlag persistFailRef remaining' ((nr, mRewrite) : acc)
+          atomically $ writeTVar startGateFlag True >> writeTVar cancelRunningFlag True
+        Right persistedState -> do
+          atomically $ writeTVar gsVar persistedState
+          markTerminalOutcome startGateFlag nr.nrOutcome
+          markTerminalOutcome cancelRunningFlag nr.nrOutcome
+      collectWorkerResults
+        env
+        gsVar
+        startGateFlag
+        cancelRunningFlag
+        persistFailRef
+        remaining'
+        ((nr, mRewrite) : acc)
     Left ex ->
       case mCompletedWorker of
         Just worker -> do
@@ -428,7 +440,6 @@ collectWorkerResults env gsVar terminalFlag persistFailRef remaining acc = do
                 <> T.pack (displayException ex)
             )
             Nothing
-          markTerminalOutcome terminalFlag nr.nrOutcome
           atomically . modifyTVar' gsVar $
             \s -> s {pgsGraphState = applyNodeFact nr s.pgsGraphState}
           currentState <- readTVarIO gsVar
@@ -436,9 +447,19 @@ collectWorkerResults env gsVar terminalFlag persistFailRef remaining acc = do
           case persistResult of
             Left err -> do
               atomically $ writeTVar persistFailRef (Just err)
-              atomically $ writeTVar terminalFlag True
-            Right persistedState -> atomically $ writeTVar gsVar persistedState
-          collectWorkerResults env gsVar terminalFlag persistFailRef remaining' ((nr, mRewrite) : acc)
+              atomically $ writeTVar startGateFlag True >> writeTVar cancelRunningFlag True
+            Right persistedState -> do
+              atomically $ writeTVar gsVar persistedState
+              markTerminalOutcome startGateFlag nr.nrOutcome
+              markTerminalOutcome cancelRunningFlag nr.nrOutcome
+          collectWorkerResults
+            env
+            gsVar
+            startGateFlag
+            cancelRunningFlag
+            persistFailRef
+            remaining'
+            ((nr, mRewrite) : acc)
         Nothing -> do
           recordRunEvent
             env
@@ -448,8 +469,8 @@ collectWorkerResults env gsVar terminalFlag persistFailRef remaining acc = do
                 <> T.pack (displayException ex)
             )
             Nothing
-          atomically $ writeTVar terminalFlag True
-          collectWorkerResults env gsVar terminalFlag persistFailRef remaining' acc
+          atomically $ writeTVar startGateFlag True >> writeTVar cancelRunningFlag True
+          collectWorkerResults env gsVar startGateFlag cancelRunningFlag persistFailRef remaining' acc
 
 {- | Classify the graph after a concurrent frontier completes.  Persists the
 classified state when it differs from the raw accumulated state, then
@@ -571,7 +592,8 @@ runFrontierConcurrent env task stagePlan gsVar readyNodeIds = do
                   { rasRemainingBudget = budgetRef
                   , rasAdmissionLock = admissionLock
                   }
-          terminalFlag <- newTVarIO False
+          startGateFlag <- newTVarIO False
+          cancelRunningFlag <- newTVarIO False
           asyncHandles <-
             forM pendingNodeIds $
               spawnNodeWorker
@@ -580,14 +602,15 @@ runFrontierConcurrent env task stagePlan gsVar readyNodeIds = do
                 stagePlan
                 rewriteAdmission
                 markRunningState'.pgsRemainingRewriteBudget
-                terminalFlag
+                startGateFlag
                 sem
                 inputsMap
           monitor <- async $ do
-            atomically $ readTVar terminalFlag >>= check
+            atomically $ readTVar cancelRunningFlag >>= check
             forM_ asyncHandles (cancel . whAsync)
           persistFailRef <- newTVarIO Nothing
-          results <- collectWorkerResults env gsVar terminalFlag persistFailRef asyncHandles []
+          results <-
+            collectWorkerResults env gsVar startGateFlag cancelRunningFlag persistFailRef asyncHandles []
           cancel monitor
           mPersistFail <- readTVarIO persistFailRef
           case mPersistFail of

--- a/src/Cortex/Pulse/PlanHydration.hs
+++ b/src/Cortex/Pulse/PlanHydration.hs
@@ -36,6 +36,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
 
+import Cortex.Algebra.Graph (relVertices)
 import Cortex.Pulse.Node
   ( NodeId (..)
   )
@@ -230,9 +231,11 @@ planRewriteDelta
   -> StagePlan stageId
   -> Either [RewriteValidationError] (PlannedRewriteDelta (StageDefinition stageId))
 planRewriteDelta rewrite plan = do
+  first (pure . RewriteDuplicateTemplate) (buildStageTemplateRegistry plan.spDefinitions) $> ()
+  let activeDefinitions = Map.restrictKeys plan.spDefinitions (relVertices plan.spTopology)
   delta <-
     first (fmap RewritePlanningIssue) $
-      planGraphRewrite rewrite plan.spTopology plan.spDefinitions
+      planGraphRewrite rewrite plan.spTopology activeDefinitions
   first (pure . RewriteDuplicateTemplate) (buildStageTemplateRegistry delta.prdDefinitions) $> ()
   pure delta
 

--- a/test/Cortex/Pulse/ExecutorSpec.hs
+++ b/test/Cortex/Pulse/ExecutorSpec.hs
@@ -2832,13 +2832,12 @@ spec = beforeAll setupTestDb $ do
           Map.lookup nodeDelta m `shouldBe` Just NodeFailed
 
     it "prefers a settled failure over a sibling rewrite in the same frontier" $ \mPool -> withDb mPool $ \pool -> do
-      pendingWith "Pre-existing rewrite-subsystem failure (not run-terminal); tracked in #266"
       (_, taskContext) <- mkTaskContextWith pool 4
       taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-concurrent-rewrite-failure"
       runId <- createTestRun pool taskId
       task <- loadTaskDef pool taskId
       betaRewrote <- newEmptyMVar
-      let mkDynStage stageId action =
+      let mkDynStage stageId stageAction =
             StageDefinition
               { sdStageId = DynStageId stageId
               , sdTemplateId = stageTemplateId (DynStageId stageId)
@@ -2847,7 +2846,7 @@ spec = beforeAll setupTestDb $ do
               , sdReplayPolicyOverride = Nothing
               , sdTimeoutSeconds = Nothing
               , sdRetryPolicy = Nothing
-              , sdAction = action
+              , sdAction = stageAction
               , sdMemoryStrategy = defaultMemoryStrategy
               }
           nodeAlpha = NodeId "alpha"
@@ -2974,12 +2973,80 @@ spec = beforeAll setupTestDb $ do
       peak <- readIORef peakRef
       peak `shouldSatisfy` (<= 2)
 
+    it "blocks semaphore-queued workers after a terminal sibling finishes" $ \mPool -> withDb mPool $ \pool -> do
+      (_, taskContext) <- mkTaskContextWith pool 2
+      taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-terminal-blocks-queued-worker"
+      runId <- createTestRun pool taskId
+      task <- loadTaskDef pool taskId
+      roleRef <- newIORef (0 :: Int)
+      blockerStarted <- newEmptyMVar
+      blockerGate <- newEmptyMVar
+      blockerCancelled <- newEmptyMVar
+      lateStarts <- newIORef (0 :: Int)
+      let mkDynStage stageId stageAction =
+            StageDefinition
+              { sdStageId = DynStageId stageId
+              , sdTemplateId = stageTemplateId (DynStageId stageId)
+              , sdActionId = stageActionId (DynStageId stageId)
+              , sdReplaySafety = SafeToReplay
+              , sdReplayPolicyOverride = Nothing
+              , sdTimeoutSeconds = Nothing
+              , sdRetryPolicy = Nothing
+              , sdAction = stageAction
+              , sdMemoryStrategy = defaultMemoryStrategy
+              }
+          roleAction _ = do
+            role <- atomicModifyIORef' roleRef (\n -> let n' = n + 1 in (n', n'))
+            case role of
+              1 ->
+                flip finally (void (tryPutMVar blockerCancelled ())) $ do
+                  putMVar blockerStarted ()
+                  _ <- readMVar blockerGate
+                  pure (StageComplete (Aeson.String "blocker"))
+              2 -> do
+                mBlocker <- timeout 2_000_000 (readMVar blockerStarted)
+                case mBlocker of
+                  Nothing -> throwIO (userError "timed out waiting for blocker worker")
+                  Just () -> throwIO (userError "terminal worker fails after blocker starts")
+              _ -> do
+                atomicModifyIORef' lateStarts (\c -> (c + 1, ()))
+                pure (StageComplete (Aeson.String "late"))
+          nodes = [NodeId "a", NodeId "b", NodeId "c", NodeId "d"]
+          topology = toRelation (mconcat [Vertex n | n <- nodes])
+          defs =
+            Map.fromList
+              [ (NodeId "a", mkDynStage "a" roleAction)
+              , (NodeId "b", mkDynStage "b" roleAction)
+              , (NodeId "c", mkDynStage "c" roleAction)
+              , (NodeId "d", mkDynStage "d" roleAction)
+              ]
+          stagePlan =
+            StagePlan
+              { spInitialState = Aeson.Null
+              , spCheckpointRuntimeVersion = 1
+              , spReplayPolicy = ReplayPolicyWarn
+              , spInitialRewriteBudget = defaultRewriteBudget
+              , spRewriteExhaustionPolicy = RewriteExhaustionFail
+              , spBudgetExceededExhaustionPolicy = Nothing
+              , spMaxRewriteReExecutions = 2
+              , spTopology = topology
+              , spDefinitions = defs
+              , spTemplateRegistry = mkTemplateRegistry defs
+              }
+      result <- timeout 5_000_000 $ executeStagePlan taskContext runId task stagePlan
+      case result of
+        Nothing -> expectationFailure "Timed out waiting for terminal frontier"
+        Just outcome -> outcome `shouldBe` OutcomeFailed
+      starts <- readIORef lateStarts
+      starts `shouldBe` 0
+      cancelled <- timeout 2_000_000 (readMVar blockerCancelled)
+      cancelled `shouldSatisfy` isJust
+
     it "cancels semaphore-queued workers without leaving stale NodeRunning statuses" $ \mPool -> withDb mPool $ \pool -> do
-      -- cap=1 means only one worker runs at a time; the other two are blocked
-      -- on waitQSem.  When the first worker fails, the monitor cancels the
-      -- queued workers.  They must produce NodeResult (not escape as Left
-      -- through waitAnyCatch) so the graph state is clean.
-      (_, taskContext) <- mkTaskContextWith pool 1
+      -- cap=2 with three ready roots leaves one worker blocked on waitQSem.
+      -- When the first worker fails, the queued worker must produce NodeResult
+      -- (not escape as Left through waitAnyCatch) so the graph state is clean.
+      (_, taskContext) <- mkTaskContextWith pool 2
       taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-semaphore-cancel"
       runId <- createTestRun pool taskId
       task <- loadTaskDef pool taskId
@@ -4618,7 +4685,6 @@ spec = beforeAll setupTestDb $ do
                 )
 
     it "materializes admitted rewrites from lineage when graph_state watermark lags" $ \mPool -> withDb mPool $ \pool -> do
-      pendingWith "Pre-existing rewrite-subsystem failure (not run-terminal); tracked in #266"
       (shutdownFlag, taskContext) <- mkTaskContext pool
       taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-rewrite-watermark-gap"
       runId <- createTestRun pool taskId
@@ -4835,7 +4901,6 @@ spec = beforeAll setupTestDb $ do
           successors topology (NodeId "alpha") `shouldBe` Set.singleton (NodeId "alpha:sub1")
 
     it "repairs missing rewritten node statuses from the materialized watermark topology on resume" $ \mPool -> withDb mPool $ \pool -> do
-      pendingWith "Pre-existing rewrite-subsystem failure (not run-terminal); tracked in #266"
       (shutdownFlag, taskContext) <- mkTaskContext pool
       taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-rewrite-resume-repair"
       runId <- createTestRun pool taskId
@@ -5304,7 +5369,6 @@ spec = beforeAll setupTestDb $ do
       fmap Q.pravErrorType runView `shouldBe` Just (Just "invalid_rewrite")
 
     it "hydrates rewritten stages by template id even when semantic stage ids are reused" $ \mPool -> withDb mPool $ \pool -> do
-      pendingWith "Pre-existing rewrite-subsystem failure (not run-terminal); tracked in #266"
       (shutdownFlag, taskContext) <- mkTaskContext pool
       taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-rewrite-template-identity"
       runId <- createTestRun pool taskId


### PR DESCRIPTION
## Summary

Fixes #266.

This repairs the rewrite-resume regressions that were pending in the Pulse executor suite:

- delays concurrent-frontier terminal cancellation until a worker result has been persisted, so a sibling rewrite cannot be converted into `NodeInterrupted` after the action has already produced the rewrite result
- validates latent stage-template registry conflicts from the full `StagePlan` while passing only active topology definitions into graph rewrite planning
- unpends the four #266 regression tests

## Root Cause

Two separate invariants were getting crossed:

1. Concurrent frontier workers marked the terminal flag before the collector persisted their result. A failing sibling could therefore cancel an already-decided rewrite worker before its result became durable.
2. Runtime rewrite planning was seeing latent template definitions as if they were active topology nodes, while resume hydration still needs those latent templates to remain registered.

## Validation

- `just test-db` -> `839 examples, 0 failures`
- `just fmt-check`
- `just lint`
- `git diff --check`
- `just check-commit-provenance origin/main..HEAD`

Targeted #266 tests also passed individually before the full DB suite:

- `prefers a settled failure over a sibling rewrite in the same frontier`
- `materializes admitted rewrites from lineage when graph_state watermark lags`
- `repairs missing rewritten node statuses from the materialized watermark topology on resume`
- `hydrates rewritten stages by template id even when semantic stage ids are reused`
