### PR TITLE
fix(wire): canonicalize formatter overlay grouping

### DIFF
--- a/src/Cortex/Wire/Format.hs
+++ b/src/Cortex/Wire/Format.hs
@@ -395,7 +395,7 @@ formatTopologyChain level (TopologyChain first rest) =
 formatStage :: Int -> Expr -> [Text]
 formatStage level = \case
   expr@ExprOverlay {} ->
-    parenthesizeInlineStage level (formatOverlay level (flattenOverlay expr))
+    formatOverlay level (flattenOverlay expr)
   expr@ExprConnect {} ->
     parenthesizeMultiline level (formatGraphExpr (level + 1) expr)
   expr@ExprStar {} ->
@@ -408,9 +408,7 @@ formatOverlay level items
   | length items <= 4 && all isInlineGraphAtom items && T.length inline <= 100 =
       [indentText level inline]
   | otherwise =
-      [indentText level "("]
-        <> formatOverlayItems (level + 1) items
-        <> [indentText level ")"]
+      formatOverlayItems level items
   where
     inline =
       T.intercalate " <> " (fmap formatExprInline items)
@@ -425,9 +423,10 @@ formatOverlayItems level =
           ExprConnect {} -> parenthesizeMultiline level (formatGraphExpr (level + 1) item)
           ExprStar {} -> parenthesizeMultiline level (formatGraphExpr (level + 1) item)
           -- Nested ExprOverlay only reaches this branch from explicit source
-          -- grouping (flattenOverlay walks the left spine only). Wrap in
-          -- parens so the right-nested AST round-trips through the parser.
-          ExprOverlay {} -> parenthesizeInlineStage level (formatOverlay level (flattenOverlay item))
+          -- grouping (flattenOverlay walks the left spine only). parenthesizeMultiline
+          -- always wraps, so the right-nested AST round-trips regardless of how the
+          -- inner frontier renders (e.g. a leading parenthesized connect/select).
+          ExprOverlay {} -> parenthesizeMultiline level (formatGraphExpr (level + 1) item)
           _ -> [indentText level (formatExprInline item)]
       where
         prefix = if index == 0 then "" else "<> "
@@ -440,13 +439,6 @@ parenthesizeMultiline level = \case
     [indentText level "("]
       <> lines'
       <> [indentText level ")"]
-
-parenthesizeInlineStage :: Int -> [Text] -> [Text]
-parenthesizeInlineStage level = \case
-  [single]
-    | not ("(" `T.isPrefixOf` T.strip single) ->
-        [indentText level ("(" <> T.strip single <> ")")]
-  lines' -> lines'
 
 addPrefix :: Text -> [Text] -> [Text]
 addPrefix "" lines' =

--- a/test/Cortex/Wire/FormatSpec.hs
+++ b/test/Cortex/Wire/FormatSpec.hs
@@ -30,15 +30,15 @@ spec = do
 
     it "formats small frontiers horizontally inside connect chains" $ do
       formatWireSource "test" "a=>(b<>c<>d)=>e"
-        `shouldBe` Right "a\n  => (b <> c <> d)\n  => e\n"
+        `shouldBe` Right "a\n  => b <> c <> d\n  => e\n"
 
-    it "formats large frontiers vertically with leading overlay operators" $ do
+    it "formats large frontiers with stage-aligned leading overlay operators" $ do
       formatWireSource "test" "a=>(b<>c<>d<>e<>f)=>g"
-        `shouldBe` Right "a\n  => (\n    b\n    <> c\n    <> d\n    <> e\n    <> f\n  )\n  => g\n"
+        `shouldBe` Right "a\n  => b\n  <> c\n  <> d\n  <> e\n  <> f\n  => g\n"
 
-    it "preserves explicit right-nested connect groups" $ do
+    it "preserves explicit right-nested connect groups without redundant frontier parens" $ do
       formatWireSource "test" "a=>b=>((c<>d)=>e)"
