### PR TITLE
feat(wire): extend CorePure with fold + list/string/record stdlib (batch 1)

### DIFF
--- a/cortex.cabal
+++ b/cortex.cabal
@@ -185,6 +185,7 @@ library
         Cortex.Wire.LeanFixture
         Cortex.Wire.Parser
         Cortex.Wire.Pure
+        Cortex.Wire.Pure.Bounds
         Cortex.Wire.Std
         Cortex.Wire.Syntax
         Cortex.Wire.Package

--- a/docs/ADRs/0061-corepure-bounded-iteration-primitives.md
+++ b/docs/ADRs/0061-corepure-bounded-iteration-primitives.md
@@ -1,0 +1,163 @@
+---
+title: "ADR 0061 - CorePure Bounded Iteration Primitives"
+description:
+  "Admits range, fold, and foldRight into CorePure as total primitives bounded by a fixed
+  deterministic cap, refining the fold deferral in ADR 0020 and ADR 0023."
+sidebar:
+  label: "0061. CorePure bounded iteration"
+  order: 61
+status: proposed
+date: 2026-06-26
+superseded_by: null
+related:
+  - docs/Reference/Wire/pure-execution.md
+  - docs/ADRs/0020-wire-pure-output-equations.md
+  - docs/ADRs/0023-corepure-expression-surface.md
+  - docs/ADRs/0050-wire-corepure-output-residue.md
+  - docs/ADRs/0056-admission-modes-witnessed-and-gas.md
+  - "GitHub #295"
+  - "GitHub #301"
+---
+
+# ADR 0061 - CorePure Bounded Iteration Primitives
+
+## Status
+
+Proposed - refines the `fold` deferral in ADR 0020 and ADR 0023. Those ADRs remain canon; this ADR
+narrows when reduction and finite generation are admitted into CorePure. It does not edit them.
+
+## Context
+
+CorePure (ADR 0023) is the closed, total, authority-free expression layer Wire authors use for
+JSON-shaped report and value logic. Its builtin set already iterates finite input structure (`map`,
+`filter`, `sum`, `zipWith`, `all`, `any`), but it has no general reducer and no way to generate a
+finite sequence from a count. Without those, real list/string report logic — the kind that currently
+forces a Haskell extension such as `Cortex.Quantum.Qec.renderReport` — cannot be written in pure
+Wire (issue #295).
+
+Two earlier decisions gated exactly these primitives:
+
+- ADR 0023 disallows "unbounded `fold`" and states `fold` "can be reconsidered only after budget
+  accounting is solid enough to state its cost model".
+- ADR 0020 lists "unbounded `fold`" out of scope and records that "budget exhaustion is a typed
+  evaluator error", with "bounded `fold` after budget accounting is tested" as future work.
+
+The gate is about _cost_, not termination. A list-driven `fold` always terminates, but a general
+accumulator function can grow the accumulator super-linearly (a step that doubles its input reaches
+`2^n` after `n` elements), and `range(0, N)` materialises `N` elements from a scalar argument. Both
+turn a small input into unbounded work. Meanwhile ADR 0056 deliberately keeps CorePure budget-free:
+its gas account governs rewrite and Pulse-iteration admission, and "no fourth budget is introduced"
+for CorePure, which "stays total".
+
+So the open question is narrow: how can `fold`/`range` be admitted while keeping CorePure total and
+without introducing the operator-tunable budget ADR 0056 declined.
+
+## Decision
+
+Admit three bounded-iteration builtins into the closed CorePure environment, each a total
+`CorePureBuiltinPureValue` on the existing builtin-call path (no AST or parser change):
+
+- `range(start, end)` - the half-open integer sequence `[start, end)`;
+- `fold(f, init, list)` - left reduction, `f acc item`;
+- `foldRight(f, init, list)` - right reduction, `f item acc`.
+
+Their cost is bounded by a single **fixed deterministic cap**, `corePureBoundedIterationCap`, a
+compile-time constant in the evaluator. It is a _totality guard_, not a budget: it is not authored,
+not configured, and not operator-tunable, so it does not reintroduce the gas account ADR 0056 keeps
+out of CorePure. Exhausting it is a typed evaluator failure, `PureBoundExceeded`, consistent with
+ADR 0020's "budget exhaustion is a typed evaluator error".
+
+The cap binds the two cost vectors that argument _values_ (not input _structure_) control:
+
+- `range` rejects when `end - start` exceeds the cap (`PureBoundExceeded "range span"`);
+- `fold`/`foldRight` reject when the running accumulator exceeds the cap measured as value cost -
+  one per JSON node plus string lengths, number magnitudes, and object key lengths, so structural
+  nesting, string concatenation, numeric growth, and key growth are all caught
+  (`PureBoundExceeded "fold accumulator"`). The seed is guarded before the loop and a
+  function-valued accumulator is rejected, so the accumulator is always a within-cap JSON value. The
+  guard short-circuits, so it stays bounded itself.
+
+CorePure therefore stays total: every admitted program either produces a value or fails with a typed
+error in bounded work. This satisfies the ADR 0023 cost-model precondition by stating the cost model
+explicitly (a fixed node/element ceiling) rather than deferring to an accounting system.
+
+The accompanying ergonomic stdlib (issue #295 batch 1: `reverse`, `sort`, `sortBy`, `take`, `drop`,
+search, string, and record builtins) is _not_ gated by this ADR. Those iterate finite input
+structure, exactly the termination class of the existing `map`/`filter`/`sum`, and need no cap.
+
+`sortBy(keyFn, list)` is admitted: it sorts by a deterministic key projection under a fixed total
+order over JSON values, so it is not the "sort with user comparators" ADR 0023 defers. A free
+comparator form (`sortWith(cmp, list)`) remains deferred, because a user comparator can be non-total
+or inconsistent and would make the sort result undefined.
+
+## Alternatives considered
+
+- **A global evaluation fuel counter threaded through the whole evaluator.** A per-reduction step
+  budget would bound all CorePure cost uniformly, including the fold accumulator pathology. Rejected
+  for this change: it is an evaluator-wide refactor of a hot path and its fast paths for a problem
+  with only two new unbounded vectors, and a per-step _count_ edges closer to the tunable budget ADR
+  0056 excludes than a fixed structural ceiling does. The cap can be promoted to a fuel model later
+  without changing the authored surface.
+- **Admit `fold`/`range` with structural bounds only and no cap.** Simplest, but leaves the
+  documented super-linear-accumulator and scalar-driven-`range` holes open, contradicting the ADR
+  0023 cost-model precondition. Rejected.
+- **Keep `fold`/`range` deferred and ship only the ungated stdlib.** Delivers most of the list and
+  string ergonomics, but leaves Wire unable to reduce to a custom accumulator or generate a sequence
+  from a count - the structural gap issue #295 set out to close. Rejected.
+
+## Consequences
+
+### Positive
+
+- Pure Wire can author general list/string/record report logic end to end, including reduction and
+  finite generation, removing the need to compile that logic into a Haskell extension.
+- CorePure stays total and authority-free; the new failure mode is typed and deterministic.
+- The cost model is stated, not deferred, satisfying the ADR 0023 precondition with a single legible
+  constant.
+- The policy is enforced by a typed boundary module (`Cortex.Wire.Pure.Bounds`) whose result types
+  (`FoldAccumulator`, `ClampedIndex`, `RangePlan`, `CostCheck`) have hidden constructors and are
+  only built through smart constructors that apply the cap. The bounded-iteration builtins cannot
+  iterate from an unguarded seed or step result, narrow a range before the span decision, or compare
+  a raw cost count incorrectly, and the policy cannot be re-derived with ad-hoc conditionals at each
+  call site. QuickCheck properties back the invariants.
+
+### Negative
+
+- A fixed cap can reject a legitimately large in-memory computation; the bound is a constant, not
+  tunable per run. CorePure is intentionally not the place for very large iteration - that is
+  Pulse-admitted bounded iteration (ADR 0055).
+- The fold accumulator guard measures value cost each step, a small constant-factor overhead on
+  reduction.
+- **The cap is per-operation, not a global allocation budget.** It bounds each `range` span and each
+  `fold`/`foldRight` accumulator. It does not bound the combined cost of composed or nested
+  expressions: a `range` may generate a cap-sized array that `map`/`enumerate`/`split`/`replace`
+  then amplifies by a constant factor, and nesting a generator inside `map` (for example
+  `range 0 n |> map (i: range 0 n)`) multiplies costs and can allocate a large intermediate before
+  any single operation trips. These are bounded but can be large; for an authored expression they
+  are a footgun, not a data-driven amplification (data-derived `range`/`fold` are themselves
+  capped). A true total-allocation bound is a global cost budget, deferred as the fuel-model work
+  below and tracked in GitHub #301.
+
+### Obligations
+
+- The Lean proof-side closed-builtin signature mirror (`theory/Cortex/Wire/Pure.lean`) tracks the
+  Haskell `corePureBuiltinSignature`; both list the new builtins. No new termination theorem is
+  required because every builtin is total and the cap bounds cost.
+- `docs/Reference/Wire/pure-execution.md` documents the new builtins, the cap, and the
+  `PureBoundExceeded` failure.
+- If CorePure later needs a total-allocation bound across composed expressions, or tunable or larger
+  iteration, promote the fixed per-operation cap to a stated global fuel model rather than widening
+  it silently. Tracked in GitHub #301.
+
+## Related
+
+- [0020 - Wire Pure Output Equations](0020-wire-pure-output-equations.md) - original `fold` deferral
+  and the typed-budget-exhaustion principle.
+- [0023 - CorePure Expression Surface](0023-corepure-expression-surface.md) - the closed surface and
+  the cost-model precondition this ADR satisfies.
+- [0050 - Wire CorePure Output Residue](0050-wire-corepure-output-residue.md) - CorePure stays total
+  and non-recursive.
+- [0056 - Admission Modes: Witnessed Materialization and Open Rewrite Gas](0056-admission-modes-witnessed-and-gas.md)
+  - CorePure introduces no tunable budget; the cap here is a totality guard, not gas.
+- [Wire Reference - Pure Execution](../Reference/Wire/pure-execution.md) - builtin catalogue and
+  failure surface.

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -77,6 +77,7 @@ values: `proposed`, `accepted`, `superseded`, `deprecated`.
 | [0058](0058-pulse-atomic-suspend-settlement.md)                    | Pulse Atomic Suspend Settlement                                     | proposed   |
 | [0059](0059-durable-external-call-frontiers-on-pulse.md)           | Durable External-Call Frontiers on Pulse                            | proposed   |
 | [0060](0060-filesystem-package-and-binding-manifests.md)           | Filesystem Package and Binding Manifests                            | proposed   |
+| [0061](0061-corepure-bounded-iteration-primitives.md)              | CorePure Bounded Iteration Primitives                               | proposed   |
 
 ## Writing a new ADR
 

--- a/docs/Reference/Wire/pure-execution.md
+++ b/docs/Reference/Wire/pure-execution.md
@@ -16,6 +16,8 @@ related:
   - docs/ADRs/0050-wire-corepure-output-residue.md
   - docs/ADRs/0031-wire-binding-forms-and-where-clauses.md
   - docs/ADRs/0039-wire-node-boundary-transform-normal-form.md
+  - docs/ADRs/0023-corepure-expression-surface.md
+  - docs/ADRs/0061-corepure-bounded-iteration-primitives.md
 ---
 
 # Wire Reference — Pure Execution
@@ -244,8 +246,79 @@ The implemented builtin environment is closed:
 | `toJson`   | 1     | Canonical compact JSON serialization for structured values.          |
 | `fromJson` | 1     | Parses a JSON string into a structured CorePure value.               |
 
+List, search, string, record, and bounded-iteration builtins (issue #295 batch 1):
+
+| Builtin       | Arity | Meaning                                                             |
+| ------------- | ----- | ------------------------------------------------------------------- |
+| `reverse`     | 1     | Reverses an array.                                                  |
+| `sort`        | 1     | Sorts an array by a fixed total order over JSON values.             |
+| `sortBy`      | 2     | `sortBy keyFn list`, stable sort by `keyFn item` under that order.  |
+| `take`        | 2     | `take n list`, the first `n` items, clamped to length.              |
+| `drop`        | 2     | `drop n list`, dropping the first `n` items, clamped.               |
+| `enumerate`   | 1     | Pairs each item with its index as `{index, value}`.                 |
+| `mapIndexed`  | 2     | `mapIndexed f list`, applying `f index value` to each item.         |
+| `find`        | 2     | First item matching the predicate, or `null`.                       |
+| `findIndex`   | 2     | Index of the first matching item, or `-1`.                          |
+| `contains`    | 2     | `contains x list`, whether `x` equals some array element.           |
+| `indexOf`     | 2     | Index of the first element equal to `x`, or `-1`.                   |
+| `count`       | 2     | Number of array items matching the predicate.                       |
+| `split`       | 2     | `split sep s`; an empty separator splits into characters.           |
+| `replace`     | 3     | `replace old new s`, replacing every `old`; empty `old` is a no-op. |
+| `substring`   | 3     | `substring start end s`, a half-open code-point slice, clamped.     |
+| `trim`        | 1     | Removes leading and trailing whitespace.                            |
+| `toLower`     | 1     | Lowercases a string.                                                |
+| `toUpper`     | 1     | Uppercases a string.                                                |
+| `startsWith`  | 2     | `startsWith prefix s`, whether `s` begins with `prefix`.            |
+| `endsWith`    | 2     | `endsWith suffix s`, whether `s` ends with `suffix`.                |
+| `strLength`   | 1     | Code-point length of a string.                                      |
+| `lines`       | 1     | Splits a string into an array of lines.                             |
+| `unlines`     | 1     | Joins an array of strings with newlines, with no trailing newline.  |
+| `keys`        | 1     | Object keys as a key-sorted array of strings.                       |
+| `values`      | 1     | Object values, in key-sorted order.                                 |
+| `entries`     | 1     | Object fields as a key-sorted array of `{key, value}`.              |
+| `withDefault` | 2     | `withDefault default x`, returning `x` unless it is `null`.         |
+| `isNull`      | 1     | Whether a value is `null`.                                          |
+| `range`       | 2     | `range start end`, the half-open integer sequence `[start, end)`.   |
+| `fold`        | 3     | `fold f init list`, left reduction applying `f acc item`.           |
+| `foldRight`   | 3     | `foldRight f init list`, right reduction applying `f item acc`.     |
+
 Every builtin is ordinary CorePure function application. Builtins do not receive host authority.
 Functions intended for pipe use are data-last.
+
+### Conventions
+
+- Functions are data-last: the collection or string carried by the pipe is the final argument, so
+  `items |> filter keep |> take 5` reads left to right.
+- Absent-result builtins use in-band sentinels: `find` returns `null`, while `findIndex` and
+  `indexOf` return `-1`.
+- `take`, `drop`, and `substring` clamp out-of-range indices instead of failing.
+- `range` is half-open, so `range 0 n` yields `[0, 1, ..., n - 1]`.
+- `keys`, `values`, `entries`, and `sort` produce a deterministic key/value order, independent of
+  the host hash-map layout.
+
+### Bounded iteration
+
+`range`, `fold`, and `foldRight` are the bounded-iteration primitives. CorePure stays total, so they
+are bounded by a fixed deterministic cap rather than an operator budget, per
+[ADR 0061](../../ADRs/0061-corepure-bounded-iteration-primitives.md): `range` rejects a span beyond
+the cap (its direction is decided first, so a backwards or equal range is empty at any magnitude,
+and the span is then computed in unbounded integers so endpoints near the machine word bounds cannot
+overflow the check), and `fold`/`foldRight` reject when the accumulator exceeds the cap measured as
+value cost (JSON nodes plus string lengths, number magnitudes, and object key lengths). Exhaustion
+is the typed `PureBoundExceeded` failure. A `fold` accumulator must reduce to a JSON value; a
+function-valued accumulator is rejected, since a closure can capture a chain that only explodes when
+applied.
+
+`range` also bounds its endpoints, not only its span: a forward range whose endpoint magnitude
+exceeds a fixed decimal-digit bound (far above the Int range) is rejected as over-cap even when its
+span is small, so the emitted numbers — whose total size is the span times the endpoint width — stay
+bounded. Equal and backwards endpoints remain an empty range at any magnitude.
+
+The cap is per-operation, not a global allocation budget: it bounds each `range` and each `fold`,
+but not the combined cost of composed or nested expressions (for example a `range` feeding `map`, or
+a generator nested inside `map`), which stay bounded by input structure but can be large. CorePure
+is not the place for very large iteration; runtime-sized work belongs to Pulse-admitted bounded
+iteration (ADR 0055).
 
 ## Failure Surface
 
@@ -267,6 +340,8 @@ Pure execution fails deterministically. The evaluator reports typed failures, in
 - duplicate binding names within one scope;
 - duplicate lambda parameters;
 - invalid JSON passed to `fromJson`;
+- exceeding the fixed CorePure bounded-iteration cap (a `range` span or `fold` accumulator past the
+  ceiling);
 - `where` expressions that do not evaluate to records.
 
 These failures are runtime pure-task failures after the graph has been admitted. Source and binding

--- a/examples/wire/pure-stdlib-report.wire
+++ b/examples/wire/pure-stdlib-report.wire
@@ -1,0 +1,69 @@
+# Pure Wire stdlib demonstration.
+#
+# Run:
+#
+#   wire run examples/wire/pure-stdlib-report.wire
+#
+# Everything below the seed source is CorePure. `range` generates the row
+# indices, `fold` reduces them into Markdown rows, and the string builtins
+# format each cell. This is the report-rendering shape that previously had to
+# live in a compiled Haskell extension; the whole table is now pure Wire,
+# chained with `|>` and the batch 1 list/string builtins.
+
+use std.io.{@stdout, @writeFile};
+
+contract Seed;
+contract Report;
+
+let tableHeader = "| n | square | cube | size |\n| --- | --- | --- | --- |";
+
+# One Markdown row per index, appended to the running table text. `fold` is the
+# bounded reducer: it folds each generated index onto the accumulated string.
+let appendRow = acc: n:
+  let
+    size = if n * n > 10 then "big" else "small";
+    cells = [
+      toString n,
+      toString (n * n),
+      toString (n * n * n),
+      toUpper size
+    ];
+  in
+  concat [acc, "\n| ", cells |> joinWith " | ", " |"];
+
+# `range 1 6` generates [1, 2, 3, 4, 5] with no loop or recursion; `fold`
+# reduces it; `length` and the string builtins shape the surrounding prose.
+let buildReport = seed:
+  let
+    rows = range 1 6;
+    table = rows |> fold appendRow tableHeader;
+  in
+  concat [
+    "# Wire pure stdlib report\n\n",
+    "seed: ", seed, "\n",
+    "rows: ", toString (length rows), "\n\n",
+    table, "\n"
+  ];
+
+node make_seed
+  -> seed: Seed = "demo";
+
+node render_report
+  <- seed: Seed;
+  -> print_summary: Report = summary;
+  -> write_summary: Report = summary;
+  where let
+    summary = buildReport seed;
+  in { inherit summary; };
+
+node print_report
+  <- print_summary: Report;
+  = @stdout { newline = true; } (print_summary);
+
+node write_report
+  <- write_summary: Report;
+  = @writeFile { path = "./wire-stdlib-report.md"; } (write_summary);
+
+make_seed
+  => render_report
+  => print_report <> write_report

--- a/src/Cortex/Wire/Pure.hs
+++ b/src/Cortex/Wire/Pure.hs
@@ -48,6 +48,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
 import Data.Scientific (Scientific, toBoundedInteger)
 import Data.Scientific qualified as Scientific
 import Data.Set (Set)
@@ -64,6 +65,16 @@ import Cortex.Wire.Executor
   , WireExecutorId (..)
   , WireExecutorPortPolicy (..)
   , WireExecutorProjection (..)
+  )
+import Cortex.Wire.Pure.Bounds
+  ( FoldAccumulator
+  , clampIndex
+  , clampedIndexValue
+  , corePureBoundedIterationCap
+  , foldAccumulatorValue
+  , foldRangePlan
+  , mkFoldAccumulator
+  , planRange
   )
 import Cortex.Wire.Runtime (WireInputBundle (..))
 import Cortex.Wire.Syntax
@@ -100,6 +111,7 @@ data PureEvalError
   | PureDuplicateLambdaParam !Text
   | PureDuplicateRecordFieldPath ![Text] ![Text]
   | PureJsonParseError !Text
+  | PureBoundExceeded !Text
   | PureWhereExpectedRecord !Text
   | PureStaticFieldSetUndeterminable
   | PureStaticBindingCycle !Text
@@ -218,6 +230,8 @@ renderPureEvalError = \case
       <> "."
   PureJsonParseError reason ->
     "Pure expression could not parse JSON: " <> reason <> "."
+  PureBoundExceeded boundName ->
+    "Pure expression exceeded the fixed CorePure " <> boundName <> " bound."
   PureWhereExpectedRecord actual ->
     "Pure where-clause must evaluate to a record, but received " <> actual <> "."
   PureStaticFieldSetUndeterminable ->
@@ -1120,6 +1134,46 @@ corePureBuiltinSpecs =
   , builtin "joinWith" 2 corePureJoinWith
   , builtin "toJson" 1 corePureToJson
   , builtin "fromJson" 1 corePureFromJson
+  , -- List-shape builtins (issue #295, batch 1).
+    builtin "reverse" 1 corePureReverse
+  , builtin "sort" 1 corePureSort
+  , builtin "sortBy" 2 corePureSortBy
+  , builtin "take" 2 corePureTake
+  , builtin "drop" 2 corePureDrop
+  , builtin "enumerate" 1 corePureEnumerate
+  , builtin "mapIndexed" 2 corePureMapIndexed
+  , -- List-search builtins.
+    builtin "find" 2 corePureFind
+  , builtin "findIndex" 2 corePureFindIndex
+  , builtin "contains" 2 corePureContains
+  , builtin "indexOf" 2 corePureIndexOf
+  , builtin "count" 2 corePureCount
+  , -- String builtins.
+    builtin "split" 2 corePureSplit
+  , builtin "replace" 3 corePureReplace
+  , builtin "substring" 3 corePureSubstring
+  , builtin "trim" 1 (stringUnaryBuiltin "trim" (Aeson.String . T.strip))
+  , builtin "toLower" 1 (stringUnaryBuiltin "toLower" (Aeson.String . T.toLower))
+  , builtin "toUpper" 1 (stringUnaryBuiltin "toUpper" (Aeson.String . T.toUpper))
+  , builtin "startsWith" 2 (stringBinaryBoolBuiltin "startsWith" T.isPrefixOf)
+  , builtin "endsWith" 2 (stringBinaryBoolBuiltin "endsWith" T.isSuffixOf)
+  , builtin "strLength" 1 (stringUnaryBuiltin "strLength" (Aeson.Number . fromIntegral . T.length))
+  , builtin
+      "lines"
+      1
+      (stringUnaryBuiltin "lines" (Aeson.Array . Vector.fromList . fmap Aeson.String . T.lines))
+  , builtin "unlines" 1 corePureUnlines
+  , -- Record builtins.
+    builtin "keys" 1 corePureKeys
+  , builtin "values" 1 corePureValues
+  , builtin "entries" 1 corePureEntries
+  , -- Null / option builtins.
+    builtin "withDefault" 2 corePureWithDefault
+  , builtin "isNull" 1 corePureIsNull
+  , -- Bounded-iteration builtins (capped; see ADR on CorePure bounded iteration).
+    builtin "range" 2 corePureRange
+  , builtin "fold" 3 corePureFold
+  , builtin "foldRight" 3 corePureFoldRight
   ]
   where
     builtin name arity implementation =
@@ -1379,6 +1433,332 @@ corePureFromJson [value] = do
     Right jsonValue -> Right (CorePureJson jsonValue)
     Left reason -> Left (PureJsonParseError (T.pack reason))
 corePureFromJson args = impossibleBuiltinArity "fromJson" 1 args
+
+corePureReverse :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureReverse [listValue] = do
+  values <- corePureArray listValue
+  Right (CorePureJson (Aeson.Array (Vector.reverse values)))
+corePureReverse args = impossibleBuiltinArity "reverse" 1 args
+
+corePureSort :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureSort [listValue] = do
+  values <- Vector.toList <$> corePureArray listValue
+  Right (CorePureJson (Aeson.Array (Vector.fromList (List.sortBy compareJsonValues values))))
+corePureSort args = impossibleBuiltinArity "sort" 1 args
+
+corePureSortBy :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureSortBy [keyFunction, listValue] = do
+  values <- Vector.toList <$> corePureArray listValue
+  keyed <-
+    traverse
+      ( \value -> do
+          key <- applyJsonFunction keyFunction value >>= corePureValueToJson
+          Right (key, value)
+      )
+      values
+  let sorted = List.sortBy (\lhs rhs -> compareJsonValues (fst lhs) (fst rhs)) keyed
+  Right (CorePureJson (Aeson.Array (Vector.fromList (fmap snd sorted))))
+corePureSortBy args = impossibleBuiltinArity "sortBy" 2 args
+
+corePureTake :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureTake [countValue, listValue] = do
+  values <- corePureArray listValue
+  count <- boundedIndex (Vector.length values) countValue
+  Right (CorePureJson (Aeson.Array (Vector.take count values)))
+corePureTake args = impossibleBuiltinArity "take" 2 args
+
+corePureDrop :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureDrop [countValue, listValue] = do
+  values <- corePureArray listValue
+  count <- boundedIndex (Vector.length values) countValue
+  Right (CorePureJson (Aeson.Array (Vector.drop count values)))
+corePureDrop args = impossibleBuiltinArity "drop" 2 args
+
+corePureEnumerate :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureEnumerate [listValue] = do
+  values <- corePureArray listValue
+  let indexed =
+        Vector.imap
+          (\index value -> Aeson.object ["index" Aeson..= index, "value" Aeson..= value])
+          values
+  Right (CorePureJson (Aeson.Array indexed))
+corePureEnumerate args = impossibleBuiltinArity "enumerate" 1 args
+
+corePureMapIndexed :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureMapIndexed [functionValue, listValue] = do
+  values <- corePureArray listValue
+  mapped <-
+    Vector.imapM
+      ( \index value ->
+          applyCorePureValue
+            functionValue
+            [CorePureJson (Aeson.Number (fromIntegral index)), CorePureJson value]
+            >>= corePureValueToJson
+      )
+      values
+  Right (CorePureJson (Aeson.Array mapped))
+corePureMapIndexed args = impossibleBuiltinArity "mapIndexed" 2 args
+
+corePureFind :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureFind [predicateValue, listValue] = do
+  values <- Vector.toList <$> corePureArray listValue
+  findFirst values
+  where
+    findFirst [] = Right (CorePureJson Aeson.Null)
+    findFirst (value : rest) = do
+      keep <- applyJsonFunction predicateValue value >>= corePureBool
+      if keep then Right (CorePureJson value) else findFirst rest
+corePureFind args = impossibleBuiltinArity "find" 2 args
+
+corePureFindIndex :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureFindIndex [predicateValue, listValue] = do
+  values <- Vector.toList <$> corePureArray listValue
+  findFrom (0 :: Int) values
+  where
+    findFrom _ [] = Right (CorePureJson (Aeson.Number (-1)))
+    findFrom index (value : rest) = do
+      keep <- applyJsonFunction predicateValue value >>= corePureBool
+      if keep
+        then Right (CorePureJson (Aeson.Number (fromIntegral index)))
+        else findFrom (index + 1) rest
+corePureFindIndex args = impossibleBuiltinArity "findIndex" 2 args
+
+corePureContains :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureContains [needleValue, listValue] = do
+  needle <- corePureValueToJson needleValue
+  values <- corePureArray listValue
+  Right (CorePureJson (Aeson.Bool (Vector.elem needle values)))
+corePureContains args = impossibleBuiltinArity "contains" 2 args
+
+corePureIndexOf :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureIndexOf [needleValue, listValue] = do
+  needle <- corePureValueToJson needleValue
+  values <- corePureArray listValue
+  let foundIndex = fromMaybe (-1) (Vector.elemIndex needle values)
+  Right (CorePureJson (Aeson.Number (fromIntegral foundIndex)))
+corePureIndexOf args = impossibleBuiltinArity "indexOf" 2 args
+
+corePureCount :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureCount [predicateValue, listValue] = do
+  values <- Vector.toList <$> corePureArray listValue
+  results <- traverse (applyJsonFunction predicateValue >=> corePureBool) values
+  Right (CorePureJson (Aeson.Number (fromIntegral (length (filter id results)))))
+corePureCount args = impossibleBuiltinArity "count" 2 args
+
+corePureSplit :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureSplit [separatorValue, stringValue] = do
+  separator <- corePureStringValue separatorValue
+  text <- corePureStringValue stringValue
+  let parts = if T.null separator then T.chunksOf 1 text else T.splitOn separator text
+  Right (CorePureJson (Aeson.Array (Vector.fromList (fmap Aeson.String parts))))
+corePureSplit args = impossibleBuiltinArity "split" 2 args
+
+corePureReplace :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureReplace [oldValue, newValue, stringValue] = do
+  oldText <- corePureStringValue oldValue
+  newText <- corePureStringValue newValue
+  text <- corePureStringValue stringValue
+  let result = if T.null oldText then text else T.replace oldText newText text
+  Right (CorePureJson (Aeson.String result))
+corePureReplace args = impossibleBuiltinArity "replace" 3 args
+
+corePureSubstring :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureSubstring [startValue, endValue, stringValue] = do
+  text <- corePureStringValue stringValue
+  let len = T.length text
+  lo <- boundedIndex len startValue
+  hi0 <- boundedIndex len endValue
+  let hi = max lo hi0
+  Right (CorePureJson (Aeson.String (T.take (hi - lo) (T.drop lo text))))
+corePureSubstring args = impossibleBuiltinArity "substring" 3 args
+
+{- | Clamp a CorePure number to a @[0, upper]@ index, mapping a non-integer to a
+typed error and unwrapping the guarded 'ClampedIndex' from "Cortex.Wire.Pure.Bounds".
+-}
+boundedIndex :: Int -> CorePureValue -> Either PureEvalError Int
+boundedIndex upper value = do
+  number <- corePureNumber value
+  case clampIndex upper number of
+    Just clamped -> Right (clampedIndexValue clamped)
+    Nothing -> Left (PureTypeMismatch "integer" "number")
+
+corePureUnlines :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureUnlines [listValue] = do
+  values <- Vector.toList <$> corePureArray listValue
+  strings <- traverse corePureJsonString values
+  Right (CorePureJson (Aeson.String (T.intercalate "\n" strings)))
+corePureUnlines args = impossibleBuiltinArity "unlines" 1 args
+
+stringUnaryBuiltin
+  :: Text -> (Text -> Aeson.Value) -> [CorePureValue] -> Either PureEvalError CorePureValue
+stringUnaryBuiltin _ render [stringValue] = do
+  text <- corePureStringValue stringValue
+  Right (CorePureJson (render text))
+stringUnaryBuiltin name _ args = impossibleBuiltinArity name 1 args
+
+stringBinaryBoolBuiltin
+  :: Text -> (Text -> Text -> Bool) -> [CorePureValue] -> Either PureEvalError CorePureValue
+stringBinaryBoolBuiltin _ predicate [firstValue, stringValue] = do
+  firstText <- corePureStringValue firstValue
+  text <- corePureStringValue stringValue
+  Right (CorePureJson (Aeson.Bool (predicate firstText text)))
+stringBinaryBoolBuiltin name _ args = impossibleBuiltinArity name 2 args
+
+corePureKeys :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureKeys [objectValue] = do
+  object <- corePureObject objectValue
+  let sortedKeys =
+        [Aeson.String (Key.toText key) | (key, _value) <- List.sortOn fst (KeyMap.toList object)]
+  Right (CorePureJson (Aeson.Array (Vector.fromList sortedKeys)))
+corePureKeys args = impossibleBuiltinArity "keys" 1 args
+
+corePureValues :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureValues [objectValue] = do
+  object <- corePureObject objectValue
+  let sortedValues = [value | (_key, value) <- List.sortOn fst (KeyMap.toList object)]
+  Right (CorePureJson (Aeson.Array (Vector.fromList sortedValues)))
+corePureValues args = impossibleBuiltinArity "values" 1 args
+
+corePureEntries :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureEntries [objectValue] = do
+  object <- corePureObject objectValue
+  let entries =
+        [ Aeson.object ["key" Aeson..= Key.toText key, "value" Aeson..= value]
+        | (key, value) <- List.sortOn fst (KeyMap.toList object)
+        ]
+  Right (CorePureJson (Aeson.Array (Vector.fromList entries)))
+corePureEntries args = impossibleBuiltinArity "entries" 1 args
+
+corePureWithDefault :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureWithDefault [defaultValue, value] =
+  case value of
+    CorePureJson Aeson.Null -> Right defaultValue
+    _ -> Right value
+corePureWithDefault args = impossibleBuiltinArity "withDefault" 2 args
+
+corePureIsNull :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureIsNull [value] =
+  Right
+    ( CorePureJson
+        ( Aeson.Bool
+            ( case value of
+                CorePureJson Aeson.Null -> True
+                _ -> False
+            )
+        )
+    )
+corePureIsNull args = impossibleBuiltinArity "isNull" 1 args
+
+corePureRange :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureRange [startValue, endValue] = do
+  startNumber <- corePureNumber startValue
+  endNumber <- corePureNumber endValue
+  case planRange corePureBoundedIterationCap startNumber endNumber of
+    Nothing -> Left (PureTypeMismatch "integer" "number")
+    Just plan ->
+      foldRangePlan
+        (Right (CorePureJson (Aeson.Array Vector.empty)))
+        ( \start end ->
+            let elements = [Aeson.Number (fromInteger index) | index <- [start .. end - 1]]
+             in Right (CorePureJson (Aeson.Array (Vector.fromList elements)))
+        )
+        (Left (PureBoundExceeded "range span"))
+        plan
+corePureRange args = impossibleBuiltinArity "range" 2 args
+
+corePureFold :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureFold [functionValue, initialValue, listValue] = do
+  values <- corePureArray listValue
+  -- The accumulator is a guarded FoldAccumulator throughout: the seed and every
+  -- step result pass through foldAccumulatorOf (JSON shape and cost cap), so a
+  -- function-valued or over-cap accumulator cannot slip in or out.
+  seed <- foldAccumulatorOf initialValue
+  result <- Vector.foldM' step seed values
+  Right (CorePureJson (foldAccumulatorValue result))
+  where
+    step accumulator item =
+      applyCorePureValue
+        functionValue
+        [CorePureJson (foldAccumulatorValue accumulator), CorePureJson item]
+        >>= foldAccumulatorOf
+corePureFold args = impossibleBuiltinArity "fold" 3 args
+
+corePureFoldRight :: [CorePureValue] -> Either PureEvalError CorePureValue
+corePureFoldRight [functionValue, initialValue, listValue] = do
+  values <- corePureArray listValue
+  -- Right fold expressed as a strict left fold over the reversed vector, so it
+  -- stays iterative while preserving the f(item, acc) application order; the
+  -- accumulator stays a guarded FoldAccumulator, bounded before any reducer call.
+  seed <- foldAccumulatorOf initialValue
+  result <- Vector.foldM' step seed (Vector.reverse values)
+  Right (CorePureJson (foldAccumulatorValue result))
+  where
+    step accumulator item =
+      applyCorePureValue
+        functionValue
+        [CorePureJson item, CorePureJson (foldAccumulatorValue accumulator)]
+        >>= foldAccumulatorOf
+corePureFoldRight args = impossibleBuiltinArity "foldRight" 3 args
+
+{- | Guard a reducer result or seed into a 'FoldAccumulator': reject a
+function-valued accumulator, then enforce the JSON cost cap. This is the only way
+the fold builtins obtain an accumulator, so the guard cannot be skipped.
+-}
+foldAccumulatorOf :: CorePureValue -> Either PureEvalError FoldAccumulator
+foldAccumulatorOf value =
+  case value of
+    CorePureJson json ->
+      maybe
+        (Left (PureBoundExceeded "fold accumulator"))
+        Right
+        (mkFoldAccumulator corePureBoundedIterationCap json)
+    _ ->
+      Left (PureTypeMismatch "JSON fold accumulator" (corePureValueKind value))
+
+{- | Total order over JSON values for @sort@ and @sortBy@. Aeson @Value@ has @Eq@
+but no @Ord@; this ranks by type then orders within a type, recursing into
+arrays and key-sorted objects, so the result is deterministic across builds.
+-}
+compareJsonValues :: Aeson.Value -> Aeson.Value -> Ordering
+compareJsonValues left right =
+  case (left, right) of
+    (Aeson.Null, Aeson.Null) -> EQ
+    (Aeson.Bool lhs, Aeson.Bool rhs) -> compare lhs rhs
+    (Aeson.Number lhs, Aeson.Number rhs) -> compare lhs rhs
+    (Aeson.String lhs, Aeson.String rhs) -> compare lhs rhs
+    (Aeson.Array lhs, Aeson.Array rhs) ->
+      compareJsonList (Vector.toList lhs) (Vector.toList rhs)
+    (Aeson.Object lhs, Aeson.Object rhs) ->
+      compareJsonFields (List.sortOn fst (KeyMap.toList lhs)) (List.sortOn fst (KeyMap.toList rhs))
+    _ -> compare (jsonTypeRank left) (jsonTypeRank right)
+  where
+    compareJsonList [] [] = EQ
+    compareJsonList [] _ = LT
+    compareJsonList _ [] = GT
+    compareJsonList (lhs : lhsRest) (rhs : rhsRest) =
+      case compareJsonValues lhs rhs of
+        EQ -> compareJsonList lhsRest rhsRest
+        ordering -> ordering
+
+    compareJsonFields [] [] = EQ
+    compareJsonFields [] _ = LT
+    compareJsonFields _ [] = GT
+    compareJsonFields ((lhsKey, lhsValue) : lhsRest) ((rhsKey, rhsValue) : rhsRest) =
+      case compare lhsKey rhsKey of
+        EQ ->
+          case compareJsonValues lhsValue rhsValue of
+            EQ -> compareJsonFields lhsRest rhsRest
+            ordering -> ordering
+        ordering -> ordering
+
+jsonTypeRank :: Aeson.Value -> Int
+jsonTypeRank = \case
+  Aeson.Null -> 0
+  Aeson.Bool {} -> 1
+  Aeson.Number {} -> 2
+  Aeson.String {} -> 3
+  Aeson.Array {} -> 4
+  Aeson.Object {} -> 5
 
 applyJsonFunction :: CorePureValue -> Aeson.Value -> Either PureEvalError CorePureValue
 applyJsonFunction functionValue value =

--- a/src/Cortex/Wire/Pure/Bounds.hs
+++ b/src/Cortex/Wire/Pure/Bounds.hs
@@ -1,0 +1,321 @@
+{- |
+Module      : Cortex.Wire.Pure.Bounds
+Description : Typed boundary enforcing the CorePure bounded-iteration policy.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+This module is the single place that enforces CorePure's termination and cost
+policy for the bounded-iteration builtins (@fold@, @foldRight@, @range@) and the
+clamped index builtins (@take@, @drop@, @substring@).
+
+The result types have hidden constructors, so the only way to obtain a
+'FoldAccumulator', 'ClampedIndex', or 'RangePlan' is through the smart
+constructors here, which apply the cost cap, JSON value cost, and
+integer/magnitude rules. "Cortex.Wire.Pure" interprets the typed results into
+the evaluator's error type. Keeping the policy behind these constructors stops it
+from being re-implemented with ad-hoc local conditionals at each call site.
+-}
+module Cortex.Wire.Pure.Bounds
+  ( -- * Cap
+    IterationCap
+  , corePureBoundedIterationCap
+  , iterationCapValue
+
+    -- * Value cost
+  , CostCheck (..)
+  , checkValueCost
+
+    -- * Fold accumulators
+  , FoldAccumulator
+  , foldAccumulatorValue
+  , mkFoldAccumulator
+
+    -- * Clamped indices
+  , ClampedIndex
+  , clampedIndexValue
+  , clampIndex
+
+    -- * Range planning
+  , RangePlan
+  , planRange
+  , foldRangePlan
+  )
+where
+
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Bits (countLeadingZeros, finiteBitSize, shiftR)
+import Data.Scientific (Scientific, toBoundedInteger)
+import Data.Scientific qualified as Scientific
+import Data.Text qualified as T
+import Data.Vector qualified as Vector
+
+{- | The fixed deterministic ceiling for scalar-driven CorePure iteration. It is
+a totality guard, not an operator-tunable budget (ADR 0056); it is not
+authored, configured, or per-run.
+-}
+newtype IterationCap = IterationCap Int
+  deriving stock (Eq, Show)
+
+corePureBoundedIterationCap :: IterationCap
+corePureBoundedIterationCap = IterationCap 1000000
+
+iterationCapValue :: IterationCap -> Int
+iterationCapValue (IterationCap limit) = limit
+
+{- | Result of a value-cost check. Returning a type rather than the raw count
+stops callers from comparing the number incorrectly or forgetting what it
+means.
+-}
+data CostCheck = WithinLimit | OverLimit
+  deriving stock (Eq, Show)
+
+{- | Whether a JSON value's cost is within the cap. Cost is one per node plus
+string lengths, number magnitudes, and object key lengths, so structural
+nesting, string concatenation, numeric growth, and key growth are all bounded.
+-}
+checkValueCost :: IterationCap -> Aeson.Value -> CostCheck
+checkValueCost (IterationCap limit) value
+  | valueCostAtMost limit value > limit = OverLimit
+  | otherwise = WithinLimit
+
+{- | A fold accumulator that has passed the cost guard. The constructor is
+hidden, so 'mkFoldAccumulator' is the only way to build one; @fold@/@foldRight@
+therefore cannot iterate from an unchecked seed or step result.
+-}
+newtype FoldAccumulator = FoldAccumulator Aeson.Value
+  deriving stock (Eq, Show)
+
+foldAccumulatorValue :: FoldAccumulator -> Aeson.Value
+foldAccumulatorValue (FoldAccumulator value) = value
+
+{- | Admit a JSON value as a fold accumulator iff its cost is within the cap.
+Callers reject non-JSON (function) accumulators before reaching here, so a
+'FoldAccumulator' is always a within-cap JSON value.
+-}
+mkFoldAccumulator :: IterationCap -> Aeson.Value -> Maybe FoldAccumulator
+mkFoldAccumulator cap value =
+  case checkValueCost cap value of
+    WithinLimit -> Just (FoldAccumulator value)
+    OverLimit -> Nothing
+
+{- | An index clamped into a valid @[0, upper]@ range. The constructor is hidden,
+so a 'ClampedIndex' is always usable directly with @Vector.take@/@Data.Text@
+slicing without a further bounds check.
+-}
+newtype ClampedIndex = ClampedIndex Int
+  deriving stock (Eq, Show)
+
+clampedIndexValue :: ClampedIndex -> Int
+clampedIndexValue (ClampedIndex value) = value
+
+{- | Clamp a finite number to a @[0, upper]@ index. 'Nothing' for non-integers.
+Out-of-Int-range integers clamp to the nearer bound rather than failing,
+matching the documented index semantics, and never materialise a huge integer.
+-}
+clampIndex :: Int -> Scientific -> Maybe ClampedIndex
+clampIndex upper number =
+  fmap (ClampedIndex . clampToBound) (spanEndpoint number)
+  where
+    clampToBound = \case
+      SpanValue value -> fromInteger (max 0 (min (toInteger upper) value))
+      SpanAbove -> upper
+      SpanBelow -> 0
+
+{- | A range reduced to a plan before any enumeration: empty, an explicit
+@[start, end)@ Integer enumeration within the cap, or over the cap. Separating
+the plan from the enumeration keeps the span/cap decision distinct from the
+machine narrowing that follows it.
+
+The constructors are not exported: a 'RangePlan' is built only by 'planRange' and
+consumed only through 'foldRangePlan', so it acts as a proof that the range bounds
+were checked. A caller cannot forge an @EnumerateRange@ with an over-cap span.
+-}
+data RangePlan = EmptyRange | EnumerateRange !Integer !Integer | RangeOverCap
+  deriving stock (Eq, Show)
+
+{- | Decide a range plan from its endpoints. 'Nothing' for non-integer endpoints.
+Direction is decided first by a safe magnitude comparison, so a backwards or
+equal range (for example @range(10^2000000, 10^2000000)@) is an empty half-open
+range regardless of endpoint magnitude. A forward range enumerates when both
+endpoints are within the 'maxSpanDigits' endpoint bound and their exact span is
+within the cap; a forward range whose endpoint exceeds the endpoint bound is
+over-cap (this keeps emitted elements bounded, since output is the span times the
+endpoint width). No enormous integer is ever materialised or emitted.
+-}
+planRange :: IterationCap -> Scientific -> Scientific -> Maybe RangePlan
+planRange (IterationCap cap) startNumber endNumber = do
+  start <- spanEndpoint startNumber
+  end <- spanEndpoint endNumber
+  Just $ case safeIntCompare endNumber startNumber of
+    LT -> EmptyRange
+    EQ -> EmptyRange
+    GT -> case (start, end) of
+      (SpanValue startValue, SpanValue endValue)
+        | endValue - startValue > toInteger cap -> RangeOverCap
+        | otherwise -> EnumerateRange startValue endValue
+      -- Forward, but an endpoint exceeds the documented endpoint-magnitude bound;
+      -- reject so emitted elements stay bounded.
+      _ -> RangeOverCap
+
+{- | Eliminate a 'RangePlan'. Because the constructors are hidden, this is the
+only way to interpret a plan, and a plan is only produced by 'planRange', so the
+@onEnumerate@ start/end always denote a within-cap forward range.
+-}
+foldRangePlan :: a -> (Integer -> Integer -> a) -> a -> RangePlan -> a
+foldRangePlan onEmpty onEnumerate onOverCap = \case
+  EmptyRange -> onEmpty
+  EnumerateRange start end -> onEnumerate start end
+  RangeOverCap -> onOverCap
+
+-- Internal --------------------------------------------------------------------
+
+{- | Order two integer-valued numbers without materialising an astronomically
+large integer: by sign, then decimal width, then by the values aligned to a
+common exponent. Equal values compare EQ without scaling, so a backwards or equal
+huge-endpoint range is recognised without building either integer; alignment only
+materialises when two values share a decimal width, which is bounded by that
+width.
+-}
+safeIntCompare :: Scientific -> Scientific -> Ordering
+safeIntCompare left right =
+  let a = Scientific.normalize left
+      b = Scientific.normalize right
+      coefficientA = Scientific.coefficient a
+      coefficientB = Scientific.coefficient b
+   in case compare (signum coefficientA) (signum coefficientB) of
+        EQ
+          | coefficientA == 0 -> EQ
+          | otherwise ->
+              -- Widths are computed in Integer: a Scientific exponent near the Int
+              -- bounds would otherwise overflow the addition and misorder the range.
+              let widthA = toInteger (decimalWidth coefficientA) + toInteger (Scientific.base10Exponent a)
+                  widthB = toInteger (decimalWidth coefficientB) + toInteger (Scientific.base10Exponent b)
+               in case compare widthA widthB of
+                    EQ -> compareAligned a b
+                    widthOrdering
+                      | coefficientA > 0 -> widthOrdering
+                      | otherwise -> flipOrdering widthOrdering
+        signOrdering -> signOrdering
+  where
+    compareAligned a b =
+      let exponentFloor = min (Scientific.base10Exponent a) (Scientific.base10Exponent b)
+          valueA = Scientific.coefficient a * 10 ^ (Scientific.base10Exponent a - exponentFloor)
+          valueB = Scientific.coefficient b * 10 ^ (Scientific.base10Exponent b - exponentFloor)
+       in compare valueA valueB
+
+-- | Decimal-digit width of @abs n@.
+decimalWidth :: Integer -> Int
+decimalWidth n = length (show (abs n))
+
+flipOrdering :: Ordering -> Ordering
+flipOrdering LT = GT
+flipOrdering EQ = EQ
+flipOrdering GT = LT
+
+{- | A range/index endpoint: an exact Integer when its magnitude is small enough
+to materialise cheaply (covering values at and just past the Int bounds), or a
+sign flag for integers whose magnitude is too large to materialise.
+-}
+data SpanEnd = SpanValue !Integer | SpanAbove | SpanBelow
+
+{- | Largest decimal width of a @range@ endpoint we still materialise (and so the
+largest magnitude @range@ will enumerate). This is the documented endpoint bound:
+endpoints up to this many digits are measured and enumerated by their exact span,
+while a forward range with a wider endpoint is rejected as over-cap so emitted
+elements stay bounded (worst-case output is the cap times this width). The bound
+is far above the Int range, so any ordinary index range materialises; only
+astronomically large endpoints are classified by sign instead.
+-}
+maxSpanDigits :: Int
+maxSpanDigits = 40
+
+spanEndpoint :: Scientific -> Maybe SpanEnd
+spanEndpoint number =
+  case toBoundedInteger number :: Maybe Int of
+    Just value -> Just (SpanValue (toInteger value))
+    Nothing
+      | not (Scientific.isInteger number) -> Nothing
+      | otherwise ->
+          let normalized = Scientific.normalize number
+              exponent10 = Scientific.base10Exponent normalized
+              coefficient = Scientific.coefficient normalized
+           in Just $
+                if exponent10 < maxSpanDigits && abs coefficient < 10 ^ (maxSpanDigits - exponent10)
+                  then SpanValue (coefficient * 10 ^ exponent10)
+                  else if coefficient < 0 then SpanBelow else SpanAbove
+
+{- | Worklist item for the value-cost traversal: a JSON node still to measure, or
+a flat number of cost units. Object key lengths enter as 'CostUnits'
+interleaved with their values, so the traversal can stop at the limit instead
+of summing every key of a large object first.
+-}
+data CostItem = CostNode !Aeson.Value | CostUnits !Int
+
+{- | Cost of a JSON value: one per node, plus string lengths, number magnitudes,
+and object key lengths, so structural nesting, string concatenation, numeric
+growth, and key growth are all bounded. Every contribution (including each object
+key) flows through one lazily generated worklist and the traversal short-circuits
+once the running cost passes @limit@, so even an object with far more than @limit@
+entries is only partially measured before the cap is noticed.
+-}
+valueCostAtMost :: Int -> Aeson.Value -> Int
+valueCostAtMost limit root =
+  go 0 [CostNode root]
+  where
+    go cost _ | cost > limit = cost
+    go cost [] = cost
+    go cost (CostUnits units : rest) = go (cost + units) rest
+    go cost (CostNode value : rest) =
+      case value of
+        Aeson.String text -> go (cost + 1 + T.length text) rest
+        Aeson.Number number -> go (cost + numberCost limit number) rest
+        Aeson.Array items -> go (cost + 1) (fmap CostNode (Vector.toList items) <> rest)
+        Aeson.Object object -> go (cost + 1) (objectCostItems object <> rest)
+        Aeson.Bool _ -> go (cost + 1) rest
+        Aeson.Null -> go (cost + 1) rest
+
+{- | Lazily interleave each object entry's key-length cost with its value, so a
+large object stops being measured once the running cost passes the limit.
+-}
+objectCostItems :: KeyMap.KeyMap Aeson.Value -> [CostItem]
+objectCostItems object =
+  concatMap
+    (\(key, value) -> [CostUnits (T.length (Key.toText key)), CostNode value])
+    (KeyMap.toList object)
+
+{- | Approximate footprint of a number: coefficient bit-length plus exponent
+magnitude. A fold that grows a numeric accumulator by squaring or scaling is then
+bounded the same way string growth is, instead of counting as one node. Both
+terms are capped so the measurement stays bounded on an already-huge value.
+-}
+numberCost :: Int -> Scientific -> Int
+numberCost limit number =
+  1
+    + boundedBitLength limit (Scientific.coefficient number)
+    + exponentCost
+  where
+    -- The exponent magnitude is taken in Integer first: abs (minBound :: Int)
+    -- overflows back to a negative value, which would let a number with a huge
+    -- negative exponent slip under the cap.
+    exponentCost =
+      fromInteger (min (toInteger limit + 1) (abs (toInteger (Scientific.base10Exponent number))))
+
+{- | Bit-length of @abs value@, exact for word-sized integers and counted in
+64-bit chunks above that, stopping once it passes @cap@ so the count stays
+bounded even when the integer is enormous.
+-}
+boundedBitLength :: Int -> Integer -> Int
+boundedBitLength cap = go 0 . abs
+  where
+    go cost magnitude
+      | cost > cap = cost
+      | magnitude == 0 = cost
+      | magnitude <= maxWord = cost + wordBitLength (fromInteger magnitude)
+      | otherwise = go (cost + 64) (magnitude `shiftR` 64)
+    maxWord = toInteger (maxBound :: Word)
+    wordBitLength :: Word -> Int
+    wordBitLength word = finiteBitSize word - countLeadingZeros word

--- a/test/Cortex/Wire/ParserSpec.hs
+++ b/test/Cortex/Wire/ParserSpec.hs
@@ -100,6 +100,9 @@ spec = describe "Cortex.Wire.Parser" $ do
     it "runtime-bounded iteration Wire example: parses the paginated ingest kernel" $
       parseWireFixture "examples/wire/runtime-bounded-paginated-ingest/page-kernel.wire"
 
+    it "parses the pure stdlib report example" $
+      parseWireFixture "examples/wire/pure-stdlib-report.wire"
+
     it "parses the C build example" $
       parseIncludedWireFixture "examples/wire/c-build/c-build.wire"
 

--- a/test/Cortex/Wire/PureSpec.hs
+++ b/test/Cortex/Wire/PureSpec.hs
@@ -13,6 +13,7 @@ Tests may import the surface they exercise, but they do not define downstream pr
 module Cortex.Wire.PureSpec (spec) where
 
 import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Map.Strict qualified as Map
 import Data.Scientific (Scientific, scientific)
@@ -21,6 +22,19 @@ import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Test.Hspec
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck
+  ( Gen
+  , NonNegative (..)
+  , Property
+  , arbitrary
+  , choose
+  , forAll
+  , listOf
+  , oneof
+  , (.&&.)
+  , (===)
+  )
 
 import Cortex.Pulse.Node (NodeId (..))
 import Cortex.Wire
@@ -52,6 +66,19 @@ import Cortex.Wire
   , preparePureTaskOutputs
   , validatePurePorts
   , wireInputBundleFromStageInputs
+  )
+import Cortex.Wire.Pure.Bounds
+  ( CostCheck (..)
+  , RangePlan
+  , checkValueCost
+  , clampIndex
+  , clampedIndexValue
+  , corePureBoundedIterationCap
+  , foldAccumulatorValue
+  , foldRangePlan
+  , iterationCapValue
+  , mkFoldAccumulator
+  , planRange
   )
 
 spec :: Spec
