### PR TITLE
feat(wire,pulse): committed-variant select runtime entrypoint

### DIFF
--- a/cortex.cabal
+++ b/cortex.cabal
@@ -151,6 +151,7 @@ library
         Cortex.Pulse
         Cortex.Pulse.Attempt
         Cortex.Pulse.Checkpoint
+        Cortex.Pulse.Circuit
         Cortex.Pulse.Database
         Cortex.Pulse.Event
         Cortex.Pulse.Executor

--- a/src/Cortex/Pulse.hs
+++ b/src/Cortex/Pulse.hs
@@ -13,6 +13,7 @@ Pulse modules implement durable runtime mechanics without binding consumer task 
 module Cortex.Pulse
   ( runPulse
   , module Cortex.Pulse.Checkpoint
+  , module Cortex.Pulse.Circuit
   , module Cortex.Pulse.Executor
   , module Cortex.Pulse.Hydrate
   , module Cortex.Pulse.Iteration
@@ -43,6 +44,7 @@ import System.Exit (exitFailure)
 import System.Posix.Signals (Handler (CatchOnce), installHandler, sigINT, sigTERM)
 
 import Cortex.Pulse.Checkpoint
+import Cortex.Pulse.Circuit
 import Cortex.Pulse.Database qualified as PulseDB
 import Cortex.Pulse.Executor (TaskContext (..), TaskRegistry)
 import Cortex.Pulse.Executor qualified as Executor

--- a/src/Cortex/Pulse/Circuit.hs
+++ b/src/Cortex/Pulse/Circuit.hs
@@ -1,0 +1,154 @@
+{- |
+Module      : Cortex.Pulse.Circuit
+Description : Run a compiled Wire circuit through the durable Pulse executor.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The module belongs to Cortex's upstream runtime and library surface.
+
+Generic production entrypoint that lowers a compiled Wire circuit to a stage plan
+and drives it through the durable Pulse executor — fresh run and resume —
+including @select(...)@ over committed output variants (ADR 0062, GitHub #321).
+
+Branch selection is by committed variant label: a producer commits exactly one
+labelled variant ('Cortex.Wire.Value.wireValuePort'), and the lowered condition
+stages route it to the matching arm via 'committedVariantConditionBinding'.
+Downstream callers supply the task-node bindings (their effect resolution) through
+'CircuitPulseBinder'; this module supplies only the lowering and the durable
+execution glue, never effect or capability resolution.
+
+A lowered plan embeds each condition as a runnable stage and additionally carries a
+parallel 'StageLatentCondition' encoding for provenance/recovery. For every
+condition this executor runs, that encoding is covered by an embedded stage. A
+latent condition with no covering stage is a deferred control form this executor
+cannot run, so it is rejected loudly ('CircuitRunUnsupportedLatentConditions')
+rather than executed partially. With the current compiler this never fires; it
+guards the public entrypoint against future deferred forms.
+-}
+module Cortex.Pulse.Circuit
+  ( CircuitRunError (..)
+  , runCompiledCircuit
+  , resumeCompiledCircuit
+  , lowerRunnableCircuit
+  , ensureRunnable
+  )
+where
+
+import Data.Bifunctor (first)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.UUID (UUID)
+import Rel8 (Result)
+
+import Cortex.Pulse.Executor (TaskContext, executeStagePlan, resumeStagePlan)
+import Cortex.Pulse.Node (NodeId)
+import Cortex.Pulse.Plan
+  ( SomeStagePlan (..)
+  , StageLatentCondition (..)
+  , slbNestedConditions
+  , slbNodes
+  , spDefinitions
+  )
+import Cortex.Pulse.Schema (PulseTaskDefinitionRow)
+import Cortex.Wire.Circuit.Artifact (CompiledCircuit)
+import Cortex.Wire.Circuit.Lowering
+  ( CircuitLoweringError
+  , CircuitPulseBinder
+  , CircuitPulseConfig
+  , lowerCompiledCircuitToSomeStagePlan
+  )
+
+import Platform.DurableTask.Types (RunOutcome)
+
+-- | Why a compiled circuit could not be run through this entrypoint.
+data CircuitRunError
+  = -- | Lowering the compiled circuit to a stage plan failed.
+    CircuitRunLoweringError CircuitLoweringError
+  | {- | The lowered plan carries latent conditions with no covering executable
+    stage — a deferred control form this executor cannot run. Carries the
+    anchor node id of each uncovered condition. With the current compiler this
+    never occurs (every @select(...)@ condition is embedded as a runnable
+    stage); it guards the public entrypoint against future deferred forms.
+    -}
+    CircuitRunUnsupportedLatentConditions [NodeId]
+  deriving stock (Eq, Show)
+
+{- | Reject a lowered plan this entrypoint cannot execute.
+
+Committed-variant @select(...)@ embeds each condition as a runnable stage in the
+plan definitions, so the parallel latent-condition encoding is redundant for
+execution: every latent condition's anchor is also an embedded stage. A latent
+condition whose anchor has no embedded stage is a genuinely deferred form, which
+this executor cannot run; surface it loudly instead of dropping it silently.
+-}
+ensureRunnable :: SomeStagePlan -> Either CircuitRunError SomeStagePlan
+ensureRunnable plan@(SomeStagePlan stagePlan latentConditions) =
+  case uncoveredConditions (Map.keysSet (spDefinitions stagePlan)) latentConditions of
+    [] -> Right plan
+    uncovered ->
+      Left (CircuitRunUnsupportedLatentConditions uncovered)
+
+uncoveredConditions :: Set NodeId -> [StageLatentCondition] -> [NodeId]
+uncoveredConditions coveringNodes =
+  concatMap uncoveredCondition
+  where
+    uncoveredCondition condition =
+      [slcAnchorNodeId condition | Set.notMember (slcAnchorNodeId condition) coveringNodes]
+        <> foldMap uncoveredBranch condition.slcBranches
+
+    uncoveredBranch branch =
+      uncoveredConditions (Map.keysSet branch.slbNodes) branch.slbNestedConditions
+
+{- | Lower a compiled circuit to a runnable stage plan, rejecting deferred forms
+this entrypoint cannot execute. Pure; a caller may validate a circuit with this
+before acquiring execution resources.
+-}
+lowerRunnableCircuit
+  :: CircuitPulseConfig
+  -> CircuitPulseBinder
+  -> CompiledCircuit
+  -> Either CircuitRunError SomeStagePlan
+lowerRunnableCircuit pulseConfig binder compiledCircuit =
+  first
+    CircuitRunLoweringError
+    (lowerCompiledCircuitToSomeStagePlan pulseConfig binder compiledCircuit)
+    >>= ensureRunnable
+
+{- | Lower and execute a compiled Wire circuit as a fresh durable run, dispatching
+@select(...)@ on committed variant labels. Returns 'Left' if lowering fails or the
+plan carries an unsupported latent form; otherwise the executor 'RunOutcome'.
+-}
+runCompiledCircuit
+  :: TaskContext
+  -> UUID
+  -> PulseTaskDefinitionRow Result
+  -> CircuitPulseConfig
+  -> CircuitPulseBinder
+  -> CompiledCircuit
+  -> IO (Either CircuitRunError RunOutcome)
+runCompiledCircuit taskContext runId task pulseConfig binder compiledCircuit =
+  case lowerRunnableCircuit pulseConfig binder compiledCircuit of
+    Left err -> pure (Left err)
+    Right (SomeStagePlan stagePlan _latentConditions) ->
+      Right <$> executeStagePlan taskContext runId task stagePlan
+
+{- | Lower a compiled Wire circuit and resume its durable run from persisted graph
+state. Re-evaluating a committed-variant selector reads the persisted label and
+never re-invokes the producer effect (ADR 0062).
+-}
+resumeCompiledCircuit
+  :: TaskContext
+  -> UUID
+  -> PulseTaskDefinitionRow Result
+  -> CircuitPulseConfig
+  -> CircuitPulseBinder
+  -> CompiledCircuit
+  -> IO (Either CircuitRunError RunOutcome)
+resumeCompiledCircuit taskContext runId task pulseConfig binder compiledCircuit =
+  case lowerRunnableCircuit pulseConfig binder compiledCircuit of
+    Left err -> pure (Left err)
+    Right (SomeStagePlan stagePlan _latentConditions) ->
+      Right <$> resumeStagePlan taskContext runId task stagePlan

--- a/src/Cortex/Wire/Circuit/Lowering.hs
+++ b/src/Cortex/Wire/Circuit/Lowering.hs
@@ -280,14 +280,20 @@ lowerConditionNode pulseConfig binder conditionNode = do
       selectBranch = circuitConditionSelectBranch conditionBinding
       action ctx = do
         selection <- selectBranch ctx.scRunId ctx.scInputs
+        -- Anchor the branch-materializing rewrite on the condition's runtime node
+        -- id, not its lower-time id. A nested select condition is materialized
+        -- under its parent's namespace ({parent}:{local}), so the lower-time id is
+        -- not a live topology node; only ctx.scNodeId reflects the actual anchor
+        -- (ADR 0062, GitHub #321).
+        let anchorNodeId = ctx.scNodeId
         pure $
           case selection.circuitConditionSelectionBranch of
             CircuitConditionThen ->
-              StageRewrite selection.circuitConditionSelectionOutput (AppendAfter stageId thenFragment)
+              StageRewrite selection.circuitConditionSelectionOutput (AppendAfter anchorNodeId thenFragment)
             CircuitConditionElse ->
               maybe
                 (StageComplete selection.circuitConditionSelectionOutput)
-                (StageRewrite selection.circuitConditionSelectionOutput . AppendAfter stageId)
+                (StageRewrite selection.circuitConditionSelectionOutput . AppendAfter anchorNodeId)
                 elseFragment
   pure
     StageDefinition

--- a/test/Cortex/Pulse/ExecutorSpec.hs
+++ b/test/Cortex/Pulse/ExecutorSpec.hs
@@ -70,6 +70,12 @@ import Cortex.Capability.Catalog.RuntimeBindingRecord
   ( RuntimeBindingRecord (..)
   , RuntimeStageActionRef (..)
   )
+import Cortex.Pulse.Circuit
+  ( CircuitRunError (..)
+  , ensureRunnable
+  , resumeCompiledCircuit
+  , runCompiledCircuit
+  )
 import Cortex.Pulse.Executor
   ( LoopInstanceKey (..)
   , ReplayPolicy (..)
@@ -79,6 +85,10 @@ import Cortex.Pulse.Executor
   , StageContext (..)
   , StageDefinition (..)
   , StageFailure (..)
+  , StageLatentBranch (..)
+  , StageLatentCondition (..)
+  , StageLatentDeltaSignature (..)
+  , StageLatentNode (..)
   , StagePlan (..)
   , StageRejectedRewrite (..)
   , StageReplaySafety (..)
@@ -151,10 +161,14 @@ import Cortex.Pulse.Query.ExternalCall
   , loadExternalCallAttempt
   )
 import Cortex.Pulse.Rewrite
-  ( BudgetContext (..)
+  ( AnchorBoundaryUse (..)
+  , BoundaryLaw (..)
+  , BoundaryResourceUse (..)
+  , BudgetContext (..)
   , BudgetDimension (..)
   , ExpansionMode (..)
   , GraphRewrite (..)
+  , RewriteAnchorDisposition (..)
   , RewriteBudget (..)
   , RewriteRejectionContext (..)
   , SubgraphSpec (..)
@@ -722,6 +736,107 @@ selectVariantBinder produceCount recoverCount okCount =
     , bindCircuitConditionNode = committedVariantConditionBinding
     }
 
+{- | A producer exposing a 3-way exclusive output, committing the middle @b@
+variant, with one handler arm per label. Exercises N-way committed-label
+dispatch through the nested binary condition tree (ADR 0062, #321).
+-}
+threeWaySelectSource :: Text
+threeWaySelectSource =
+  T.unlines
+    [ "node produce"
+    , "  -> a: P | b: P | c: P ;"
+    , "  = @test.produce ({}) ;"
+    , "node handle_a"
+    , "  <- a: P ;"
+    , "  -> done: P"
+    , "  = @test.handle_a (a) ;"
+    , "node handle_b"
+    , "  <- b: P ;"
+    , "  -> done: P"
+    , "  = @test.handle_b (b) ;"
+    , "node handle_c"
+    , "  <- c: P ;"
+    , "  -> done: P"
+    , "  = @test.handle_c (c) ;"
+    , "produce select("
+    , "  a: handle_a,"
+    , "  b: handle_b,"
+    , "  c: handle_c"
+    , ")"
+    ]
+
+{- | As 'selectVariantPulseConfig', but with a rewrite budget generous enough for
+the nested condition tree an N-way select lowers to (one @AppendAfter@ per
+condition node).
+-}
+threeWaySelectPulseConfig :: CircuitPulseConfig
+threeWaySelectPulseConfig =
+  CircuitPulseConfig
+    { circuitPulseInitialState = Aeson.Null
+    , circuitPulseRuntimeVersion = 1
+    , circuitPulseReplayPolicy = ReplayPolicyWarn
+    , circuitPulseInitialRewriteBudget =
+        RewriteBudget
+          { rbAddedNodesMax = 64
+          , rbAddedEdgesMax = 128
+          , rbAddedDepthMax = 16
+          , rbFrontierDeltaMax = 16
+          , rbRewriteOpsMax = 16
+          }
+    , circuitPulseRewriteExhaustionPolicy = RewriteExhaustionFail
+    , circuitPulseBudgetExceededExhaustionPolicy = Nothing
+    , circuitPulseMaxRewriteReExecutions = 8
+    }
+
+{- | Binder for 'threeWaySelectSource': the producer commits the @b@ variant
+(incrementing an invocation counter); each arm increments its own counter so the
+test can assert the selected arm ran exactly once and the non-selected arms never
+ran. The condition uses the production 'committedVariantConditionBinding'.
+-}
+threeWaySelectBinder
+  :: IORef Int -> IORef Int -> IORef Int -> IORef Int -> CircuitPulseBinder
+threeWaySelectBinder produceCount aCount bCount cCount =
+  CircuitPulseBinder
+    { bindCircuitTaskNode = \taskNode ->
+        let nodeId = nodeIdFromCircuitRef taskNode.circuitTaskNodeRef
+         in Right $ case unNodeId nodeId of
+              "produce" ->
+                nodeStage nodeId $ \_ -> do
+                  atomicModifyIORef' produceCount (\c -> (c + 1, ()))
+                  pure
+                    ( StageComplete
+                        ( Aeson.toJSON
+                            ( ( mkWireValue
+                                  "P"
+                                  WirePayloadJson
+                                  Nothing
+                                  (Aeson.object ["pick" Aeson..= ("b" :: Text)])
+                              )
+                                { wireValuePort = Just "b"
+                                }
+                            )
+                        )
+                    )
+              "handle_a" ->
+                nodeStage nodeId $ \_ -> do
+                  atomicModifyIORef' aCount (\c -> (c + 1, ()))
+                  pure (StageComplete (Aeson.String "a"))
+              "handle_b" ->
+                nodeStage nodeId $ \_ -> do
+                  atomicModifyIORef' bCount (\c -> (c + 1, ()))
+                  pure (StageComplete (Aeson.String "b"))
+              "handle_c" ->
+                nodeStage nodeId $ \_ -> do
+                  atomicModifyIORef' cCount (\c -> (c + 1, ()))
+                  pure (StageComplete (Aeson.String "c"))
+              other ->
+                nodeStage nodeId $ \_ -> pure (StageComplete (Aeson.String ("passthrough:" <> other)))
+    , bindCircuitSignalBoundary = \_ -> Left (CircuitTemplateRegistryInvalid "three-way select test: no signal nodes")
+    , bindCircuitArtifactBoundary = \_ -> Left (CircuitTemplateRegistryInvalid "three-way select test: no artifact nodes")
+    , bindCircuitRewriteBoundary = \_ -> Left (CircuitTemplateRegistryInvalid "three-way select test: no rewrite boundaries")
+    , bindCircuitConditionNode = committedVariantConditionBinding
+    }
+
 analysisFragmentInOutPorts :: WirePorts
 analysisFragmentInOutPorts =
   WirePorts
@@ -1103,6 +1218,110 @@ spec = beforeAll setupTestDb $ do
       outcome2 `shouldBe` OutcomeCompleted
       readIORef produceCount `shouldReturn` 1
       readIORef recoverCount `shouldReturn` 1
+
+  describe "Cortex.Pulse.Circuit entrypoint (ADR 0062, #321)" $ do
+    it "dispatches an N-way committed-label select and resumes without re-running the effect" $ \mPool -> withDb mPool $ \pool -> do
+      (_, taskContext) <- mkTaskContext pool
+      taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-entrypoint-nway-select"
+      runId <- createTestRun pool taskId
+      task <- loadTaskDef pool taskId
+      produceCount <- newIORef (0 :: Int)
+      aCount <- newIORef (0 :: Int)
+      bCount <- newIORef (0 :: Int)
+      cCount <- newIORef (0 :: Int)
+      compiled <-
+        case compileWireText threeWaySelectSource of
+          Right circuit -> pure circuit
+          Left err -> expectationFailure ("compile failed: " <> show err) >> fail "unreachable"
+      let binder = threeWaySelectBinder produceCount aCount bCount cCount
+      -- Fresh run through the entrypoint: the producer commits the "b" variant; select routes to handle_b.
+      outcome1 <- runCompiledCircuit taskContext runId task threeWaySelectPulseConfig binder compiled
+      outcome1 `shouldBe` Right OutcomeCompleted
+      readIORef produceCount `shouldReturn` 1
+      readIORef aCount `shouldReturn` 0
+      readIORef bCount `shouldReturn` 1
+      readIORef cCount `shouldReturn` 0
+      statuses <-
+        readGraphNodeStatuses pool runId
+          >>= maybe (expectationFailure "expected persisted graph state" >> fail "unreachable") pure
+      let completedNodes = [nid | (nid, NodeCompleted) <- Map.toList statuses]
+      -- The selected b arm materialized and ran; the non-selected a/c arms never materialized.
+      any (T.isInfixOf "handle_b" . unNodeId) completedNodes `shouldBe` True
+      any (T.isInfixOf "handle_a" . unNodeId) (Map.keys statuses) `shouldBe` False
+      any (T.isInfixOf "handle_c" . unNodeId) (Map.keys statuses) `shouldBe` False
+      -- Resume must not re-run the producer effect or the selected arm.
+      outcome2 <- resumeCompiledCircuit taskContext runId task threeWaySelectPulseConfig binder compiled
+      outcome2 `shouldBe` Right OutcomeCompleted
+      readIORef produceCount `shouldReturn` 1
+      readIORef bCount `shouldReturn` 1
+    it "rejects a lowered plan whose latent condition has no covering executable stage" $ \_ -> do
+      let anchoredPlan =
+            mkLinearStagePlan
+              [nodeStage (NodeId "anchor") (const (pure (StageComplete Aeson.Null)))]
+              Aeson.Null
+              1
+              ReplayPolicyWarn
+          coveredCondition = StageLatentCondition {slcAnchorNodeId = NodeId "anchor", slcBranches = []}
+          orphanCondition = StageLatentCondition {slcAnchorNodeId = NodeId "ghost", slcBranches = []}
+          nestedCoveredCondition = StageLatentCondition {slcAnchorNodeId = NodeId "anchor:nested", slcBranches = []}
+          nestedOrphanCondition = StageLatentCondition {slcAnchorNodeId = NodeId "anchor:ghost", slcBranches = []}
+          branchWithNested nested =
+            StageLatentBranch
+              { slbBranchId = "then"
+              , slbAnchorNodeId = NodeId "anchor"
+              , slbNodes =
+                  Map.singleton
+                    (NodeId "anchor:nested")
+                    StageLatentNode
+                      { slnTemplateId = stageTemplateId (NodeId "nested")
+                      , slnActionId = stageActionId (NodeId "nested")
+                      }
+              , slbTopology = mempty
+              , slbEntryNodes = []
+              , slbExitNodes = []
+              , slbPostSuccessorNodes = []
+              , slbDeltaSignature =
+                  StageLatentDeltaSignature
+                    { sldsAnchorNodeId = NodeId "anchor"
+                    , sldsAnchorDisposition = RewriteAnchorRetained
+                    , sldsBoundaryResourceUse =
+                        BoundaryResourceUse
+                          { bruLaw = AppendContinuation
+                          , bruSlotAnchor = NodeId "anchor"
+                          , bruAnchorBoundaryUse = AnchorBoundaryRetained
+                          }
+                    , sldsNewNodes = Set.empty
+                    , sldsAddedEdges = Set.empty
+                    , sldsEntryNodes = []
+                    , sldsExitNodes = []
+                    }
+              , slbNestedConditions = nested
+              }
+      -- A latent condition backed by an embedded stage is covered and accepted.
+      case ensureRunnable (SomeStagePlan anchoredPlan [coveredCondition]) of
+        Right _ -> pure ()
+        Left err -> expectationFailure ("expected covered latent condition to pass, got " <> show err)
+      -- Nested latent conditions are checked against the branch-local nodes that
+      -- would become executable if the parent arm materializes.
+      case ensureRunnable
+        ( SomeStagePlan
+            anchoredPlan
+            [coveredCondition {slcBranches = [branchWithNested [nestedCoveredCondition]]}]
+        ) of
+        Right _ -> pure ()
+        Left err -> expectationFailure ("expected nested covered latent condition to pass, got " <> show err)
+      -- A latent condition with no covering stage is rejected loudly.
+      case ensureRunnable (SomeStagePlan anchoredPlan [orphanCondition]) of
+        Left err -> err `shouldBe` CircuitRunUnsupportedLatentConditions [NodeId "ghost"]
+        Right _ -> expectationFailure "expected orphan latent condition to be rejected"
+      -- The same rejection applies inside branch-local latent metadata.
+      case ensureRunnable
+        ( SomeStagePlan
+            anchoredPlan
+            [coveredCondition {slcBranches = [branchWithNested [nestedOrphanCondition]]}]
+        ) of
+        Left err -> err `shouldBe` CircuitRunUnsupportedLatentConditions [NodeId "anchor:ghost"]
+        Right _ -> expectationFailure "expected nested orphan latent condition to be rejected"
 
   describe "durable external-call stages (ADR 0059)" $ do
     it "submits, parks, refuses forged wakes, then completes from the driver on resume" $ \mPool -> withDb mPool $ \pool -> do

--- a/test/Cortex/Wire/Circuit/CompilerSpec.hs
+++ b/test/Cortex/Wire/Circuit/CompilerSpec.hs
@@ -277,7 +277,9 @@ spec = do
       let conditionNodeId = NodeId "__cortex_workflow__/condition/1"
       conditionStage <-
         requireLookup "Expected lowered condition stage" conditionNodeId stagePlan.spDefinitions
-      stageResult <- conditionStage.sdAction nilStageCtx
+      -- The executor runs a stage with scNodeId set to its live topology id; a
+      -- condition anchors its branch rewrite on that id (ADR 0062, #321).
+      stageResult <- conditionStage.sdAction (nilStageCtx {scNodeId = conditionNodeId})
       case stageResult of
         StageRewrite (Aeson.Bool True) rewrite ->
           case planRewriteDelta rewrite stagePlan of
@@ -301,7 +303,7 @@ spec = do
           unselectedRuntimeNodeId = NodeId "__cortex_workflow__/condition/1:else_work"
       conditionStage <-
         requireLookup "Expected lowered condition stage" conditionNodeId stagePlan.spDefinitions
-      stageResult <- conditionStage.sdAction nilStageCtx
+      stageResult <- conditionStage.sdAction (nilStageCtx {scNodeId = conditionNodeId})
       case stageResult of
         StageRewrite (Aeson.Bool True) rewrite@(AppendAfter anchor selectedSpec) -> do
           anchor `shouldBe` conditionNodeId


### PR DESCRIPTION
## Summary

Implements #321: the reusable `Cortex.Pulse` library entrypoint for running compiled Wire circuits through durable Pulse execution with committed-variant `select(...)` dispatch. This is slice (a) of the ADR 0062 production select runtime — the entrypoint and its guards. Effect/capability resolution stays with the downstream binder.

## Progress

Delivered in this PR:

- [x] `Cortex.Pulse.Circuit` entrypoint: `runCompiledCircuit` / `resumeCompiledCircuit` (+ pure `lowerRunnableCircuit` / `ensureRunnable`)
- [x] Lower via `lowerCompiledCircuitToSomeStagePlan`; execute/resume through the production Pulse executor
- [x] `select(...)` dispatch from committed `wireValuePort` labels (`committedVariantConditionBinding`)
- [x] Recursive latent-condition guard — reject deferred forms with no covering executable stage, at any nesting depth (`CircuitRunUnsupportedLatentConditions`)
- [x] Fix nested-select branch materialization (anchor on runtime `StageContext.scNodeId`)
- [x] Re-export the entrypoint from the public `Cortex.Pulse` facade
- [x] Tests: N-way committed-label dispatch + durable resume; uncovered latent-condition rejection (top-level and nested)

Follow-ups (separate issues, **not** this PR):

- `committedVariantBinder` binder-ergonomics smart constructor — #323
- Host-type codec registry / real contract-schema layer — #315
- Logos downstream adoption (synchronous gateway) — Digimuoto/logos#44
- cortex-qc submit/park/resume hardening — Digimuoto/cortex-qc#24

## Changes

- Add `Cortex.Pulse.Circuit`:
  - `runCompiledCircuit` / `resumeCompiledCircuit` — lower + execute/resume.
  - `lowerRunnableCircuit` / `ensureRunnable` — pure lower-and-validate, reusable for pre-flight validation.
  - `CircuitRunError` (`CircuitRunLoweringError` | `CircuitRunUnsupportedLatentConditions`).
- Dispatch `select(...)` on committed variant labels via `committedVariantConditionBinding`.
- Reject latent conditions (recursively, including nested branches) that no executable stage covers, instead of silently dropping unsupported deferred control forms.
- Fix nested select branch materialization: a condition's branch rewrite now anchors on the runtime `StageContext.scNodeId` rather than its lower-time id, which is required once a nested condition is materialized under its parent's `{parent}:{local}` namespace. Top-level conditions are unaffected, so the existing 2-way path is unchanged.
- Re-export the entrypoint from the public `Cortex.Pulse` facade.
- Align ADR 0033 / 0062 notes and the feature-status matrix.

## Tests

- DB-backed 3-way committed-label `select(...)` through the entrypoint.
- Durable resume proves the producer effect and the selected arm are not re-run.
- Non-selected arms never materialize.
- Uncovered latent-condition guard, top-level and nested.
- Existing #314 committed-variant select behavior remains green.

## Validation

- [x] `just test-db` — **1014 examples, 0 failures**
- [x] `just fmt-check`
- [x] `just lint` — No hints
- [x] `git diff --check`
- [x] `just check-commit-provenance origin/main..HEAD`
- [x] CI — all required checks green (18 pass, 3 skipped)

## Feature status

`wire.typed_effect_variant_outputs` (ADR 0062; #313 / #314 / #321) is `partial` in `docs/Reference/feature-status.md`, and correctly stays there: per ADR 0063, a row governed by a `proposed` ADR remains `partial` even with merged, tested substrate, until the ADR is accepted and all matrix evidence is in place. The boundary, committed-variant select runtime, and production entrypoint are all on `main`; proof is tracked separately in `proof-status.md`.

Closes #321.
