### PR TITLE
fix(nix): support aarch64-darwin GHC bootstrap

### DIFF
--- a/docs/Reference/development.md
+++ b/docs/Reference/development.md
@@ -21,6 +21,20 @@ Cortex builds through Nix and the repo `justfile`. Use these surfaces rather tha
 nix develop
 ```
 
+### Apple Silicon
+
+`aarch64-darwin` builds are supported through the flake. Use `nix build`, `nix run`, or
+`nix develop`; do not build Cortex by invoking Cabal or GHC directly.
+
+The flake provides the Darwin SDK, libc++, and GHC bootstrap toolchain through Nix. You should not
+need to install or point Cortex at a separate C++ standard library. A cold macOS build may still
+take a long time when the binary cache does not contain the exact bootstrap compiler path, because
+Nix may build intermediate GHCs from source.
+
+During successful executable links, Darwin may print warnings for optional library search paths that
+do not exist in the local store, such as a `pg_config/lib` path. Treat those as non-fatal when the
+build reaches install and fixup phases successfully.
+
 ## Core Commands
 
 | Command            | Purpose                                                  |

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -12,6 +12,85 @@
   }: let
     overlays = [
       inputs.haskell-nix.overlay
+      (final: prev: let
+        patchDarwinBootstrapGhc = compiler:
+          compiler.overrideAttrs (old: {
+            postConfigure =
+              (old.postConfigure or "")
+              + final.lib.optionalString (final.stdenv.hostPlatform.isDarwin && final.stdenv.hostPlatform.isAarch64) ''
+                for config in mk/config.mk hadrian/cfg/system.config; do
+                  if grep -q '${final.stdenv.cc}/bin/cc -std=gnu23' "$config"; then
+                    substituteInPlace "$config" \
+                      --replace-fail "${final.stdenv.cc}/bin/cc -std=gnu23" "${final.stdenv.cc}/bin/cc"
+                  fi
+                done
+              '';
+            preConfigure =
+              final.lib.optionalString (final.stdenv.hostPlatform.isDarwin && final.stdenv.hostPlatform.isAarch64) ''
+                export ac_cv_prog_cc_c23=
+                export CXX_STD_LIB_LIBS="c++ c++abi"
+                export CXX_STD_LIB_LIB_DIRS="${final.darwin.libcxx}/lib"
+                export CXX_STD_LIB_DYN_LIB_DIRS="${final.darwin.libcxx}/lib"
+              ''
+              + (old.preConfigure or "");
+            preInstall =
+              final.lib.optionalString (final.stdenv.hostPlatform.isDarwin && final.stdenv.hostPlatform.isAarch64) ''
+                export ac_cv_prog_cc_c23=
+                export CXX_STD_LIB_LIBS="c++ c++abi"
+                export CXX_STD_LIB_LIB_DIRS="${final.darwin.libcxx}/lib"
+                export CXX_STD_LIB_DYN_LIB_DIRS="${final.darwin.libcxx}/lib"
+              ''
+              + (old.preInstall or "");
+            postInstall =
+              (old.postInstall or "")
+              + final.lib.optionalString (final.stdenv.hostPlatform.isDarwin && final.stdenv.hostPlatform.isAarch64) ''
+                packageDb=$(find "$out/lib" -path '*/package.conf.d' -type d | head -n1)
+                if [ -n "$packageDb" ]; then
+                  mkdir -p "$out/envDeps" "$out/exactDeps"
+                  for pkgId in $("$out/bin/ghc-pkg" -v0 --global-package-db="$packageDb" list --simple-output); do
+                    if name=$("$out/bin/ghc-pkg" -v0 --global-package-db="$packageDb" field "$pkgId" name --simple-output 2>/dev/null); then
+                      id=$("$out/bin/ghc-pkg" -v0 --global-package-db="$packageDb" field "$pkgId" id --simple-output)
+                      ver=$("$out/bin/ghc-pkg" -v0 --global-package-db="$packageDb" field "$pkgId" version --simple-output)
+                      mkdir -p "$out/exactDeps/$name"
+                      echo "--dependency=$name=$id" > "$out/exactDeps/$name/configure-flags"
+                      {
+                        echo "constraint: $name == $ver"
+                        echo "constraint: $name installed"
+                      } > "$out/exactDeps/$name/cabal.config"
+                      echo "package-id $id" > "$out/envDeps/$name"
+                    fi
+                  done
+                fi
+              '';
+            buildInputs =
+              (old.buildInputs or [])
+              ++ final.lib.optionals (final.stdenv.hostPlatform.isDarwin && final.stdenv.hostPlatform.isAarch64) [
+                final.darwin.libcxx
+              ];
+            passthru =
+              (old.passthru or {})
+              // final.lib.optionalAttrs (compiler ? buildGHC) {
+                buildGHC = compiler.buildGHC;
+              }
+              // final.lib.optionalAttrs (compiler ? raw-src) {
+                raw-src = compiler.raw-src;
+              };
+          });
+      in {
+        haskell =
+          prev.haskell
+          // {
+            compiler =
+              prev.haskell.compiler
+              // {
+                # GHC 9.10's Darwin toolchain may bootstrap through older GHCs.
+                # When that compiler has to build from source on aarch64-darwin,
+                # its configure script probes libc++ linkage via CC without LDFLAGS.
+                ghc948 = patchDarwinBootstrapGhc prev.haskell.compiler.ghc948;
+                ghc967 = patchDarwinBootstrapGhc prev.haskell.compiler.ghc967;
+              };
+          };
+      })
       (final: _prev: {
         cortexProject = final.haskell-nix.project' {
           src = ../.;


### PR DESCRIPTION
## Summary

- fixes aarch64-darwin source builds of the GHC bootstrap chain used by the GHC 9.10.3 Cortex plan
- supplies Darwin libc++ and the C++ stdlib configure environment inside the affected GHC derivations
- removes the Darwin `cc -std=gnu23` executable-path leak from generated GHC config files
- preserves haskell.nix metadata and emits exact-deps/env-deps for global packages from source-built bootstrap GHCs
- documents Apple Silicon expectations in the development workflow guide

## Why

On Apple Silicon, the build can fall back to source-building intermediate GHCs before reaching the project compiler, GHC 9.10.3. Those bootstrap compilers were failing in a few Darwin-specific ways:

- GHC configure could not find libc++ because the probe did not see the normal Nix linker context.
- Autoconf could record `cc -std=gnu23` as the compiler command, which later broke helper tools that expect a bare executable path.
- Source-built bootstrap GHC outputs lacked the exact dependency metadata haskell.nix expects when building Hadrian dependencies with `--exact-configuration`.

Keeping this in the derivation means developers should use the Nix flake as intended instead of installing or pointing Cortex at separate C++ libraries manually.

## Validation

- `scripts/check-commit-provenance origin/main..HEAD`
- `git diff --check origin/main...HEAD`
- commit hooks: `doc-wire-examples`, `docs-lint`, `treefmt`, `wire-style`
- `nix eval --raw .#packages.aarch64-darwin.wire.name --no-write-lock-file`
- `nix eval --raw .#packages.x86_64-linux.wire.name --no-write-lock-file`
- `nix build .#wire --no-write-lock-file --keep-failed --print-build-logs` completed on aarch64-darwin and linked/installed `cortex-exe-wire-0.1.0.0`