@@ -933,6 +960,37 @@ spec = describe "Cortex.Wire.Pure" $ do
                  , ("joinWith", 2)
                  , ("toJson", 1)
                  , ("fromJson", 1)
+                 , ("reverse", 1)
+                 , ("sort", 1)
+                 , ("sortBy", 2)
+                 , ("take", 2)
+                 , ("drop", 2)
+                 , ("enumerate", 1)
+                 , ("mapIndexed", 2)
+                 , ("find", 2)
+                 , ("findIndex", 2)
+                 , ("contains", 2)
+                 , ("indexOf", 2)
+                 , ("count", 2)
+                 , ("split", 2)
+                 , ("replace", 3)
+                 , ("substring", 3)
+                 , ("trim", 1)
+                 , ("toLower", 1)
+                 , ("toUpper", 1)
+                 , ("startsWith", 2)
+                 , ("endsWith", 2)
+                 , ("strLength", 1)
+                 , ("lines", 1)
+                 , ("unlines", 1)
+                 , ("keys", 1)
+                 , ("values", 1)
+                 , ("entries", 1)
+                 , ("withDefault", 2)
+                 , ("isNull", 1)
+                 , ("range", 2)
+                 , ("fold", 3)
+                 , ("foldRight", 3)
                  ]
 
   it "keeps the CorePure builtin authority report closed and authority-free" $ do
