### PR TITLE
fix(pulse): harden managed consumer execution

### DIFF
--- a/src/Cortex/Pulse.hs
+++ b/src/Cortex/Pulse.hs
@@ -359,7 +359,7 @@ resumeOneRun registry taskContext leaseDuration runId = do
               ]
             pure Nothing
       outcome <-
-        Scheduler.withLeaseRenewal pool runId leaseDuration $
+        Scheduler.withLeaseRenewal pool runId (pulseLeaseOwner taskContext.tcConfig) leaseDuration $
           Executor.resumeTask registry taskContext runId task
       endTime <- getCurrentTime
       Scheduler.finalizeTaskSchedule pool (Just runId) task triggerSource endTime outcome

--- a/src/Cortex/Pulse/Circuit.hs
+++ b/src/Cortex/Pulse/Circuit.hs
@@ -32,7 +32,9 @@ module Cortex.Pulse.Circuit
   , runCompiledCircuit
   , resumeCompiledCircuit
   , runCompiledCircuitManaged
+  , runCompiledCircuitManagedOn
   , resumeCompiledCircuitManaged
+  , resumeCompiledCircuitManagedOn
   , lowerRunnableCircuit
   , ensureRunnable
   , committedVariantBinder
@@ -45,7 +47,15 @@ module Cortex.Pulse.Circuit
 where
 
 import Control.Concurrent.STM (newTVarIO)
-import Control.Exception (finally)
+import Control.Exception
+  ( SomeAsyncException
+  , SomeException
+  , displayException
+  , finally
+  , fromException
+  , throwIO
+  , try
+  )
 import Data.Aeson qualified as Aeson
 import Data.Bifunctor (first)
 import Data.Int (Int32)
@@ -68,6 +78,7 @@ import Cortex.Pulse.Database
   , withConnection
   )
 import Cortex.Pulse.Executor (TaskContext (..), executeStagePlan, resumeStagePlan)
+import Cortex.Pulse.Executor.Persistence (failRun)
 import Cortex.Pulse.Node (NodeId)
 import Cortex.Pulse.Plan
   ( SomeStagePlan (..)
@@ -79,8 +90,10 @@ import Cortex.Pulse.Plan
   , taskStage
   )
 import Cortex.Pulse.Query
-  ( PulseTaskDefinitionInsert (..)
+  ( ManagedResumeClaim (..)
+  , PulseTaskDefinitionInsert (..)
   , claimAndCreateRun
+  , claimManagedRunForResume
   , createTaskDefinition
   , getTaskById
   , getTaskForRun
@@ -100,7 +113,12 @@ import Cortex.Wire.Circuit.Lowering
   , signalStage
   )
 
-import Platform.DurableTask.Types (RunOutcome, TriggerSource (..))
+import Platform.DurableTask.Types
+  ( RunOutcome (..)
+  , RunStatus (..)
+  , TriggerSource (..)
+  , runStatusFromText
+  )
 
 -- | Why a compiled circuit could not be run through this entrypoint.
 data CircuitRunError
@@ -117,6 +135,16 @@ data CircuitRunError
     execution could begin (managed facade).
     -}
     CircuitRunSetupError Text
