### PR TITLE
fix(pulse): stabilize rewrite failure frontier test

### DIFF
--- a/test/Cortex/Pulse/ExecutorSpec.hs
+++ b/test/Cortex/Pulse/ExecutorSpec.hs
@@ -2836,7 +2836,6 @@ spec = beforeAll setupTestDb $ do
       taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-concurrent-rewrite-failure"
       runId <- createTestRun pool taskId
       task <- loadTaskDef pool taskId
-      betaRewrote <- newEmptyMVar
       let mkDynStage stageId stageAction =
             StageDefinition
               { sdStageId = DynStageId stageId
@@ -2874,21 +2873,28 @@ spec = beforeAll setupTestDb $ do
               , sgsEntryNodes = [NodeId "sub1"]
               , sgsExitNodes = [NodeId "sub1"]
               }
+          waitForBetaRewritten = do
+            maybeStatuses <- readGraphNodeStatuses pool runId
+            case maybeStatuses >>= Map.lookup nodeBeta of
+              Just NodeRewritten -> pure ()
+              _ -> do
+                threadDelay 10000
+                waitForBetaRewritten
           defs =
             Map.fromList
               [ (nodeAlpha, mkDynStage "alpha" (\_ -> pure (StageComplete Aeson.Null)))
               ,
                 ( nodeBeta
-                , mkDynStage "beta" $ \_ -> do
-                    putMVar betaRewrote ()
-                    pure (StageRewrite (Aeson.String "beta-output") (ExpandNode nodeBeta ExpandReplaceNode rewriteSpec))
+                , mkDynStage "beta" $
+                    \_ ->
+                      pure (StageRewrite (Aeson.String "beta-output") (ExpandNode nodeBeta ExpandReplaceNode rewriteSpec))
                 )
               ,
                 ( nodeGamma
                 , mkDynStage "gamma" $ \_ -> do
-                    maybeBetaRewrote <- timeout 2_000_000 (readMVar betaRewrote)
-                    case maybeBetaRewrote of
-                      Nothing -> throwIO (userError "timed out waiting for beta rewrite")
+                    maybeBetaRewritten <- timeout 2_000_000 waitForBetaRewritten
+                    case maybeBetaRewritten of
+                      Nothing -> throwIO (userError "timed out waiting for beta rewrite persistence")
                       Just () -> pure ()
                     throwIO (userError "gamma fails after sibling rewrite")
                 )


### PR DESCRIPTION
## Summary

Fixes the red post-merge `main` CI run on `d17545b`.

The failing test was:

`Cortex.Pulse.Executor/concurrent frontier execution/prefers a settled failure over a sibling rewrite in the same frontier`

CI failed because the test signaled `betaRewrote` before beta's rewrite result had returned to the frontier and been persisted. Gamma could then fail quickly enough to cancel beta, producing `NodeInterrupted InterruptedSiblingCancelled` instead of the asserted `NodeRewritten`.

This PR makes gamma wait until beta is durably observed as `NodeRewritten` in persisted graph state before it fails, so the test now exercises the settled-rewrite/failure ordering it claims to cover.

## Checks

- [x] `just fmt-check`
- [x] `just lint`
- [x] `just test-db "--match '/Cortex.Pulse.Executor/concurrent frontier execution/prefers a settled failure over a sibling rewrite in the same frontier/' --seed 1780901397"`
- [x] 15 repeated runs of the same DB-backed spec
- [x] `just test-db "--match '/Cortex.Pulse.Executor/concurrent frontier execution/'"`
- [x] `just test-db` — 846 examples, 0 failures
- [x] `just check-commit-provenance origin/main..HEAD`