@@ -963,6 +1021,37 @@ spec = describe "Cortex.Wire.Pure" $ do
                  , ("joinWith", 2, CorePureBuiltinPureValue)
                  , ("toJson", 1, CorePureBuiltinPureValue)
                  , ("fromJson", 1, CorePureBuiltinPureValue)
+                 , ("reverse", 1, CorePureBuiltinPureValue)
+                 , ("sort", 1, CorePureBuiltinPureValue)
+                 , ("sortBy", 2, CorePureBuiltinPureValue)
+                 , ("take", 2, CorePureBuiltinPureValue)
+                 , ("drop", 2, CorePureBuiltinPureValue)
+                 , ("enumerate", 1, CorePureBuiltinPureValue)
+                 , ("mapIndexed", 2, CorePureBuiltinPureValue)
+                 , ("find", 2, CorePureBuiltinPureValue)
+                 , ("findIndex", 2, CorePureBuiltinPureValue)
+                 , ("contains", 2, CorePureBuiltinPureValue)
+                 , ("indexOf", 2, CorePureBuiltinPureValue)
+                 , ("count", 2, CorePureBuiltinPureValue)
+                 , ("split", 2, CorePureBuiltinPureValue)
+                 , ("replace", 3, CorePureBuiltinPureValue)
+                 , ("substring", 3, CorePureBuiltinPureValue)
+                 , ("trim", 1, CorePureBuiltinPureValue)
+                 , ("toLower", 1, CorePureBuiltinPureValue)
+                 , ("toUpper", 1, CorePureBuiltinPureValue)
+                 , ("startsWith", 2, CorePureBuiltinPureValue)
+                 , ("endsWith", 2, CorePureBuiltinPureValue)
+                 , ("strLength", 1, CorePureBuiltinPureValue)
+                 , ("lines", 1, CorePureBuiltinPureValue)
+                 , ("unlines", 1, CorePureBuiltinPureValue)
+                 , ("keys", 1, CorePureBuiltinPureValue)
+                 , ("values", 1, CorePureBuiltinPureValue)
+                 , ("entries", 1, CorePureBuiltinPureValue)
+                 , ("withDefault", 2, CorePureBuiltinPureValue)
+                 , ("isNull", 1, CorePureBuiltinPureValue)
+                 , ("range", 2, CorePureBuiltinPureValue)
+                 , ("fold", 3, CorePureBuiltinPureValue)
+                 , ("foldRight", 3, CorePureBuiltinPureValue)
                  ]
 
   it "establishes CorePure static context from top-level record bindings" $ do
