### PR TITLE
docs: canonicalize the documentation contract (ADR 0080 + doc sweep)

### DIFF
--- a/docs/ADRs/0001-canonical-documentation-contract.md
+++ b/docs/ADRs/0001-canonical-documentation-contract.md
@@ -1,0 +1,176 @@
+---
+title: "ADR 0001 — Canonical Documentation Contract"
+description:
+  "The canonical documentation tree, doc-kind set, canonical-vs-dated boundary, per-kind frontmatter
+  and format rules, and the Cortex-first policy — decided once; the mechanical subset gated by
+  docs-lint."
+sidebar:
+  label: "0001. Documentation contract"
+  order: 1
+status: accepted
+date: 2026-06-28
+superseded_by: null
+related:
+  - docs/taxonomy.md
+  - docs/map.md
+  - docs/Templates/adr.md
+  - docs/Reference/feature-status.md
+  - docs/ADRs/0063-adr-traceability-and-feature-status-canon.md
+  - docs/ADRs/0018-canonical-haskell-module-tree.md
+  - "GitHub #300"
+  - "GitHub #320"
+  - "GitHub #326"
+  - "GitHub #147"
+---
+
+# ADR 0001 — Canonical Documentation Contract
+
+## Status
+
+Accepted — ratifies the documentation structure, format, and policy already described across
+`docs/taxonomy.md`, `docs/map.md`, and `docs/Templates/`, and partly enforced by
+`scripts/docs-lint`, by recording it as one governed decision and drawing the line between what is
+gated and what is authoring guidance. This is a docs-process governance decision, not a shipped
+substrate capability, so it carries **no** Traceability block and **no** feature-status row (ADR
+0063, rule 1).
+
+This ADR deliberately reclaims the `0001` slot vacated by the #304 sweep, placing the documentation
+contract at the foundation of the canon. It is an intentional exception to the otherwise
+allocation-order numbering the index notes — recorded here rather than deferred to the held Stage-5
+renumber, because a foundational contract belongs at the floor.
+
+## Context
+
+Cortex governs the shapes it cares about with append-only decision records: ADR 0018 decides the
+canonical Haskell module tree, and ADR 0063 decides the ADR-to-feature-status traceability slice.
+The documentation system's own shape has no such record.
+
+It is, however, already **described** and partly **enforced**:
+
+- `docs/taxonomy.md` (`## Doc-kind taxonomy`) and `docs/map.md` (`## By Kind`,
+  `## Canonical Docs Versus Dated Artifacts`) classify every doc and route a new one to its home.
+- `docs/Templates/` carries a frontmatter and section skeleton for the doc-kinds that have a
+  template (authoring convention; the templates are not themselves linted).
+- `scripts/docs-lint` — the gate run by `just docs-lint` in the pre-commit hook and in CI — enforces
+  a set of mechanical minima (common frontmatter, the status enum, table / whitespace / Mermaid /
+  link structure, and the canonical-docs lexical policy on canonical paths). It does **not**
+  validate per-kind skeletons; the line between what is gated and what is authoring guidance is
+  exactly what this decision draws.
+
+What is missing is the **decision**: the contract is convention plus a linter, with no canonical
+rationale, no stated boundaries, and no supersession discipline. A change to the doc taxonomy or a
+lint rule is currently an undecided edit. This ADR closes that gap; it ratifies current practice
+rather than introducing new rules.
+
+## Decision
+
+The documentation system is a governed contract. As with ADR 0063, the ADR **decides**; the named
+living surfaces **describe and enforce**. Two edges fix the taxonomy (what kinds exist and where
+they live); the other two separate what `scripts/docs-lint` mechanically **enforces** from what is
+**authoring guidance**.
+
+### 1. Canonical documentation tree and doc-kinds
+
+Every document has exactly one **doc-kind** with one home. The authoritative, living census of
+kinds, homes, and per-kind lifetimes is `docs/map.md` (`## By Kind`) and `docs/taxonomy.md`
+(`## Doc-kind taxonomy`); this ADR governs that census rather than restating it, so the two never
+drift from a copy kept here. A new kind or a relocation is an amendment to this ADR, kept in step
+with those pages. This is the documentation analog of ADR 0018's canonical module tree.
+
+### 2. Canonical versus dated
+
+One axis cuts across every kind: whether a doc is **edited to stay current** or **preserves a point
+in time**. Canonical docs (the `Dated? = No` kinds in `docs/map.md`) are kept current and evolve by
+append or supersession; dated artifacts (`Research-notes/`, `Experiments/` — the `Dated? = Yes`
+kinds) preserve reasoning from a moment and are removed once they no longer explain the current
+system. The full per-kind lifetime model (active / completed / archived / published / working) is
+`docs/map.md`'s `Lifetime` column, not restated here. This canonical/dated split is the same
+boundary `docs-lint`'s `is_canonical` draws for the lexical policy in rule 3.
+
+### 3. What `scripts/docs-lint` enforces
+
+The gate runs in the pre-commit hook and in CI over every Markdown and `.mmd` file except
+`docs/Templates/` (which is not linted). It enforces, mechanically:
+
+- **Frontmatter minima** — `title` and `description` on every doc; `status`, when present, is a
+  member of one global enum (it is **not** dispatched per doc-kind); `date` / `updated`, when
+  present, are ISO dates not in the future. Publication bundles: `manuscript.md` additionally
+  requires `authors`, `kind`, `related`, `updated`; other bundle files require `date`,
+  `description`, `related`, `status`, `title`.
+- **Structure** — tables are well-formed (cell counts agree); no trailing whitespace or carriage
+  returns; every local Markdown link, and any `#anchor`, resolves.
+- **Mermaid hygiene** — diagram blocks carry no cosmetic styling (`classDef … fill:`, inline
+  `style … fill:`, `linkStyle`) unless a line opts out with `lint: allow semantic`.
+- **Cortex-first lexical policy**, on canonical paths only (`Architecture/`, `Reference/`,
+  `Publications/`, and top-level `docs/*.md`): no internal `Track N`, no `GitHub` / `PR #N`, and the
+  stable term "Pulse runtime" rather than "Cortex Pulse". `ADRs/` and dated artifacts sit outside
+  these paths, so a `GitHub #...` reference there is legitimate provenance, not drift.
+- **The feature-status matrix join** (ADR 0063) — one instance of this contract with its own
+  validator.
+
+### 4. Authoring guidance (not gated)
+
+The rest of the contract is convention the gate does not check; it is honored by authoring
+discipline and review:
+
+- **Per-kind frontmatter and section shape** live in `docs/Templates/<kind>.md` for the kinds that
+  have a template (currently nine; kinds without one follow the nearest template). The templates are
+  guidance and are not themselves linted.
+- **Per-kind status conventions** — ADRs use `proposed` / `accepted` / `superseded`; the gate checks
+  only global enum membership, so per-kind discipline is authored, not enforced.
+- **Cortex-first framing** — canonical docs treat Cortex as the independent upstream substrate;
+  downstream product documentation belongs in `Consumers/`, not in the canonical trees. This is a
+  human-judgment rule with no validator.
+
+## Alternatives considered
+
+- **Leave it to `docs-lint` and the templates.** Rejected — a linter encodes rules but decides
+  nothing; the taxonomy and policy boundaries had no canonical home, no rationale, and no
+  supersession path, so changes were undecided edits.
+- **Fold it into ADR 0063.** Rejected — 0063 is one decision (the traceability/matrix slice). The
+  documentation contract is the broader system 0063 sits within; bundling them would repeat the
+  two-decisions-in-one-ADR drift seen in ADR 0062.
+- **Split into a structure ADR and a format ADR.** Rejected for now — taxonomy, format, and policy
+  are facets of one contract (the canonical documentation system) sharing one enforcement gate; one
+  record keeps them coherent. If either facet later grows its own decision surface, supersede with a
+  split.
+
+## Consequences
+
+### Positive
+
+- The documentation system gains the governance the code tree (0018) and the traceability slice
+  (0063) already have: a canonical rationale, stated boundaries, and supersession discipline.
+- `docs-lint`'s rules become decisions with a recorded why, not unexplained gate behavior.
+- The living surfaces (`taxonomy.md`, `map.md`, `Templates/`) gain a governing-decision anchor.
+
+### Negative
+
+- One more governance ADR to keep honest; its accuracy depends on the living surfaces and the linter
+  staying in step with it.
+
+### Obligations
+
+- Anchor `docs/taxonomy.md`, `docs/map.md`, and the `docs/Templates/` set to this ADR as their
+  governing decision.
+- Reconcile `docs/Templates/index.md` with `docs/map.md`'s `## By Kind` set: add a template for each
+  governed kind that lacks one, or record which kinds intentionally have none (the template set
+  currently covers fewer kinds than `map.md` lists).
+- A doc-kind or format-rule change lands as an amendment to this ADR (or a superseding ADR), kept in
+  step with `docs/taxonomy.md` / `docs/map.md` and `scripts/docs-lint`.
+- This push brings the adjacent doc work into conformance: the operator-meanings table and ADR
+  0048/0049/0052 status reconciliation (GitHub #300); the ADR 0023 `//` ratification and ADR 0062
+  split / cross-link notes (GitHub #320); the glossary frontier vocabulary (GitHub #326); and the
+  standalone Wire usage docs (GitHub #147).
+
+## Related
+
+- [ADR 0018 — Canonical Haskell Module Tree](./0018-canonical-haskell-module-tree.md) — the
+  code-tree analog; this ADR is the documentation counterpart.
+- [ADR 0063 — ADR Traceability and Feature Status Canon](./0063-adr-traceability-and-feature-status-canon.md)
+  — one instance of this contract (the feature-status join).
+- [ADR 0038 — Wire Proof-Track Theorem Ledger](./0038-wire-proof-track-theorem-ledger.md) — the
+  decision-in-ADR / current-state-in-Reference precedent this contract generalizes.
+- [Cortex Taxonomy](../taxonomy.md) — the living doc-kind taxonomy.
+- [Cortex Docs Map](../map.md) — the living where-does-it-go index.
+- [ADR template](../Templates/adr.md)

--- a/docs/ADRs/0023-corepure-expression-surface.md
+++ b/docs/ADRs/0023-corepure-expression-surface.md
@@ -119,6 +119,13 @@ the call site.
 Authors who want override behavior write `defaults // { field = newValue; }` rather than declaring
 `field` twice in one record literal.
 
+CorePure's `//` is a **recursive** merge, deviating from Nix's shallow `//`: when a key holds an
+object on both sides the objects merge recursively, and right-biased replacement applies only at
+leaf values (or where the two sides disagree on kind). This lets an author override one nested field
+with `base // { a = { x = 9; }; }` without restating the rest of `a`. The recursive behavior is what
+the evaluator implements (`mergeObjects` / `mergeJsonValue` in `Cortex.Wire.Pure`); this clause
+records it so the canon matches the code.
+
 ### Pipe Sugar
 
 `|>` is the canonical function-composition operator inside CorePure expressions. It is

--- a/docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
+++ b/docs/ADRs/0047-wire-frontier-linearity-and-precedence.md
@@ -105,7 +105,8 @@ adapter introduced by ADR 0052).
 
 - Every output endpoint in `∂⁺G` and every input endpoint in `∂⁻H` has zero or one compatible
   counterpart on the opposite side, where compatible means matching `(label, contract)`.
-- Zero counterparts: the endpoint remains exposed on the composed frontier.
+- Zero counterparts: the endpoint remains exposed on the composed frontier — a **carried endpoint**
+  (an identity wire for an open boundary; see the [glossary](../glossary.md)).
 - One counterpart: the pair is consumed and the matching edge is added.
 - More than one counterpart on either side: static error.
 
@@ -131,6 +132,10 @@ inverted ladder makes that natural without parens: the trailing overlay binds fi
 operand of the final `=>`. The connect still obeys the linear endpoint rule above; if `transform`
 exposes one output that would feed all three branches, the expression is rejected rather than
 rewritten by source-level distributivity.
+
+This is the **stage-structured pipeline** reading the ladder enables: `<>` forms a same-stage
+frontier (stage formation) and `=>` advances to the next stage (stage advancement). See the
+[glossary](../glossary.md).
 
 ### 4. Retire ADR 0028's parens-when-mixing rule
 

--- a/docs/ADRs/0062-typed-effect-variant-output-boundaries.md
+++ b/docs/ADRs/0062-typed-effect-variant-output-boundaries.md
@@ -200,6 +200,10 @@ substrate (#313), the committed-label select guard/lowering path exercised by du
 explicitly **out of scope** and deferred (#315); this ADR ships on Layer-1 payload-kind/shape
 validation over the current `WireValue`.
 
+This ADR bundles two decisions against the one-decision-per-ADR rule: the emission boundary (#313)
+and the production select runtime (#314/#321). Whether to split it into an emission-boundary ADR and
+a select-runtime ADR is tracked in #320.
+
 ## Alternatives considered
 
 - **A new `StageResult` constructor (`StageCompleteVariant label payload`).** Rejected: it forces
@@ -302,3 +306,6 @@ validation over the current `WireValue`.
     output envelope.
 - [0059 - Durable External-Call Frontiers on Pulse](0059-durable-external-call-frontiers-on-pulse.md)
   - the typed-error-output option this ADR generalises to N variants.
+- [0079 - Wire Admission Artifact as Haskell-to-Lean Proof-Witness Exchange Schema](0079-wire-admission-witness-schema.md)
+  - the proof-side counterpart: the admission witness retains the select-variant exclusive-group
+    provenance (`selectVariantsShareExclusiveGroup`) this ADR drops before runtime.

--- a/docs/ADRs/0079-wire-admission-witness-schema.md
+++ b/docs/ADRs/0079-wire-admission-witness-schema.md
@@ -201,5 +201,8 @@ reader refuse an artifact it was not built to understand.
   — the Haskell/Lean layering this boundary lives inside.
 - [ADR 0053 — Executor Catalog Manifests and Pulse Runtime Bindings](./0053-executor-catalog-manifests-and-pulse-bindings.md)
   — the sibling pattern of a schema-versioned Haskell-emitted artifact crossing a runtime boundary.
+- [ADR 0062 — Typed Effect Variant Output Boundaries](./0062-typed-effect-variant-output-boundaries.md)
+  — the runtime counterpart: emits the committed select variants whose exclusive-group provenance
+  this artifact's select rows retain at the proof boundary.
 - [Cortex Proof Status](../Reference/proof-status.md)
 - GitHub #304

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -17,6 +17,7 @@ values: `proposed`, `accepted`, `superseded`, `deprecated`.
 
 | #                                                                  | Title                                                                      | Status     |
 | ------------------------------------------------------------------ | -------------------------------------------------------------------------- | ---------- |
+| [0001](0001-canonical-documentation-contract.md)                   | Canonical Documentation Contract                                           | accepted   |
 | [0002](0002-cortex-downstream-ownership-boundary.md)               | Cortex and Downstream Ownership Boundary                                   | accepted   |
 | [0003](0003-pulse-service-and-host-action-boundary.md)             | Pulse Service and Host-Action Boundary                                     | accepted   |
 | [0004](0004-graph-native-pulse-execution.md)                       | Graph-Native Pulse Execution                                               | accepted   |
@@ -98,10 +99,13 @@ values: `proposed`, `accepted`, `superseded`, `deprecated`.
 
 A browse-by-concern view of the current ADRs (primary category from the issue #304 Stage-3
 classification; the superseded 0049 is omitted). Numbering stays in allocation order — the order
-ADRs were added (chronological by repository entry; some frontmatter dates drift) — so this is only
-the category lens, not a renumber. A few ADRs cross-cut; only the primary category is shown here.
+ADRs were added (chronological by repository entry; some frontmatter dates drift) — with one
+deliberate exception: ADR 0001 reclaims the vacated floor slot for the foundational documentation
+contract, placed out of allocation order by design (see ADR 0001 Status). So this is only the
+category lens, not a renumber. A few ADRs cross-cut; only the primary category is shown here.
 
-- **Boundary & governance** (8): [0002](0002-cortex-downstream-ownership-boundary.md),
+- **Boundary & governance** (9): [0001](0001-canonical-documentation-contract.md),
+  [0002](0002-cortex-downstream-ownership-boundary.md),
   [0003](0003-pulse-service-and-host-action-boundary.md),
   [0006](0006-compiled-workflow-artifact-boundary.md),
   [0016](0016-cortex-roots-and-logos-pattern-extraction.md),

--- a/docs/Reference/Wire/grammar.md
+++ b/docs/Reference/Wire/grammar.md
@@ -521,6 +521,23 @@ a
 parses as `a => b => (c <> d)`. The expression is still admitted only if the final connect obeys the
 linear endpoint rule.
 
+### Operator meanings by phase
+
+The same glyph can mean different things in **graph position** (a `wire_expr` composing topology)
+versus **CorePure expression position** (inside a node body). Wire has no implicit fan-out: topology
+is formed only by the graph operators and compile-time generation.
+
+| Glyph / form                     | Graph position                                                                         | CorePure expression position                                               |
+| -------------------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `<>`                             | Overlay — set-union of fragments; never clones nodes                                   | —                                                                          |
+| `=>`                             | Connect — linear `(contract, label)` port matching; no implicit fan-out or aggregation | —                                                                          |
+| `*`                              | Explicit finite-product adapter node (generated)                                       | Arithmetic multiplication                                                  |
+| `make(N, K)` / `makeEach(xs, K)` | Compile-time generation of a bounded fresh node family                                 | —                                                                          |
+| `map` / `fold` / `zip` / `range` | —                                                                                      | Operate on JSON values inside a node body; they never instantiate topology |
+
+Fan-in and fan-out are authored as explicit nodes (an adapter, sharing, or persistence node), never
+as implicit concatenation or list aggregation.
+
 `()` is the empty graph value and identity for overlay/connect.
 
 `select(...)` is the conditional continuation form over an exclusive output boundary. Its detailed

--- a/docs/Reference/Wire/pure-execution.md
+++ b/docs/Reference/Wire/pure-execution.md
@@ -204,7 +204,7 @@ Implemented expression forms:
 - arithmetic `+`, `-`, `*`, `/`;
 - comparisons `==`, `!=`, `<`, `<=`, `>`, `>=`;
 - boolean `&&`, `||`;
-- right-biased record merge `//`;
+- recursive right-biased record merge `//` (deep merge; leaf values are right-biased);
 - non-recursive `let ... in`;
 - `if ... then ... else ...`;
 - string interpolation: `"Score: ${item.score}"`.

--- a/docs/Templates/index.md
+++ b/docs/Templates/index.md
@@ -27,10 +27,14 @@ frontmatter, section shape, and placement discipline.
 
 ## Discipline
 
-- Frontmatter is required.
-- Status values follow a closed vocabulary: `draft`, `active`, `accepted`,
-  `completed`, `superseded`, `archived`, `deprecated`.
-- Dates in frontmatter are ISO dates (`YYYY-MM-DD`).
+The structure, frontmatter, format, and Cortex-first policy these templates encode are governed by
+[ADR 0001 — Canonical Documentation Contract](../ADRs/0001-canonical-documentation-contract.md);
+`scripts/docs-lint` is the gate.
+
+- Frontmatter is required (`title` and `description` always).
+- Status values follow the canonical enum the contract pins (ADRs use `proposed`, `accepted`,
+  `superseded`); `scripts/docs-lint` enforces it.
+- Dates in frontmatter are ISO dates (`YYYY-MM-DD`), never in the future.
 - Canonical docs should frame Cortex directly. Downstream consumers can appear
   as examples, not as the system boundary.
 - Dated artifacts should be retained only while they explain current canon,

--- a/docs/Usage/02-first-wire-workflow.md
+++ b/docs/Usage/02-first-wire-workflow.md
@@ -54,6 +54,46 @@ must be registered by the host or consumer library.
 Wire also does not run the workflow directly. It compiles source into a circuit artifact. Pulse runs
 the materialized circuit.
 
+## Run A Ready-Made Example
+
+For local exploration the standalone `wire` CLI bundles compile-and-run: it compiles a source file
+and drives the compiled circuit through the in-memory runner (ADR 0043) — no Postgres, task
+registry, or deployment. The repository ships a catalog of `.wire` programs under `examples/wire/`;
+each file's header comment gives its run command.
+
+A pure CorePure example — `range` / `fold` and the string builtins, no executors:
+
+```bash
+nix run .#wire -- run examples/wire/pure-stdlib-report.wire
+```
+
+It prints a deterministic Markdown report:
+
+```text
+# Wire pure stdlib report
+
+seed: demo
+rows: 5
+
+| n | square | cube | size |
+| --- | --- | --- | --- |
+| 1 | 1 | 1 | SMALL |
+| 2 | 4 | 8 | SMALL |
+| 5 | 25 | 125 | BIG |
+```
+
+What an example needs to run depends on its leaves:
+
+- **Pure** (e.g. `pure-stdlib-report.wire`) — run directly with `wire run`; the body is all
+  CorePure.
+- **Interactive or effectful** (e.g. `mini-build-system.wire`, `interactive-priority-planner.wire`)
+  — need the standard IO executors. See
+  [Executors and alphabet](../Reference/Wire/executors-and-alphabet.md).
+- **Quantum** (`quantum-*.wire`) — need a hardware or simulator backend. See the
+  [Quantum consumer](../Consumers/Quantum.md).
+- **Durable** runs — persistence, resume, and signals are a Pulse concern, not the in-memory runner.
+  See [Running Pulse](03-running-pulse.md).
+
 ## Compiling From Haskell
 
 The current public surface is the Haskell API:

--- a/docs/Usage/index.md
+++ b/docs/Usage/index.md
@@ -41,17 +41,18 @@ from a consumer repo and pass a populated registry to `Cortex.Pulse.runPulse`.
 
 ## Reading Path
 
-| If you want to...                     | Start with                                                 |
-| ------------------------------------- | ---------------------------------------------------------- |
-| Build the repo and see the surfaces   | [Quickstart](01-quickstart.md)                             |
-| Understand the shape of a Wire file   | [Your first Wire workflow](02-first-wire-workflow.md)      |
-| Learn what Pulse needs at runtime     | [Running Pulse](03-running-pulse.md)                       |
-| Prepare an operator-facing service    | [Deploying Pulse](04-deploying-pulse.md)                   |
-| Embed Cortex in another Haskell repo  | [Integrating from Haskell](05-integrating-from-haskell.md) |
-| Diagnose common failures              | [Troubleshooting](06-troubleshooting.md)                   |
-| Check proof and correspondence status | [Proof status](../Reference/proof-status.md)               |
-| Look up exact syntax or schemas       | [Reference](../Reference/)                                 |
-| Understand the design commitments     | [Architecture overview](../Architecture/01-overview.md)    |
+| If you want to...                     | Start with                                                                     |
+| ------------------------------------- | ------------------------------------------------------------------------------ |
+| Build the repo and see the surfaces   | [Quickstart](01-quickstart.md)                                                 |
+| Understand the shape of a Wire file   | [Your first Wire workflow](02-first-wire-workflow.md)                          |
+| Run a ready-made Wire example         | [Run a ready-made example](02-first-wire-workflow.md#run-a-ready-made-example) |
+| Learn what Pulse needs at runtime     | [Running Pulse](03-running-pulse.md)                                           |
+| Prepare an operator-facing service    | [Deploying Pulse](04-deploying-pulse.md)                                       |
+| Embed Cortex in another Haskell repo  | [Integrating from Haskell](05-integrating-from-haskell.md)                     |
+| Diagnose common failures              | [Troubleshooting](06-troubleshooting.md)                                       |
+| Check proof and correspondence status | [Proof status](../Reference/proof-status.md)                                   |
+| Look up exact syntax or schemas       | [Reference](../Reference/)                                                     |
+| Understand the design commitments     | [Architecture overview](../Architecture/01-overview.md)                        |
 
 ## What This First Pass Covers
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -57,6 +57,15 @@ orientation.
 - **Sum group** — output-port form `-> A | B` where exactly one variant fires.
 - **Wire value** — a node, a composed graph expression, or the empty wire `()`.
 - **Port-boundary** — a wire's currently unconnected input and output ports.
+- **Frontier** — the multiset of named, contract-typed port instances a wire exposes on its
+  boundary; the formal name for a wire's port-boundary.
+- **Frontier transformer** — a Wire source expression read as a function from an input frontier to
+  an output frontier; composition transforms frontiers rather than wiring a fixed graph.
+- **Carried endpoint** — a frontier endpoint that crosses a `=>` composition unmatched and remains
+  exposed on the composed frontier (an identity wire for an open boundary).
+- **Stage-structured pipeline** — the reading where `<>` forms a same-stage frontier (stage
+  formation) and `=>` advances to the next stage (stage advancement); the basis for the ADR 0047
+  precedence ladder.
 - **File-return expression** — the last expression in a `.wire` file, which becomes the file's
   value.
 - **Evaluation-boundary check** — the runnable-wire gate: every singular input must be connected
@@ -66,7 +75,7 @@ orientation.
 
 - **`<>` overlay** — set union of nodes and edges.
 - **`=>` connect** — port-key-matched edge addition over boundaries.
-- **`//` merge** — right-biased shallow record merge.
+- **`//` merge** — recursive right-biased record merge (deep merge; leaves are right-biased).
 - **`++` concat** — string and list concatenation.
 - **`|` sum** — output-port mutual-exclusion constructor.
 - **`@` application** — stages registered executor authority with config: `@qualified.name { ... }`.

--- a/docs/map.md
+++ b/docs/map.md
@@ -70,6 +70,8 @@ research snapshots should be removed instead of preserved by default.
 
 ## Related
 
+- [ADRs/0001-canonical-documentation-contract.md](ADRs/0001-canonical-documentation-contract.md) -
+  the governing decision for this map and the doc-kind contract.
 - [index.md](index.md) - docs landing and reading order.
 - [taxonomy.md](taxonomy.md) - concept classification.
 - [glossary.md](glossary.md) - term definitions.

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -106,6 +106,10 @@ contracts, ports, templates, prompts, memory presets, and evaluation policy.
 
 ## Doc-kind taxonomy
 
+This taxonomy, the canonical-vs-dated boundary, and the per-kind frontmatter and format contract are
+governed by
+[ADR 0001 — Canonical Documentation Contract](ADRs/0001-canonical-documentation-contract.md).
+
 Docs are classified on two axes:
 
 |                         | Stable canon                                     | Dated artifacts   |
@@ -120,6 +124,8 @@ Papers: `Publications/paper-N-*/`
 
 ## Related
 
+- [ADRs/0001-canonical-documentation-contract.md](ADRs/0001-canonical-documentation-contract.md) —
+  the governing decision for this taxonomy.
 - [map.md](map.md) — where to put a new doc.
 - [glossary.md](glossary.md) — term definitions.
 - [Architecture/01-overview.md](Architecture/01-overview.md) — architectural starting point.

--- a/scripts/docs-lint
+++ b/scripts/docs-lint
@@ -38,6 +38,7 @@ STATUS_VALUES = {
     "accepted",
     "active",
     "canonical",
+    "deprecated",
     "draft",
     "final",
     "historical",


### PR DESCRIPTION
## Summary

Decide the documentation system's own structure and format in canon. Today the doc taxonomy and
format contract is **described** (`docs/taxonomy.md`, `docs/map.md`, `docs/Templates/*`) and
**enforced** (`scripts/docs-lint`) but never **decided** in an append-only ADR — an asymmetry with
the code tree (ADR 0018) and the traceability slice (ADR 0063). This push adds the deciding ADR and
brings the adjacent doc work into conformance with it.

## Plan (staged signed commits; lead with the ADR — riders conform to it)

**Phase 1 — Anchor (the decision)**
- [ ] ADR 0080 "Canonical Documentation Contract": doc taxonomy/tree + doc-kind set; canonical-vs-dated
      boundary; doc-kind → frontmatter/format contract (what `docs-lint` enforces); Cortex-first policy
      (no downstream product docs in canon, no transient IDs, stable terms). Governance ADR → no
      feature-status row; cross-refs 0063 + 0018; `accepted` on merge (ratifies enforced practice).
- [ ] Anchor `docs/taxonomy.md`, `docs/map.md`, `docs/Templates/*` to ADR 0080 (they reference no
      governing ADR today).

**Phase 2 — Conformance & drift**
- [ ] Operator-meanings-by-phase table in the Wire reference + reconcile ADR 0048/0049/0052
      proposed-vs-accepted status drift (#300).
- [ ] Amend ADR 0023 to ratify the recursive `//` merge the evaluator already implements (docs-only);
      add the 0062 split/annotate note + reciprocal 0062↔0079 cross-link (#320).

**Phase 3 — New content under the new contract**
- [ ] Glossary frontier vocabulary: frontier transformer / carried endpoint / stage-structured
      pipeline, referenced from ADR 0047 (#326).
- [ ] Capped getting-started Wire usage page + 2–3 runnable examples (#147).

## Checklist
- [ ] `just fmt-check`, `just docs-lint`, `just docs-check` green per phase
- [ ] `just check-commit-provenance origin/main..HEAD` clean
- [ ] `just check` passes locally
- [ ] Ready for review

## Issues
Closes #300
Closes #326
Closes #147
Advances #320