-        `shouldBe` Right "a\n  => b\n  => (\n    (c <> d)\n      => e\n  )\n"
+        `shouldBe` Right "a\n  => b\n  => (\n    c <> d\n      => e\n  )\n"
 
     it "formats star adapters as topology stages" $ do
       formatWireSource "test" "a*b=>c"
@@ -46,7 +46,7 @@ spec = do
 
     it "formats star adapters after overlay stages" $ do
       formatWireSource "test" "(a<>b)*sink"
-        `shouldBe` Right "(a <> b)\n  * sink\n"
+        `shouldBe` Right "a <> b\n  * sink\n"
 
     it "preserves explicit right-nested star groups" $ do
       formatWireSource "test" "a*(b*c)"
@@ -78,7 +78,7 @@ spec = do
       formatWireSource "test" source `shouldBe` Right expected
 
     it "is idempotent" $ do
-      let source = "a\n  => (b <> c <> d)\n  => e\n"
+      let source = "a\n  => b <> c <> d\n  => e\n"
       formatted <- requireRight (formatWireSource "test" source)
       formatWireSource "test" formatted `shouldBe` Right formatted
 
@@ -177,7 +177,7 @@ spec = do
       formatWireSource "test" source
         `shouldBe` Right "let frontier = a <> (b <> c);\n\nfrontier\n"
 
-    it "preserves nested indentation across multi-line let RHS" $ do
+    it "keeps nested large frontiers aligned with their graph stage" $ do
       let source =
             "let pipeline =\n\
             \  a\n\
@@ -193,13 +193,11 @@ spec = do
           expected =
             "let pipeline =\n\
             \  a\n\
-            \    => (\n\
-            \      b\n\
-            \      <> c\n\
-            \      <> d\n\
-            \      <> e\n\
-            \      <> f\n\
-            \    )\n\
+            \    => b\n\
+            \    <> c\n\
+            \    <> d\n\
+            \    <> e\n\
+            \    <> f\n\
             \    => g;\n\
             \\n\
             \pipeline\n"


### PR DESCRIPTION
## Summary

`wire fmt` now matches ADR 0074's parenthesis policy and is total on the right-nested overlay cases found during review:

- overlay frontiers in graph/stage position render **open** instead of being wrapped in precedence-redundant `(...)`;
- right-nested overlay items headed by grouped topology keep their load-bearing grouping, so valid Wire no longer trips the formatter's reparse-equality guard.

Canonical stage shape:

```wire
a
  => b
  <> c
  <> d
  => e
```

Load-bearing grouping is still preserved:

```wire
a
  => b
  => (
    c <> d
      => e
  )
```

## What changed

- `src/Cortex/Wire/Format.hs`: graph/stage overlays use the open frontier renderer, while nested overlay items that need grouping route through the explicit always-wrapping graph path. The old parenthesized overlay/string-sniffing helper path is gone.
- `test/Cortex/Wire/FormatSpec.hs`: pins the canonical open-frontier shape and adversarial right-nested overlay round-trips so totality and idempotence stay covered.

## Why it is safe

The formatter reparses its own output and requires full AST equality (`reparsed == wireFile`) before emitting. Dropping a load-bearing parenthesis fails loudly instead of silently changing topology.

Verified review cases include redundant overlays such as `a => (b <> c)` and load-bearing/adversarial groups such as `a <> (b => c)` and `w <> x <> y <> z <> ((a => b) <> c)`.

## Verification

Post-sync local verification on top of `origin/main`:

- `just check-commit-provenance origin/main..HEAD`: OK
- `just fmt-check`: passed
- `just test-match "Cortex.Wire.Format"`: 61 examples, 0 failures, including corpus round-trip

Earlier pre-sync full gate:

- `just check`: passed
- PR CI: 21/21 passing before the rebase/squash refresh

## Issue

Advances #297.

Follow-up tracked separately: #342 centralizes graph parenthesization and stage indentation, including the remaining first-stage-overlay cosmetic alignment concern.