@@ -1168,6 +1257,350 @@ spec = describe "Cortex.Wire.Pure" $ do
     validatePurePorts scorePorts (Map.singleton "confidence" (num 1))
       `shouldBe` Left (PureOutputPortsMismatch ["score"] ["confidence"])
 
+  describe "batch 1 list, string, record, and bounded-iteration builtins" $ do
+    it "reshapes lists with reverse, sort, sortBy, take, and drop" $ do
+      evalBuiltin (call (var "reverse") [nums [1, 2, 3]])
+        `shouldBe` Right (Aeson.toJSON ([3, 2, 1] :: [Int]))
+      evalBuiltin
+        (call (var "sort") [CorePureList [num 3, str "a", bool True, num 1, nullLit]])
+        `shouldBe` Right
+          ( Aeson.toJSON
+              [Aeson.Null, Aeson.Bool True, Aeson.Number 1, Aeson.Number 3, Aeson.String "a"]
+          )
+      evalBuiltin
+        ( call
+            (var "sortBy")
+            [ lambda ("x" :| []) (field (var "x") "k")
+            , CorePureList [record [("k", num 2)], record [("k", num 1)]]
+            ]
+        )
+        `shouldBe` Right
+          (Aeson.toJSON [Aeson.object ["k" Aeson..= (1 :: Int)], Aeson.object ["k" Aeson..= (2 :: Int)]])
+      evalBuiltin (call (var "take") [num 2, nums [1, 2, 3]])
+        `shouldBe` Right (Aeson.toJSON ([1, 2] :: [Int]))
+      evalBuiltin (call (var "take") [num 9, nums [1, 2]])
+        `shouldBe` Right (Aeson.toJSON ([1, 2] :: [Int]))
+      evalBuiltin (call (var "drop") [num 5, nums [1, 2]])
+        `shouldBe` Right (Aeson.toJSON ([] :: [Int]))
+
+    it "indexes lists with enumerate and mapIndexed" $ do
+      evalBuiltin (call (var "enumerate") [strs ["a", "b"]])
+        `shouldBe` Right
+          ( Aeson.toJSON
+              [ Aeson.object ["index" Aeson..= (0 :: Int), "value" Aeson..= ("a" :: Text)]
+              , Aeson.object ["index" Aeson..= (1 :: Int), "value" Aeson..= ("b" :: Text)]
+              ]
+          )
+      evalBuiltin
+        (call (var "mapIndexed") [lambda ("i" :| ["x"]) (var "i"), strs ["a", "b", "c"]])
+        `shouldBe` Right (Aeson.toJSON ([0, 1, 2] :: [Int]))
+
+    it "searches lists with find, findIndex, contains, indexOf, and count" $ do
+      let greaterThanOne = lambda ("x" :| []) (bin CorePureGreaterThan (var "x") (num 1))
+      evalBuiltin (call (var "find") [greaterThanOne, nums [0, 2, 3]])
+        `shouldBe` Right (Aeson.Number 2)
+      evalBuiltin (call (var "find") [greaterThanOne, nums [0, 1]])
+        `shouldBe` Right Aeson.Null
+      evalBuiltin (call (var "findIndex") [greaterThanOne, nums [0, 2, 3]])
+        `shouldBe` Right (Aeson.Number 1)
+      evalBuiltin (call (var "findIndex") [greaterThanOne, nums [0, 1]])
+        `shouldBe` Right (Aeson.Number (-1))
+      evalBuiltin (call (var "contains") [num 2, nums [1, 2, 3]])
+        `shouldBe` Right (Aeson.Bool True)
+      evalBuiltin (call (var "contains") [num 9, nums [1, 2, 3]])
+        `shouldBe` Right (Aeson.Bool False)
+      evalBuiltin (call (var "indexOf") [num 2, nums [1, 2, 3]])
+        `shouldBe` Right (Aeson.Number 1)
+      evalBuiltin (call (var "indexOf") [num 9, nums [1, 2, 3]])
+        `shouldBe` Right (Aeson.Number (-1))
+      evalBuiltin (call (var "count") [greaterThanOne, nums [0, 2, 3]])
+        `shouldBe` Right (Aeson.Number 2)
+
+    it "processes strings with split, replace, substring, and case folds" $ do
+      evalBuiltin (call (var "split") [str ",", str "a,b,c"])
+        `shouldBe` Right (Aeson.toJSON (["a", "b", "c"] :: [Text]))
+      evalBuiltin (call (var "split") [str "", str "ab"])
+        `shouldBe` Right (Aeson.toJSON (["a", "b"] :: [Text]))
+      evalBuiltin (call (var "replace") [str "a", str "X", str "banana"])
+        `shouldBe` Right (Aeson.String "bXnXnX")
+      evalBuiltin (call (var "replace") [str "", str "X", str "ab"])
+        `shouldBe` Right (Aeson.String "ab")
+      evalBuiltin (call (var "substring") [num 1, num 3, str "hello"])
+        `shouldBe` Right (Aeson.String "el")
+      evalBuiltin (call (var "substring") [num 0, num 99, str "hi"])
+        `shouldBe` Right (Aeson.String "hi")
+      evalBuiltin (call (var "trim") [str "  hi  "])
+        `shouldBe` Right (Aeson.String "hi")
+      evalBuiltin (call (var "toLower") [str "AbC"]) `shouldBe` Right (Aeson.String "abc")
+      evalBuiltin (call (var "toUpper") [str "AbC"]) `shouldBe` Right (Aeson.String "ABC")
+      evalBuiltin (call (var "startsWith") [str "ba", str "banana"])
+        `shouldBe` Right (Aeson.Bool True)
+      evalBuiltin (call (var "endsWith") [str "na", str "banana"])
+        `shouldBe` Right (Aeson.Bool True)
+      evalBuiltin (call (var "strLength") [str "h\233llo"]) `shouldBe` Right (Aeson.Number 5)
+      evalBuiltin (call (var "lines") [str "a\nb"])
+        `shouldBe` Right (Aeson.toJSON (["a", "b"] :: [Text]))
+      evalBuiltin (call (var "unlines") [strs ["a", "b"]])
+        `shouldBe` Right (Aeson.String "a\nb")
+
+    it "reads records with key-sorted keys, values, and entries" $ do
+      let object = record [("b", num 2), ("a", num 1)]
+      evalBuiltin (call (var "keys") [object])
+        `shouldBe` Right (Aeson.toJSON (["a", "b"] :: [Text]))
+      evalBuiltin (call (var "values") [object])
+        `shouldBe` Right (Aeson.toJSON ([1, 2] :: [Int]))
+      evalBuiltin (call (var "entries") [object])
+        `shouldBe` Right
+          ( Aeson.toJSON
+              [ Aeson.object ["key" Aeson..= ("a" :: Text), "value" Aeson..= (1 :: Int)]
+              , Aeson.object ["key" Aeson..= ("b" :: Text), "value" Aeson..= (2 :: Int)]
+              ]
+          )
+
+    it "guards null with withDefault and isNull" $ do
+      evalBuiltin (call (var "withDefault") [num 0, nullLit]) `shouldBe` Right (Aeson.Number 0)
+      evalBuiltin (call (var "withDefault") [num 0, num 5]) `shouldBe` Right (Aeson.Number 5)
+      evalBuiltin (call (var "isNull") [nullLit]) `shouldBe` Right (Aeson.Bool True)
+      evalBuiltin (call (var "isNull") [num 0]) `shouldBe` Right (Aeson.Bool False)
+
+    it "iterates with range, fold, and foldRight" $ do
+      evalBuiltin (call (var "range") [num 2, num 5])
+        `shouldBe` Right (Aeson.toJSON ([2, 3, 4] :: [Int]))
+      evalBuiltin (call (var "range") [num 5, num 2])
+        `shouldBe` Right (Aeson.toJSON ([] :: [Int]))
+      evalBuiltin
+        ( call
+            (var "fold")
+            [lambda ("acc" :| ["x"]) (bin CorePureAdd (var "acc") (var "x")), num 0, nums [1, 2, 3]]
+        )
+        `shouldBe` Right (Aeson.Number 6)
+      evalBuiltin
+        ( call
+            (var "foldRight")
+            [ lambda ("x" :| ["acc"]) (bin CorePureSubtract (var "x") (var "acc"))
+            , num 0
+            , nums [1, 2, 3]
+            ]
+        )
+        `shouldBe` Right (Aeson.Number 2)
+
+    it "renders a markdown table end to end with range, fold, and string ops" $ do
+      -- The capability that currently forces a Haskell report extension: build a
+      -- whole Markdown table in pure Wire by folding generated rows with string ops.
+      let header = str "| n | square |\n| --- | --- |"
+          rowStep =
+            lambda
+              ("acc" :| ["n"])
+              ( call
+                  (var "concat")
+                  [ CorePureList
+                      [ var "acc"
+                      , str "\n| "
+                      , call (var "toString") [var "n"]
+                      , str " | "
+                      , call (var "toString") [bin CorePureMultiply (var "n") (var "n")]
+                      , str " |"
+                      ]
+                  ]
+              )
+      evalBuiltin (call (var "fold") [rowStep, header, call (var "range") [num 1, num 4]])
+        `shouldBe` Right
+          (Aeson.String "| n | square |\n| --- | --- |\n| 1 | 1 |\n| 2 | 4 |\n| 3 | 9 |")
+
+    it "rejects iteration past the fixed bounded-iteration cap" $ do
+      evalBuiltin (call (var "range") [num 0, num 1000001])
+        `shouldBe` Left (PureBoundExceeded "range span")
+      evalBuiltin
+        ( call
+            (var "fold")
+            [ lambda ("acc" :| ["x"]) (call (var "concat") [CorePureList [var "acc", var "acc"]])
+            , str "a"
+            , call (var "range") [num 0, num 25]
+            ]
+        )
+        `shouldBe` Left (PureBoundExceeded "fold accumulator")
+
+    it "bounds numeric accumulator growth and range endpoint overflow" $ do
+      -- A squaring reducer over a tiny list still grows the accumulator without
+      -- limit; the cap must charge the number's magnitude, not count it as one node.
+      evalBuiltin
+        ( call
+            (var "fold")
+            [ lambda ("acc" :| ["x"]) (bin CorePureMultiply (var "acc") (var "acc"))
+            , num 2
+            , call (var "range") [num 0, num 25]
+            ]
+        )
+        `shouldBe` Left (PureBoundExceeded "fold accumulator")
+      -- Endpoints near the Int bounds must not overflow the span check into a
+      -- small value that slips an astronomically large enumeration through.
+      evalBuiltin
+        ( call
+            (var "range")
+            [num (fromIntegral (minBound :: Int)), num (fromIntegral (maxBound :: Int))]
+        )
+        `shouldBe` Left (PureBoundExceeded "range span")
+      evalBuiltin
+        ( call
+            (var "range")
+            [num (fromIntegral (maxBound :: Int)), num (fromIntegral (maxBound :: Int))]
+        )
+        `shouldBe` Right (Aeson.toJSON ([] :: [Int]))
+
+    it "rejects function accumulators and charges object key growth in fold" $ do
+      -- A reducer that returns a closure escapes the JSON cost guard and explodes
+      -- only when applied; fold must reduce to a JSON value, not a function.
+      evalBuiltin
+        ( call
+            (var "fold")
+            [lambda ("acc" :| ["x"]) (lambda ("y" :| []) (var "y")), num 0, nums [1, 2, 3]]
+        )
+        `shouldBe` Left (PureTypeMismatch "JSON fold accumulator" "function")
+      -- A fold can double an object key each step while the value stays null; the
+      -- cost must charge key text, not just enqueue values, or it never trips.
+      let firstKey = CorePureIndex (call (var "keys") [var "acc"]) (num 0)
+          doubledKey = call (var "concat") [CorePureList [firstKey, firstKey]]
+          jsonText = call (var "concat") [CorePureList [str "{\"", doubledKey, str "\":null}"]]
+      evalBuiltin
+        ( call
+            (var "fold")
+            [ lambda ("acc" :| ["item"]) (call (var "fromJson") [jsonText])
+            , call (var "fromJson") [str "{\"a\":null}"]
+            , call (var "range") [num 0, num 25]
+            ]
+        )
+        `shouldBe` Left (PureBoundExceeded "fold accumulator")
+      -- The seed is guarded before the reducer runs, so over-cap and function
+      -- seeds are rejected up front on both empty and non-empty folds.
+      evalBuiltin
+        ( call
+            (var "fold")
+            [lambda ("acc" :| ["x"]) (var "acc"), num (scientific 1 2000000), CorePureList []]
+        )
+        `shouldBe` Left (PureBoundExceeded "fold accumulator")
+      evalBuiltin
+        ( call
+            (var "fold")
+            [lambda ("acc" :| ["x"]) (num 0), num (scientific 1 2000000), nums [1]]
+        )
+        `shouldBe` Left (PureBoundExceeded "fold accumulator")
+      evalBuiltin
+        ( call
+            (var "fold")
+            [lambda ("acc" :| ["x"]) (num 0), lambda ("z" :| []) (str "a"), nums [1]]
+        )
+        `shouldBe` Left (PureTypeMismatch "JSON fold accumulator" "function")
+      -- A number with an exponent at the Int minimum must not slip under the cap:
+      -- abs minBound overflows, so the exponent magnitude is taken in Integer.
+      evalBuiltin
+        ( call
+            (var "fold")
+            [lambda ("acc" :| ["x"]) (var "acc"), num (scientific 1 minBound), CorePureList []]
+        )
+        `shouldBe` Left (PureBoundExceeded "fold accumulator")
+
+    it "clamps out-of-Int indices and caps out-of-Int range spans" $ do
+      let big = num (scientific 1 20) -- 10^20, beyond the Int range
+          negBig = num (scientific (-1) 20) -- -10^20
+      evalBuiltin (call (var "take") [big, nums [1, 2, 3]])
+        `shouldBe` Right (Aeson.toJSON ([1, 2, 3] :: [Int]))
+      evalBuiltin (call (var "drop") [big, nums [1, 2, 3]])
+        `shouldBe` Right (Aeson.toJSON ([] :: [Int]))
+      evalBuiltin (call (var "substring") [num 0, big, str "hello"])
+        `shouldBe` Right (Aeson.String "hello")
+      evalBuiltin (call (var "range") [num 0, big])
+        `shouldBe` Left (PureBoundExceeded "range span")
+      evalBuiltin (call (var "range") [num 0, negBig])
+        `shouldBe` Right (Aeson.toJSON ([] :: [Int]))
+      -- A small range straddling the Int boundary is measured, not rejected.
+      evalBuiltin
+        ( call
+            (var "range")
+            [num (fromIntegral (maxBound :: Int)), num (fromIntegral (maxBound :: Int) + 1)]
+        )
+        `shouldBe` Right (Aeson.toJSON ([maxBound] :: [Int]))
+      evalBuiltin
+        ( call
+            (var "range")
+            [num (fromIntegral (maxBound :: Int) + 1), num (fromIntegral (maxBound :: Int))]
+        )
+        `shouldBe` Right (Aeson.toJSON ([] :: [Int]))
+      -- A genuinely huge exponent is capped by sign, never materialised.
+      evalBuiltin (call (var "range") [num 0, num (scientific 1 2000000)])
+        `shouldBe` Left (PureBoundExceeded "range span")
+      -- Equal or backwards huge endpoints are an empty half-open range, not an
+      -- over-cap error: the direction is decided before the cap classification.
+      evalBuiltin (call (var "range") [num (scientific 1 2000000), num (scientific 1 2000000)])
+        `shouldBe` Right (Aeson.toJSON ([] :: [Int]))
+      evalBuiltin (call (var "range") [num (scientific 1 3000000), num (scientific 1 2000000)])
+        `shouldBe` Right (Aeson.toJSON ([] :: [Int]))
+      -- A small forward span past Int is enumerated by its exact span, not
+      -- rejected: range(10^20, 10^20 + 1) is [10^20].
+      evalBuiltin
+        (call (var "range") [num (scientific 1 20), num (scientific (10 ^ (20 :: Int) + 1) 0)])
+        `shouldBe` Right (Aeson.toJSON ([10 ^ (20 :: Int)] :: [Integer]))
+      -- Endpoints with exponents near the Int bounds must not overflow the width
+      -- comparison: a forward over-cap range stays over-cap, not empty.
+      evalBuiltin
+        ( call
+            (var "range")
+            [num (scientific 1 (maxBound - 1)), num (scientific 1 maxBound)]
+        )
+        `shouldBe` Left (PureBoundExceeded "range span")
+      -- Non-integer indices are still rejected.
+      evalBuiltin (call (var "take") [num (scientific 15 (-1)), nums [1, 2, 3]])
+        `shouldBe` Left (PureTypeMismatch "integer" "number")
+
+  describe "Cortex.Wire.Pure.Bounds typed boundary" $ do
+    prop "clampIndex keeps integer indices within [0, upper]" $
+      \(n :: Int) (NonNegative upper) ->
+        fmap clampedIndexValue (clampIndex upper (fromIntegral n))
+          === Just (max 0 (min upper n))
+
+    prop "clampIndex never fails for huge integers and stays within bounds" $
+      \(NonNegative upper) ->
+        forAll genHugeInteger $ \number ->
+          case clampIndex upper number of
+            Just clamped ->
+              let value = clampedIndexValue clamped in value >= 0 && value <= upper
+            Nothing -> False
+
+    prop "clampIndex rejects non-integer indices" $
+      \(NonNegative upper) (n :: Integer) ->
+        clampIndex upper (scientific (2 * n + 1) (-1)) === Nothing
+
+    prop "planRange classifies in-range spans by the documented semantics" $
+      \(start :: Int) (end :: Int) ->
+        let capValue = toInteger (iterationCapValue corePureBoundedIterationCap)
+            width = toInteger end - toInteger start
+            expected
+              | width <= 0 = TagEmpty
+              | width > capValue = TagOverCap
+              | otherwise = TagEnumerate (toInteger start) (toInteger end)
+         in fmap
+              rangeTag
+              (planRange corePureBoundedIterationCap (fromIntegral start) (fromIntegral end))
+              === Just expected
+
+    prop "planRange treats equal endpoints as an empty range at any magnitude" $
+      forAll
+        genHugeInteger
+        ( \number ->
+            fmap rangeTag (planRange corePureBoundedIterationCap number number) === Just TagEmpty
+        )
+
+    prop "mkFoldAccumulator admits exactly within-cap JSON and preserves the value" $
+      forAll genBoundedJson withinCapAdmission
+
+    it "checkValueCost charges object keys and number magnitude" $ do
+      let capValue = iterationCapValue corePureBoundedIterationCap
+          hugeKeyObject =
+            Aeson.object [Key.fromText (T.replicate (capValue + 1) "k") Aeson..= Aeson.Null]
+      checkValueCost corePureBoundedIterationCap hugeKeyObject `shouldBe` OverLimit
+      checkValueCost corePureBoundedIterationCap (Aeson.Number (scientific 1 (capValue + 1)))
+        `shouldBe` OverLimit
+      checkValueCost corePureBoundedIterationCap (Aeson.Number 5) `shouldBe` WithinLimit
+
 scorePorts :: WirePorts
 scorePorts =
   WirePorts
