### PR TITLE
feat(wire): inspect selected frontier returns

### DIFF
--- a/app/wire/Main.hs
+++ b/app/wire/Main.hs
@@ -285,7 +285,7 @@ usageText =
     , "  wire fmt [--check | --stdout] FILE..."
     , "  wire lean-fixtures OUTDIR    (regenerate emitted Lean artifact fixtures)"
     , "  wire parse FILE              (expand includes and parse; no compilation)"
-    , "  wire frontier [--closure | --open] [--node NODE] [--json] FILE"
+    , "  wire frontier [--return NAME] [--closure | --open] [--node NODE] [--json] FILE"
     , "                              (inspect endpoint-use / closure accounting; no execution)"
     , ""
     , "global options:"
@@ -325,8 +325,13 @@ frontierWire :: [FilePath] -> FrontierCommand -> IO ()
 frontierWire packagePaths frontierCommand = do
   compileEnv <- loadCliWireCompileEnv packagePaths
   modules <- loadWireModules frontierCommand.frontierCommandFile
+  let compile =
+        maybe
+          (compileWireModules compileEnv)
+          (compileWireModulesWithReturn compileEnv)
+          frontierCommand.frontierCommandSelectedReturn
   compiled <-
-    either (dieText . renderWireError) pure (compileWireModules compileEnv modules)
+    either (dieText . renderWireError) pure (compile modules)
   artifact <-
     maybe
       (dieText "compiled circuit carries no Wire admission artifact")

--- a/docs/ADRs/0081-wire-endpoint-closure-accounting.md
+++ b/docs/ADRs/0081-wire-endpoint-closure-accounting.md
@@ -153,6 +153,7 @@ reports the frontier accounting persisted in the admission artifact:
 
 ```text
 wire frontier FILE --node NODE
+wire frontier FILE --return NAME
 wire frontier FILE --closure
 wire frontier FILE --open
 wire frontier FILE --json
@@ -165,12 +166,14 @@ fan-out/fan-in/repeated-reference conflicts using the same endpoint vocabulary a
 with zero output ports may be reported as a terminating node, but that is derived from its declared
 port shape, not from a separate policy.
 
-`--closure` reports graph-level endpoint accounting for the selected return graph and is the default
-projection. `--open` reprojects the same validator-ready admission artifact as an open fragment for
-inspection, classifying top-level inputs as imported obligations and carried outputs as exported
-boundaries without changing the compiled circuit metadata. `--json` is the future editor/code-server
-bridge: an editor can render inline "missing upstream", "open downstream", "consumed here", "returns
-to host", and "terminates here" hints from the same data rather than inventing a second analysis.
+`--return NAME` selects a named graph-valued export before inspection, matching
+`wire build --return NAME`. `--closure` reports graph-level endpoint accounting for the selected
+return graph and is the default projection. `--open` reprojects the same validator-ready admission
+artifact as an open fragment for inspection, classifying top-level inputs as imported obligations
+and carried outputs as exported boundaries without changing the compiled circuit metadata. `--json`
+is the future editor/code-server bridge: an editor can render inline "missing upstream", "open
+downstream", "consumed here", "returns to host", and "terminates here" hints from the same data
+rather than inventing a second analysis.
 
 This slice exposes the evidence currently available from the compiler and admission artifact. It
 does not infer solely from the final `CompiledCircuit` node relation, which has already forgotten

--- a/docs/Reference/Wire/modules-imports-and-file-returns.md
+++ b/docs/Reference/Wire/modules-imports-and-file-returns.md
@@ -41,10 +41,12 @@ The CLI can compile a named graph-valued binding instead of the default file-ret
 
 ```sh
 wire build --return exported_planner ./pipeline.wire
