### PR TITLE
docs: synchronize documentation canon

### DIFF
--- a/docs/ADRs/0063-adr-traceability-and-feature-status-canon.md
+++ b/docs/ADRs/0063-adr-traceability-and-feature-status-canon.md
@@ -106,7 +106,7 @@ feature-status matrix cite durable artifacts only.
 
 Never collapse these into one field:
 
-- **ADR status** — `proposed` | `accepted` | `superseded` | `deprecated` (the decision).
+- **ADR status** — `proposed` | `accepted` | `superseded` (the decision; see Amendments).
 - **Implementation status** — `planned` | `partial` | `implemented` | `verified` | `retired` (the
   code).
 - **Proof status** — owned by `proof-status.md`. The matrix's `Theory` cell links to the
@@ -197,8 +197,8 @@ CI.
   not silently skipped.
 - **Feature-key grammar and uniqueness** — keys are lowercase-dotted with a known subsystem prefix
   (Decision rule 2), and no key has more than one row.
-- **Status enums** — `ADR status` is one of `proposed`/`accepted`/`superseded`/`deprecated` and
-  `Impl status` is one of `planned`/`partial`/`implemented`/`verified`/`retired` (Decision rule 4).
+- **Status enums** — `ADR status` is one of `proposed`/`accepted`/`superseded` and `Impl status` is
+  one of `planned`/`partial`/`implemented`/`verified`/`retired` (Decision rule 4).
 - **Governing-ADR resolution** — every ADR number in the `Governing ADR` cell, including the
   `NNNN (amend)` and `NNNN / NNNN (amend)` forms, resolves to an ADR file.
 - **Evidence-cell shape** — the `Tests`, `Theory`, and `Reference` cells are either the empty marker
@@ -229,3 +229,15 @@ form — a row with no declaration, or a declaration with no row.
 Accepted ADRs and the feature-status matrix do not carry tracker state. Proposed ADRs may keep
 temporary planning links in a final `## Tracking` section under ADR 0001, but that section is
 deleted before acceptance.
+
+## Amendments
+
+- **ADR status enum narrowed to three values.** The original Decision rule 4 listed `deprecated` as
+  a fourth ADR status. The ADR lifecycle is owned by ADR 0001, which defines exactly `proposed`,
+  `accepted`, and `superseded`; a decision that is withdrawn or replaced is recorded with
+  `superseded` (plus a `superseded_by` forward-pointer), so `deprecated` had no distinct lifecycle
+  meaning and is retired. `ADR status` is now `proposed` | `accepted` | `superseded` across the
+  template, the ADR index, this contract, and the `feature-status.md` legend, and
+  `scripts/docs-lint` enforces the three-value set on both ADR frontmatter and the feature-status
+  matrix from one shared definition. (`deprecated` remains available as a general document status
+  for non-ADR doc kinds.)

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -10,8 +10,9 @@ sidebar:
 
 # Architecture Decision Records
 
-Each ADR captures one committed design decision. Files use `NNNN-kebab-slug.md` naming. Status
-values: `proposed`, `accepted`, `superseded`, `deprecated`.
+Each ADR captures one committed design decision. Files use `NNNN-kebab-slug.md` naming. ADR
+lifecycle status values are `proposed`, `accepted`, and `superseded`. ADR 0001 governs the
+documentation lifecycle; ADR 0063 governs feature traceability and feature-status joins.
 
 ## Current ADRs
 
@@ -182,6 +183,9 @@ Use the [template](../Templates/adr.md). Key discipline:
 - Proposed ADRs may end with a temporary `## Tracking` section for issue/PR planning state. Delete
   that section before moving the ADR to `accepted`; accepted ADRs should cite durable artifacts, not
   issue-tracker archaeology.
+- Before accepting an ADR, reconcile the living docs that should synthesize it: Architecture,
+  Reference, Usage, feature-status/proof-status when applicable, and consumer docs if the decision
+  changes a downstream-facing boundary.
 - An accepted ADR is canon — supersede it with a new numbered ADR rather than editing the original,
   except to update `status` and add a forward-pointer.
 