@@ -1301,6 +1734,81 @@ bin =
 record :: [(Text, CorePureExpr)] -> CorePureExpr
 record fields =
   CorePureRecord [CorePureField (fieldName :| []) fieldExpr | (fieldName, fieldExpr) <- fields]
+
+nums :: [Scientific] -> CorePureExpr
+nums values =
+  CorePureList (fmap num values)
+
+strs :: [Text] -> CorePureExpr
+strs values =
+  CorePureList (fmap str values)
+
+nullLit :: CorePureExpr
+nullLit =
+  CorePureLit CorePureNull
+
+{- | Integer-valued numbers spanning the Int range and far beyond it (exponent up
+to 100000), so clamp/range properties exercise out-of-Int magnitudes.
+-}
+genHugeInteger :: Gen Scientific
+genHugeInteger =
+  scientific <$> arbitrary <*> choose (0, 100000)
+
+{- | Observable tag of a 'RangePlan' for property assertions, since the plan's
+constructors are hidden behind 'foldRangePlan'.
+-}
+data RangeTag = TagEmpty | TagEnumerate Integer Integer | TagOverCap
+  deriving stock (Eq, Show)
+
+rangeTag :: RangePlan -> RangeTag
+rangeTag = foldRangePlan TagEmpty TagEnumerate TagOverCap
+
+{- | Small JSON values for the fold-accumulator cost property: scalars and
+shallow numeric arrays, enough to exercise the within/over-cap boundary.
+-}
+genBoundedJson :: Gen Aeson.Value
+genBoundedJson =
+  oneof
+    [ pure Aeson.Null
+    , Aeson.Bool <$> arbitrary
+    , Aeson.Number . fromInteger <$> arbitrary
+    , Aeson.String . T.pack <$> arbitrary
+    , Aeson.toJSON <$> listOf (Aeson.Number . fromInteger <$> (arbitrary :: Gen Integer))
+    ]
+
+{- | mkFoldAccumulator admits a JSON value iff its cost is within the cap, and
+preserves the value unchanged when it admits it.
+-}
+withinCapAdmission :: Aeson.Value -> Property
+withinCapAdmission value =
+  case mkFoldAccumulator corePureBoundedIterationCap value of
+    Just accumulator ->
+      (foldAccumulatorValue accumulator === value)
+        .&&. ( checkValueCost corePureBoundedIterationCap (foldAccumulatorValue accumulator)
+                 === WithinLimit
+             )
+    Nothing ->
+      checkValueCost corePureBoundedIterationCap value === OverLimit
+
+{- | Evaluate a single CorePure expression with no inputs, returning the @out@ port
+value. Used to exercise individual builtins without per-test port scaffolding.
+-}
+evalBuiltin :: CorePureExpr -> Either PureEvalError Aeson.Value
+evalBuiltin expr =
+  (Map.! "out")
+    <$> evaluatePureTaskOutputs
+      builtinOutPorts
+      (wireInputBundleFromStageInputs Map.empty)
+      []
+      Nothing
+      (Map.singleton "out" expr)
+
+builtinOutPorts :: WirePorts
+builtinOutPorts =
+  WirePorts
+    { wirePortsInputs = Map.empty
+    , wirePortsOutputs = Map.singleton "out" WireOutputPort {wireOutputPortContract = "Any"}
+    }
 
 numJson :: Scientific -> Aeson.Value
 numJson =