+wire frontier --return exported_planner --json ./pipeline.wire
 ```
 
 This is useful for files that serve as a catalog of exported graph values while still having a
-default executable file-return.
+default executable file-return. `wire frontier --return` inspects endpoint-use / closure accounting
+for the same selected graph without executing it.
 
 ## Imports
 

--- a/src/Cortex/Wire/Cli/Frontier.hs
+++ b/src/Cortex/Wire/Cli/Frontier.hs
@@ -47,33 +47,40 @@ data FrontierCommand = FrontierCommand
   { frontierCommandClosure :: !FrontierClosure
   , frontierCommandScope :: !FrontierScope
   , frontierCommandFormat :: !FrontierFormat
+  , frontierCommandSelectedReturn :: !(Maybe Text)
   , frontierCommandFile :: !FilePath
   }
   deriving stock (Eq, Show)
 
 frontierUsage :: Text
-frontierUsage = "usage: wire frontier [--closure | --open] [--node NODE] [--json] FILE"
+frontierUsage = "usage: wire frontier [--return NAME] [--closure | --open] [--node NODE] [--json] FILE"
 
 parseFrontierCommand :: [String] -> Either Text FrontierCommand
-parseFrontierCommand = collect Nothing Nothing FrontierText []
+parseFrontierCommand = collect Nothing Nothing Nothing FrontierText []
   where
-    collect maybeClosure maybeScope format files = \case
-      [] -> finish maybeClosure maybeScope format files
-      ("--json" : rest) -> collect maybeClosure maybeScope FrontierJson files rest
+    collect maybeClosure maybeScope maybeReturn format files = \case
+      [] -> finish maybeClosure maybeScope maybeReturn format files
+      ("--json" : rest) -> collect maybeClosure maybeScope maybeReturn FrontierJson files rest
       ("--closure" : rest) -> do
         closure <- setClosure FrontierClosed maybeClosure
-        collect (Just closure) maybeScope format files rest
+        collect (Just closure) maybeScope maybeReturn format files rest
       ("--open" : rest) -> do
         closure <- setClosure FrontierOpen maybeClosure
-        collect (Just closure) maybeScope format files rest
+        collect (Just closure) maybeScope maybeReturn format files rest
+      ("--return" : selectedReturn : rest)
+        | "-" `isPrefixOf` selectedReturn -> Left frontierUsage
+        | otherwise -> do
+            selected <- setReturn (T.pack selectedReturn) maybeReturn
+            collect maybeClosure maybeScope (Just selected) format files rest
       ("--node" : nodeName : rest)
         | "-" `isPrefixOf` nodeName -> Left frontierUsage
         | otherwise -> do
             scope <- setScope (FrontierNode (T.pack nodeName)) maybeScope
-            collect maybeClosure (Just scope) format files rest
+            collect maybeClosure (Just scope) maybeReturn format files rest
+      ["--return"] -> Left frontierUsage
       ["--node"] -> Left frontierUsage
       (('-' : _) : _) -> Left frontierUsage
-      (path : rest) -> collect maybeClosure maybeScope format (path : files) rest
+      (path : rest) -> collect maybeClosure maybeScope maybeReturn format (path : files) rest
 
     setClosure newClosure = \case
       Nothing -> Right newClosure
@@ -87,7 +94,13 @@ parseFrontierCommand = collect Nothing Nothing FrontierText []
         | oldScope == newScope -> Right oldScope
         | otherwise -> Left "wire frontier accepts only one --node selection."
 
-    finish maybeClosure maybeScope format files =
+    setReturn newReturn = \case
+      Nothing -> Right newReturn
+      Just oldReturn
+        | oldReturn == newReturn -> Right oldReturn
+        | otherwise -> Left "wire frontier accepts only one --return selection."
+
+    finish maybeClosure maybeScope maybeReturn format files =
       case reverse files of
         [path] ->
           Right
@@ -95,6 +108,7 @@ parseFrontierCommand = collect Nothing Nothing FrontierText []
               { frontierCommandClosure = fromMaybe FrontierClosed maybeClosure
               , frontierCommandScope = fromMaybe FrontierGraph maybeScope
               , frontierCommandFormat = format
+              , frontierCommandSelectedReturn = maybeReturn
               , frontierCommandFile = path
               }
         _ -> Left frontierUsage

--- a/test/Cortex/Wire/Cli/FrontierSpec.hs
+++ b/test/Cortex/Wire/Cli/FrontierSpec.hs
@@ -24,6 +24,7 @@ spec = describe "Cortex.Wire.Cli.Frontier.parseFrontierCommand" $ do
           { frontierCommandClosure = FrontierClosed
           , frontierCommandScope = FrontierGraph
           , frontierCommandFormat = FrontierText
+          , frontierCommandSelectedReturn = Nothing
           , frontierCommandFile = "workflow.wire"
           }
 
@@ -34,6 +35,7 @@ spec = describe "Cortex.Wire.Cli.Frontier.parseFrontierCommand" $ do
           { frontierCommandClosure = FrontierClosed
           , frontierCommandScope = FrontierGraph
           , frontierCommandFormat = FrontierJson
+          , frontierCommandSelectedReturn = Nothing
           , frontierCommandFile = "workflow.wire"
           }
 
@@ -44,22 +46,32 @@ spec = describe "Cortex.Wire.Cli.Frontier.parseFrontierCommand" $ do
           { frontierCommandClosure = FrontierClosed
           , frontierCommandScope = FrontierGraph
           , frontierCommandFormat = FrontierText
+          , frontierCommandSelectedReturn = Nothing
           , frontierCommandFile = "workflow.wire"
           }
 
-  it "parses open node inspection with flags after the file" $
-    parseFrontierCommand ["workflow.wire", "--open", "--node", "planner", "--json"]
+  it "parses selected-return open node inspection with flags after the file" $
+    parseFrontierCommand
+      ["workflow.wire", "--open", "--node", "planner", "--return", "library_graph", "--json"]
       `shouldBe` Right
         FrontierCommand
           { frontierCommandClosure = FrontierOpen
           , frontierCommandScope = FrontierNode "planner"
           , frontierCommandFormat = FrontierJson
+          , frontierCommandSelectedReturn = Just "library_graph"
           , frontierCommandFile = "workflow.wire"
           }
 
   it "rejects --node when the next token is another flag" $
     parseFrontierCommand ["--node", "--json", "workflow.wire"] `shouldBe` Left frontierUsage
 
+  it "rejects --return when the next token is another flag" $
+    parseFrontierCommand ["--return", "--json", "workflow.wire"] `shouldBe` Left frontierUsage
+
   it "rejects conflicting closure projections" $
     parseFrontierCommand ["--closure", "--open", "workflow.wire"]
       `shouldBe` Left "wire frontier accepts only one of --closure or --open."
+
+  it "rejects conflicting selected returns" $
+    parseFrontierCommand ["--return", "first", "--return", "second", "workflow.wire"]
+      `shouldBe` Left "wire frontier accepts only one --return selection."

--- a/test/Cortex/Wire/EndpointUseSpec.hs
+++ b/test/Cortex/Wire/EndpointUseSpec.hs
@@ -15,6 +15,7 @@ module Cortex.Wire.EndpointUseSpec (spec) where
 
 import Data.Aeson qualified as Aeson
 import Data.Text (Text)
+import Data.Text qualified as T
 import Test.Hspec
 
 import Cortex.Wire (CircuitNodeRef (..), Connection (..), EndpointRef (..))
@@ -27,7 +28,9 @@ import Cortex.Wire.AdmissionArtifact
   , emptyWireAdmissionArtifact
   , finalizeWireAdmissionArtifact
   )
+import Cortex.Wire.Compile (compileWireTextWithReturn)
 import Cortex.Wire.EndpointUse
+import Cortex.Wire.LeanFixture (compiledWireAdmissionArtifact)
 
 nodeA, nodeB :: CircuitNodeRef
 nodeA = CircuitNodeRef "A"
@@ -252,3 +255,36 @@ spec = describe "Cortex.Wire.EndpointUse.endpointUseReportFromArtifact" $ do
       Nothing -> expectationFailure "node B missing from report"
 
     reportUnaccounted report `shouldBe` ([], [])
+
+  it "reports endpoint-use for a selected exported graph return" $ do
+    compiled <- requireRight (compileWireTextWithReturn "library_graph" exportedGraphLibrarySourceText)
+    artifact <-
+      case compiledWireAdmissionArtifact compiled of
+        Just value -> pure value
+        Nothing -> fail "compiled circuit carries no admission artifact"
+    let report = endpointUseReportFromArtifact artifact
+
+    fmap (.nodeFrontierRef) report.reportNodes `shouldBe` [CircuitNodeRef "library"]
+    case lookupNodeFrontier (CircuitNodeRef "library") report of
+      Just frontier ->
+        fmap outputFrontierUse frontier.nodeFrontierOutputs
+          `shouldBe` [TerminalDischarge HostReturn]
+      Nothing -> expectationFailure "library node missing from selected-return report"
+
+exportedGraphLibrarySourceText :: T.Text
+exportedGraphLibrarySourceText =
+  T.unlines
+    [ "contract LibraryOutput;"
+    , "contract MainOutput;"
+    , "node library"
+    , "  -> out: LibraryOutput = \"library\";"
+    , "node main"
+    , "  -> out: MainOutput = \"main\";"
+    , "export let library_graph = library ;"
+    , "main"
+    ]
+
+requireRight :: Show err => Either err a -> IO a
+requireRight = \case
+  Right value -> pure value
+  Left err -> fail ("expected Right, got: " <> show err)


### PR DESCRIPTION
## Summary
Start issue #347 implementation workspace for the `wire frontier` inspection surface.

Current `main` already contains the core endpoint-use/frontier command from PR #346, so this branch will first reconcile the issue acceptance criteria against the landed surface, then add any missing tests/docs or narrow the issue before review.

## Plan
- [ ] Audit landed `wire frontier` implementation against #347 acceptance criteria.
- [ ] Add any missing focused tests/docs for the stable CLI/JSON surface.
- [ ] Update issue/PR notes if remaining #347 scope is only follow-up diagnostics.

## Checklist
- [ ] Implementation complete
- [ ] Tests added/updated
- [ ] `just check` passes locally
- [ ] Ready for review

## Issue
Closes #347