--- a/docs/Reference/feature-status.md
+++ b/docs/Reference/feature-status.md
@@ -35,7 +35,7 @@ validates that every evidence link resolves.
 
 | Dimension      | Values                                                                         |
 | -------------- | ------------------------------------------------------------------------------ |
-| ADR status     | `proposed` · `accepted` · `superseded` · `deprecated`                          |
+| ADR status     | `proposed` · `accepted` · `superseded`                                         |
 | Implementation | `planned` · `partial` · `implemented` · `verified` · `retired`                 |
 | Proof          | see [`proof-status.md`](proof-status.md) (`proven`/`hooked`/`tested`/`open`/…) |
 

--- a/docs/Templates/adr.md
+++ b/docs/Templates/adr.md
@@ -4,7 +4,7 @@ description: "{One-sentence description of the decision.}"
 sidebar:
   label: "NNNN. {Short label}"
   order: N
-status: proposed   # proposed | accepted | superseded | deprecated
+status: proposed   # proposed | accepted | superseded
 date: YYYY-MM-DD
 superseded_by: null   # if superseded, path to the replacing ADR
 related:
@@ -15,7 +15,7 @@ related:
 
 ## Status
 
-{Proposed | Accepted | Superseded | Deprecated} — {one sentence with rationale for the status}.
+{Proposed | Accepted | Superseded} — {one sentence with rationale for the status}.
 
 ## Context
 

--- a/docs/Templates/consumer-binding.md
+++ b/docs/Templates/consumer-binding.md
@@ -1,0 +1,52 @@
+---
+title: "{Consumer} Consumer Binding"
+description: "{One-sentence description of how this consumer binds Cortex.}"
+sidebar:
+  label: "{Consumer}"
+  order: N
+---
+
+# {Consumer} Consumer Binding
+
+<!--
+Consumer-specific binding, not Cortex substrate canon and not private product design. Use this
+shape to explain where the consumer attaches to Cortex while keeping reusable rules in
+Architecture/Reference and product policy in the downstream repository.
+-->
+
+## Boundary
+
+| Cortex owns | {Consumer} owns |
+| --- | --- |
+| ... | ... |
+
+## Binding Points
+
+| Binding point | Cortex role | {Consumer} role |
+| --- | --- | --- |
+| ... | ... | ... |
+
+## Host Responsibilities
+
+<!--
+Authentication, side effects, storage, policy, or operator experience owned by the consumer.
+-->
+
+- ...
+
+## Cortex References
+
+<!--
+Substrate surfaces this binding depends on. Do not duplicate their normative rules here.
+-->
+
+- [../Architecture/...](../Architecture/...)
+- [../Reference/...](../Reference/...)
+
+## Related
+
+<!--
+Other consumer docs, ADRs, or host-owned docs when they are public and stable.
+-->
+
+- ...

--- a/docs/Templates/index.md
+++ b/docs/Templates/index.md
@@ -8,22 +8,34 @@ sidebar:
 
 # Cortex Doc Templates
 
-Start new docs from the closest template. Templates define expected
-frontmatter, section shape, and placement discipline.
+Start new docs from the closest template. Templates define expected frontmatter, section shape, and
+placement discipline. ADR 0001 makes this directory the authoring guide for doc-kind shape; the
+template set is guidance, while `scripts/docs-lint` enforces the mechanical subset.
 
-## Templates
+## Template Coverage
 
