### PR TITLE
refactor(wire): centralize formatter graph layout

### DIFF
--- a/docs/Reference/Wire/style.md
+++ b/docs/Reference/Wire/style.md
@@ -94,17 +94,28 @@ plan_build
   => summarize_build
 ```
 
-Break large frontiers vertically with a leading `<>` on each member, aligned with the `=>` stages so
-each line reads as another member of the same frontier:
+Break large frontiers vertically with a leading `<>` on each continuation, indented under the first
+frontier member so each line reads as another member of the same frontier:
 
 ```wire
 plan_build
   => compile_check
-  <> test_check
+    <> test_check
+    <> docs_check
+    <> lint_check
+    <> audit_check
+    <> package_check
+  => summarize_build
+```
+
+When a large frontier is the first graph stage, keep the first two compact members on the first line
+and indent the remaining members beneath them:
+
+```wire
+compile_check <> test_check
   <> docs_check
   <> lint_check
   <> audit_check
-  <> package_check
   => summarize_build
 ```
 

--- a/src/Cortex/Wire/Format.hs
+++ b/src/Cortex/Wire/Format.hs
@@ -371,85 +371,124 @@ formatExecutorConfig record =
   " " <> formatRecordInline record
 
 formatGraphExpr :: Int -> Expr -> [Text]
-formatGraphExpr level expr =
+formatGraphExpr level = formatGraphWithPrefix level noLinePrefix
+
+data LinePrefix
+  = LinePrefixNone
+  | LinePrefix !Text
+  deriving stock (Eq, Show)
+
+noLinePrefix :: LinePrefix
+noLinePrefix = LinePrefixNone
+
+prefixText :: LinePrefix -> Text
+prefixText = \case
+  LinePrefixNone -> ""
+  LinePrefix prefix -> prefix
+
+indentPrefixed :: Int -> LinePrefix -> Text -> Text
+indentPrefixed level prefix content =
+  indentText level (prefixText prefix <> content)
+
+formatGraphWithPrefix :: Int -> LinePrefix -> Expr -> [Text]
+formatGraphWithPrefix level prefix expr =
   case expr of
     ExprConnect {} ->
-      formatTopologyChain level (flattenTopology expr)
+      formatTopologyChain level prefix (flattenTopology expr)
     ExprStar {} ->
-      formatTopologyChain level (flattenTopology expr)
+      formatTopologyChain level prefix (flattenTopology expr)
     ExprOverlay {} ->
-      formatOverlay level (flattenOverlay expr)
+      formatOverlay level prefix (flattenOverlay expr)
     _ ->
-      [indentText level (formatExprInline expr)]
+      [indentPrefixed level prefix (formatExprInline expr)]
 
-formatTopologyChain :: Int -> TopologyChain -> [Text]
-formatTopologyChain level (TopologyChain first rest) =
-  formatStage level first <> concatMap formatNext rest
+formatTopologyChain :: Int -> LinePrefix -> TopologyChain -> [Text]
+formatTopologyChain level LinePrefixNone chain
+  | Just line <- formatInlineTopologyChain chain =
+      [indentText level line]
+formatTopologyChain level prefix (TopologyChain first rest) =
+  formatStage level prefix first <> concatMap formatNext rest
   where
     formatNext (TopologyStep op stageExpr) =
-      case formatStage (level + 1) stageExpr of
-        [] -> []
-        firstLine : moreLines ->
-          (indentText (level + 1) (formatTopologyOp op <> " ") <> T.dropWhile (== ' ') firstLine) : moreLines
+      formatStage (level + 1) (LinePrefix (formatTopologyOp op <> " ")) stageExpr
 
-formatStage :: Int -> Expr -> [Text]
-formatStage level = \case
+formatStage :: Int -> LinePrefix -> Expr -> [Text]
+formatStage level prefix = \case
   expr@ExprOverlay {} ->
-    formatOverlay level (flattenOverlay expr)
+    formatOverlay level prefix (flattenOverlay expr)
   expr@ExprConnect {} ->
-    parenthesizeMultiline level (formatGraphExpr (level + 1) expr)
+    parenthesizeMultiline level prefix (formatGraphExpr (level + 1) expr)
   expr@ExprStar {} ->
-    parenthesizeMultiline level (formatGraphExpr (level + 1) expr)
+    parenthesizeMultiline level prefix (formatGraphExpr (level + 1) expr)
   expr ->
-    [indentText level (formatExprInline expr)]
+    [indentPrefixed level prefix (formatExprInline expr)]
 
-formatOverlay :: Int -> [Expr] -> [Text]
-formatOverlay level items
+formatOverlay :: Int -> LinePrefix -> [Expr] -> [Text]
+formatOverlay level prefix items
   | length items <= 4 && all isInlineGraphAtom items && T.length inline <= 100 =
-      [indentText level inline]
+      [indentPrefixed level prefix inline]
   | otherwise =
-      formatOverlayItems level items
+      formatOverlayItems level prefix items
   where
     inline =
       T.intercalate " <> " (fmap formatExprInline items)
 
-formatOverlayItems :: Int -> [Expr] -> [Text]
-formatOverlayItems level =
-  concat . zipWith formatItem [0 :: Int ..]
+formatOverlayItems :: Int -> LinePrefix -> [Expr] -> [Text]
+formatOverlayItems level firstPrefix items =
+  case firstStagePair items of
+    Just (first, second, rest) ->
+      [indentPrefixed level firstPrefix (formatExprInline first <> " <> " <> formatExprInline second)]
+        <> concatMap formatContinuation rest
+    Nothing ->
+      concat (zipWith formatItem [0 :: Int ..] items)
   where
-    formatItem index item =
-      addPrefix prefix $
-        case item of
-          ExprConnect {} -> parenthesizeMultiline level (formatGraphExpr (level + 1) item)
-          ExprStar {} -> parenthesizeMultiline level (formatGraphExpr (level + 1) item)
-          -- Nested ExprOverlay only reaches this branch from explicit source
-          -- grouping (flattenOverlay walks the left spine only). parenthesizeMultiline
-          -- always wraps, so the right-nested AST round-trips regardless of how the
-          -- inner frontier renders (e.g. a leading parenthesized connect/select).
-          ExprOverlay {} -> parenthesizeMultiline level (formatGraphExpr (level + 1) item)
-          _ -> [indentText level (formatExprInline item)]
-      where
-        prefix = if index == 0 then "" else "<> "
+    firstStagePair = \case
+      first : second : rest
+        | firstPrefix == LinePrefixNone
+        , isSimpleOverlayContinuation first
+        , isSimpleOverlayContinuation second ->
+            Just (first, second, rest)
+      _ -> Nothing
 
-parenthesizeMultiline :: Int -> [Text] -> [Text]
-parenthesizeMultiline level = \case
-  [] -> [indentText level "()"]
-  [single] -> [indentText level ("(" <> T.strip single <> ")")]
+    formatItem index =
+      formatItemAt itemLevel prefix
+      where
+        (itemLevel, prefix) =
+          if index == 0
+            then (level, firstPrefix)
+            else (level + 1, overlayContinuationPrefix)
+
+    formatItemAt itemLevel prefix item =
+      case item of
+        ExprConnect {} -> parenthesizeMultiline itemLevel prefix (formatGraphExpr (itemLevel + 1) item)
+        ExprStar {} -> parenthesizeMultiline itemLevel prefix (formatGraphExpr (itemLevel + 1) item)
+        -- Nested ExprOverlay only reaches this branch from explicit source
+        -- grouping (flattenOverlay walks the left spine only). parenthesizeMultiline
+        -- always wraps, so the right-nested AST round-trips regardless of how the
+        -- inner frontier renders.
+        ExprOverlay {} -> parenthesizeMultiline itemLevel prefix (formatGraphExpr (itemLevel + 1) item)
+        _ -> [indentPrefixed itemLevel prefix (formatExprInline item)]
+
+    formatContinuation =
+      formatItemAt (level + 1) overlayContinuationPrefix
+
+    overlayContinuationPrefix = LinePrefix "<> "
+
+isSimpleOverlayContinuation :: Expr -> Bool
+isSimpleOverlayContinuation = \case
+  ExprConnect {} -> False
+  ExprStar {} -> False
+  ExprOverlay {} -> False
+  expr -> isInlineGraphAtom expr
+
+parenthesizeMultiline :: Int -> LinePrefix -> [Text] -> [Text]
+parenthesizeMultiline level prefix = \case
+  [] -> [indentPrefixed level prefix "()"]
+  [single] -> [indentPrefixed level prefix ("(" <> T.strip single <> ")")]
   lines' ->
-    [indentText level "("]
+    [indentPrefixed level prefix "("]
       <> lines'
       <> [indentText level ")"]
-
-addPrefix :: Text -> [Text] -> [Text]
-addPrefix "" lines' =
-  lines'
-addPrefix prefix lines' =
-  case lines' of
-    [] -> []
-    firstLine : rest ->
-      let spaces = T.takeWhile (== ' ') firstLine
-          content = T.dropWhile (== ' ') firstLine
-       in (spaces <> prefix <> content) : rest
 
 data TopologyOp
   = TopologyConnect
@@ -466,6 +505,27 @@ formatTopologyOp :: TopologyOp -> Text
 formatTopologyOp = \case
   TopologyConnect -> "=>"
   TopologyStar -> "*"
+
+formatInlineTopologyChain :: TopologyChain -> Maybe Text
+formatInlineTopologyChain = \case
+  TopologyChain first [TopologyStep op second]
+    | isInlineTopologyAtom first
+    , isInlineTopologyAtom second
+    , T.length line <= 100 ->
+        Just line
+    where
+      line = formatExprInline first <> " " <> formatTopologyOp op <> " " <> formatExprInline second
+  _ -> Nothing
+
+isInlineTopologyAtom :: Expr -> Bool
+isInlineTopologyAtom = \case
+  ExprOverlay {} -> False
+  ExprConnect {} -> False
+  ExprStar {} -> False
+  ExprMerge {} -> False
+  ExprConcat {} -> False
+  ExprList {} -> False
+  expr -> T.length (formatExprInline expr) <= 80
 
 flattenTopology :: Expr -> TopologyChain
 flattenTopology expr =

--- a/test/Cortex/Wire/FormatSpec.hs
+++ b/test/Cortex/Wire/FormatSpec.hs
@@ -28,13 +28,29 @@ spec = do
       formatWireSource "test" "a=>b=>c"
         `shouldBe` Right "a\n  => b\n  => c\n"
 
+    it "formats simple connect pairs inline" $ do
+      formatWireSource "test" "a=>b"
+        `shouldBe` Right "a => b\n"
+
+    it "formats simple star pairs inline" $ do
+      formatWireSource "test" "a*b"
+        `shouldBe` Right "a * b\n"
+
+    it "formats short configured graph atoms inline" $ do
+      formatWireSource "test" "@exec { mode = fast; }=>sink"
+        `shouldBe` Right "@exec { mode = fast; } => sink\n"
+
     it "formats small frontiers horizontally inside connect chains" $ do
       formatWireSource "test" "a=>(b<>c<>d)=>e"
         `shouldBe` Right "a\n  => b <> c <> d\n  => e\n"
 
-    it "formats large frontiers with stage-aligned leading overlay operators" $ do
+    it "formats large frontiers with payload-indented overlay continuations" $ do
       formatWireSource "test" "a=>(b<>c<>d<>e<>f)=>g"
-        `shouldBe` Right "a\n  => b\n  <> c\n  <> d\n  <> e\n  <> f\n  => g\n"
+        `shouldBe` Right "a\n  => b\n    <> c\n    <> d\n    <> e\n    <> f\n  => g\n"
+
+    it "formats first-stage large frontiers without synthetic stage indentation" $ do
+      formatWireSource "test" "(a<>b<>c<>d<>e)=>sink"
+        `shouldBe` Right "a <> b\n  <> c\n  <> d\n  <> e\n  => sink\n"
 
     it "preserves explicit right-nested connect groups without redundant frontier parens" $ do
       formatWireSource "test" "a=>b=>((c<>d)=>e)"
@@ -50,7 +66,7 @@ spec = do
 
     it "preserves explicit right-nested star groups" $ do
       formatWireSource "test" "a*(b*c)"
-        `shouldBe` Right "a\n  * (\n    b\n      * c\n  )\n"
+        `shouldBe` Right "a\n  * (b * c)\n"
 
     it "formats contract record shapes" $ do
       formatWireSource "test" "contract Result{summary: Text;};"
@@ -88,7 +104,7 @@ spec = do
 
     it "does not treat # inside strings as a comment" $ do
       formatWireSource "test" "let flake = \".#wire\";\na\n  => b\n"
-        `shouldBe` Right "let flake = \".#wire\";\n\na\n  => b\n"
+        `shouldBe` Right "let flake = \".#wire\";\n\na => b\n"
 
     it "allows non-cyclic graph-domain compile errors before formatting" $ do
       let source =
@@ -98,7 +114,7 @@ spec = do
             \  -> input: T = input;\n\
             \a=>a\n"
           expected =
-            "contract T;\n\nnode a\n  <- input: T;\n  -> input: T = input;\n\na\n  => a\n"
+            "contract T;\n\nnode a\n  <- input: T;\n  -> input: T = input;\n\na => a\n"
       formatWireSource "test" source `shouldBe` Right expected
 
     it "preserves kind declarations rather than expanding them" $ do
@@ -194,10 +210,10 @@ spec = do
             "let pipeline =\n\
             \  a\n\
             \    => b\n\
-            \    <> c\n\
-            \    <> d\n\
-            \    <> e\n\
-            \    <> f\n\
+            \      <> c\n\
+            \      <> d\n\
+            \      <> e\n\
+            \      <> f\n\
             \    => g;\n\
             \\n\
             \pipeline\n"
@@ -232,8 +248,7 @@ spec = do
           \  <- score: Score;\n\
           \  -> text: Text = concat [toString score];\n\
           \\n\
-          \home\n\
-          \  => report\n"
+          \home => report\n"
 
     it "preserves CorePure field access on a parenthesised ident" $ do
       let source = "let x = (a).b;\nx\n"


### PR DESCRIPTION
## Summary
Centralize Wire graph formatter layout decisions so parenthesization and stage indentation are driven by AST/context rather than rendered text shape.

## Plan
- [x] Inspect current `Cortex.Wire.Format` graph/stage rendering and existing adversarial formatter tests.
- [x] Add explicit first-stage overlay layout coverage in `FormatSpec`.
- [x] Refactor graph rendering around explicit layout context for graph/stage/open-overlay/closed groups.
- [x] Keep existing right-nested overlay/connect/star cases total and idempotent.
- [x] Run focused formatter tests and broader checks.

## Checklist
- [x] Implementation complete
- [x] Tests added/updated
- [x] `just check` passes locally
- [ ] Ready for review

## Issue
Closes #342