+  | -- | Opening a managed database pool failed.
+    CircuitRunPoolError Text
+  | -- | Setup reached a database that does not look provisioned with the Pulse schema.
+    CircuitRunSchemaMissing Text
+  | -- | A managed run could not be claimed without violating its ownership contract.
+    CircuitRunTaskClaimConflict Text
+  | -- | A managed resume target exists but is not currently resumable by this caller.
+    CircuitRunResumeRejected Text
+  | -- | Circuit execution raised an exception after a durable run was claimed.
+    CircuitRunExecutionError Text
   deriving stock (Eq, Show)
 
 {- | Reject a lowered plan this entrypoint cannot execute.
@@ -198,21 +226,26 @@ resumeCompiledCircuit taskContext runId task pulseConfig binder compiledCircuit 
 
 {- | Lower and execute a compiled Wire circuit as a fresh, durable, *managed* run:
 open a pool from the 'PulseConfig', create a task definition + run, execute it under a
-renewed lease, and return the durable run id alongside the outcome. The caller
-supplies only config + binder + circuit; run/lease/'TaskContext' assembly is hidden
-(GitHub #330). The circuit is lowered before any durable rows are created, so
+renewed lease, and return the durable run id alongside the outcome. This is a
+one-shot convenience facade; high-throughput consumers should use
+'runCompiledCircuitManagedOn' with a caller-owned pool. The caller supplies only
+config + binder + circuit; run/lease/'TaskContext' assembly is hidden by GitHub
+issue 330. The circuit is lowered before any durable rows are created, so
 validation failures are side-effect-free.
 
 Each managed run creates a scheduler-inert task definition (@enabled = false@, so the
 Pulse scheduler never auto-claims it), grouped under @task_type = workflowKey@ with a
 unique @task_name@, then claims one run against it. The task-definition and run rows
-are durable records and are not cleaned up. The managed run assumes the Pulse schema
-is already provisioned ('Cortex.Pulse.Database.provisionPulseSchema').
+are durable records and are not cleaned up; operators need a retention policy for
+long-lived hosts that drive many one-off managed runs. The managed run assumes the
+Pulse schema is already provisioned ('Cortex.Pulse.Database.provisionPulseSchema').
 
 The returned run id is the durable handle: a consumer records it to correlate,
 inspect, or 'resumeCompiledCircuitManaged' the run after a crash. Execution runs under
 'withLeaseRenewal' with @pulseLeaseOwner@, so a run that outlives its lease duration
-keeps its lease and a co-located scheduler does not reclaim it mid-flight.
+keeps its lease and a co-located scheduler does not reclaim it mid-flight. If
+execution raises an exception after the run is claimed, the facade marks the run
+failed and returns 'CircuitRunExecutionError' rather than leaking an IO exception.
 -}
 runCompiledCircuitManaged
   :: PulseConfig
@@ -224,20 +257,51 @@ runCompiledCircuitManaged
 runCompiledCircuitManaged pulseConfig workflowKey circuitConfig binder circuit =
   case lowerRunnableCircuit circuitConfig binder circuit of
     Left err -> pure (Left err)
-    Right (SomeStagePlan stagePlan _latentConditions) ->
-      withManagedRun pulseConfig workflowKey $ \taskContext runId task ->
-        Right
-          <$> withLeaseRenewal
-            taskContext.tcPool
-            runId
-            (leaseSecondsOf pulseConfig)
-            (executeStagePlan taskContext runId task stagePlan)
+    Right lowered ->
+      withManagedPool pulseConfig $ \pool ->
+        runLoweredCompiledCircuitManagedOn pool pulseConfig workflowKey lowered
+
+{- | Pool-reuse variant of 'runCompiledCircuitManaged'. The caller owns schema
+provisioning and pool lifetime; this function still owns the durable managed run
+row lifecycle.
+-}
+runCompiledCircuitManagedOn
+  :: Pool
+  -> PulseConfig
+  -> Text
+  -> CircuitPulseConfig
+  -> CircuitPulseBinder
+  -> CompiledCircuit
+  -> IO (Either CircuitRunError (UUID, RunOutcome))
+runCompiledCircuitManagedOn pool pulseConfig workflowKey circuitConfig binder circuit =
+  case lowerRunnableCircuit circuitConfig binder circuit of
+    Left err -> pure (Left err)
+    Right lowered ->
+      runLoweredCompiledCircuitManagedOn pool pulseConfig workflowKey lowered
+
+runLoweredCompiledCircuitManagedOn
+  :: Pool
+  -> PulseConfig
+  -> Text
+  -> SomeStagePlan
+  -> IO (Either CircuitRunError (UUID, RunOutcome))
+runLoweredCompiledCircuitManagedOn pool pulseConfig workflowKey (SomeStagePlan stagePlan _latentConditions) =
+  withManagedRun pool pulseConfig workflowKey $ \taskContext runId task ->
+    runManagedExecution taskContext.tcPool runId $
+      withLeaseRenewal
+        taskContext.tcPool
+        runId
+        (pulseLeaseOwner pulseConfig)
+        (leaseSecondsOf pulseConfig)
+        (executeStagePlan taskContext runId task stagePlan)
 
 {- | Resume a durable, *managed* run from persisted graph state, addressed by the run
-id 'runCompiledCircuitManaged' returned. Opens a pool from the 'PulseConfig', loads the
-run's task definition, and re-drives the plan under a renewed lease. A committed-variant
-selector re-reads its persisted label and never re-invokes the producer effect (ADR
-0062); a stage that already completed is not re-run.
+id 'runCompiledCircuitManaged' returned. Opens a pool from the 'PulseConfig' and
+atomically claims a resumable run before loading its task definition and re-driving
+the plan under a renewed lease. Live running runs are rejected instead of being
+co-owned; terminal/waiting runs return their stored outcome without re-driving the
+plan. A committed-variant selector re-reads its persisted label and never re-invokes
+the producer effect (ADR 0062); a stage that already completed is not re-run.
 
 The binder and 'CircuitPulseConfig' must match the original run's (persisted graph
 state is keyed by node id). Returns the same run id alongside the outcome.
@@ -252,14 +316,43 @@ resumeCompiledCircuitManaged
 resumeCompiledCircuitManaged pulseConfig runId circuitConfig binder circuit =
   case lowerRunnableCircuit circuitConfig binder circuit of
     Left err -> pure (Left err)
-    Right (SomeStagePlan stagePlan _latentConditions) ->
-      withManagedResume pulseConfig runId $ \taskContext task ->
-        Right
-          <$> withLeaseRenewal
-            taskContext.tcPool
-            runId
-            (leaseSecondsOf pulseConfig)
-            (resumeStagePlan taskContext runId task stagePlan)
+    Right lowered ->
+      withManagedPool pulseConfig $ \pool ->
+        resumeLoweredCompiledCircuitManagedOn pool pulseConfig runId lowered
+
+{- | Pool-reuse variant of 'resumeCompiledCircuitManaged'. The caller owns schema
+provisioning and pool lifetime. The resume path still atomically claims ownership
+of a resumable run before driving the graph.
+-}
+resumeCompiledCircuitManagedOn
+  :: Pool
+  -> PulseConfig
+  -> UUID
+  -> CircuitPulseConfig
+  -> CircuitPulseBinder
+  -> CompiledCircuit
+  -> IO (Either CircuitRunError (UUID, RunOutcome))
+resumeCompiledCircuitManagedOn pool pulseConfig runId circuitConfig binder circuit =
+  case lowerRunnableCircuit circuitConfig binder circuit of
+    Left err -> pure (Left err)
+    Right lowered ->
+      resumeLoweredCompiledCircuitManagedOn pool pulseConfig runId lowered
+
+resumeLoweredCompiledCircuitManagedOn
+  :: Pool
+  -> PulseConfig
+  -> UUID
+  -> SomeStagePlan
+  -> IO (Either CircuitRunError (UUID, RunOutcome))
+resumeLoweredCompiledCircuitManagedOn pool pulseConfig runId (SomeStagePlan stagePlan _latentConditions) =
+  withManagedResume pool pulseConfig runId $ \taskContext task ->
+    runManagedExecution taskContext.tcPool runId $
+      withLeaseRenewal
+        taskContext.tcPool
+        runId
+        (pulseLeaseOwner pulseConfig)
+        (leaseSecondsOf pulseConfig)
+        (resumeStagePlan taskContext runId task stagePlan)
 
 -- | The configured lease duration as the 'Int32' seconds the run/claim API expects.
 leaseSecondsOf :: PulseConfig -> Int32
@@ -276,7 +369,7 @@ withManagedPool
 withManagedPool pulseConfig use = do
   poolResult <- createPulsePool (connectionConfigOf pulseConfig)
   case poolResult of
-    Left err -> pure (setupError "pool" err)
+    Left err -> pure (Left (CircuitRunPoolError (T.pack err)))
     Right pool -> use pool `finally` HP.release pool
 
 {- | Assemble a fresh managed run (a scheduler-inert task definition, a claimed run,
@@ -287,73 +380,139 @@ task is loaded /before/ the run is claimed, so a load failure leaves no orphaned
 action renews the lease under.
 -}
 withManagedRun
-  :: PulseConfig
+  :: Pool
+  -> PulseConfig
   -> Text
   -> (TaskContext -> UUID -> PulseTaskDefinitionRow Result -> IO (Either CircuitRunError RunOutcome))
   -> IO (Either CircuitRunError (UUID, RunOutcome))
-withManagedRun pulseConfig workflowKey run =
-  withManagedPool pulseConfig $ \pool -> do
-    now <- getCurrentTime
-    uniqueSuffix <- toText <$> UUIDv4.nextRandom
-    let taskName = workflowKey <> "/" <> uniqueSuffix
-    created <- runTransaction pool (createTaskDefinition (inertTaskDefInsert workflowKey taskName now))
-    case created of
-      Left err -> pure (setupError "create task definition" err)
-      Right Nothing -> pure (Left (CircuitRunSetupError "create task definition: unexpected conflict"))
-      Right (Just taskId) -> do
-        loaded <- withConnection pool (getTaskById taskId)
-        case loaded of
-          Left err -> pure (setupError "load task" err)
-          Right Nothing -> pure (Left (CircuitRunSetupError "load task: definition not found"))
-          Right (Just task) -> do
-            claimed <-
-              runTransaction
-                pool
-                ( claimAndCreateRun
-                    taskId
-                    (pulseLeaseOwner pulseConfig)
-                    TriggerManual
-                    now
-                    (leaseSecondsOf pulseConfig)
-                )
-            case claimed of
-              Left err -> pure (setupError "claim run" err)
-              Right Nothing -> pure (Left (CircuitRunSetupError "claim run: task could not be claimed"))
-              Right (Just runId) -> do
-                shutdownFlag <- newTVarIO False
-                outcome <-
-                  run
-                    TaskContext {tcPool = pool, tcConfig = pulseConfig, tcShutdownFlag = shutdownFlag}
-                    runId
-                    task
-                pure (fmap (runId,) outcome)
+withManagedRun pool pulseConfig workflowKey run = do
+  now <- getCurrentTime
+  uniqueSuffix <- toText <$> UUIDv4.nextRandom
+  let taskName = workflowKey <> "/" <> uniqueSuffix
+  created <- runTransaction pool (createTaskDefinition (inertTaskDefInsert workflowKey taskName now))
+  case created of
+    Left err -> pure (setupError "create task definition" err)
+    Right Nothing -> pure (Left (CircuitRunTaskClaimConflict "create task definition: unexpected conflict"))
+    Right (Just taskId) -> do
+      loaded <- withConnection pool (getTaskById taskId)
+      case loaded of
+        Left err -> pure (setupError "load task" err)
+        Right Nothing -> pure (Left (CircuitRunSetupError "load task: definition not found"))
+        Right (Just task) -> do
+          claimed <-
+            runTransaction
+              pool
+              ( claimAndCreateRun
+                  taskId
+                  (pulseLeaseOwner pulseConfig)
+                  TriggerManual
+                  now
+                  (leaseSecondsOf pulseConfig)
+              )
+          case claimed of
+            Left err -> pure (setupError "claim run" err)
+            Right Nothing -> pure (Left (CircuitRunTaskClaimConflict "claim run: task could not be claimed"))
+            Right (Just runId) -> do
+              shutdownFlag <- newTVarIO False
+              outcome <-
+                run
+                  TaskContext {tcPool = pool, tcConfig = pulseConfig, tcShutdownFlag = shutdownFlag}
+                  runId
+                  task
+              pure (fmap (runId,) outcome)
 
-{- | Load the task definition for an existing run, assemble a 'TaskContext', run the
-action, and pair its outcome with the run id. A missing run or a load failure becomes
-a 'CircuitRunSetupError'.
+{- | Load the task definition for an existing run, claim resumable ownership, assemble
+a 'TaskContext', run the action, and pair its outcome with the run id. A missing run
+or a load failure becomes a 'CircuitRunSetupError' before the claim is attempted.
 -}
 withManagedResume
-  :: PulseConfig
+  :: Pool
+  -> PulseConfig
   -> UUID
   -> (TaskContext -> PulseTaskDefinitionRow Result -> IO (Either CircuitRunError RunOutcome))
   -> IO (Either CircuitRunError (UUID, RunOutcome))
-withManagedResume pulseConfig runId run =
-  withManagedPool pulseConfig $ \pool -> do
-    loaded <- withConnection pool (getTaskForRun runId)
-    case loaded of
-      Left err -> pure (setupError "load run task" err)
-      Right Nothing -> pure (Left (CircuitRunSetupError "load run task: run not found"))
-      Right (Just task) -> do
-        shutdownFlag <- newTVarIO False
-        outcome <-
-          run
-            TaskContext {tcPool = pool, tcConfig = pulseConfig, tcShutdownFlag = shutdownFlag}
-            task
-        pure (fmap (runId,) outcome)
+withManagedResume pool pulseConfig runId run = do
+  loaded <- withConnection pool (getTaskForRun runId)
+  case loaded of
+    Left err -> pure (setupError "load run task" err)
+    Right Nothing -> pure (Left (CircuitRunSetupError "load run task: run not found"))
+    Right (Just task) -> do
+      now <- getCurrentTime
+      claimed <-
+        runTransaction
+          pool
+          (claimManagedRunForResume runId (pulseLeaseOwner pulseConfig) now (leaseSecondsOf pulseConfig))
+      case claimed of
+        Left err -> pure (setupError "claim resume run" err)
+        Right Nothing -> pure (Left (CircuitRunSetupError "claim resume run: run not found"))
+        Right (Just claim)
+          | claim.mrcClaimed -> do
+              shutdownFlag <- newTVarIO False
+              outcome <-
+                run
+                  TaskContext {tcPool = pool, tcConfig = pulseConfig, tcShutdownFlag = shutdownFlag}
+                  task
+              pure (fmap (runId,) outcome)
+          | otherwise ->
+              case runOutcomeForStoredStatus claim.mrcStatus of
+                Just outcome -> pure (Right (runId, outcome))
+                Nothing ->
+                  pure
+                    ( Left
+                        ( CircuitRunResumeRejected
+                            ("run is not resumable while status is " <> claim.mrcStatus)
+                        )
+                    )
 
 -- | Tag a setup-phase DB failure with the phase that produced it.
 setupError :: Text -> String -> Either CircuitRunError a
-setupError context err = Left (CircuitRunSetupError (context <> ": " <> T.pack err))
+setupError context err =
+  let errText = T.pack err
+      full = context <> ": " <> errText
+   in Left $
+        if looksLikeMissingPulseSchema errText
+          then CircuitRunSchemaMissing full
+          else CircuitRunSetupError full
+
+looksLikeMissingPulseSchema :: Text -> Bool
+looksLikeMissingPulseSchema err =
+  let normalized = T.replace "\\\"" "\"" err
+   in any
+        (`T.isInfixOf` normalized)
+        [ "3F000" -- invalid_schema_name
+        , "42P01" -- undefined_table
+        , "42704" -- undefined_object
+        , "schema \"pulse\""
+        , "relation \"pulse."
+        , "type \"pulse."
+        ]
+
+runOutcomeForStoredStatus :: Text -> Maybe RunOutcome
+runOutcomeForStoredStatus status =
+  case runStatusFromText status of
+    Just Completed -> Just OutcomeCompleted
+    Just Failed -> Just OutcomeFailed
+    Just Cancelled -> Just OutcomeCancelled
+    Just Timeout -> Just OutcomeTimedOut
+    Just Waiting -> Just OutcomeSuspended
+    Just Pending -> Nothing
+    Just Running -> Nothing
+    Just Skipped -> Nothing
+    Nothing -> Nothing
+
+runManagedExecution :: Pool -> UUID -> IO RunOutcome -> IO (Either CircuitRunError RunOutcome)
+runManagedExecution pool runId action = do
+  result <- try action :: IO (Either SomeException RunOutcome)
+  case result of
+    Right outcome -> pure (Right outcome)
+    Left err ->
+      case fromException err :: Maybe SomeAsyncException of
+        Just _ -> throwIO err
+        Nothing -> do
+          now <- getCurrentTime
+          let errText = T.take 200 (T.pack (displayException err))
+          failRun pool runId now "executor_exception" errText True
+          pure (Left (CircuitRunExecutionError errText))
 
 {- | A scheduler-inert task definition (enabled = false; next_run_at set so a direct
 claim succeeds while the scheduler's due query, which requires enabled, skips it).

--- a/src/Cortex/Pulse/Database.hs
+++ b/src/Cortex/Pulse/Database.hs
@@ -29,14 +29,16 @@ module Cortex.Pulse.Database
 where
 
 import Control.Exception (IOException, try)
+import Control.Monad (unless)
 import Data.ByteString qualified as BS
+import Data.Int (Int64)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Hasql.Decoders qualified as D
 import Hasql.Encoders qualified as E
-import Hasql.Session (Session)
-import Hasql.Session qualified as Session
 import Hasql.Statement (Statement (..))
+import Hasql.Transaction (Transaction)
+import Hasql.Transaction qualified as Tx
 import Paths_cortex (getDataFileName)
 
 import Platform.Database (ConnectionConfig (..), Pool)
@@ -74,11 +76,16 @@ runTransactionAt
 runTransactionAt =
   DB.runTransactionWithRetry pulseDbRetryBudget
 
-{- | Provision the Pulse schema into a database. Idempotent: if the @pulse@ schema
-already exists this is a no-op (so applying twice never errors); otherwise the shipped
-@pulse-schema.sql@ data-file is applied through the simple query protocol — a single
-implicit transaction, so a mid-script failure rolls back rather than leaving a partial
-schema. Schema presence is checked against @pg_catalog.pg_namespace@ rather than the
+{- | Provision the Pulse schema into a database. Idempotent for an already-current
+schema: if @pulse@ exists, the current required shape is validated before returning
+success; stale or partial schemas return 'Left' instead of failing later at runtime.
+If @pulse@ is absent, the shipped @pulse-schema.sql@ data-file is applied through the
+transaction simple-query protocol — a mid-script failure rolls back rather than
+leaving a partial schema — and then the same shape check runs. The absent-schema
+apply path takes a transaction-scoped advisory lock, so concurrent first
+provisioners serialize and later callers see the completed schema instead of racing
+the create-only dump; current-schema checks stay lock-free.
+Schema presence is checked against @pg_catalog.pg_namespace@ rather than the
 privilege-filtered @information_schema.schemata@ (a role without privileges on @pulse@
 must still see it as present), and a missing or unreadable data-file is returned as
 'Left' rather than thrown — the @IO (Either Text ())@ contract is total.
@@ -88,26 +95,169 @@ provision its own Postgres without reaching into Cortex test SQL.
 -}
 provisionPulseSchema :: Pool -> IO (Either Text ())
 provisionPulseSchema pool = do
-  existing <- withConnection pool pulseSchemaExistsSession
-  case existing of
+  checked <- runTransaction pool provisionPulseSchemaCheckTx
+  case checked of
     Left err -> pure (Left (T.pack err))
-    Right True -> pure (Right ())
-    Right False -> do
+    Right PulseSchemaCurrent -> pure (Right ())
+    Right (PulseSchemaStale missing) -> pure (staleSchemaError missing)
+    Right PulseSchemaAbsent -> do
       scriptOrErr <- try (getDataFileName "pulse-schema.sql" >>= BS.readFile)
       case scriptOrErr of
         Left ioErr ->
           pure (Left ("reading pulse-schema.sql: " <> T.pack (show (ioErr :: IOException))))
         Right script -> do
-          result <- withConnection pool (Session.sql script)
-          pure (either (Left . T.pack) Right result)
+          applied <- runTransaction pool (provisionPulseSchemaApplyTx script)
+          pure $ case applied of
+            Left err -> Left (T.pack err)
+            Right PulseSchemaCurrent -> Right ()
+            Right (PulseSchemaStale missing) -> staleSchemaError missing
+            Right PulseSchemaAbsent ->
+              Left "pulse schema provisioning did not create the pulse schema"
 
-pulseSchemaExistsSession :: Session Bool
-pulseSchemaExistsSession = Session.statement () pulseSchemaExistsStatement
-  where
-    pulseSchemaExistsStatement :: Statement () Bool
-    pulseSchemaExistsStatement =
+data PulseSchemaProvisionState
+  = PulseSchemaCurrent
+  | PulseSchemaAbsent
+  | PulseSchemaStale [Text]
+  deriving stock (Eq, Show)
+
+staleSchemaError :: [Text] -> Either Text a
+staleSchemaError names =
+  Left
+    ( "pulse schema exists but is stale or incomplete; missing: "
+        <> T.intercalate ", " names
+    )
+
+provisionPulseSchemaCheckTx :: Transaction PulseSchemaProvisionState
+provisionPulseSchemaCheckTx =
+  pulseSchemaProvisionStateTx
+
+provisionPulseSchemaApplyTx :: BS.ByteString -> Transaction PulseSchemaProvisionState
+provisionPulseSchemaApplyTx script = do
+  lockPulseSchemaProvisionTx
+  exists <- pulseSchemaExistsTx
+  unless exists (Tx.sql script)
+  pulseSchemaProvisionStateTx
+
+pulseSchemaProvisionStateTx :: Transaction PulseSchemaProvisionState
+pulseSchemaProvisionStateTx = do
+  exists <- pulseSchemaExistsTx
+  if exists
+    then do
+      missing <- pulseSchemaMissingRequiredObjectsTx
+      pure $
+        case missing of
+          [] -> PulseSchemaCurrent
+          names -> PulseSchemaStale names
+    else pure PulseSchemaAbsent
+
+lockPulseSchemaProvisionTx :: Transaction ()
+lockPulseSchemaProvisionTx = do
+  _ <-
+    Tx.statement pulseSchemaProvisionLockKey $
       Statement
-        "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = 'pulse')"
-        E.noParams
-        (D.singleRow (D.column (D.nonNullable D.bool)))
-        True
+        "WITH locked AS (SELECT pg_advisory_xact_lock($1)) SELECT 1::int4 FROM locked"
+        (E.param (E.nonNullable E.int8))
+        (D.singleRow (D.column (D.nonNullable D.int4)))
+        False
+  pure ()
+
+pulseSchemaProvisionLockKey :: Int64
+pulseSchemaProvisionLockKey = 5600060
+
+pulseSchemaExistsTx :: Transaction Bool
+pulseSchemaExistsTx = Tx.statement () pulseSchemaExistsStatement
+
+pulseSchemaExistsStatement :: Statement () Bool
+pulseSchemaExistsStatement =
+  Statement
+    "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = 'pulse')"
+    E.noParams
+    (D.singleRow (D.column (D.nonNullable D.bool)))
+    True
+
+pulseSchemaMissingRequiredObjectsTx :: Transaction [Text]
+pulseSchemaMissingRequiredObjectsTx =
+  Tx.statement () pulseSchemaMissingRequiredObjectsStatement
+
+pulseSchemaMissingRequiredObjectsStatement :: Statement () [Text]
+pulseSchemaMissingRequiredObjectsStatement =
+  Statement
+    pulseSchemaMissingRequiredObjectsSql
+    E.noParams
+    (D.rowList (D.column (D.nonNullable D.text)))
+    True
+
+pulseSchemaMissingRequiredObjectsSql :: BS.ByteString
+pulseSchemaMissingRequiredObjectsSql =
+  "SELECT required_name FROM ("
+    <> BS.intercalate
+      " UNION ALL "
+      ( (tableProbe <$> pulseSchemaRequiredTables)
+          <> (columnProbe <$> pulseSchemaRequiredColumns)
+          <> (enumProbe <$> pulseSchemaRequiredRunStatusLabels)
+      )
+    <> ") missing ORDER BY required_name"
+
+pulseSchemaRequiredTables :: [BS.ByteString]
+pulseSchemaRequiredTables =
+  [ "task_definitions"
+  , "runs"
+  , "graph_state"
+  , "graph_rewrites"
+  , "external_call_attempts"
+  , "run_events"
+  , "signals"
+  ]
+
+pulseSchemaRequiredColumns :: [(BS.ByteString, BS.ByteString)]
+pulseSchemaRequiredColumns =
+  [ ("task_definitions", "scheduler_claimed")
+  , ("graph_rewrites", "admission_mode")
+  , ("runs", "lease_owner")
+  ]
+
+pulseSchemaRequiredRunStatusLabels :: [BS.ByteString]
+pulseSchemaRequiredRunStatusLabels =
+  ["waiting"]
+
+tableProbe :: BS.ByteString -> BS.ByteString
+tableProbe tableName =
+  "SELECT 'table pulse."
+    <> tableName
+    <> "'::text AS required_name WHERE NOT EXISTS ( \
+       \SELECT 1 FROM pg_catalog.pg_class c \
+       \JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+       \WHERE n.nspname = 'pulse' AND c.relname = '"
+    <> tableName
+    <> "' AND c.relkind IN ('r', 'p') \
+       \)"
+
+columnProbe :: (BS.ByteString, BS.ByteString) -> BS.ByteString
+columnProbe (tableName, columnName) =
+  "SELECT 'column pulse."
+    <> tableName
+    <> "."
+    <> columnName
+    <> "'::text AS required_name WHERE NOT EXISTS ( \
+       \SELECT 1 FROM pg_catalog.pg_attribute a \
+       \JOIN pg_catalog.pg_class c ON c.oid = a.attrelid \
+       \JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+       \WHERE n.nspname = 'pulse' AND c.relname = '"
+    <> tableName
+    <> "' AND a.attname = '"
+    <> columnName
+    <> "' AND NOT a.attisdropped \
+       \)"
+
+enumProbe :: BS.ByteString -> BS.ByteString
+enumProbe enumLabel =
+  "SELECT 'enum pulse.run_status."
+    <> enumLabel
+    <> "'::text AS required_name WHERE NOT EXISTS ( \
+       \SELECT 1 FROM pg_catalog.pg_type t \
+       \JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace \
+       \JOIN pg_catalog.pg_enum e ON e.enumtypid = t.oid \
+       \WHERE n.nspname = 'pulse' AND t.typname = 'run_status' AND e.enumlabel = '"
+    <> enumLabel
+    <> "' \
+       \)"

--- a/src/Cortex/Pulse/Query.hs
+++ b/src/Cortex/Pulse/Query.hs
@@ -17,6 +17,8 @@ module Cortex.Pulse.Query
     -- * Run Management
   , claimAndCreateRun
   , claimNextPendingRun
+  , ManagedResumeClaim (..)
+  , claimManagedRunForResume
   , createPendingRun
   , getRunStatusForUpdate
   , TerminalRunStatus (..)
@@ -399,6 +401,12 @@ data PulsePendingRunClaim = PulsePendingRunClaim
   }
   deriving stock (Eq, Show)
 
+data ManagedResumeClaim = ManagedResumeClaim
+  { mrcStatus :: Text
+  , mrcClaimed :: Bool
+  }
+  deriving stock (Eq, Show)
+
 data PulseExpiredRunRecovery = PulseExpiredRunRecovery
   { perrRunId :: UUID
   , perrTaskId :: UUID
@@ -566,6 +574,58 @@ claimNextPendingRun leaseOwner now leaseDurationSec excludedTypes deprioritized 
       )
       False
 
+{- | Claim an existing managed run before resuming it.
+
+The managed facade is used by scheduler-less consumers, so resume must perform the
+same ownership transition that the scheduler claim path provides. A run is claimed
+only when it is pending, or when it is running with an expired lease. Terminal and
+waiting runs are reported to the caller without changing ownership; a live running
+run returns @mrcClaimed = False@ so the facade can reject split-brain execution.
+-}
+claimManagedRunForResume
+  :: UUID -> Text -> UTCTime -> Int32 -> Transaction (Maybe ManagedResumeClaim)
+claimManagedRunForResume runId leaseOwner now leaseDurationSec =
+  Tx.statement (runId, leaseOwner, now, leaseDurationSec) $
+    Statement
+      "WITH target AS ( \
+      \  SELECT run_id, status, lease_expires_at \
+      \  FROM pulse.runs \
+      \  WHERE run_id = $1 \
+      \  FOR UPDATE \
+      \), claimable AS ( \
+      \  SELECT run_id \
+      \  FROM target \
+      \  WHERE status = 'pending'::pulse.run_status \
+      \     OR ( \
+      \       status = 'running'::pulse.run_status \
+      \       AND lease_expires_at IS NOT NULL \
+      \       AND lease_expires_at < $3 \
+      \     ) \
+      \), claimed AS ( \
+      \  UPDATE pulse.runs r SET \
+      \    status = 'running'::pulse.run_status, \
+      \    started_at = COALESCE(r.started_at, $3), \
+      \    lease_owner = $2, \
+      \    lease_expires_at = $3 + make_interval(secs => $4::double precision) \
+      \  FROM claimable c \
+      \  WHERE r.run_id = c.run_id \
+      \  RETURNING r.run_id \
+      \) \
+      \SELECT target.status, EXISTS (SELECT 1 FROM claimed) \
+      \FROM target"
+      ( Enc.encode4
+          ((\(a, _, _, _) -> a), Enc.nonNullable Enc.uuid)
+          ((\(_, b, _, _) -> b), Enc.nonNullable Enc.text)
+          ((\(_, _, c, _) -> c), Enc.nonNullable Enc.timestamptz)
+          ((\(_, _, _, d) -> d), Enc.nonNullable Enc.int4)
+      )
+      ( D.rowMaybe $
+          ManagedResumeClaim
+            <$> D.column (D.nonNullable D.text)
+            <*> D.column (D.nonNullable D.bool)
+      )
+      False
+
 createPendingRun
   :: UUID -> TriggerSource -> Maybe UUID -> Maybe UUID -> UTCTime -> Transaction (Maybe UUID)
 createPendingRun taskId triggerSource parentRunId maybeUserId now =
@@ -724,35 +784,48 @@ updateRunStarted rId now =
 updateRunCompleted :: UUID -> UTCTime -> Transaction ()
 updateRunCompleted rId now = do
   lockRunTerminalProtocolTx
-  Tx.statement (rId, now) $
-    Statement
-      "UPDATE pulse.runs SET status = 'completed'::pulse.run_status, completed_at = $2 WHERE run_id = $1"
-      (Enc.encode2 (fst, Enc.nonNullable Enc.uuid) (snd, Enc.nonNullable Enc.timestamptz))
-      D.noResult
-      False
-  deliverTerminalFor rId RunCompleted now
+  changed <-
+    Tx.statement (rId, now) $
+      Statement
+        "WITH updated AS ( \
+        \  UPDATE pulse.runs \
+        \  SET status = 'completed'::pulse.run_status, completed_at = $2 \
+        \  WHERE run_id = $1 \
+        \    AND status NOT IN ('completed'::pulse.run_status, 'failed'::pulse.run_status, 'cancelled'::pulse.run_status, 'timeout'::pulse.run_status) \
+        \  RETURNING run_id \
+        \) SELECT EXISTS (SELECT 1 FROM updated)"
+        (Enc.encode2 (fst, Enc.nonNullable Enc.uuid) (snd, Enc.nonNullable Enc.timestamptz))
+        (D.singleRow (D.column (D.nonNullable D.bool)))
+        False
+  when changed (deliverTerminalFor rId RunCompleted now)
 
 -- | Mark a run as failed with error details and wake its run-terminal waiters.
 updateRunFailed :: RunFailureUpdate -> Transaction ()
 updateRunFailed input = do
   lockRunTerminalProtocolTx
-  Tx.statement input $
-    Statement
-      "UPDATE pulse.runs SET status = 'failed'::pulse.run_status, completed_at = $2, \
-      \error_type = $3, error_message = $4, error_retryable = $5 \
-      \WHERE run_id = $1 AND status != 'failed'::pulse.run_status"
-      ( Enc.encodeParams
-          ( Enc.col (.rfuRunId) (Enc.nonNullable Enc.uuid)
-              :| [ Enc.col (.rfuCompletedAt) (Enc.nonNullable Enc.timestamptz)
-                 , Enc.col (.rfuErrType) (Enc.nonNullable Enc.text)
-                 , Enc.col (.rfuErrMsg) (Enc.nonNullable Enc.text)
-                 , Enc.col (.rfuRetryable) (Enc.nonNullable Enc.bool)
-                 ]
-          )
-      )
-      D.noResult
-      False
-  deliverTerminalFor input.rfuRunId RunFailed input.rfuCompletedAt
+  changed <-
+    Tx.statement input $
+      Statement
+        "WITH updated AS ( \
+        \  UPDATE pulse.runs \
+        \  SET status = 'failed'::pulse.run_status, completed_at = $2, \
+        \      error_type = $3, error_message = $4, error_retryable = $5 \
+        \  WHERE run_id = $1 \
+        \    AND status NOT IN ('completed'::pulse.run_status, 'failed'::pulse.run_status, 'cancelled'::pulse.run_status, 'timeout'::pulse.run_status) \
+        \  RETURNING run_id \
+        \) SELECT EXISTS (SELECT 1 FROM updated)"
+        ( Enc.encodeParams
+            ( Enc.col (.rfuRunId) (Enc.nonNullable Enc.uuid)
+                :| [ Enc.col (.rfuCompletedAt) (Enc.nonNullable Enc.timestamptz)
+                   , Enc.col (.rfuErrType) (Enc.nonNullable Enc.text)
+                   , Enc.col (.rfuErrMsg) (Enc.nonNullable Enc.text)
+                   , Enc.col (.rfuRetryable) (Enc.nonNullable Enc.bool)
+                   ]
+            )
+        )
+        (D.singleRow (D.column (D.nonNullable D.bool)))
+        False
+  when changed (deliverTerminalFor input.rfuRunId RunFailed input.rfuCompletedAt)
 
 {- | Mark a run as cancelled. Preserves the operator-provided cancel_reason
 from requestCancellation; only sets it if not already present. Wakes the
@@ -761,18 +834,25 @@ run's run-terminal waiters.
 updateRunCancelled :: UUID -> UTCTime -> Text -> Transaction ()
 updateRunCancelled rId now reason = do
   lockRunTerminalProtocolTx
-  Tx.statement (rId, now, reason) $
-    Statement
-      "UPDATE pulse.runs SET status = 'cancelled'::pulse.run_status, completed_at = $2, \
-      \cancel_reason = COALESCE(cancel_reason, $3) WHERE run_id = $1"
-      ( Enc.encode3
-          ((\(a, _, _) -> a), Enc.nonNullable Enc.uuid)
-          ((\(_, b, _) -> b), Enc.nonNullable Enc.timestamptz)
-          ((\(_, _, c) -> c), Enc.nonNullable Enc.text)
-      )
-      D.noResult
-      False
-  deliverTerminalFor rId RunCancelled now
+  changed <-
+    Tx.statement (rId, now, reason) $
+      Statement
+        "WITH updated AS ( \
+        \  UPDATE pulse.runs \
+        \  SET status = 'cancelled'::pulse.run_status, completed_at = $2, \
+        \      cancel_reason = COALESCE(cancel_reason, $3) \
+        \  WHERE run_id = $1 \
+        \    AND status NOT IN ('completed'::pulse.run_status, 'failed'::pulse.run_status, 'cancelled'::pulse.run_status, 'timeout'::pulse.run_status) \
+        \  RETURNING run_id \
+        \) SELECT EXISTS (SELECT 1 FROM updated)"
+        ( Enc.encode3
+            ((\(a, _, _) -> a), Enc.nonNullable Enc.uuid)
+            ((\(_, b, _) -> b), Enc.nonNullable Enc.timestamptz)
+            ((\(_, _, c) -> c), Enc.nonNullable Enc.text)
+        )
+        (D.singleRow (D.column (D.nonNullable D.bool)))
+        False
+  when changed (deliverTerminalFor rId RunCancelled now)
 
 {- | Mark a run as timed out and wake its run-terminal waiters. A retry, if
 any, is a fresh run under a new run id (parent_run_id lineage), so timeout is
@@ -781,22 +861,28 @@ terminal for this run id.
 updateRunTimedOut :: RunTimeoutUpdate -> Transaction ()
 updateRunTimedOut input = do
   lockRunTerminalProtocolTx
-  Tx.statement input $
-    Statement
-      "UPDATE pulse.runs SET status = 'timeout'::pulse.run_status, completed_at = $2, \
-      \error_type = $3, error_message = $4, error_retryable = false \
-      \WHERE run_id = $1"
-      ( Enc.encodeParams
-          ( Enc.col (.rtuRunId) (Enc.nonNullable Enc.uuid)
-              :| [ Enc.col (.rtuCompletedAt) (Enc.nonNullable Enc.timestamptz)
-                 , Enc.col (.rtuErrType) (Enc.nonNullable Enc.text)
-                 , Enc.col (.rtuErrMsg) (Enc.nonNullable Enc.text)
-                 ]
-          )
-      )
-      D.noResult
-      False
-  deliverTerminalFor input.rtuRunId RunTimedOut input.rtuCompletedAt
+  changed <-
+    Tx.statement input $
+      Statement
+        "WITH updated AS ( \
+        \  UPDATE pulse.runs \
+        \  SET status = 'timeout'::pulse.run_status, completed_at = $2, \
+        \      error_type = $3, error_message = $4, error_retryable = false \
+        \  WHERE run_id = $1 \
+        \    AND status NOT IN ('completed'::pulse.run_status, 'failed'::pulse.run_status, 'cancelled'::pulse.run_status, 'timeout'::pulse.run_status) \
+        \  RETURNING run_id \
+        \) SELECT EXISTS (SELECT 1 FROM updated)"
+        ( Enc.encodeParams
+            ( Enc.col (.rtuRunId) (Enc.nonNullable Enc.uuid)
+                :| [ Enc.col (.rtuCompletedAt) (Enc.nonNullable Enc.timestamptz)
+                   , Enc.col (.rtuErrType) (Enc.nonNullable Enc.text)
+                   , Enc.col (.rtuErrMsg) (Enc.nonNullable Enc.text)
+                   ]
+            )
+        )
+        (D.singleRow (D.column (D.nonNullable D.bool)))
+        False
+  when changed (deliverTerminalFor input.rtuRunId RunTimedOut input.rtuCompletedAt)
 
 getRunStartedAt :: UUID -> Session (Maybe UTCTime)
 getRunStartedAt rId =
@@ -1163,24 +1249,28 @@ releaseSchedulerClaimByRunId rId now =
 -- Lease Management
 -- ============================================================================
 
-{- | Renew lease for a specific run (run-scoped, not owner-wide).
-Used by withLeaseRenewal during task execution.
+{- | Renew lease for a specific run and owner.
+Used by withLeaseRenewal during task execution. The owner predicate is part of the
+fencing contract: once another process claims the run, stale workers can no longer
+renew it.
 -}
-renewRunLease :: UUID -> UTCTime -> Int32 -> Session Bool
-renewRunLease rId now leaseDurationSec =
-  Session.statement (rId, now, leaseDurationSec) $
+renewRunLease :: UUID -> Text -> UTCTime -> Int32 -> Session Bool
+renewRunLease rId leaseOwner now leaseDurationSec =
+  Session.statement (rId, leaseOwner, now, leaseDurationSec) $
     Statement
       "WITH renewed AS ( \
       \  UPDATE pulse.runs SET \
-      \    lease_expires_at = $2 + make_interval(secs => $3::double precision) \
+      \    lease_expires_at = $3 + make_interval(secs => $4::double precision) \
       \  WHERE run_id = $1 \
       \    AND status = 'running'::pulse.run_status \
+      \    AND lease_owner = $2 \
       \  RETURNING run_id \
       \) SELECT EXISTS (SELECT 1 FROM renewed)"
-      ( Enc.encode3
-          ((\(a, _, _) -> a), Enc.nonNullable Enc.uuid)
-          ((\(_, b, _) -> b), Enc.nonNullable Enc.timestamptz)
-          ((\(_, _, c) -> c), Enc.nonNullable Enc.int4)
+      ( Enc.encode4
+          ((\(a, _, _, _) -> a), Enc.nonNullable Enc.uuid)
+          ((\(_, b, _, _) -> b), Enc.nonNullable Enc.text)
+          ((\(_, _, c, _) -> c), Enc.nonNullable Enc.timestamptz)
+          ((\(_, _, _, d) -> d), Enc.nonNullable Enc.int4)
       )
       (D.singleRow (D.column (D.nonNullable D.bool)))
       False

--- a/src/Cortex/Pulse/Scheduler.hs
+++ b/src/Cortex/Pulse/Scheduler.hs
@@ -479,7 +479,13 @@ runSchedulerLoop registry taskContext healthState = do
         , ("task_id", Aeson.toJSON task.taskId)
         , ("trigger_source", Aeson.toJSON (renderTriggerSource triggerSource))
         ]
-      let runAction = withLeaseRenewal pool runId leaseDuration (Executor.executeTask registry taskContext runId task)
+      let runAction =
+            withLeaseRenewal
+              pool
+              runId
+              leaseOwner
+              leaseDuration
+              (Executor.executeTask registry taskContext runId task)
       pure (Just (runId, task, triggerSource, runAction))
 
     markRunFailedForUnexpectedExit :: UUID -> SomeException -> IO RunOutcome
@@ -664,8 +670,8 @@ recoverExpiredRuns pool currentLeaseOwner now = do
 Renews the specific run's lease every half the lease duration and cancels
 the in-flight action if renewal becomes ambiguous.
 -}
-withLeaseRenewal :: DB.Pool -> UUID -> Int32 -> IO RunOutcome -> IO RunOutcome
-withLeaseRenewal pool runId leaseDuration action = do
+withLeaseRenewal :: DB.Pool -> UUID -> Text -> Int32 -> IO RunOutcome -> IO RunOutcome
+withLeaseRenewal pool runId leaseOwner leaseDuration action = do
   let renewalInterval = max 1 (fromIntegral leaseDuration `div` 2) * 1_000_000 -- microseconds
       leaseMicros = fromIntegral leaseDuration * 1_000_000 :: Int
       -- Cap jitter so renewal + max jitter stays below the full lease duration.
@@ -689,15 +695,13 @@ withLeaseRenewal pool runId leaseDuration action = do
         Left (Left err) -> throwIO err
         Right () -> do
           now <- getCurrentTime
-          result <- PulseDB.withConnection pool $ Q.renewRunLease runId now leaseDuration
+          result <- PulseDB.withConnection pool $ Q.renewRunLease runId leaseOwner now leaseDuration
           case result of
             Left err ->
-              failRunForLeaseLoss
+              stopAfterLeaseRenewalStopped
                 actionAsync
-                now
                 "lease_renewal_failed"
                 ("Run lease renewal failed, cancelling in-flight execution: " <> T.pack err)
-                True
             Right True ->
               renewLoop interval jitter actionAsync
             Right False -> do
@@ -715,15 +719,13 @@ withLeaseRenewal pool runId leaseDuration action = do
                 Just (Left err) ->
                   throwIO err
                 Nothing ->
-                  failRunForLeaseLoss
+                  stopAfterLeaseRenewalStopped
                     actionAsync
-                    now
                     "lease_lost"
                     "Run lease no longer belongs to this executor, cancelling in-flight execution"
-                    True
 
-    failRunForLeaseLoss :: Async RunOutcome -> UTCTime -> Text -> Text -> Bool -> IO RunOutcome
-    failRunForLeaseLoss actionAsync now errType errMsg retryable = do
+    stopAfterLeaseRenewalStopped :: Async RunOutcome -> Text -> Text -> IO RunOutcome
+    stopAfterLeaseRenewalStopped actionAsync errType errMsg = do
       cancel actionAsync
       waitCatch actionAsync >>= \case
         Right outcome -> do
@@ -737,24 +739,6 @@ withLeaseRenewal pool runId leaseDuration action = do
             ]
           pure outcome
         Left _ -> do
-          Err.logDbFailure_
-            ( \dbErr ->
-                emitSchedulerEvent
-                  ObsError
-                  "pulse.lease.fail.write"
-                  ("Failed to mark run as failed after lease loss: " <> T.pack dbErr)
-                  [("run_id", Aeson.toJSON runId), ("error_type", Aeson.toJSON errType)]
-            )
-            ( PulseDB.runTransaction pool $
-                Q.updateRunFailed
-                  Q.RunFailureUpdate
-                    { rfuRunId = runId
-                    , rfuCompletedAt = now
-                    , rfuErrType = errType
-                    , rfuErrMsg = errMsg
-                    , rfuRetryable = retryable
-                    }
-            )
           emitSchedulerEvent
             ObsError
             "pulse.lease.lost"

--- a/test/Cortex/Pulse/ExecutorSpec.hs
+++ b/test/Cortex/Pulse/ExecutorSpec.hs
@@ -14,7 +14,7 @@ Tests may import the surface they exercise, but they do not define downstream pr
 module Cortex.Pulse.ExecutorSpec (spec) where
 
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (cancel, waitCatch, withAsync)
+import Control.Concurrent.Async (cancel, wait, waitCatch, withAsync)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, readMVar, tryPutMVar)
 import Control.Concurrent.STM (TVar, atomically, newTVarIO, writeTVar)
 import Control.Exception
@@ -35,7 +35,7 @@ import Data.Maybe (isJust)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Time (addUTCTime, diffUTCTime, getCurrentTime)
+import Data.Time (UTCTime, addUTCTime, diffUTCTime, getCurrentTime)
 import Data.UUID (UUID)
 import Data.UUID qualified as UUID
 import GHC.Generics (Generic)
@@ -299,6 +299,15 @@ readRunStatus :: Pool -> UUID -> IO (Maybe Text)
 readRunStatus pool runId =
   runSession pool $ Q.readRunStatus runId
 
+setRunLeaseExpiry :: Pool -> UUID -> UTCTime -> IO ()
+setRunLeaseExpiry pool runId leaseExpiry =
+  runSession pool . Session.statement (runId, leaseExpiry) $
+    Statement
+      "UPDATE pulse.runs SET lease_expires_at = $2 WHERE run_id = $1"
+      (Enc.encode2 (fst, Enc.nonNullable Enc.uuid) (snd, Enc.nonNullable Enc.timestamptz))
+      D.noResult
+      False
+
 {- | Read persisted graph state and decode node statuses.
 Fails the test with a descriptive message if the JSON cannot be decoded.
 -}
@@ -355,6 +364,24 @@ readStageAttemptLogs pool runId =
 readRunEvents :: Pool -> UUID -> IO [PulseRunEvent]
 readRunEvents pool runId =
   runSession pool $ Q.listRunEvents runId
+
+readManagedRunRows :: Pool -> Text -> IO [(UUID, Text, Maybe Text)]
+readManagedRunRows pool workflowKey =
+  runSession pool . Session.statement workflowKey $
+    Statement
+      "SELECT r.run_id, r.status, r.error_type \
+      \FROM pulse.runs r \
+      \INNER JOIN pulse.task_definitions td ON td.task_id = r.task_id \
+      \WHERE td.task_type = $1 \
+      \ORDER BY r.created_at ASC"
+      (Enc.encode1 (id, Enc.nonNullable Enc.text))
+      ( D.rowList $
+          (,,)
+            <$> D.column (D.nonNullable D.uuid)
+            <*> D.column (D.nonNullable D.text)
+            <*> D.column (D.nullable D.text)
+      )
+      True
 
 mkTaskContext :: Pool -> IO (TVar Bool, TaskContext)
 mkTaskContext pool = do
@@ -1220,7 +1247,7 @@ spec = beforeAll setupTestDb $ do
                   let nodeId = nodeIdFromCircuitRef taskNode.circuitTaskNodeRef
                    in Right $ case unNodeId nodeId of
                         "produce" ->
-                          taskStage nodeId SafeToReplay $ \_ -> do
+                          taskStage nodeId Irreversible $ \_ -> do
                             atomicModifyIORef' produceCount (\c -> (c + 1, ()))
                             pure
                               ( StageComplete
@@ -1232,15 +1259,15 @@ spec = beforeAll setupTestDb $ do
                                   )
                               )
                         "handle_err" ->
-                          taskStage nodeId SafeToReplay $ \_ -> do
+                          taskStage nodeId Irreversible $ \_ -> do
                             atomicModifyIORef' recoverCount (\c -> (c + 1, ()))
                             pure (StageComplete (Aeson.String "recovered"))
                         "handle_ok" ->
-                          taskStage nodeId SafeToReplay $ \_ -> do
+                          taskStage nodeId Irreversible $ \_ -> do
                             atomicModifyIORef' okCount (\c -> (c + 1, ()))
                             pure (StageComplete (Aeson.String "ok"))
                         other ->
-                          taskStage nodeId SafeToReplay $ \_ -> pure (StageComplete (Aeson.String ("passthrough:" <> other)))
+                          taskStage nodeId Irreversible $ \_ -> pure (StageComplete (Aeson.String ("passthrough:" <> other)))
           -- #330 managed facade end-to-end on the #331 testkit-provisioned ephemeral DB.
           result <-
             runCompiledCircuitManaged
@@ -1257,9 +1284,8 @@ spec = beforeAll setupTestDb $ do
               readIORef produceCount `shouldReturn` 1
               readIORef recoverCount `shouldReturn` 1
               readIORef okCount `shouldReturn` 0
-              -- #330 #2 managed resume: addressed by the returned run id, resuming the
-              -- now-settled run returns the same run id, completes, and re-invokes no
-              -- producer effect (ADR 0062).
+              -- Terminal managed resume returns the stored outcome without re-driving
+              -- completed graph work or invoking the producer again.
               resumed <-
                 resumeCompiledCircuitManaged
                   (tcConfig ctx)
@@ -1272,6 +1298,212 @@ spec = beforeAll setupTestDb $ do
                 Right (resumedRunId, resumedOutcome) -> do
                   resumedRunId `shouldBe` runId
                   resumedOutcome `shouldBe` OutcomeCompleted
+              readIORef produceCount `shouldReturn` 1
+
+    it "does not swallow async managed execution cancellation" $ \_ -> do
+      mHost <- lookupEnv "PGHOST"
+      case mHost of
+        Nothing -> pendingWith "PGHOST not set; ephemeral-DB consumer test skipped"
+        Just _ -> withEphemeralPulseDb $ \ctx -> do
+          compiled <-
+            case compileWireText selectVariantSource of
+              Right circuit -> pure circuit
+              Left err -> expectationFailure ("compile failed: " <> show err) >> fail "unreachable"
+          let workflowKey = "consumer-exception-test"
+              binder =
+                committedVariantBinder $ \taskNode ->
+                  let nodeId = nodeIdFromCircuitRef taskNode.circuitTaskNodeRef
+                   in Right . taskStage nodeId Irreversible $ \_ ->
+                        throwIO ThreadKilled
+          result <-
+            try
+              ( runCompiledCircuitManaged
+                  (tcConfig ctx)
+                  workflowKey
+                  selectVariantPulseConfig
+                  binder
+                  compiled
+              )
+              :: IO (Either SomeException (Either CircuitRunError (UUID, RunOutcome)))
+          case result of
+            Left err ->
+              T.pack (displayException err) `shouldSatisfy` T.isInfixOf "thread killed"
+            Right other -> expectationFailure ("expected async cancellation to escape, got: " <> show other)
+          rows <- readManagedRunRows (tcPool ctx) workflowKey
+          case rows of
+            [(_, status, errType)] -> do
+              status `shouldBe` "running"
+              errType `shouldBe` Nothing
+            other -> expectationFailure ("expected one unfailed managed run row, got: " <> show other)
+
+    it "resumes an expired managed run without re-running completed producer work" $ \_ -> do
+      mHost <- lookupEnv "PGHOST"
+      case mHost of
+        Nothing -> pendingWith "PGHOST not set; ephemeral-DB consumer test skipped"
+        Just _ -> withEphemeralPulseDb $ \ctx -> do
+          compiled <-
+            case compileWireText selectVariantSource of
+              Right circuit -> pure circuit
+              Left err -> expectationFailure ("compile failed: " <> show err) >> fail "unreachable"
+          handlerStarted <- newEmptyMVar
+          releaseOriginalHandler <- newEmptyMVar
+          produceCount <- newIORef (0 :: Int)
+          handlerAttempts <- newIORef (0 :: Int)
+          let workflowKey = "consumer-expired-resume"
+              binder =
+                committedVariantBinder $ \taskNode ->
+                  let nodeId = nodeIdFromCircuitRef taskNode.circuitTaskNodeRef
+                   in Right $ case unNodeId nodeId of
+                        "produce" ->
+                          taskStage nodeId Irreversible $ \_ -> do
+                            atomicModifyIORef' produceCount (\c -> (c + 1, ()))
+                            pure
+                              ( StageComplete
+                                  ( Aeson.toJSON
+                                      ( (mkWireValue "P" WirePayloadJson Nothing (Aeson.object ["issue" Aeson..= ("rejected" :: Text)]))
+                                          { wireValuePort = Just "err"
+                                          }
+                                      )
+                                  )
+                              )
+                        "handle_err" ->
+                          taskStage nodeId Irreversible $ \_ -> do
+                            attempt <- atomicModifyIORef' handlerAttempts (\c -> let next = c + 1 in (next, next))
+                            when (attempt == 1) $ do
+                              void (tryPutMVar handlerStarted ())
+                              readMVar releaseOriginalHandler
+                            pure (StageComplete (Aeson.String "recovered"))
+                        "handle_ok" ->
+                          taskStage nodeId Irreversible $ \_ ->
+                            pure (StageComplete (Aeson.String "ok"))
+                        other ->
+                          taskStage nodeId Irreversible $ \_ ->
+                            pure (StageComplete (Aeson.String ("passthrough:" <> other)))
+          withAsync
+            ( runCompiledCircuitManaged
+                (tcConfig ctx)
+                workflowKey
+                selectVariantPulseConfig
+                binder
+                compiled
+            )
+            $ \worker -> do
+              timeout 5000000 (readMVar handlerStarted) `shouldReturn` Just ()
+              rows <- readManagedRunRows (tcPool ctx) workflowKey
+              runId <- case rows of
+                [(rid, "running", Nothing)] -> pure rid
+                other ->
+                  expectationFailure ("expected one blocked managed run row, got: " <> show other)
+                    >> fail "unreachable"
+              cancel worker
+              waitCatch worker >>= \case
+                Left _ -> pure ()
+                Right other -> expectationFailure ("expected cancelled managed worker, got: " <> show other)
+              liveResume <-
+                resumeCompiledCircuitManaged
+                  (tcConfig ctx)
+                  runId
+                  selectVariantPulseConfig
+                  binder
+                  compiled
+              case liveResume of
+                Left (CircuitRunResumeRejected msg) ->
+                  msg `shouldSatisfy` T.isInfixOf "running"
+                Left err -> expectationFailure ("expected live resume rejection, got: " <> show err)
+                Right other -> expectationFailure ("expected live resume rejection, got: " <> show other)
+              readIORef produceCount `shouldReturn` 1
+              readIORef handlerAttempts `shouldReturn` 1
+              expiredAt <- addUTCTime (-1) <$> getCurrentTime
+              setRunLeaseExpiry (tcPool ctx) runId expiredAt
+              resumed <-
+                resumeCompiledCircuitManaged
+                  (tcConfig ctx)
+                  runId
+                  selectVariantPulseConfig
+                  binder
+                  compiled
+              case resumed of
+                Left err -> expectationFailure ("managed crash resume failed: " <> show err)
+                Right (resumedRunId, resumedOutcome) -> do
+                  resumedRunId `shouldBe` runId
+                  resumedOutcome `shouldBe` OutcomeCompleted
+              readIORef produceCount `shouldReturn` 1
+              readIORef handlerAttempts `shouldReturn` 2
+              readRunStatus (tcPool ctx) runId `shouldReturn` Just "completed"
+
+    it "rejects managed resume while another owner still has a live lease" $ \_ -> do
+      mHost <- lookupEnv "PGHOST"
+      case mHost of
+        Nothing -> pendingWith "PGHOST not set; ephemeral-DB consumer test skipped"
+        Just _ -> withEphemeralPulseDb $ \ctx -> do
+          compiled <-
+            case compileWireText selectVariantSource of
+              Right circuit -> pure circuit
+              Left err -> expectationFailure ("compile failed: " <> show err) >> fail "unreachable"
+          started <- newEmptyMVar
+          release <- newEmptyMVar
+          produceCount <- newIORef (0 :: Int)
+          let workflowKey = "consumer-live-resume-rejected"
+              binder =
+                committedVariantBinder $ \taskNode ->
+                  let nodeId = nodeIdFromCircuitRef taskNode.circuitTaskNodeRef
+                   in Right $ case unNodeId nodeId of
+                        "produce" ->
+                          taskStage nodeId Irreversible $ \_ -> do
+                            atomicModifyIORef' produceCount (\c -> (c + 1, ()))
+                            putMVar started ()
+                            readMVar release
+                            pure
+                              ( StageComplete
+                                  ( Aeson.toJSON
+                                      ( (mkWireValue "P" WirePayloadJson Nothing (Aeson.object ["issue" Aeson..= ("rejected" :: Text)]))
+                                          { wireValuePort = Just "err"
+                                          }
+                                      )
+                                  )
+                              )
+                        "handle_err" ->
+                          taskStage nodeId Irreversible $ \_ ->
+                            pure (StageComplete (Aeson.String "recovered"))
+                        "handle_ok" ->
+                          taskStage nodeId Irreversible $ \_ ->
+                            pure (StageComplete (Aeson.String "ok"))
+                        other ->
+                          taskStage nodeId Irreversible $ \_ ->
+                            pure (StageComplete (Aeson.String ("passthrough:" <> other)))
+          withAsync
+            ( runCompiledCircuitManaged
+                (tcConfig ctx)
+                workflowKey
+                selectVariantPulseConfig
+                binder
+                compiled
+            )
+            $ \worker -> do
+              readMVar started
+              rows <- readManagedRunRows (tcPool ctx) workflowKey
+              runId <- case rows of
+                [(rid, "running", Nothing)] -> pure rid
+                other ->
+                  expectationFailure ("expected one live managed run row, got: " <> show other) >> fail "unreachable"
+              resumed <-
+                resumeCompiledCircuitManaged
+                  (tcConfig ctx)
+                  runId
+                  selectVariantPulseConfig
+                  binder
+                  compiled
+              case resumed of
+                Left (CircuitRunResumeRejected msg) ->
+                  msg `shouldSatisfy` T.isInfixOf "running"
+                Left err -> expectationFailure ("expected CircuitRunResumeRejected, got: " <> show err)
+                Right _ -> expectationFailure "expected live managed resume to be rejected"
+              putMVar release ()
+              wait worker >>= \case
+                Right (completedRunId, outcome) -> do
+                  completedRunId `shouldBe` runId
+                  outcome `shouldBe` OutcomeCompleted
+                Left err -> expectationFailure ("managed run failed after release: " <> show err)
               readIORef produceCount `shouldReturn` 1
 
   describe "boundary binders for circuits with non-task nodes (#323, #36)" $ do
@@ -4868,6 +5100,25 @@ spec = beforeAll setupTestDb $ do
       -- The first error_type should be preserved
       runView <- runSession pool $ Q.getRunAdminView runId
       fmap Q.pravErrorType runView `shouldBe` Just (Just "graph_state_persist_failed")
+
+    it "late failRun does not overwrite a completed run" $ \mPool -> withDb mPool $ \pool -> do
+      taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-failrun-after-completed"
+      runId <- createTestRun pool taskId
+      now <- getCurrentTime
+      _ <- DB.runTransaction pool $ Q.updateRunCompleted runId now
+      _ <-
+        DB.runTransaction pool $
+          Q.updateRunFailed
+            Q.RunFailureUpdate
+              { rfuRunId = runId
+              , rfuCompletedAt = now
+              , rfuErrType = "executor_exception"
+              , rfuErrMsg = "late failure"
+              , rfuRetryable = True
+              }
+      runView <- runSession pool $ Q.getRunAdminView runId
+      fmap Q.pravStatus runView `shouldBe` Just "completed"
+      fmap Q.pravErrorType runView `shouldBe` Just Nothing
 
   describe "signal node_id scoping" $ do
     it "reused signal name does not consume stale delivery from different node" $ \mPool -> withDb mPool $ \pool -> do

--- a/test/Cortex/Pulse/SchedulerSpec.hs
+++ b/test/Cortex/Pulse/SchedulerSpec.hs
@@ -16,7 +16,7 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (wait, withAsync)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, readMVar)
 import Control.Concurrent.STM (atomically, newTVarIO, writeTVar)
-import Control.Exception (SomeException, displayException, try)
+import Control.Exception (SomeException, bracket, displayException, try)
 import Control.Monad (join)
 import Data.Aeson qualified as Aeson
 import Data.IORef (atomicModifyIORef', newIORef, readIORef)
@@ -25,6 +25,7 @@ import Data.List (sort)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (isJust)
 import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Time
   ( UTCTime (..)
   , addUTCTime
@@ -34,15 +35,18 @@ import Data.Time
   , secondsToDiffTime
   )
 import Data.UUID (UUID)
+import Data.Word (Word16)
 import GHC.Generics (Generic)
 import Hasql.Decoders qualified as D
 import Hasql.Encoders qualified as E
 import Hasql.Pool (Pool)
+import Hasql.Pool qualified as HP
 import Hasql.Session qualified as Session
 import Hasql.Statement (Statement (..))
 import Rel8 (Result)
-import System.Environment (lookupEnv)
+import System.Environment (getEnv, lookupEnv)
 import Test.Hspec
+import Text.Read (readMaybe)
 
 import Cortex.Pulse.Executor
   ( ReplayPolicy (..)
@@ -73,6 +77,8 @@ import Cortex.Pulse.Schema (PulseTaskDefinitionRow (..))
 import Cortex.Pulse.Types (PulseConfig (..), defaultRewriteBudget)
 import Cortex.TestSupport.Database (createTestDB, insertTestUser, runSession, runTx)
 
+import Platform.Database (ConnectionConfig (..))
+import Platform.Database qualified as PlatformDB
 import Platform.Database.Encode qualified as Enc
 import Platform.DurableTask.Types (RunOutcome (..), RunStatus (..), TriggerSource (..))
 
@@ -212,7 +218,7 @@ dbSpec = beforeAll setupTestDb $ do
       initialLeaseExpiry <- readRunLeaseExpiry pool runId
       initialLeaseExpiry `shouldSatisfy` isJust
       withAsync
-        ( withLeaseRenewal pool runId 2 $ do
+        ( withLeaseRenewal pool runId "test-owner" 2 $ do
             threadDelay 2500000
             completedAt <- getCurrentTime
             runTx pool $ Q.updateRunCompleted runId completedAt
@@ -232,22 +238,55 @@ dbSpec = beforeAll setupTestDb $ do
       taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-lease-loss"
       runId <- createTestRunWithLease pool taskId 2
       startTime <- getCurrentTime
-      withAsync (withLeaseRenewal pool runId 2 (threadDelay 5000000 >> pure OutcomeCompleted)) $ \worker -> do
-        threadDelay 1100000
-        now <- getCurrentTime
-        runTx pool $ Q.updateRunCancelled runId now "simulate lost lease owner"
-        outcome <- wait worker
-        outcome `shouldBe` OutcomeFailed
+      withAsync
+        (withLeaseRenewal pool runId "test-owner" 2 (threadDelay 5000000 >> pure OutcomeCompleted))
+        $ \worker -> do
+          threadDelay 1100000
+          now <- getCurrentTime
+          runTx pool $ Q.updateRunCancelled runId now "simulate lost lease owner"
+          outcome <- wait worker
+          outcome `shouldBe` OutcomeFailed
       endTime <- getCurrentTime
       diffUTCTime endTime startTime `shouldSatisfy` (< 3)
       runView <- runSession pool $ Q.getRunAdminView runId
-      fmap Q.pravStatus runView `shouldBe` Just "failed"
-      fmap Q.pravErrorType runView `shouldBe` Just (Just "lease_lost")
+      fmap Q.pravStatus runView `shouldBe` Just "cancelled"
+      fmap Q.pravErrorType runView `shouldBe` Just Nothing
+
+    it "fails closed when the renewing owner does not match the run lease owner" $ \mPool -> withDb mPool $ \pool -> do
+      taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-lease-owner-mismatch"
+      runId <- createTestRunWithLease pool taskId 2
+      withAsync
+        (withLeaseRenewal pool runId "other-owner" 2 (threadDelay 5000000 >> pure OutcomeCompleted))
+        $ \worker -> do
+          outcome <- wait worker
+          outcome `shouldBe` OutcomeFailed
+      runView <- runSession pool $ Q.getRunAdminView runId
+      fmap Q.pravStatus runView `shouldBe` Just "running"
+      fmap Q.pravErrorType runView `shouldBe` Just Nothing
+
+    it "does not mark the run failed when lease renewal errors before ownership is known" $ \mPool -> withDb mPool $ \_ ->
+      withSingleConnectionTestPool $ \pool -> do
+        taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-lease-renew-error"
+        runId <- createTestRunWithLease pool taskId 2
+        withAsync (holdOnlyConnection pool) $ \holder -> do
+          threadDelay 100000
+          outcome <-
+            withLeaseRenewal
+              pool
+              runId
+              "test-owner"
+              2
+              (threadDelay 15000000 >> pure OutcomeCompleted)
+          outcome `shouldBe` OutcomeFailed
+          wait holder
+        runView <- runSession pool $ Q.getRunAdminView runId
+        fmap Q.pravStatus runView `shouldBe` Just "running"
+        fmap Q.pravErrorType runView `shouldBe` Just Nothing
 
     it "accepts a completed outcome when run finishes just before lease renewal" $ \mPool -> withDb mPool $ \pool -> do
       taskId <- insertTestTaskDef pool "paper_portfolio_cycle" "test-lease-race-completed"
       runId <- createTestRunWithLease pool taskId 2
-      outcome <- withLeaseRenewal pool runId 2 $ do
+      outcome <- withLeaseRenewal pool runId "test-owner" 2 $ do
         completedAt <- getCurrentTime
         runTx pool $ Q.updateRunCompleted runId completedAt
         pure OutcomeCompleted
@@ -682,7 +721,8 @@ dbSpec = beforeAll setupTestDb $ do
         expectCreatedRun "create scheduled run"
           =<< runTx pool (Q.claimAndCreateRun taskId leaseOwner TriggerSchedule claimTime 300)
       task <- loadTaskDef pool taskId
-      firstOutcome <- withLeaseRenewal pool runId 300 (executeStagePlan taskContext runId task stagePlan)
+      firstOutcome <-
+        withLeaseRenewal pool runId leaseOwner 300 (executeStagePlan taskContext runId task stagePlan)
       firstOutcome `shouldBe` OutcomeShutdown
       runSession pool (Q.readRunStatus runId) `shouldReturn` Just "running"
       betaAfterShutdown <- readIORef betaRuns
@@ -690,7 +730,8 @@ dbSpec = beforeAll setupTestDb $ do
       reclaimedRunIds <- runSession pool $ Q.reclaimOwnedRuns leaseOwner reclaimTime 300
       reclaimedRunIds `shouldBe` [runId]
       atomically $ writeTVar shutdownFlag False
-      secondOutcome <- withLeaseRenewal pool runId 300 (resumeStagePlan taskContext runId task stagePlan)
+      secondOutcome <-
+        withLeaseRenewal pool runId leaseOwner 300 (resumeStagePlan taskContext runId task stagePlan)
       secondOutcome `shouldBe` OutcomeCompleted
       finalizeTaskSchedule pool (Just runId) task (Just TriggerSchedule) finishedAt secondOutcome
       runSession pool (Q.readRunStatus runId) `shouldReturn` Just "completed"
@@ -761,6 +802,41 @@ setRunLeaseExpiry pool runId leaseExpiry =
       (Enc.encode2 (fst, Enc.nonNullable Enc.uuid) (snd, Enc.nonNullable Enc.timestamptz))
       D.noResult
       False
+
+withSingleConnectionTestPool :: (Pool -> IO a) -> IO a
+withSingleConnectionTestPool =
+  bracket open PlatformDB.releasePool
+  where
+    open = do
+      dbHost <- T.pack <$> getEnv "PGHOST"
+      portStr <- getEnv "PGPORT"
+      dbPort <- case readMaybe portStr of
+        Just p -> pure p
+        Nothing -> fail $ "Invalid PGPORT value: " <> portStr
+      dbUser <- T.pack <$> getEnv "PGUSER"
+      dbDatabase <- T.pack <$> getEnv "PGDATABASE"
+      dbPassword <- maybe "" T.pack <$> lookupEnv "PGPASSWORD"
+      result <-
+        PlatformDB.initConnectionPool
+          ConnectionConfig
+            { dbHost = dbHost
+            , dbPort = dbPort :: Word16
+            , dbUser = dbUser
+            , dbPassword = dbPassword
+            , dbDatabase = dbDatabase
+            , dbPoolSize = 1
+            , dbPoolTimeout = 1
+            }
+      case result of
+        Left err -> fail $ "Failed to create single-connection test pool: " <> err
+        Right pool -> pure pool
+
+holdOnlyConnection :: Pool -> IO ()
+holdOnlyConnection pool = do
+  result <- HP.use pool (Session.sql "SELECT pg_sleep(8)")
+  case result of
+    Left err -> expectationFailure ("Failed to hold the only pool connection: " <> show err)
+    Right () -> pure ()
 
 holdRunTerminalProtocolLock :: Pool -> IO ()
 holdRunTerminalProtocolLock pool =


### PR DESCRIPTION
## Summary

Harden the durable Postgres-backed managed Pulse consumer surface after the #329/#330/#331/#323 merge.

This PR batches the correctness and operability follow-ups from #340 so the managed facade has a coherent contract for scheduler-less downstream consumers such as Logos.

## Implemented

- [x] Persist managed execution exceptions as failed runs and return `Left`, not thrown IO exceptions.
- [x] Add atomic managed-resume ownership acquisition and owner-checked lease renewal.
- [x] Add stale/current-shape validation to `provisionPulseSchema`.
- [x] Serialize concurrent first provisioning with a transaction-scoped advisory lock.
- [x] Add structured managed setup/execution errors for pool, schema, claim, resume, and execution failures.
- [x] Add pool-reuse entrypoints for managed run/resume.
- [x] Document managed durable-row retention boundaries; full GC/reuse policy remains tracked in #334.
- [x] Update consumer-facing effectful test examples to default to `Irreversible` replay safety.
- [x] Add focused tests for exception persistence, live-resume rejection, and owner-fenced renewal failure.

## Related Issues

Closes #340
Refs #334
Refs #335
Refs #338
Refs #144

## Validation

- [x] `just fmt`
- [x] `just check`