-| Doc kind | Template | Where the doc lives |
-|---|---|---|
-| Architecture chapter | [architecture-page.md](architecture-page.md) | `Architecture/NN-*.md` |
-| Normative reference | [reference-spec.md](reference-spec.md) | `Reference/**/*.md` |
-| ADR | [adr.md](adr.md) | `ADRs/NNNN-*.md` |
-| Roadmap epic | [roadmap-epic.md](roadmap-epic.md) | `Roadmap/Epics/*.md` |
-| Implementation plan | [implementation-plan.md](implementation-plan.md) | `Roadmap/Plans/*.md` |
-| Research memo | [research-memo.md](research-memo.md) | `Research-notes/{scope}/YYYY-MM-DD-*.md` |
-| Experiment | [experiment.md](experiment.md) | `Experiments/{scope}/YYYY-MM-DD-*.md` |
-| Publication manuscript | [publication-manuscript.md](publication-manuscript.md) | `Publications/paper-N-*/manuscript.md` |
-| Section index | [section-index.md](section-index.md) | any directory's `index.md` |
+Every doc kind from [../map.md](../map.md#by-kind) is accounted for here. Some narrow archive and
+single-page kinds intentionally carry no bespoke file; authoring-heavy kinds have a dedicated
+template or an explicit section-index shape.
+
+| Doc kind | Template | Where the doc lives | Notes |
+| --- | --- | --- | --- |
+| Usage guide | [usage-guide.md](usage-guide.md); [section-index.md](section-index.md) for `Usage/index.md` | `Usage/index.md`, `Usage/NN-*.md` | Usage pages are task-oriented canon; keep commands runnable and routes explicit. |
+| Canonical architecture chapter | [architecture-page.md](architecture-page.md) | `Architecture/NN-*.md` | Canonical synthesis, not decision history. |
+| Normative specification | [reference-spec.md](reference-spec.md) | `Reference/**/*.md` | Stable contract and exact rules. |
+| Code style guide | No dedicated template | `Style.md` | Single top-level canon page; follow existing page structure and ADR 0001 frontmatter rules. |
+| Architecture decision record | [adr.md](adr.md) | `ADRs/NNNN-*.md` | One decision per ADR; proposed ADRs may carry temporary tracking. |
+| Downstream consumer binding | [consumer-binding.md](consumer-binding.md) | `Consumers/{consumer}.md` | Consumer-specific substrate binding; keep Cortex rules in Architecture/Reference and product policy downstream. |
+| Logos reasoning library | [section-index.md](section-index.md) | `Consumers/Logos/` | Larger downstream library canon; use section indexes plus focused reference pages. |
+| Active roadmap plan | [implementation-plan.md](implementation-plan.md) | `Roadmap/Plans/*.md` | Active, supersedable work plan. |
+| Active roadmap epic | [roadmap-epic.md](roadmap-epic.md) | `Roadmap/Epics/*.md` | Coordinated child work. |
+| Completed initiative | No dedicated template | `Roadmap/Completed/` | Historical retained selectively; summarize what shipped and link durable canon. |
+| Archived idea | No dedicated template | `Roadmap/Archive/` | Historical retained selectively; preserve only context still worth carrying. |
+| Paper manuscript and figures | [publication-manuscript.md](publication-manuscript.md) | `Publications/Paper-N-*/manuscript.md` | Bundle files have publication-specific frontmatter rules in docs-lint. |
+| Paper notes and ideas | [publication-notes.md](publication-notes.md) | `Publications/Notes/` | Working publication ideas and bundle seeds, not dated research memos. |
+| Research or synthesis memo | [research-memo.md](research-memo.md) | `Research-notes/{scope}/YYYY-MM-DD-*.md` | Dated synthesis; retain only while useful. |
+| Controlled experiment | [experiment.md](experiment.md) | `Experiments/{scope}/YYYY-MM-DD-*.md` | Dated experiment record tied to active work. |
+| Template | No dedicated template | `Templates/*.md` | Template files are not linted (placeholder frontmatter and dates); this index is linted and `scripts/docs-lint` checks it against map.md's By-Kind list. |
 
 ## Discipline
 
@@ -32,13 +44,16 @@ The structure, frontmatter, format, and Cortex-first policy these templates enco
 `scripts/docs-lint` is the gate.
 
 - Frontmatter is required (`title` and `description` always).
-- Status values follow the canonical enum the contract pins (ADRs use `proposed`, `accepted`,
-  `superseded`); `scripts/docs-lint` enforces it.
+- Status values follow the canonical enum the contract pins. ADR lifecycle status is narrower:
+  ADRs use `proposed`, `accepted`, or `superseded`; other docs may use other lifecycle statuses
+  admitted by `scripts/docs-lint`.
 - Dates in frontmatter are ISO dates (`YYYY-MM-DD`), never in the future.
 - Canonical docs should frame Cortex directly. Downstream consumers can appear
   as examples, not as the system boundary.
 - Dated artifacts should be retained only while they explain current canon,
   active work, or a live research thread.
+- Proposed ADRs may carry a `## Tracking` section for issue/PR state. Delete it before accepting
+  the ADR; accepted ADRs cite durable canon, source, tests, proof rows, merged PRs, or commits.
 
 ## Related
 

--- a/docs/Templates/publication-notes.md
+++ b/docs/Templates/publication-notes.md
@@ -1,0 +1,52 @@
+---
+title: "{Publication note title}"
+description: "{One-sentence description of the publication idea or paper-bundle seed.}"
+status: active   # active | superseded | archived
+related:
+  - docs/Publications/...
+---
+
+# {Publication note title}
+
+<!--
+Working publication notes are not dated research memos. Use this shape for paper ideas,
+contribution mining, positioning notes, or seeds that may become a Publications/Paper-N-* bundle.
+-->
+
+## Thesis
+
+<!--
+The claim, contribution, or paper direction this note is testing.
+-->
+
+## Material
+
+<!--
+Relevant Cortex docs, proofs, implementation surfaces, figures, or prior manuscript fragments.
+-->
+
+- ...
+
+## Possible Paper Shape
+
+<!--
+Sketch the argument order, not a full manuscript.
+-->
+
+1. ...
+
+## Open Questions
+
+<!--
+Questions that decide whether this remains a note, moves into a paper bundle, or is archived.
+-->
+
+- ...
+
+## Related
+
+<!--
+Publication bundles, notes, ADRs, or research notes this idea depends on.
+-->
+
+- ...

--- a/docs/Templates/usage-guide.md
+++ b/docs/Templates/usage-guide.md
@@ -1,0 +1,64 @@
+---
+title: "{Task name}"
+description: "{One-sentence description of the task this guide helps the reader complete.}"
+sidebar:
+  label: "{NN. Short task label}"
+  order: N
+---
+
+# {Task name}
+
+<!--
+Task-oriented canon. Start with the outcome and prerequisites, then give commands and decision
+points in the order a user will actually encounter them. Link to Architecture for rationale and
+Reference for exact rules; do not restate either surface at length.
+-->
+
+## Goal
+
+<!--
+What the reader will be able to do after following this page.
+-->
+
+## Prerequisites
+
+<!--
+Repository state, tools, services, credentials, or prior docs the task assumes.
+-->
+
+- ...
+
+## Steps
+
+<!--
+Prefer copyable commands and concrete expected observations. Keep alternatives explicit.
+-->
+
+```bash
+...
+```
+
+## Check The Result
+
+<!--
+How the reader knows the task worked; include commands, output shape, or UI/API observations.
+-->
+
+## Troubleshooting
+
+<!--
+Common failure modes and the next diagnostic step. Route deep rules to Reference.
+-->
+
+| Symptom | Check |
+| --- | --- |
+| ... | ... |
+
+## Related
+
+<!--
+Adjacent usage pages, architecture rationale, and normative reference pages.
+-->
+
+- [../Architecture/...](../Architecture/...)
+- [../Reference/...](../Reference/...)

--- a/docs/map.md
+++ b/docs/map.md
@@ -26,11 +26,15 @@ here.
 | Active roadmap epic            | [Roadmap/Epics/](Roadmap/Epics/)           | Active while retained                 | No     |
 | Completed initiative           | [Roadmap/Completed/](Roadmap/Completed/)   | Historical, retained selectively      | No     |
 | Archived idea                  | [Roadmap/Archive/](Roadmap/Archive/)       | Historical, retained selectively      | No     |
-| Paper manuscript and figures   | [Publications/paper-N-\*/](Publications/)  | Published-once                        | No     |
+| Paper manuscript and figures   | [Publications/Paper-N-\*/](Publications/)  | Published-once                        | No     |
 | Paper notes and ideas          | [Publications/Notes/](Publications/Notes/) | Working                               | No     |
 | Research or synthesis memo     | [Research-notes/{scope}/](Research-notes/) | Historical, retained selectively      | Yes    |
 | Controlled experiment          | [Experiments/{scope}/](Experiments/)       | Epic-controlled, retained selectively | Yes    |
 | Template                       | [Templates/](Templates/)                   | Long-term canon                       | No     |
+
+Template coverage for every kind is maintained in
+[Templates/index.md](Templates/index.md#template-coverage). A kind may reuse a generic template or
+record that no dedicated template is needed; absence from that table is a documentation-canon bug.
 
 ## By Question
 

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -112,15 +112,21 @@ governed by
 
 Docs are classified on two axes:
 
-|                         | Stable canon                                     | Dated artifacts   |
-| ----------------------- | ------------------------------------------------ | ----------------- |
-| **Canonical authority** | `Usage/`, `Architecture/`, `Reference/`, `ADRs/` | none              |
-| **Project working**     | `Roadmap/Epics/`, `Roadmap/Plans/`               | `Research-notes/` |
-| **Historical**          | `Roadmap/Completed/`, `Roadmap/Archive/`         | `Experiments/`    |
+| Classification      | Stable canon                                                     | Dated artifacts           |
+| ------------------- | ---------------------------------------------------------------- | ------------------------- |
+| Canonical authority | `Usage/`, `Architecture/`, `Reference/`, `Style.md`, `ADRs/`     | none                      |
+| Project working     | `Roadmap/Epics/`, `Roadmap/Plans/`                               | `Research-notes/{scope}/` |
+| Historical          | `Roadmap/Completed/`, `Roadmap/Archive/`                         | `Experiments/{scope}/`    |
+| Cross-cutting canon | `Templates/`, `index.md`, `map.md`, `glossary.md`, `taxonomy.md` | none                      |
+| Consumer-specific   | `Consumers/{consumer}.md`, `Consumers/Logos/`                    | none                      |
+| Publication working | `Publications/Paper-N-*/`, `Publications/Notes/`                 | none                      |
 
-Cross-cutting canon: `Templates/`, `index.md`, `map.md`, `glossary.md`, `taxonomy.md`
-Consumer-specific: `Consumers/{consumer}.md`, or `Consumers/{consumer}/` for a larger public binding
-Papers: `Publications/paper-N-*/`
+Every home in [map.md](map.md#by-kind) must appear above as a backticked taxonomy path. Missing
+coverage is a documentation-canon bug caught by `scripts/docs-lint`.
+
+Per-kind authoring shape is tracked in [Templates/index.md](Templates/index.md#template-coverage).
+That page accounts for every kind listed in [map.md](map.md#by-kind), including kinds that
+intentionally reuse a generic template or have no dedicated template.
 
 ## Related
 

--- a/scripts/docs-lint
+++ b/scripts/docs-lint
@@ -49,11 +49,17 @@ STATUS_VALUES = {
     "superseded",
 }
 
+# ADR lifecycle status (ADR 0001 §5, ADR 0063 amendment): the narrower per-kind enum, enforced on
+# ADR frontmatter and on the feature-status matrix so the two can never drift. The global
+# STATUS_VALUES set above stays broader for non-ADR doc kinds.
+ADR_STATUS = {"proposed", "accepted", "superseded"}
+
 # --- feature-status matrix (ADR 0063) ---------------------------------------
 FEATURE_STATUS = DOCS / "Reference" / "feature-status.md"
+TEMPLATES_INDEX = DOCS / "Templates" / "index.md"
 ADRS = DOCS / "ADRs"
 
-FEATURE_ADR_STATUS = {"proposed", "accepted", "superseded", "deprecated"}
+FEATURE_ADR_STATUS = ADR_STATUS
 FEATURE_IMPL_STATUS = {"planned", "partial", "implemented", "verified", "retired"}
 FEATURE_KEY_PREFIXES = {
     "capability",
@@ -105,7 +111,10 @@ def iter_docs() -> list[Path]:
     paths: list[Path] = []
     for pattern in ("*.md", "*.mmd"):
         for path in DOCS.rglob(pattern):
-            if "Templates" in path.relative_to(DOCS).parts:
+            # Template files carry placeholder frontmatter and YYYY-MM-DD dates that intentionally
+            # violate the lint. Only Templates/index.md — the doc-kind coverage record — is linted.
+            parts = path.relative_to(DOCS).parts
+            if "Templates" in parts and path.name != "index.md":
                 continue
             paths.append(path)
     return sorted(paths)
@@ -268,6 +277,8 @@ def check_frontmatter(document: Document, errors: list[str]) -> None:
     status = fm.get("status")
     if isinstance(status, str) and status not in STATUS_VALUES:
         add(errors, path, f"unknown status {status!r}", 1)
+    if is_adr(path) and isinstance(status, str) and status not in ADR_STATUS:
+        add(errors, path, f"ADR status must be one of {sorted(ADR_STATUS)}, got {status!r}", 1)
 
     date = parse_date(fm.get("date"))
     updated = parse_date(fm.get("updated"))
@@ -780,6 +791,151 @@ def check_feature_status(errors: list[str]) -> None:
             add(errors, FEATURE_STATUS, f"ADR(s) {sorted(stray)} declare {key!r} but the matrix binds it to {sorted(governed[key])}")
 
 
+def section_text(path: Path, heading: str, errors: list[str]) -> str | None:
+    """Body text of a `## <heading>` section."""
+    if not path.exists():
+        add(errors, path, f"{heading!r} source not found")
+        return None
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = next((i for i, line in enumerate(lines) if line.strip() == f"## {heading}"), None)
+    if start is None:
+        add(errors, path, f"missing '## {heading}' section")
+        return None
+
+    section_lines: list[str] = []
+    for line in lines[start + 1 :]:
+        if line.startswith("## "):
+            break
+        section_lines.append(line)
+    return "\n".join(section_lines)
+
+
+def section_table_rows(path: Path, heading: str, errors: list[str]) -> list[list[str]] | None:
+    """Body rows of the first Markdown table under a `## <heading>` section.
+
+    Returns None (and records an error) when the file, the section, or the table is missing, so
+    callers can distinguish "could not read" from "read, found nothing".
+    """
+    if not path.exists():
+        add(errors, path, f"{heading!r} source not found")
+        return None
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = next((i for i, line in enumerate(lines) if line.strip() == f"## {heading}"), None)
+    if start is None:
+        add(errors, path, f"missing '## {heading}' section")
+        return None
+
+    in_fence = False
+    index = start + 1
+    while index < len(lines):
+        line = lines[index]
+        if line.startswith("```"):
+            in_fence = not in_fence
+            index += 1
+            continue
+        if in_fence:
+            index += 1
+            continue
+        if line.startswith("## "):
+            break
+
+        stripped = line.strip()
+        if not (stripped.startswith("|") and stripped.endswith("|")):
+            index += 1
+            continue
+        sep_stripped = lines[index + 1].strip() if index + 1 < len(lines) else ""
+        sep_cells = [c.strip() for c in split_table_row(sep_stripped)] if sep_stripped.startswith("|") else []
+        if not sep_cells or not all(SEPARATOR_CELL.match(cell) for cell in sep_cells):
+            index += 1
+            continue
+
+        rows: list[list[str]] = []
+        body = index + 2  # first row after header + separator
+        while body < len(lines):
+            body_stripped = lines[body].strip()
+            if not (body_stripped.startswith("|") and body_stripped.endswith("|")):
+                break
+            cells = [cell.strip() for cell in split_table_row(body_stripped)]
+            if cells and all(SEPARATOR_CELL.match(cell) for cell in cells):
+                break
+            if cells:
+                rows.append(cells)
+            body += 1
+        return rows
+
+    add(errors, path, f"no table found under '## {heading}'")
+    return None
+
+
+def section_table_first_column(path: Path, heading: str, errors: list[str]) -> list[str] | None:
+    rows = section_table_rows(path, heading, errors)
+    if rows is None:
+        return None
+    return [row[0] for row in rows if row]
+
+
+def markdown_link_label(cell: str) -> str:
+    """Return the displayed Markdown-link label when a table cell is a single link."""
+    match = re.fullmatch(r"\[([^\]]+)\]\([^)]*\)", cell.strip())
+    if match:
+        return match.group(1).replace(r"\*", "*")
+    return cell.strip()
+
+
+def check_taxonomy_homes(errors: list[str]) -> None:
+    """Keep taxonomy path coverage synced with map.md's displayed homes."""
+    map_path = DOCS / "map.md"
+    taxonomy_path = DOCS / "taxonomy.md"
+    rows = section_table_rows(map_path, "By Kind", errors)
+    taxonomy = section_text(taxonomy_path, "Doc-kind taxonomy", errors)
+    if rows is None or taxonomy is None:
+        return
+
+    homes = []
+    for row in rows:
+        if len(row) < 2:
+            continue
+        homes.append(markdown_link_label(row[1]))
+
+    for home in sorted(set(homes)):
+        if f"`{home}`" not in taxonomy:
+            add(errors, taxonomy_path, f"map.md home {home!r} is missing from '## Doc-kind taxonomy'")
+
+    seen: set[str] = set()
+    for home in homes:
+        if home in seen:
+            add(errors, map_path, f"duplicate map.md home {home!r}")
+        seen.add(home)
+
+
+def check_doc_kinds(errors: list[str]) -> None:
+    """Keep the doc-kind registry synced (ADR 0001 doc-kind contract).
+
+    map.md '## By Kind' is the canonical list of doc kinds; Templates/index.md '## Template
+    Coverage' must account for exactly the same set — no missing kind, no extra kind, no duplicate.
+    This is the mechanical form of map.md's "absence from that table is a documentation-canon bug".
+    """
+    map_path = DOCS / "map.md"
+    by_kind = section_table_first_column(map_path, "By Kind", errors)
+    coverage = section_table_first_column(TEMPLATES_INDEX, "Template Coverage", errors)
+    if by_kind is None or coverage is None:
+        return
+
+    map_kinds = set(by_kind)
+    coverage_kinds = set(coverage)
+    for kind in sorted(map_kinds - coverage_kinds):
+        add(errors, TEMPLATES_INDEX, f"map.md doc kind {kind!r} has no '## Template Coverage' row")
+    for kind in sorted(coverage_kinds - map_kinds):
+        add(errors, map_path, f"Template Coverage kind {kind!r} is absent from map.md '## By Kind'")
+
+    for source, names in ((map_path, by_kind), (TEMPLATES_INDEX, coverage)):
+        seen: set[str] = set()
+        for name in names:
+            if name in seen:
+                add(errors, source, f"duplicate doc kind {name!r}")
+            seen.add(name)
+
+
 def main() -> int:
     if not DOCS.exists():
         print("docs-lint: docs/ not found", file=sys.stderr)
@@ -804,6 +960,8 @@ def main() -> int:
         check_markdown_links(document, errors)
 
     check_feature_status(errors)
+    check_doc_kinds(errors)
+    check_taxonomy_homes(errors)
 
     if errors:
         print("docs-lint failed:", file=sys.stderr)


### PR DESCRIPTION
## Summary
- account for every `docs/map.md` doc kind in `docs/Templates/index.md`
- align ADR template/index lifecycle wording with ADR 0001
- cross-link map/taxonomy to the template coverage record

## Verification
- `just fmt`
- `just fmt-check`
- `just docs-lint`
- `just docs-check`
- `git diff --check`

Closes #348