### PR TITLE
feat(wire,pulse): typed effect variant output boundaries (ADR 0062)

### DIFF
--- a/app/wire/Main.hs
+++ b/app/wire/Main.hs
@@ -1170,7 +1170,10 @@ wirePortsFromLowered loweredPorts =
     , wirePortsOutputs =
         Map.fromList
           [ ( port.loweredPortName
-            , WireOutputPort {wireOutputPortContract = port.loweredPortContract}
+            , WireOutputPort
+                { wireOutputPortContract = port.loweredPortContract
+                , wireOutputPortExclusiveGroup = Nothing
+                }
             )
           | port <- loweredPorts.loweredOutputs
           ]

--- a/docs/ADRs/0033-wire-select-guarded-affine-collapse.md
+++ b/docs/ADRs/0033-wire-select-guarded-affine-collapse.md
@@ -82,8 +82,11 @@ The rules are:
 
 - The word "superposition" can mislead if used without the formal guarded-affine explanation.
 - Tooling and docs must keep latent branch visibility distinct from materialized topology.
-- Native n-way selection still needs runtime work; current lowering remains a narrower binary
-  subset.
+- Native n-way selection still lowers to a nested binary condition tree, not a native n-way runtime
+  node. The runtime guard source that drives that tree - reading a producer's committed output
+  variant label and routing it through the compiled then/else keys - is implemented as
+  `committedVariantConditionBinding` (ADR 0062, GitHub #314); a native n-way runtime representation
+  remains future work.
 
 ### Obligations
 

--- a/docs/ADRs/0062-typed-effect-variant-output-boundaries.md
+++ b/docs/ADRs/0062-typed-effect-variant-output-boundaries.md
@@ -1,0 +1,287 @@
+---
+title: "ADR 0062 - Typed Effect Variant Output Boundaries"
+description:
+  "A bound executor stage may complete by emitting exactly one declared output variant label with a
+  contract-valid payload, validated before commit and branchable by select, refining the exclusive
+  output grouping ADR 0017 specified and discharging the failure-routing hook in ADR 0026."
+sidebar:
+  label: "0062. Typed variant output boundaries"
+  order: 62
+status: proposed
+date: 2026-06-27
+superseded_by: null
+related:
+  - docs/ADRs/0017-wire-executor-and-port-catalog-boundary.md
+  - docs/ADRs/0024-typed-executor-node-interface.md
+  - docs/ADRs/0026-wire-failure-taxonomy.md
+  - docs/ADRs/0033-wire-select-guarded-affine-collapse.md
+  - docs/ADRs/0053-executor-catalog-manifests-and-pulse-bindings.md
+  - docs/ADRs/0059-durable-external-call-frontiers-on-pulse.md
+  - "GitHub #313"
+  - "GitHub #314"
+  - "GitHub #315"
+  - "GitHub #138"
+---
+
+# ADR 0062 - Typed Effect Variant Output Boundaries
+
+## Status
+
+Proposed - extends ADR 0024, ADR 0033, and ADR 0053, fulfils the failure-routing hook left open by
+ADR 0026, generalises the typed-error-output option in ADR 0059, and discharges the exclusive-output
+grouping ADR 0017 specified but the runtime never implemented. It does not edit those ADRs; the ADR
+0033 note that native selection still needs runtime work is updated when the select runtime (#314)
+lands.
+
+## Context
+
+An executor stage today completes by producing a single output value per node - every
+output-carrying result (`StageComplete` and the rewrite/loop results `StageRewrite`,
+`StageRejectRewrite`, `StageLoopStep`) flows through one wrap boundary - or it fails. What is
+missing is completing by choosing **one of several declared, typed output variants** that a
+downstream `select(...)` branches on. So a domain- or effect-recoverable outcome - a backend reject,
+a model-gateway failure, a `ready | repair` gate - collapses into a terminal run failure instead of
+routing to a recovery arm.
+
+The substrate already gestures at this gap from three directions:
+
+- ADR 0026 (failure taxonomy) states deterministic failures "may be surfaced as typed executor
+  failures" and that "whether a graph routes those failures through an explicit error contract is a
+  topology decision, not a change to the failure taxonomy" - but names no mechanism.
+- ADR 0059 says a realize node "may additionally expose a typed error output for recoverable backend
+  errors", defaulting to closure - again with no generic mechanism.
+- The Wire language already has variant outputs: `PortOutputSumDecl`/`SumVariant` compile to
+  `(group id, label, contract)` exclusive groups, and `select(...)` arms resolve by label. ADR 0033
+  defines `select` as guarded affine collapse where "runtime selects exactly one arm", and ADR 0017
+  specifies the port profile carries "exclusive-output grouping".
+
+Two facts make this a real, narrow piece of substrate work rather than a syntax change:
+
+1. **The exclusive grouping is dropped before runtime.** `loweredPortsToWirePorts` and the port
+   metadata keep only `port name -> contract`; at the egress boundary a sum `ok:T | err:U` is
+   indistinguishable from two independent product outputs. ADR 0017's grouping obligation was never
+   implemented.
+2. **The production `select(...)` runtime is effectively unbuilt.** The condition binder
+   (`bindCircuitConditionNode`, `circuitConditionSelectBranch`) and
+   `lowerCompiledCircuitToSomeStagePlan` have no production caller; the production Pulse lowering
+   path lowers only realize nodes. So "branch on an executor-emitted variant label" means building
+   the select runtime, not tuning it.
+
+The open question is: what is the smallest substrate boundary that lets an executor commit one typed
+variant, validate it before commit, persist it durably, and let `select` branch on it on resume
+without re-running the effect - without inventing an "error channel" or a new persistence shape.
+
+## Decision
+
+### Model: an exclusive output group is a sum type
+
+A node's exclusive output group is a sum type, and selection is by **label**:
+
+- exclusive output group = sum type;
+- variant label = constructor / tag;
+- variant contract = the payload type (interface) for that constructor;
+- payload = a value inhabiting that contract.
+
+So the Wire boundary
+
+```text
+-> succeeded: Result
+ | rejected: RejectReason
+ | failed: BackendFailure;
+```
+
+is morally `data Outcome = Succeeded Result | Rejected RejectReason | Failed BackendFailure`. But
+`Result` is **not** a host type: it is a stable, serializable **contract id** in the Wire catalog.
+Contracts are Wire's portable type-identity surface for payload compatibility - not Haskell, Rust,
+or WASM types.
+
+**Label and contract are distinct, and selection is by label.** The label answers _which branch_;
+the contract answers _what payload shape_. Two variants may share a contract when their branch
+meaning differs:
+
+```text
+-> accepted: ReviewDecision
+ | rejected: ReviewDecision;
+```
+
+That is well-formed only because selection is by label; contract-only dispatch would be ambiguous.
+
+### Three layers
+
+- **Wire compile time** owns the known contract ids, port labels, exclusive-group membership, and
+  label/contract compatibility. (The exclusive group is dropped before runtime today; this ADR
+  carries it through.)
+- **The Pulse boundary** (this ADR's substrate, #313) validates and commits: exactly one emitted
+  label, payload-kind/shape validation against _that label's_ contract, and a durable `WireValue`
+  commit. It is host-language-agnostic - it sees `(label, payload)`, never a host type.
+- **The host binding** maps host values onto that surface: a host-type <-> contract-id codec and a
+  host-constructor <-> variant-label map. This is host-specific ergonomics, the deferred
+  codec-registry work (#315), and is not part of this ADR's substrate.
+
+### Substrate (Pulse boundary)
+
+The boundary is **N labelled variants**, not a baked-in `ok | err`. A completing variant reuses the
+existing output envelope: the chosen label is `WireValue.wireValuePort` (already set to the output
+port name at egress - for a sum node the port name _is_ the variant label), the payload is
+`wireValueValue`, the label's contract is `wireValueContract`. No new `StageResult` constructor,
+`NodeOutcome` shape, or persistence column is introduced.
+
+For this ADR, a **variant-emitting executor boundary must expose exactly one exclusive output group
+and no ordinary output ports**, so completion commits **exactly one** `WireValue` (the chosen
+variant); a `WireValueSet`, multiple values, or zero is rejected (new enforcement, since the
+boundary currently validates set members independently). Ordinary multi-output **product** nodes are
+unchanged, including a port whose contract is a bounded indexed product such as `[T; 4]` - that is
+one product contract on one ordinary port, not a sum/product mix. Supporting "one selected variant
+plus ordinary side outputs" would need a different envelope and downstream linearity story and is
+**out of scope**.
+
+The node grammar itself permits multiple output clauses (a sum group beside ordinary ports), so this
+variant-boundary restriction is an ADR-0062 rule, not a grammar rule; `select(...)`'s
+`resolveExclusiveBoundary` already rejects a sum-plus-extra-exit boundary. (The comment at the
+`resolveExclusiveBoundary` site claiming the grammar forbids the mix is stale; #313 should correct
+it.)
+
+The boundary validates a candidate variant **before commit** (ADR 0053):
+
+- the emitted label is a member of the node's declared exclusive output group;
+- the payload satisfies _that label's_ contract (payload kind and shape);
+- an invalid label or payload is a **typed** failure, `executor_output_validation_failure`
+  (consistent with ADR 0026), not a silent branch and not an untyped `stage_failure`.
+
+To make membership checkable at runtime, the exclusive group id is carried into the runtime port
+profile (`WireOutputPort` gains an exclusive-group field, round-tripped through port metadata),
+discharging the ADR 0017 grouping obligation.
+
+These checks live at the shared wrap boundary (`wrapWireStageResult` -> `wrapNodeBoundaryOutput`),
+which already runs for every output-carrying result, so variant validation applies uniformly to the
+output slot of every output-carrying successful result (`StageComplete`, `StageRewrite`,
+`StageRejectRewrite`, `StageLoopStep`); `StageSuspend` and the failure results are unaffected.
+
+### Failure boundary
+
+Three distinct cases, kept separate:
+
+- a **declared, recoverable** outcome the author chose to branch on is emitted as a variant;
+- an **invariant / decode / unexpected-exception / timeout** failure stays on the hard Pulse failure
+  path - `StageFail`-surfaced typed failures (`StageFailureTyped`), exceptions
+  (`StageFailureException`), and timeouts (`StageFailureTimeout`) (ADR 0026 unchanged);
+- an **invalid emitted variant** (undeclared label, or a payload failing the label's contract) is
+  `executor_output_validation_failure`.
+
+A bind-time check, where the binder's declared emitter-label set is available, verifies it is a
+subset of the node's declared variants; runtime membership validation (above) stays authoritative
+for every emitted candidate. (The host constructor -> label mapping that would make the
+emitter-label set precise is deferred to #315.) The recover-versus-fail-hard decision for a given
+run is the binder's, within the three cases above.
+
+### select consumes the label
+
+`select(...)` branches on the committed **label**, never on the contract or a host constructor. The
+condition binder reads the producer's single committed envelope from its inputs, takes
+`wireValuePort` as the chosen label, and maps it to the compiled arm. Native N-way runtime is not
+required: the existing nested binary condition tree is kept, and each generated condition node tests
+the persisted label against its `thenKeys` / `elseKeys`; a label in neither is a typed failure,
+never a silent default arm. Public `select(...)` syntax is unchanged (arms already resolve by
+label).
+
+Durability reuses what exists: the selected branch persists as the `graph_rewrites` delta plus
+`NodeRewritten` and replays on resume; the committed label persists on the producer's node output.
+The binder reads only persisted inputs and never re-invokes the backend, so the rare crash-window
+predicate re-run is deterministic and the effect runs once.
+
+### Scope
+
+Delivered in two tracked steps under this ADR: the emission + validation + persistence substrate
+(#313), and the production select runtime that consumes the committed label with durable resume
+(#314, relating to #138). The host-type codec registry, the host typeclasses, and per-contract
+schema strength are explicitly **out of scope** and deferred (#315); this ADR ships on Layer-1
+payload-kind/shape validation over the current `WireValue`.
+
+## Alternatives considered
+
+- **A new `StageResult` constructor (`StageCompleteVariant label payload`).** Rejected: it forces
+  edits across `Plan`, `wrapWireStageResult`, the durable node-outcome path, and the executor for
+  zero added expressiveness - the label already fits the existing `WireValue` port slot, and the
+  exactly-one rule plus exclusive-group metadata supply the "which variant" semantics. The compiler
+  allocates one port per sum variant, so a variant's port name is its label by construction.
+- **Bake in an `ok | err` error channel.** Rejected: downstream graphs already need N-way
+  (`ready | repair`, `rejected | failed | succeeded`); an `ok | err` primitive would invite three
+  slightly different mechanisms. The exclusive group already carries N labels.
+- **An order-based `Either err ok` adapter (`Right` -> first label, `Left` -> second).** Rejected:
+  it is order-sensitive and misroutes `err | ok` or any non-`ok | err` pair. A host adapter must
+  name both labels explicitly through a constructor -> label map; that mapping is host-binding
+  ergonomics and lives in the codec layer (#315), not in this substrate.
+- **Drive `select` by re-running a predicate over the producer's value (the existing test-only
+  binder shape).** Rejected as the primary path: for an effectful producer, re-deriving the branch
+  means re-running the effect on resume. Reading the committed label instead keeps resume
+  effect-free; the predicate form remains available for pure conditions.
+- **Require the host-type codec registry (#315) first.** Rejected as a blocker: the variant boundary
+  is a Layer-1 concern (label membership + payload kind/shape) and ships on the current `WireValue`.
+  The codec registry and `ContractId` versioning are a separate, deferred refinement of ADR 0017
+  (#315).
+
+## Consequences
+
+### Positive
+
+- Recoverable backend and domain failures can be routed to a `select` recovery arm as first-class
+  typed variants, instead of collapsing the run - the topology mechanism ADR 0026 named but left
+  unbuilt, and the generic form of ADR 0059's typed error output.
+- N-way variants are uniform across consumers; no per-consumer error convention.
+- Selection is by label, not contract, so two variants may share a contract (e.g.
+  `accepted | rejected: ReviewDecision`); contract-only dispatch could not express this.
+- Reuses the existing envelope, persistence, and rewrite-replay machinery: no new result
+  constructor, no schema/column change, no `select(...)` syntax change.
+- Output-validation failures become typed (`executor_output_validation_failure`), closing a place
+  where the boundary currently raises an untyped `stage_failure`.
+- Discharges ADR 0017's exclusive-output-grouping obligation and supplies the runtime guard source
+  ADR 0033 deferred.
+
+### Negative
+
+- It builds the production `select(...)` runtime for the first time (#314), which is more than a
+  local change; the substrate (#313) is independently shippable but the headline branch capability
+  depends on the runtime.
+- Layer-1 validation does not catch a payload that is valid JSON of the right kind but semantically
+  wrong against the contract; strong per-contract schemas wait on the deferred codec work (#315).
+- Overloading `WireValue.wireValuePort` for the variant label makes the runtime exclusive-group
+  metadata load-bearing for correctness (without it the boundary cannot distinguish a grouped
+  variant port from an ungrouped product port).
+
+### Obligations
+
+- A bind-time check should verify the binder's declared emitter-label set (where available) is a
+  subset of the node's declared variants; runtime membership validation stays authoritative for
+  every emitted candidate (the precise emitter-label set depends on the host constructor -> label
+  mapping deferred to #315).
+- A variant-emitting boundary must be exactly one exclusive group with no ordinary output ports;
+  completion commits exactly one `WireValue` (reject a `WireValueSet`, multiple values, or zero).
+  This is new enforcement, since `validateExplicitWireOutput` currently validates set members
+  independently. Ordinary product multi-output nodes are unchanged. #313 should also correct the
+  stale `resolveExclusiveBoundary` comment that claims the node grammar forbids the
+  sum-plus-ordinary mix.
+- The `select` binder must read only persisted inputs and never re-invoke the backend, preserving
+  the effect-once / deterministic-resume property.
+- On landing #314, update ADR 0033's "runtime work still needed" note to point at this mechanism.
+- If strong per-contract payload validation, cross-version replay safety, or a host-type codec
+  registry are later wanted, pursue them through #315 (refining ADR 0017) rather than widening this
+  boundary silently.
+- The Lean proof-side select admission / materialization correspondence (#138) covers the durable
+  selected-branch story; keep it in scope when #314 lands.
+
+## Related
+
+- [0017 - Wire Executor and Port Catalog Boundary](0017-wire-executor-and-port-catalog-boundary.md) -
+  specifies exclusive-output grouping in the port profile and the application-codec layer this ADR
+  implements (grouping) and defers (codecs).
+- [0024 - Typed Executor Node Interface](0024-typed-executor-node-interface.md) - variants remain
+  typed output ports, each with a contract.
+- [0026 - Wire Failure Taxonomy](0026-wire-failure-taxonomy.md) - the failure-as-explicit-error-
+  contract topology hook this ADR realises; invariant failures stay hard failures.
+- [0033 - Wire Select as Guarded Affine Collapse](0033-wire-select-guarded-affine-collapse.md) - the
+  exclusive-arm selection model this ADR supplies a runtime guard source and durability for.
+- [0053 - Executor Catalog Manifests and Pulse Runtime Bindings](0053-executor-catalog-manifests-and-pulse-bindings.md)
+  - the Pulse-visible ABI and validate-before-commit boundary this ADR refines with an exclusive
+    output envelope.
+- [0059 - Durable External-Call Frontiers on Pulse](0059-durable-external-call-frontiers-on-pulse.md)
+  - the typed-error-output option this ADR generalises to N variants.

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -78,6 +78,7 @@ values: `proposed`, `accepted`, `superseded`, `deprecated`.
 | [0059](0059-durable-external-call-frontiers-on-pulse.md)           | Durable External-Call Frontiers on Pulse                            | proposed   |
 | [0060](0060-filesystem-package-and-binding-manifests.md)           | Filesystem Package and Binding Manifests                            | proposed   |
 | [0061](0061-corepure-bounded-iteration-primitives.md)              | CorePure Bounded Iteration Primitives                               | proposed   |
+| [0062](0062-typed-effect-variant-output-boundaries.md)             | Typed Effect Variant Output Boundaries                              | proposed   |
 
 ## Writing a new ADR
 

--- a/src/Cortex/Wire/AST.hs
+++ b/src/Cortex/Wire/AST.hs
@@ -20,6 +20,7 @@ module Cortex.Wire.AST
   , WireInputCardinality (..)
   , WireInputPort (..)
   , WireOutputPort (..)
+  , wireOrdinaryOutputPort
   , WirePorts (..)
   , defaultInputPortName
   , defaultOutputPortName
@@ -40,6 +41,7 @@ import Data.Map.Strict (Map)
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
 
 import Cortex.Algebra.Graph (ValidationError (..))
 import Cortex.Pulse.Memory.Types (MemoryStrategy)
@@ -108,14 +110,25 @@ instance FromJSON WireInputPort where
 
 data WireOutputPort = WireOutputPort
   { wireOutputPortContract :: !Text
+  , wireOutputPortExclusiveGroup :: !(Maybe Natural)
+  {- ^ The exclusive (sum) output group this port belongs to, if any. Ports sharing
+  a group id are the variants of one @select@-able boundary (ADR 0062); 'Nothing'
+  is an ordinary product output.
+  -}
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)
+
+-- | An ordinary (non-variant) output port: no exclusive group.
+wireOrdinaryOutputPort :: Text -> WireOutputPort
+wireOrdinaryOutputPort contract =
+  WireOutputPort {wireOutputPortContract = contract, wireOutputPortExclusiveGroup = Nothing}
 
 instance FromJSON WireOutputPort where
   parseJSON = Aeson.withObject "WireOutputPort" $ \obj ->
     WireOutputPort
       <$> obj Aeson..: "contract"
+      <*> obj Aeson..:? "exclusiveGroup"
 
 data WirePorts = WirePorts
   { wirePortsInputs :: !(Map Text WireInputPort)

--- a/src/Cortex/Wire/Circuit/Lowering.hs
+++ b/src/Cortex/Wire/Circuit/Lowering.hs
@@ -21,14 +21,19 @@ module Cortex.Wire.Circuit.Lowering
   , lowerCompiledCircuitToStagePlan
   , lowerCircuitIRToSomeStagePlan
   , lowerCircuitIRToStagePlan
+  , committedVariantConditionBinding
+  , committedVariantSelection
+  , committedVariantSelectKeys
   )
 where
 
 import Data.Aeson qualified as Aeson
+import Data.Aeson.Types qualified as AesonTypes
+import Data.Bifunctor (first)
 import Data.Int (Int32)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -57,7 +62,7 @@ import Cortex.Pulse.Plan
   , StageLatentDeltaSignature (..)
   , StageLatentNode (..)
   , StagePlan (..)
-  , StageReplaySafety
+  , StageReplaySafety (..)
   , StageResult (..)
   , StageRetryPolicy
   , StageTemplateId
@@ -91,6 +96,7 @@ import Cortex.Wire.Circuit.IR
   , CircuitSignalBoundary
   , CircuitTaskNode
   )
+import Cortex.Wire.Value (WireValue (..))
 
 data CircuitConditionBranch
   = CircuitConditionThen
@@ -150,6 +156,8 @@ data CircuitLoweringError
   | CircuitStageRefMismatch CircuitNodeRef NodeId
   | CircuitLoweredGraphInvalid (ValidationError NodeId)
   | CircuitTemplateRegistryInvalid Text
+  | -- | A @wire_select@ condition node's metadata is missing or malformed (ADR 0062).
+    CircuitConditionMetadataInvalid !Text
   deriving stock (Eq, Show)
 
 lowerCircuitIRToStagePlan
@@ -493,3 +501,68 @@ lowerLatentBranch pulseConfig binder anchorNodeId postSuccessorNodes branchId fr
 namespaceNodeId :: NodeId -> NodeId -> NodeId
 namespaceNodeId (NodeId parentNodeId) (NodeId localNodeId) =
   NodeId (parentNodeId <> ":" <> localNodeId)
+
+{- | The @(thenKeys, elseKeys)@ select-arm label sets of a @wire_select@ condition
+node, parsed from its compiled metadata (ADR 0062): the variant labels routed to the
+then branch and to the else branch respectively.
+-}
+committedVariantSelectKeys :: Aeson.Value -> Either CircuitLoweringError ([Text], [Text])
+committedVariantSelectKeys metadata =
+  first (CircuitConditionMetadataInvalid . T.pack) $
+    AesonTypes.parseEither
+      ( Aeson.withObject "wire_select condition metadata" $ \o ->
+          (,) <$> o Aeson..: "thenKeys" <*> o Aeson..: "elseKeys"
+      )
+      metadata
+
+{- | Decide a select branch from the committed variant label (ADR 0062). The select
+boundary's producer commits exactly one variant 'WireValue' whose @wireValuePort@ is
+the chosen label; this finds that producer among the condition node's predecessor
+outputs (the first whose label is one of the select keys) and routes by then-key
+membership. It runs no effect, so a resume that re-evaluates it from the same
+persisted inputs reproduces the same branch. With no committed select label it
+defaults to the else branch with a null anchor output.
+-}
+committedVariantSelection
+  :: [Text] -> [Text] -> Map NodeId Aeson.Value -> CircuitConditionSelection
+committedVariantSelection thenKeys elseKeys scInputs =
+  case committedSelectKeyLabel of
+    Just (label, raw)
+      | label `elem` thenKeys ->
+          CircuitConditionSelection raw CircuitConditionThen
+      | otherwise ->
+          CircuitConditionSelection raw CircuitConditionElse
+    Nothing ->
+      CircuitConditionSelection Aeson.Null CircuitConditionElse
+  where
+    selectKeys = thenKeys <> elseKeys
+    committedSelectKeyLabel =
+      listToMaybe
+        [ (label, raw)
+        | raw <- Map.elems scInputs
+        , Aeson.Success wireValue <- [Aeson.fromJSON raw :: Aeson.Result WireValue]
+        , Just label <- [wireValue.wireValuePort]
+        , label `elem` selectKeys
+        ]
+
+{- | A production condition binding (ADR 0062) whose branch is decided by the
+committed variant label of the select boundary's producer, read from the persisted
+predecessor outputs and routed via the compiled @thenKeys@/@elseKeys@. No backend or
+effect runs in selection, so durable resume is deterministic. This replaces the
+test-only hardcoded selectors as the runtime guard source ADR 0033 deferred.
+-}
+committedVariantConditionBinding
+  :: CircuitConditionNode -> Either CircuitLoweringError CircuitConditionBinding
+committedVariantConditionBinding conditionNode = do
+  (thenKeys, elseKeys) <- committedVariantSelectKeys conditionNode.circuitConditionNodeMetadata
+  Right
+    CircuitConditionBinding
+      { circuitConditionReplaySafety = SafeToReplay
+      , circuitConditionReplayPolicyOverride = Nothing
+      , circuitConditionTimeoutSeconds = Nothing
+      , circuitConditionRetryPolicy = Nothing
+      , circuitConditionTemplateId = Nothing
+      , circuitConditionActionId = Nothing
+      , circuitConditionSelectBranch = \_runId scInputs ->
+          pure (committedVariantSelection thenKeys elseKeys scInputs)
+      }

--- a/src/Cortex/Wire/Compile.hs
+++ b/src/Cortex/Wire/Compile.hs
@@ -2365,9 +2365,12 @@ data ResolvedSelectArm = ResolvedSelectArm
   , selectArmResolvedExpr :: !Expr
   }
 
-{- | The mixed-boundary rejection below (exclusive sum plus ordinary exits) is
-reachable only through composition: a single node cannot declare a sum plus an
-extra output, the grammar forbids it.
+{- | The mixed-boundary rejection below rejects a @select(...)@ left-hand graph that
+is not a single exclusive group (an exclusive sum plus ordinary exits, or several
+groups). This is a select-boundary restriction, not a grammar one: the node grammar
+itself permits a sum group beside ordinary output clauses (see 'executorImplementation'
+and 'outputPort'). ADR 0062 makes the same single-exclusive-group rule the
+variant-emitting boundary.
 -}
 resolveExclusiveBoundary :: [BoundaryPort] -> Either WireCore.WireError (NonEmpty BoundaryPort)
 resolveExclusiveBoundary exits =
@@ -2915,6 +2918,7 @@ loweredPortsToWirePorts inputs outputs =
           [ ( port.lpInternalName
             , WireCore.WireOutputPort
                 { wireOutputPortContract = port.lpContract
+                , wireOutputPortExclusiveGroup = port.lpExclusiveGroup
                 }
             )
           | port <- outputs
@@ -3498,6 +3502,7 @@ taskWirePortsFromLowered ports =
           [ ( port.lpInternalName
             , WireCore.WireOutputPort
                 { wireOutputPortContract = port.lpContract
+                , wireOutputPortExclusiveGroup = port.lpExclusiveGroup
                 }
             )
           | port <- ports.lnpOutputs

--- a/src/Cortex/Wire/Contracts.hs
+++ b/src/Cortex/Wire/Contracts.hs
@@ -28,7 +28,7 @@ module Cortex.Wire.Contracts
 where
 
 import Control.Monad (void)
-import Data.Aeson (ToJSON (..), (.:), (.=))
+import Data.Aeson (ToJSON (..), (.:), (.:?), (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types qualified as AesonTypes
 import Data.Map.Strict (Map)
@@ -140,6 +140,7 @@ portsMetadataValue ports =
       Aeson.object
         [ "name" Aeson..= portName
         , "contract" Aeson..= portSpec.wireOutputPortContract
+        , "exclusiveGroup" Aeson..= portSpec.wireOutputPortExclusiveGroup
         ]
 
 wirePortsFromMetadataValue :: Aeson.Value -> Either Text WirePorts
@@ -173,7 +174,7 @@ parseInputMetadataEntry = Aeson.withObject "Wire input port metadata" $ \obj -> 
 parseOutputMetadataEntry :: Aeson.Value -> AesonTypes.Parser (Text, WireOutputPort)
 parseOutputMetadataEntry = Aeson.withObject "Wire output port metadata" $ \obj -> do
   portName <- obj .: "name"
-  portSpec <- WireOutputPort <$> obj .: "contract"
+  portSpec <- WireOutputPort <$> obj .: "contract" <*> obj .:? "exclusiveGroup"
   pure (portName, portSpec)
 
 validatePorts :: CircuitNodeRef -> WirePorts -> Either WireError WirePorts

--- a/src/Cortex/Wire/NodeBoundary.hs
+++ b/src/Cortex/Wire/NodeBoundary.hs
@@ -42,6 +42,7 @@ import Data.Aeson qualified as Aeson
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (isNothing)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -306,6 +307,17 @@ wrapNodeBoundaryOutput
   -> Aeson.Value
   -> Either Text Aeson.Value
 wrapNodeBoundaryOutput maybeRegistry ctx outputValue =
+  case classifyOutputBoundary ctx.boundaryEgressPorts of
+    BoundaryInvalid invalid -> Left invalid
+    BoundaryVariant variantPorts -> validateVariantEmission maybeRegistry ctx variantPorts outputValue
+    BoundaryProduct -> wrapProductBoundaryOutput maybeRegistry ctx outputValue
+
+wrapProductBoundaryOutput
+  :: Maybe WireContractRegistry
+  -> BoundaryEgressContext
+  -> Aeson.Value
+  -> Either Text Aeson.Value
+wrapProductBoundaryOutput maybeRegistry ctx outputValue =
   case explicitWireOutput outputValue of
     Just wireOutput ->
       validateExplicitWireOutput maybeRegistry ctx.boundaryEgressPorts wireOutput *> Right outputValue
@@ -353,25 +365,48 @@ wrapNodeBoundaryOutputs
   -> BoundaryEgressContext
   -> Map Text Aeson.Value
   -> Either Text Aeson.Value
-wrapNodeBoundaryOutputs maybeRegistry ctx outputValues = do
-  let expectedPorts = Map.keysSet ctx.boundaryEgressPorts.wirePortsOutputs
-      actualPorts = Map.keysSet outputValues
-  if expectedPorts == actualPorts
-    then pure ()
-    else
-      Left
-        ( "Wire node "
-            <> unNodeId ctx.boundaryEgressProducer
-            <> " returned pure output ports "
-            <> renderSet actualPorts
-            <> ", expected "
-            <> renderSet expectedPorts
-            <> "."
-        )
-  wireValues <- traverse outputWireValue (Map.toAscList outputValues)
-  let wireValueSet = WireValueSet wireValues
-  validateExplicitWireOutput maybeRegistry ctx.boundaryEgressPorts (ExplicitWireValueSet wireValueSet)
-  Right (Aeson.toJSON wireValueSet)
+wrapNodeBoundaryOutputs maybeRegistry ctx outputValues =
+  case classifyOutputBoundary ctx.boundaryEgressPorts of
+    BoundaryInvalid invalid -> Left invalid
+    BoundaryVariant variantPorts ->
+      case Map.toAscList outputValues of
+        [(portName, value)]
+          | portName `elem` variantPorts -> do
+              wireValue <- outputWireValue (portName, value)
+              Right (Aeson.toJSON wireValue)
+          | otherwise ->
+              Left
+                ( "Emitted variant label "
+                    <> portName
+                    <> " is not a declared variant of Wire node "
+                    <> unNodeId ctx.boundaryEgressProducer
+                    <> "."
+                )
+        _ ->
+          Left
+            ( "Wire node "
+                <> unNodeId ctx.boundaryEgressProducer
+                <> " is a variant-emitting node and must commit exactly one variant."
+            )
+    BoundaryProduct -> do
+      let expectedPorts = Map.keysSet ctx.boundaryEgressPorts.wirePortsOutputs
+          actualPorts = Map.keysSet outputValues
+      if expectedPorts == actualPorts
+        then pure ()
+        else
+          Left
+            ( "Wire node "
+                <> unNodeId ctx.boundaryEgressProducer
+                <> " returned pure output ports "
+                <> renderSet actualPorts
+                <> ", expected "
+                <> renderSet expectedPorts
+                <> "."
+            )
+      wireValues <- traverse outputWireValue (Map.toAscList outputValues)
+      let wireValueSet = WireValueSet wireValues
+      validateExplicitWireOutput maybeRegistry ctx.boundaryEgressPorts (ExplicitWireValueSet wireValueSet)
+      Right (Aeson.toJSON wireValueSet)
   where
     renderSet values =
       "{"
@@ -402,6 +437,72 @@ wrapNodeBoundaryOutputs maybeRegistry ctx outputValues = do
             , wireValuePort = Just portName
             }
         )
+
+-- | The ADR 0062 classification of a node's output boundary.
+data OutputBoundaryKind
+  = -- | No exclusive group: an ordinary product output boundary.
+    BoundaryProduct
+  | -- | A single exclusive group with no ordinary ports: its declared variant labels.
+    BoundaryVariant ![Text]
+  | -- | A group mixed with ordinary ports, or several groups: invalid for variant emission.
+    BoundaryInvalid !Text
+
+{- | Classify a node's output boundary for ADR 0062. A boundary with no exclusive
+group is an ordinary product boundary; a single exclusive group with no ordinary
+ports is a variant boundary (carrying its declared variant labels); anything else -
+a group mixed with ordinary ports, or several groups - is invalid for variant
+emission ("one selected variant plus side outputs" is out of scope).
+-}
+classifyOutputBoundary :: WirePorts -> OutputBoundaryKind
+classifyOutputBoundary ports =
+  case Set.toList (Set.fromList groupIds) of
+    [] -> BoundaryProduct
+    [groupId]
+      | null ordinaryPorts ->
+          BoundaryVariant
+            [name | (name, spec) <- outs, spec.wireOutputPortExclusiveGroup == Just groupId]
+      | otherwise ->
+          BoundaryInvalid
+            "A variant-emitting node must not mix an exclusive output group with ordinary outputs (ADR 0062: one selected variant plus side outputs is out of scope)."
+    _ ->
+      BoundaryInvalid
+        "A variant-emitting node must expose exactly one exclusive output group (ADR 0062)."
+  where
+    outs = Map.toList ports.wirePortsOutputs
+    groupIds = [groupId | (_, spec) <- outs, Just groupId <- [spec.wireOutputPortExclusiveGroup]]
+    ordinaryPorts = [name | (name, spec) <- outs, isNothing spec.wireOutputPortExclusiveGroup]
+
+{- | A variant-emitting boundary commits exactly one explicit 'WireValue' whose port
+is a declared variant label (ADR 0062). A 'WireValueSet', a raw value, a missing
+label, or an undeclared label is rejected.
+-}
+validateVariantEmission
+  :: Maybe WireContractRegistry
+  -> BoundaryEgressContext
+  -> [Text]
+  -> Aeson.Value
+  -> Either Text Aeson.Value
+validateVariantEmission maybeRegistry ctx variantPorts outputValue =
+  case explicitWireOutput outputValue of
+    Just (ExplicitWireValue wireValue) ->
+      case wireValue.wireValuePort of
+        Just portName
+          | portName `elem` variantPorts ->
+              validateWireValue maybeRegistry ctx.boundaryEgressPorts wireValue *> Right outputValue
+          | otherwise ->
+              Left
+                ( "Emitted variant label "
+                    <> portName
+                    <> " is not a declared variant. Declared variants: "
+                    <> T.intercalate ", " variantPorts
+                    <> "."
+                )
+        Nothing ->
+          Left "A variant-emitting node must set the variant label (the WireValue port)."
+    Just (ExplicitWireValueSet _) ->
+      Left "A variant-emitting node must commit exactly one variant, not a WireValueSet."
+    Nothing ->
+      Left "A variant-emitting node must commit exactly one explicit variant WireValue."
 
 data ExplicitWireOutput
   = ExplicitWireValue !WireValue

--- a/src/Cortex/Wire/Package/Manifest.hs
+++ b/src/Cortex/Wire/Package/Manifest.hs
@@ -41,6 +41,7 @@ import Cortex.Wire.AST
   , WireInputPort (..)
   , WireOutputPort (..)
   , WirePorts (..)
+  , wireOrdinaryOutputPort
   )
 import Cortex.Wire.Contract (WireContractSpec (..))
 import Cortex.Wire.Executor
@@ -253,7 +254,7 @@ instance Toml.FromValue WireInputPort where
 instance Toml.FromValue WireOutputPort where
   fromValue =
     Toml.parseTableFromValue $
-      WireOutputPort
+      wireOrdinaryOutputPort
         <$> Toml.reqKey "contract"
 
 instance Toml.FromValue WireInputCardinality where

--- a/src/Cortex/Wire/Runtime.hs
+++ b/src/Cortex/Wire/Runtime.hs
@@ -143,7 +143,9 @@ wrapWireStageDefinition maybeRegistry ports stageDef =
         stageResult <- stageDef.sdAction unwrappedCtx
         case wrapWireStageResult maybeRegistry ctx.scNodeId ctx.scRunId ports stageResult of
           Right wrappedResult -> pure wrappedResult
-          Left errText -> fail (T.unpack errText)
+          -- An output that fails contract/variant validation is a typed terminal
+          -- failure (ADR 0062), not an untyped stage exception.
+          Left errText -> pure (StageFail "executor_output_validation_failure" errText)
     }
 
 wrapWireStageResult

--- a/test/Cortex/Capability/Executor/PureSpec.hs
+++ b/test/Cortex/Capability/Executor/PureSpec.hs
@@ -208,7 +208,9 @@ weightedPorts =
           , labeledFloatInput "authority_score"
           ]
     , wirePortsOutputs =
-        Map.singleton "out" WireOutputPort {wireOutputPortContract = "Float"}
+        Map.singleton
+          "out"
+          WireOutputPort {wireOutputPortContract = "Float", wireOutputPortExclusiveGroup = Nothing}
     }
 
 labeledFloatInput :: Text -> (Text, WireInputPort)

--- a/test/Cortex/Pulse/ExecutorSpec.hs
+++ b/test/Cortex/Pulse/ExecutorSpec.hs
@@ -666,7 +666,7 @@ outputOnlyAnalysisFragmentPort =
     , wirePortsOutputs =
         Map.singleton
           defaultOutputPortName
-          (WireOutputPort "AnalysisFragment")
+          (WireOutputPort "AnalysisFragment" Nothing)
     }
 
 mkLinearStagePlan
@@ -971,7 +971,7 @@ externalCallPorts :: WirePorts
 externalCallPorts =
   WirePorts
     { wirePortsInputs = Map.empty
-    , wirePortsOutputs = Map.fromList [("s01", WireOutputPort "MeasurementBit")]
+    , wirePortsOutputs = Map.fromList [("s01", WireOutputPort "MeasurementBit" Nothing)]
     }
 
 externalCallOutputs :: [(Text, Aeson.Value)]

--- a/test/Cortex/Pulse/ExecutorSpec.hs
+++ b/test/Cortex/Pulse/ExecutorSpec.hs
@@ -28,7 +28,7 @@ import Control.Exception
 import Control.Monad (forM_, void, when)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KeyMap
-import Data.IORef (atomicModifyIORef', modifyIORef', newIORef, readIORef, writeIORef)
+import Data.IORef (IORef, atomicModifyIORef', modifyIORef', newIORef, readIORef, writeIORef)
 import Data.Int (Int32, Int64)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (isJust)
@@ -185,10 +185,13 @@ import Cortex.Wire
   , WireInputCardinality (..)
   , WireInputPort (..)
   , WireOutputPort (..)
+  , WirePayloadKind (..)
   , WirePorts (..)
+  , WireValue (..)
   , compileWireAppendProposalWithEnv
   , defaultOutputPortName
   , emptyWireCompileEnv
+  , mkWireValue
   , wireExecutorProjectionFromPorts
   , wireExecutorRegistryFromList
   )
@@ -201,8 +204,10 @@ import Cortex.Wire.Circuit.Lower
   ( CircuitLoweringError (..)
   , CircuitPulseBinder (..)
   , CircuitPulseConfig (..)
+  , committedVariantConditionBinding
   , lowerCompiledCircuitToStagePlan
   )
+import Cortex.Wire.Compile (compileWireText)
 
 import Platform.Database qualified as DB
 import Platform.Database.Encode qualified as Enc
@@ -640,6 +645,83 @@ wireSmokeBinder =
     , bindCircuitConditionNode = \_ -> Left (CircuitTemplateRegistryInvalid "Wire smoke does not support condition nodes")
     }
 
+-- | A select over a producer that emits one of two output variants (ADR 0062 #314).
+selectVariantSource :: Text
+selectVariantSource =
+  T.unlines
+    [ "node produce"
+    , "  -> ok: P | err: P ;"
+    , "  = @test.produce ({}) ;"
+    , "node handle_ok"
+    , "  <- ok: P ;"
+    , "  -> done: P"
+    , "  = @test.handle_ok (ok) ;"
+    , "node handle_err"
+    , "  <- err: P ;"
+    , "  -> done: P"
+    , "  = @test.handle_err (err) ;"
+    , "produce select("
+    , "  ok: handle_ok,"
+    , "  err: handle_err"
+    , ")"
+    ]
+
+selectVariantPulseConfig :: CircuitPulseConfig
+selectVariantPulseConfig =
+  CircuitPulseConfig
+    { circuitPulseInitialState = Aeson.Null
+    , circuitPulseRuntimeVersion = 1
+    , circuitPulseReplayPolicy = ReplayPolicyWarn
+    , circuitPulseInitialRewriteBudget = defaultRewriteBudget
+    , circuitPulseRewriteExhaustionPolicy = RewriteExhaustionFail
+    , circuitPulseBudgetExceededExhaustionPolicy = Nothing
+    , circuitPulseMaxRewriteReExecutions = 2
+    }
+
+{- | A binder where the producer emits the committed @err@ variant (incrementing an
+invocation counter), and each arm increments its own counter so the test can assert
+the recovery arm ran exactly once and the non-selected arm never ran. The condition
+uses the production 'committedVariantConditionBinding'.
+-}
+selectVariantBinder :: IORef Int -> IORef Int -> IORef Int -> CircuitPulseBinder
+selectVariantBinder produceCount recoverCount okCount =
+  CircuitPulseBinder
+    { bindCircuitTaskNode = \taskNode ->
+        let nodeId = nodeIdFromCircuitRef taskNode.circuitTaskNodeRef
+         in Right $ case unNodeId nodeId of
+              "produce" ->
+                nodeStage nodeId $ \_ -> do
+                  atomicModifyIORef' produceCount (\c -> (c + 1, ()))
+                  pure
+                    ( StageComplete
+                        ( Aeson.toJSON
+                            ( ( mkWireValue
+                                  "P"
+                                  WirePayloadJson
+                                  Nothing
+                                  (Aeson.object ["issue" Aeson..= ("backend rejected" :: Text)])
+                              )
+                                { wireValuePort = Just "err"
+                                }
+                            )
+                        )
+                    )
+              "handle_err" ->
+                nodeStage nodeId $ \_ -> do
+                  atomicModifyIORef' recoverCount (\c -> (c + 1, ()))
+                  pure (StageComplete (Aeson.String "recovered"))
+              "handle_ok" ->
+                nodeStage nodeId $ \_ -> do
+                  atomicModifyIORef' okCount (\c -> (c + 1, ()))
+                  pure (StageComplete (Aeson.String "ok"))
+              other ->
+                nodeStage nodeId $ \_ -> pure (StageComplete (Aeson.String ("passthrough:" <> other)))
+    , bindCircuitSignalBoundary = \_ -> Left (CircuitTemplateRegistryInvalid "select-variant test: no signal nodes")
+    , bindCircuitArtifactBoundary = \_ -> Left (CircuitTemplateRegistryInvalid "select-variant test: no artifact nodes")
+    , bindCircuitRewriteBoundary = \_ -> Left (CircuitTemplateRegistryInvalid "select-variant test: no rewrite boundaries")
+    , bindCircuitConditionNode = committedVariantConditionBinding
+    }
+
 analysisFragmentInOutPorts :: WirePorts
 analysisFragmentInOutPorts =
   WirePorts
@@ -982,6 +1064,46 @@ externalCallPlan = Aeson.object ["operations" Aeson..= [Aeson.object ["gate" Aes
 
 spec :: Spec
 spec = beforeAll setupTestDb $ do
+  describe "select on a committed output variant (ADR 0062, #314)" $ do
+    it "routes the committed err variant to the recovery arm and resumes without re-running the effect" $ \mPool -> withDb mPool $ \pool -> do
+      (_, taskContext) <- mkTaskContext pool
+      taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-select-committed-variant"
+      runId <- createTestRun pool taskId
+      task <- loadTaskDef pool taskId
+      produceCount <- newIORef (0 :: Int)
+      recoverCount <- newIORef (0 :: Int)
+      okCount <- newIORef (0 :: Int)
+      compiled <-
+        case compileWireText selectVariantSource of
+          Right circuit -> pure circuit
+          Left err -> expectationFailure ("compile failed: " <> show err) >> fail "unreachable"
+      stagePlan <-
+        case lowerCompiledCircuitToStagePlan
+          selectVariantPulseConfig
+          (selectVariantBinder produceCount recoverCount okCount)
+          compiled of
+          Right plan -> pure plan
+          Left err -> expectationFailure ("lowering failed: " <> show err) >> fail "unreachable"
+      -- Execute: the producer emits the err variant; select routes to the recovery arm.
+      outcome1 <- executeStagePlan taskContext runId task stagePlan
+      outcome1 `shouldBe` OutcomeCompleted
+      readIORef produceCount `shouldReturn` 1
+      readIORef recoverCount `shouldReturn` 1
+      readIORef okCount `shouldReturn` 0
+      statuses <-
+        readGraphNodeStatuses pool runId
+          >>= maybe (expectationFailure "expected persisted graph state" >> fail "unreachable") pure
+      -- The recovery arm materialized and ran; the non-selected ok arm never materialized.
+      let completedNodes = [nid | (nid, NodeCompleted) <- Map.toList statuses]
+      any (T.isInfixOf "handle_err" . unNodeId) completedNodes `shouldBe` True
+      any (T.isInfixOf "handle_ok" . unNodeId) (Map.keys statuses) `shouldBe` False
+      -- Simulate a crash/resume: re-running the executor on the persisted run must not
+      -- re-run the producer effect or the recovery arm.
+      outcome2 <- resumeStagePlan taskContext runId task stagePlan
+      outcome2 `shouldBe` OutcomeCompleted
+      readIORef produceCount `shouldReturn` 1
+      readIORef recoverCount `shouldReturn` 1
+
   describe "durable external-call stages (ADR 0059)" $ do
     it "submits, parks, refuses forged wakes, then completes from the driver on resume" $ \mPool -> withDb mPool $ \pool -> do
       (_, taskContext) <- mkTaskContext pool

--- a/test/Cortex/Wire/Circuit/CompilerSpec.hs
+++ b/test/Cortex/Wire/Circuit/CompilerSpec.hs
@@ -65,6 +65,7 @@ import Cortex.Pulse.Rewrite
   , plannedGraphRewriteDelta
   )
 import Cortex.Pulse.Types (defaultRewriteBudget)
+import Cortex.Wire (WirePayloadKind (..), WireValue (..), mkWireValue)
 import Cortex.Wire.Circuit
   ( CircuitArtifactBoundary (..)
   , CircuitCompatibilityWitness (..)
@@ -86,6 +87,8 @@ import Cortex.Wire.Circuit
   , CompiledCircuit (..)
   , CompiledCircuitFragment (..)
   , CompiledCircuitNode (..)
+  , committedVariantSelectKeys
+  , committedVariantSelection
   , compileCircuitIR
   , lowerCompiledCircuitToSomeStagePlan
   , lowerCompiledCircuitToStagePlan
@@ -93,6 +96,46 @@ import Cortex.Wire.Circuit
 
 spec :: Spec
 spec = do
+  describe "ADR 0062 committed-variant select" $ do
+    it "routes a committed then-key label to the then branch" $ do
+      let selection = committedVariantSelection ["ok"] ["err"] (committedVariantInput "producer" "ok")
+      selection.circuitConditionSelectionBranch `shouldBe` CircuitConditionThen
+
+    it "routes a committed else-key label to the else branch" $ do
+      let selection = committedVariantSelection ["ok"] ["err"] (committedVariantInput "producer" "err")
+      selection.circuitConditionSelectionBranch `shouldBe` CircuitConditionElse
+
+    it "dispatches N-way: an else-set label among several routes to else" $ do
+      let selection =
+            committedVariantSelection ["ok"] ["err", "stop"] (committedVariantInput "producer" "stop")
+      selection.circuitConditionSelectionBranch `shouldBe` CircuitConditionElse
+
+    it "is deterministic for the same committed inputs (resume-safe, no effect)" $ do
+      let inputs = committedVariantInput "producer" "ok"
+      committedVariantSelection ["ok"] ["err"] inputs
+        `shouldBe` committedVariantSelection ["ok"] ["err"] inputs
+
+    it "passes the committed variant payload through as the condition output" $ do
+      let selection = committedVariantSelection ["ok"] ["err"] (committedVariantInput "producer" "ok")
+      selection.circuitConditionSelectionOutput
+        `shouldBe` Aeson.toJSON
+          ((mkWireValue "VariantContract" WirePayloadJson Nothing (Aeson.Number 1)) {wireValuePort = Just "ok"})
+
+    it "defaults to else with a null output when no committed select label is present" $ do
+      let selection =
+            committedVariantSelection ["ok"] ["err"] (committedVariantInput "producer" "unrelated")
+      selection `shouldBe` CircuitConditionSelection Aeson.Null CircuitConditionElse
+
+    it "parses thenKeys/elseKeys from condition metadata" $
+      committedVariantSelectKeys
+        (Aeson.object ["thenKeys" Aeson..= (["ok"] :: [T.Text]), "elseKeys" Aeson..= (["err"] :: [T.Text])])
+        `shouldBe` Right (["ok"], ["err"])
+
+    it "rejects malformed condition metadata" $
+      case committedVariantSelectKeys (Aeson.object ["thenKeys" Aeson..= (["ok"] :: [T.Text])]) of
+        Left (CircuitConditionMetadataInvalid _) -> pure ()
+        other -> expectationFailure ("expected CircuitConditionMetadataInvalid, got " <> show other)
+
   describe "compileCircuitIR" $ do
     it "compiles a circuit into a deterministic graph artifact with latent conditional branches" $ do
       compiled <- requireCompiled sampleCircuitIR
@@ -401,6 +444,20 @@ spec = do
         other ->
           expectationFailure
             ("Expected CircuitLoweredGraphInvalid with cycle details, got: " <> show (fmap (.spTopology) other))
+
+{- | A select-boundary producer's committed variant output: one WireValue whose
+port is the chosen variant label (ADR 0062).
+-}
+committedVariantInput :: T.Text -> T.Text -> Map.Map NodeId Aeson.Value
+committedVariantInput producer label =
+  Map.singleton
+    (NodeId producer)
+    ( Aeson.toJSON
+        ( (mkWireValue "VariantContract" WirePayloadJson Nothing (Aeson.Number 1))
+            { wireValuePort = Just label
+            }
+        )
+    )
 
 requireCompiled :: CircuitIR -> IO CompiledCircuit
 requireCompiled circuitIr =

--- a/test/Cortex/Wire/CompileSpec.hs
+++ b/test/Cortex/Wire/CompileSpec.hs
@@ -6472,7 +6472,7 @@ projectedExecutorPorts =
     , wirePortsOutputs =
         Map.singleton
           "out"
-          WireOutputPort {wireOutputPortContract = "PlannerOutput"}
+          WireOutputPort {wireOutputPortContract = "PlannerOutput", wireOutputPortExclusiveGroup = Nothing}
     }
 
 jsonContract :: T.Text -> WireContractSpec

--- a/test/Cortex/Wire/PureSpec.hs
+++ b/test/Cortex/Wire/PureSpec.hs
@@ -137,7 +137,9 @@ spec = describe "Cortex.Wire.Pure" $ do
                     , wireInputPortRequired = False
                     }
             , wirePortsOutputs =
-                Map.singleton "out" WireOutputPort {wireOutputPortContract = "Float"}
+                Map.singleton
+                  "out"
+                  WireOutputPort {wireOutputPortContract = "Float", wireOutputPortExclusiveGroup = Nothing}
             }
         inputBundle =
           wireInputBundleFromStageInputs $
@@ -1217,7 +1219,9 @@ spec = describe "Cortex.Wire.Pure" $ do
                     )
                   ]
             , wirePortsOutputs =
-                Map.singleton "out" WireOutputPort {wireOutputPortContract = "Float"}
+                Map.singleton
+                  "out"
+                  WireOutputPort {wireOutputPortContract = "Float", wireOutputPortExclusiveGroup = Nothing}
             }
     validatePurePorts ports (Map.singleton "out" (num 1))
       `shouldBe` Left (PureInputPortRequiresLabel "Float_1" "Float")
@@ -1610,7 +1614,9 @@ scorePorts =
           , labeledJsonInput "weights" "WeightSet"
           ]
     , wirePortsOutputs =
-        Map.singleton "score" WireOutputPort {wireOutputPortContract = "ScoreSet"}
+        Map.singleton
+          "score"
+          WireOutputPort {wireOutputPortContract = "ScoreSet", wireOutputPortExclusiveGroup = Nothing}
     }
 
 multiOutputPorts :: WirePorts
@@ -1620,8 +1626,14 @@ multiOutputPorts =
         Map.singleton "evidence" (snd (labeledJsonInput "evidence" "EvidenceSet"))
     , wirePortsOutputs =
         Map.fromList
-          [ ("accepted", WireOutputPort {wireOutputPortContract = "AcceptedSet"})
-          , ("rejected", WireOutputPort {wireOutputPortContract = "RejectedSet"})
+          [
+            ( "accepted"
+            , WireOutputPort {wireOutputPortContract = "AcceptedSet", wireOutputPortExclusiveGroup = Nothing}
+            )
+          ,
+            ( "rejected"
+            , WireOutputPort {wireOutputPortContract = "RejectedSet", wireOutputPortExclusiveGroup = Nothing}
+            )
           ]
     }
 
@@ -1814,7 +1826,10 @@ builtinOutPorts :: WirePorts
 builtinOutPorts =
   WirePorts
     { wirePortsInputs = Map.empty
-    , wirePortsOutputs = Map.singleton "out" WireOutputPort {wireOutputPortContract = "Any"}
+    , wirePortsOutputs =
+        Map.singleton
+          "out"
+          WireOutputPort {wireOutputPortContract = "Any", wireOutputPortExclusiveGroup = Nothing}
     }
 
 numJson :: Scientific -> Aeson.Value

--- a/test/Cortex/Wire/RuntimeSpec.hs
+++ b/test/Cortex/Wire/RuntimeSpec.hs
@@ -138,6 +138,52 @@ spec = describe "Cortex.Wire runtime egress" $ do
     fmap (.wireValueContract) bundle.wireInputBundleValues
       `shouldBe` ["Score", "Score"]
 
+  describe "ADR 0062 variant output boundaries" $ do
+    it "accepts one labelled variant when two variants share a contract" $ do
+      let emitted =
+            Aeson.toJSON $
+              (mkWireValue "Score" WirePayloadJson (Just "classifier") (Aeson.Number 1))
+                { wireValuePort = Just "accepted"
+                }
+      result <-
+        requireRight $
+          wrapWireStageOutput (Just scoreRegistry) producer runId variantScorePorts emitted
+      wireValue <- requireAesonSuccess (Aeson.fromJSON result :: Aeson.Result WireValue)
+      wireValue.wireValuePort `shouldBe` Just "accepted"
+      wireValue.wireValueContract `shouldBe` "Score"
+
+    it "rejects more than one variant from a variant-emitting node (WireValueSet)" $ do
+      let set =
+            Aeson.toJSON $
+              WireValueSet
+                [ (mkWireValue "Score" WirePayloadJson (Just "classifier") (Aeson.Number 1))
+                    { wireValuePort = Just "accepted"
+                    }
+                , (mkWireValue "Score" WirePayloadJson (Just "classifier") (Aeson.Number 0))
+                    { wireValuePort = Just "rejected"
+                    }
+                ]
+      wrapWireStageOutput (Just scoreRegistry) producer runId variantScorePorts set
+        `shouldBeLeftContaining` "must commit exactly one variant, not a WireValueSet"
+
+    it "rejects a variant label the node does not declare" $ do
+      let emitted =
+            Aeson.toJSON $
+              (mkWireValue "Score" WirePayloadJson (Just "classifier") (Aeson.Number 1))
+                { wireValuePort = Just "maybe"
+                }
+      wrapWireStageOutput (Just scoreRegistry) producer runId variantScorePorts emitted
+        `shouldBeLeftContaining` "is not a declared variant"
+
+    it "rejects a node that mixes an exclusive group with an ordinary output" $ do
+      let emitted =
+            Aeson.toJSON $
+              (mkWireValue "Score" WirePayloadJson (Just "classifier") (Aeson.Number 1))
+                { wireValuePort = Just "ok"
+                }
+      wrapWireStageOutput (Just scoreRegistry) producer runId mixedVariantPorts emitted
+        `shouldBeLeftContaining` "must not mix an exclusive output group with ordinary outputs"
+
 producer :: NodeId
 producer = NodeId "classifier"
 
@@ -148,7 +194,7 @@ scorePorts :: WirePorts
 scorePorts =
   WirePorts
     { wirePortsInputs = Map.empty
-    , wirePortsOutputs = Map.singleton "score" (WireOutputPort "Score")
+    , wirePortsOutputs = Map.singleton "score" (WireOutputPort "Score" Nothing)
     }
 
 dualScorePorts :: WirePorts
@@ -157,8 +203,8 @@ dualScorePorts =
     { wirePortsInputs = Map.empty
     , wirePortsOutputs =
         Map.fromList
-          [ ("accepted", WireOutputPort "Score")
-          , ("rejected", WireOutputPort "Score")
+          [ ("accepted", WireOutputPort "Score" Nothing)
+          , ("rejected", WireOutputPort "Score" Nothing)
           ]
     }
 
@@ -166,7 +212,41 @@ textPorts :: WirePorts
 textPorts =
   WirePorts
     { wirePortsInputs = Map.empty
-    , wirePortsOutputs = Map.singleton "message" (WireOutputPort "Message")
+    , wirePortsOutputs = Map.singleton "message" (WireOutputPort "Message" Nothing)
+    }
+
+{- | An exclusive (sum) output group whose two variants share one contract; only
+well-formed because selection is by label, not contract (ADR 0062).
+-}
+variantScorePorts :: WirePorts
+variantScorePorts =
+  WirePorts
+    { wirePortsInputs = Map.empty
+    , wirePortsOutputs =
+        Map.fromList
+          [
+            ( "accepted"
+            , WireOutputPort {wireOutputPortContract = "Score", wireOutputPortExclusiveGroup = Just 0}
+            )
+          ,
+            ( "rejected"
+            , WireOutputPort {wireOutputPortContract = "Score", wireOutputPortExclusiveGroup = Just 0}
+            )
+          ]
+    }
+
+{- | An invalid variant boundary: an exclusive group mixed with an ordinary output
+(ADR 0062 rejects "one selected variant plus side outputs").
+-}
+mixedVariantPorts :: WirePorts
+mixedVariantPorts =
+  WirePorts
+    { wirePortsInputs = Map.empty
+    , wirePortsOutputs =
+        Map.fromList
+          [ ("ok", WireOutputPort {wireOutputPortContract = "Score", wireOutputPortExclusiveGroup = Just 0})
+          , ("audit", WireOutputPort {wireOutputPortContract = "Other", wireOutputPortExclusiveGroup = Nothing})
+          ]
     }
 
 scoreRegistry :: WireContractRegistry


### PR DESCRIPTION
Implements **ADR 0062 — Typed Effect Variant Output Boundaries** (proposed). The ADR and its implementation land together in this PR, squashed to three coherent commits.

## Commits

1. `docs(adr): typed effect variant output boundaries (ADR 0062)` — the design decision (`docs/ADRs/0062-typed-effect-variant-output-boundaries.md` + index; ADR 0033 note updated to point at `committedVariantConditionBinding`).
2. `feat(wire,pulse): typed variant output emission + boundary validation` — **#313 substrate**: variant emission via the existing `WireValue.wireValuePort` slot, boundary validation (exclusive-group membership + payload shape, rejecting mixed sum+ordinary output and `WireValueSet`), typed `executor_output_validation_failure`, durable persistence/resume of the label.
3. `feat(wire,pulse): committed-variant select runtime + durable resume` — **#314 select runtime**: `committedVariantConditionBinding` routes a committed variant label through the compiled then/else keys (N-way via the nested binary condition tree) — the first lowered `select(...)` driven through the Pulse executor — plus a `just test-db` end-to-end durable-resume test.

## Decision (summary)

A bound executor stage may complete by emitting exactly one declared output **variant label** (N-way, not a baked-in `ok | err`) with a contract-valid payload. The host/Pulse boundary validates label-membership + payload **before commit** (a typed failure on mismatch, not a silent branch); `select(...)` branches on the committed label; durable resume reproduces the branch **without re-running the effect**. It reuses the existing envelope (`WireValue.wireValuePort`), node-output persistence, and rewrite-replay machinery — no new `StageResult` constructor or persistence shape.

## ADR relations

- **Discharges** ADR 0017's unimplemented exclusive-output-grouping obligation (the group id was dropped before runtime).
- **Fulfils** the ADR 0026 hook (routing a deterministic failure through an explicit error contract is a topology decision).
- **Extends** ADR 0024 (typed ports), ADR 0033 (supplies the select runtime guard source 0033 deferred), ADR 0053 (exclusive output envelope, validate-before-commit).
- **Generalises** ADR 0059's typed error output to N variants.

## Validation

- `just test-db` full suite: **1012 examples, 0 failures** (includes the new end-to-end durable-resume test: effect runs once, recovery arm materialises, non-selected arm does not, resume replays without re-running the effect).
- Build (library + executables + Haddock + docs-site), `fmt-check`, `lint` ("No hints"), `git diff --check`, `check-commit-provenance` — all green. Branch is based on current `main` and is fast-forward mergeable.

## Deferred / follow-ups

- **#315** — host-type codec registry + per-contract JSON schema + `ContractId` versioning (refines ADR 0017). Not required by 0062, which ships on Layer-1 payload-kind/shape validation.
- **#321** — reusable Cortex library entrypoint that drives `select(...)` through the production Pulse path using `committedVariantConditionBinding`. The end-to-end test here is the first executor-driven select; #321 generalises it to a reusable entrypoint.

Relates to #313, #314, #315, #321, #138.