--- a/theory/Cortex/Wire/Pure.lean
+++ b/theory/Cortex/Wire/Pure.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Int.Basic
+import Mathlib.Tactic.FinCases
 
 /-!
 ## Overview
@@ -159,6 +160,37 @@ def closedBuiltinEnv : List BuiltinSpec :=
   , { name := "joinWith", arity := 2, authority := BuiltinAuthority.pureValue }
   , { name := "toJson", arity := 1, authority := BuiltinAuthority.pureValue }
   , { name := "fromJson", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "reverse", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "sort", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "sortBy", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "take", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "drop", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "enumerate", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "mapIndexed", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "find", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "findIndex", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "contains", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "indexOf", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "count", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "split", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "replace", arity := 3, authority := BuiltinAuthority.pureValue }
+  , { name := "substring", arity := 3, authority := BuiltinAuthority.pureValue }
+  , { name := "trim", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "toLower", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "toUpper", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "startsWith", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "endsWith", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "strLength", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "lines", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "unlines", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "keys", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "values", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "entries", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "withDefault", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "isNull", arity := 1, authority := BuiltinAuthority.pureValue }
+  , { name := "range", arity := 2, authority := BuiltinAuthority.pureValue }
+  , { name := "fold", arity := 3, authority := BuiltinAuthority.pureValue }
+  , { name := "foldRight", arity := 3, authority := BuiltinAuthority.pureValue }
   ]
 
 /-- Name/arity projection of the proof-side closed builtin mirror. -/
@@ -186,6 +218,37 @@ theorem closedBuiltinSignature_eq :
       , ("joinWith", 2)
       , ("toJson", 1)
       , ("fromJson", 1)
+      , ("reverse", 1)
+      , ("sort", 1)
+      , ("sortBy", 2)
+      , ("take", 2)
+      , ("drop", 2)
+      , ("enumerate", 1)
+      , ("mapIndexed", 2)
+      , ("find", 2)
+      , ("findIndex", 2)
+      , ("contains", 2)
+      , ("indexOf", 2)
+      , ("count", 2)
+      , ("split", 2)
+      , ("replace", 3)
+      , ("substring", 3)
+      , ("trim", 1)
+      , ("toLower", 1)
+      , ("toUpper", 1)
+      , ("startsWith", 2)
+      , ("endsWith", 2)
+      , ("strLength", 1)
+      , ("lines", 1)
+      , ("unlines", 1)
+      , ("keys", 1)
+      , ("values", 1)
+      , ("entries", 1)
+      , ("withDefault", 2)
+      , ("isNull", 1)
+      , ("range", 2)
+      , ("fold", 3)
+      , ("foldRight", 3)
       ] :=
   rfl
 
@@ -193,46 +256,9 @@ theorem closedBuiltinSignature_eq :
 theorem closedBuiltinEnv_authorityFree :
     ∀ spec, spec ∈ closedBuiltinEnv → spec.authorityFree := by
   intro spec hSpec
-  simp [closedBuiltinEnv] at hSpec
-  rcases hSpec with
-    hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec |
-      hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec | hSpec
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
-  · cases hSpec
-    rfl
+  -- `fin_cases` enumerates every concrete entry of `closedBuiltinEnv`, so this
+  -- proof stays correct as the closed builtin table grows without per-entry edits.
+  fin_cases hSpec <;> rfl
 
 /-- Unary operators in the modeled CorePure subset. -/
 inductive UnaryOp : Type where


### PR DESCRIPTION
## Summary

Extends the closed CorePure builtin environment (`corePureBuiltinSpecs`, `src/Cortex/Wire/Pure.hs`)
with **batch 1** of issue #295: an ergonomic list/string/search/record stdlib plus bounded iteration,
all data-last for `|>`. This lets pure Wire own JSON/string/list report logic that currently forces a
Haskell extension (`Cortex.Quantum.Qec.renderReport`).

All 31 builtins take the existing `CorePureCall (CorePureIdent name) args` path — one spec entry + a
handler. No language-core, AST, or parser change. Every builtin is total, deterministic, and
authority-free.

The reduce/generate primitives `range`, `fold`, `foldRight` touched a documented architectural gate
(ADR 0020/0023 deferred `fold` pending a cost model; ADR 0056 keeps CorePure budget-free). Resolved
per plan with a **fixed deterministic cap** (a totality guard raising the typed `PureBoundExceeded`,
not an operator-tunable budget), recorded in a new **ADR 0061** refining the deferral.

## What landed

- [x] List-shape: `reverse`, `sort`, `sortBy`, `take`, `drop`, `enumerate`, `mapIndexed`
- [x] Search: `find`, `findIndex`, `contains`, `indexOf`, `count`
- [x] String: `split`, `replace`, `substring`, `trim`, `toLower`, `toUpper`, `startsWith`, `endsWith`, `strLength`, `lines`, `unlines`
- [x] Record: `keys`, `values`, `entries`; Null/option: `withDefault`, `isNull`
- [x] Bounded iteration: `range`, `fold`, `foldRight` + fixed cap (`PureBoundExceeded`)
- [x] ADR 0061 refining the ADR 0020/0023 `fold` deferral
- [x] Lean closed-signature mirror updated (`theory/Cortex/Wire/Pure.lean`; `fin_cases` keeps the proof growth-proof)
- [x] `docs/Reference/Wire/pure-execution.md` builtins + conventions + bounded-iteration + failure
- [x] `PureSpec` golden-signature + authority-report updates, per-builtin behaviour, cap, and a fold+range+string markdown-table capability test
- [x] End-to-end example `examples/wire/pure-stdlib-report.wire` (range + fold + string ops -> `std.io.writeFile`/stdout), parse-guarded in `ParserSpec`

## Verification

- [x] `just build`, `just test` (917 examples, 0 failures)
- [x] `just lint`, `just fmt-check`, `just docs-check`, `just lean-check`
- [x] `just check` (full `nix flake check`) — all checks passed, incl. `check-wire-style`
- [x] `wire run examples/wire/pure-stdlib-report.wire` renders and writes the table end to end

## Issue

Closes #295 (batch 1; batches 2 and 3 remain follow-ups)