### PR TITLE
feat(wire): gate admission through bundles

### DIFF
--- a/cortex.cabal
+++ b/cortex.cabal
@@ -182,6 +182,7 @@ library
         Cortex.Pulse.Resume
         Cortex.Pulse.Runtime
         Cortex.Wire
+        Cortex.Wire.AdmissionBundle
         Cortex.Wire.AdmissionArtifact
         Cortex.Wire.AdmissionBinding
         Cortex.Wire.Compile

--- a/docs/Reference/proof-status.md
+++ b/docs/Reference/proof-status.md
@@ -76,8 +76,9 @@ The cutline is:
 - Lean owns a post-parse elaboration IR and primitive-subset admission kernel, not the textual
   parser;
 - `WireAdmissionArtifact` is the Haskell-to-Lean proof-witness exchange schema;
-- Haskell currently gates compiler output with `wireAdmissionArtifactValidatorReady` and
-  artifact-to-circuit binding checks;
+- Haskell currently gates compiler output by constructing a `WireAdmissionBundle`
+  (`src/Cortex/Wire/AdmissionBundle.hs`), whose first implementation joins
+  `wireAdmissionArtifactValidatorReady` with artifact-to-circuit binding checks;
 - Lean's executable validator is the intended authority for the artifact contract, but runtime
   validation of arbitrary freshly emitted artifacts by Lean remains an open obligation.
 
@@ -243,6 +244,12 @@ as having solved that projection rule.
   compiler's primitive trace is core-only for every emitted fixture: generated differential modules
   (`theory/Cortex/Wire/AdmissionArtifact/Differential/`) replay compiler output for the full
   eight-fixture corpus and `#guard` boundary agreement at every `lean-check`.
+- The Haskell compiler now has one named admission-boundary gate:
+  `Cortex.Wire.AdmissionBundle.admitWireAdmissionBundle`. The gate constructs a
+  `WireAdmissionBundle` only after the artifact is validator-ready and the same artifact binds to
+  the compiled circuit metadata/topology/select bodies. This is not yet Lean runtime validation of
+  arbitrary freshly emitted artifacts; it is the explicit Haskell-side join point that a future Lean
+  validation entrypoint can replace or back.
 - Derived-form elaboration is mechanized as deterministic
   (`theory/Cortex/Wire/GeneratedFormsDeterminism.lean`): `KindInstantiatedFrontiers` is determined
   by its child labels (`eq_of_childLabel_eq`), the `make`/`makeEach` label witnesses pin those

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -14,68 +14,71 @@
       inputs.haskell-nix.overlay
       (final: prev: let
         patchDarwinBootstrapGhc = compiler:
-          compiler.overrideAttrs (old: {
-            postConfigure =
-              (old.postConfigure or "")
-              + final.lib.optionalString (final.stdenv.hostPlatform.isDarwin && final.stdenv.hostPlatform.isAarch64) ''
-                for config in mk/config.mk hadrian/cfg/system.config; do
-                  if grep -q '${final.stdenv.cc}/bin/cc -std=gnu23' "$config"; then
-                    substituteInPlace "$config" \
-                      --replace-fail "${final.stdenv.cc}/bin/cc -std=gnu23" "${final.stdenv.cc}/bin/cc"
-                  fi
-                done
-              '';
-            preConfigure =
-              final.lib.optionalString (final.stdenv.hostPlatform.isDarwin && final.stdenv.hostPlatform.isAarch64) ''
-                export ac_cv_prog_cc_c23=
-                export CXX_STD_LIB_LIBS="c++ c++abi"
-                export CXX_STD_LIB_LIB_DIRS="${final.darwin.libcxx}/lib"
-                export CXX_STD_LIB_DYN_LIB_DIRS="${final.darwin.libcxx}/lib"
-              ''
-              + (old.preConfigure or "");
-            preInstall =
-              final.lib.optionalString (final.stdenv.hostPlatform.isDarwin && final.stdenv.hostPlatform.isAarch64) ''
-                export ac_cv_prog_cc_c23=
-                export CXX_STD_LIB_LIBS="c++ c++abi"
-                export CXX_STD_LIB_LIB_DIRS="${final.darwin.libcxx}/lib"
-                export CXX_STD_LIB_DYN_LIB_DIRS="${final.darwin.libcxx}/lib"
-              ''
-              + (old.preInstall or "");
-            postInstall =
-              (old.postInstall or "")
-              + final.lib.optionalString (final.stdenv.hostPlatform.isDarwin && final.stdenv.hostPlatform.isAarch64) ''
-                packageDb=$(find "$out/lib" -path '*/package.conf.d' -type d | head -n1)
-                if [ -n "$packageDb" ]; then
-                  mkdir -p "$out/envDeps" "$out/exactDeps"
-                  for pkgId in $("$out/bin/ghc-pkg" -v0 --global-package-db="$packageDb" list --simple-output); do
-                    if name=$("$out/bin/ghc-pkg" -v0 --global-package-db="$packageDb" field "$pkgId" name --simple-output 2>/dev/null); then
-                      id=$("$out/bin/ghc-pkg" -v0 --global-package-db="$packageDb" field "$pkgId" id --simple-output)
-                      ver=$("$out/bin/ghc-pkg" -v0 --global-package-db="$packageDb" field "$pkgId" version --simple-output)
-                      mkdir -p "$out/exactDeps/$name"
-                      echo "--dependency=$name=$id" > "$out/exactDeps/$name/configure-flags"
-                      {
-                        echo "constraint: $name == $ver"
-                        echo "constraint: $name installed"
-                      } > "$out/exactDeps/$name/cabal.config"
-                      echo "package-id $id" > "$out/envDeps/$name"
+          if final.stdenv.hostPlatform.isDarwin && final.stdenv.hostPlatform.isAarch64
+          then
+            compiler.overrideAttrs (old: {
+              postConfigure =
+                (old.postConfigure or "")
+                + ''
+                  for config in mk/config.mk hadrian/cfg/system.config; do
+                    if grep -q '${final.stdenv.cc}/bin/cc -std=gnu23' "$config"; then
+                      substituteInPlace "$config" \
+                        --replace-fail "${final.stdenv.cc}/bin/cc -std=gnu23" "${final.stdenv.cc}/bin/cc"
                     fi
                   done
-                fi
-              '';
-            buildInputs =
-              (old.buildInputs or [])
-              ++ final.lib.optionals (final.stdenv.hostPlatform.isDarwin && final.stdenv.hostPlatform.isAarch64) [
-                final.darwin.libcxx
-              ];
-            passthru =
-              (old.passthru or {})
-              // final.lib.optionalAttrs (compiler ? buildGHC) {
-                buildGHC = compiler.buildGHC;
-              }
-              // final.lib.optionalAttrs (compiler ? raw-src) {
-                raw-src = compiler.raw-src;
-              };
-          });
+                '';
+              preConfigure =
+                ''
+                  export ac_cv_prog_cc_c23=
+                  export CXX_STD_LIB_LIBS="c++ c++abi"
+                  export CXX_STD_LIB_LIB_DIRS="${final.darwin.libcxx}/lib"
+                  export CXX_STD_LIB_DYN_LIB_DIRS="${final.darwin.libcxx}/lib"
+                ''
+                + (old.preConfigure or "");
+              preInstall =
+                ''
+                  export ac_cv_prog_cc_c23=
+                  export CXX_STD_LIB_LIBS="c++ c++abi"
+                  export CXX_STD_LIB_LIB_DIRS="${final.darwin.libcxx}/lib"
+                  export CXX_STD_LIB_DYN_LIB_DIRS="${final.darwin.libcxx}/lib"
+                ''
+                + (old.preInstall or "");
+              postInstall =
+                (old.postInstall or "")
+                + ''
+                  packageDb=$(find "$out/lib" -path '*/package.conf.d' -type d | head -n1)
+                  if [ -n "$packageDb" ]; then
+                    mkdir -p "$out/envDeps" "$out/exactDeps"
+                    for pkgId in $("$out/bin/ghc-pkg" -v0 --global-package-db="$packageDb" list --simple-output); do
+                      if name=$("$out/bin/ghc-pkg" -v0 --global-package-db="$packageDb" field "$pkgId" name --simple-output 2>/dev/null); then
+                        id=$("$out/bin/ghc-pkg" -v0 --global-package-db="$packageDb" field "$pkgId" id --simple-output)
+                        ver=$("$out/bin/ghc-pkg" -v0 --global-package-db="$packageDb" field "$pkgId" version --simple-output)
+                        mkdir -p "$out/exactDeps/$name"
+                        echo "--dependency=$name=$id" > "$out/exactDeps/$name/configure-flags"
+                        {
+                          echo "constraint: $name == $ver"
+                          echo "constraint: $name installed"
+                        } > "$out/exactDeps/$name/cabal.config"
+                        echo "package-id $id" > "$out/envDeps/$name"
+                      fi
+                    done
+                  fi
+                '';
+              buildInputs =
+                (old.buildInputs or [])
+                ++ [
+                  final.darwin.libcxx
+                ];
+              passthru =
+                (old.passthru or {})
+                // final.lib.optionalAttrs (compiler ? buildGHC) {
+                  buildGHC = compiler.buildGHC;
+                }
+                // final.lib.optionalAttrs (compiler ? raw-src) {
+                  raw-src = compiler.raw-src;
+                };
+            })
+          else compiler;
       in {
         haskell =
           prev.haskell

--- a/src/Cortex/Wire/AdmissionBundle.hs
+++ b/src/Cortex/Wire/AdmissionBundle.hs
@@ -1,0 +1,83 @@
+{- |
+Module      : Cortex.Wire.AdmissionBundle
+Description : Unified Wire admission bundle gate.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The module belongs to Cortex's upstream runtime and library surface.
+
+`Cortex.Wire.AdmissionArtifact` validates the internal proof-witness artifact,
+and `Cortex.Wire.AdmissionBinding` checks that the artifact travels with the
+compiled circuit it describes. This module is the named join between those two
+surfaces: a `WireAdmissionBundle` is only constructed after both gates pass.
+
+The first implementation slice is still Haskell-side. Its purpose is to make
+the boundary explicit and replaceable: a later Lean runtime checker can become
+the authority behind this module without every compiler call site having to
+remember the individual predicates and their ordering.
+-}
+module Cortex.Wire.AdmissionBundle
+  ( AdmissionBundleError (..)
+  , WireAdmissionBundle (..)
+  , admitWireAdmissionBundle
+  )
+where
+
+import Data.Aeson (FromJSON, ToJSON)
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+
+import Cortex.Wire.AdmissionArtifact
+  ( WireAdmissionArtifact (..)
+  , wireAdmissionArtifactValidatorReady
+  , wireAdmissionCurrentSchemaVersion
+  )
+import Cortex.Wire.AdmissionBinding
+  ( AdmissionBindingError
+  , admissionArtifactBindsCompiledCircuit
+  )
+import Cortex.Wire.Circuit.Compiled (CompiledCircuit)
+
+{- | Why a candidate artifact/circuit pair did not form a unified admission
+bundle. The validator-ready check runs first because circuit binding is only
+meaningful for an internally sound artifact.
+-}
+data AdmissionBundleError
+  = AdmissionBundleArtifactNotValidatorReady
+  | AdmissionBundleCircuitBindingFailed !AdmissionBindingError
+  deriving stock (Eq, Show)
+
+{- | A proof-witness artifact that has passed the current Haskell-side unified
+admission gate for the compiled circuit it travels with.
+
+The bundle deliberately stores the artifact, not the full circuit. The binding
+checker validates the circuit relationship at construction time; consumers that
+need to re-check a transported pair should call `admitWireAdmissionBundle`
+again with the current circuit.
+-}
+data WireAdmissionBundle = WireAdmissionBundle
+  { wireAdmissionBundleSchemaVersion :: !Natural
+  , wireAdmissionBundleArtifact :: !WireAdmissionArtifact
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+admitWireAdmissionBundle
+  :: WireAdmissionArtifact
+  -> CompiledCircuit
+  -> Either AdmissionBundleError WireAdmissionBundle
+admitWireAdmissionBundle artifact circuit
+  | not (wireAdmissionArtifactValidatorReady artifact) =
+      Left AdmissionBundleArtifactNotValidatorReady
+  | otherwise =
+      case admissionArtifactBindsCompiledCircuit artifact circuit of
+        Left bindingError ->
+          Left (AdmissionBundleCircuitBindingFailed bindingError)
+        Right () ->
+          Right
+            WireAdmissionBundle
+              { wireAdmissionBundleSchemaVersion = wireAdmissionCurrentSchemaVersion
+              , wireAdmissionBundleArtifact = artifact
+              }

--- a/src/Cortex/Wire/Compile.hs
+++ b/src/Cortex/Wire/Compile.hs
@@ -95,11 +95,13 @@ import Cortex.Wire.AdmissionArtifact
   , combineWireAdmissionArtifacts
   , emptyWireAdmissionArtifact
   , finalizeWireAdmissionArtifact
-  , wireAdmissionArtifactValidatorReady
   , wireAdmissionMetadataKey
   , wireAdmissionMetadataValue
   )
-import Cortex.Wire.AdmissionBinding (admissionArtifactBindsCompiledCircuit)
+import Cortex.Wire.AdmissionBundle
+  ( AdmissionBundleError (..)
+  , admitWireAdmissionBundle
+  )
 import Cortex.Wire.Circuit.Artifact
   ( CircuitCompatibilityWitness (..)
   , CircuitConditionNode (..)
@@ -751,11 +753,10 @@ compileLoweredWireFile compileEnv requireConnected wireFile lowered = do
           else AdmissionOpenFragment
       finalizedAdmission =
         finalizeWireAdmissionArtifact closureMode lowered.lwfFragment.gfAdmission
-  admission <- validateWireAdmissionArtifact finalizedAdmission
   let metadataValue =
         attachAdmissionMetadata
           lowered.lwfMetadata
-          admission
+          finalizedAdmission
       compiled =
         CompiledCircuit
           { compiledCircuitId = lowered.lwfCircuitId
@@ -768,28 +769,24 @@ compileLoweredWireFile compileEnv requireConnected wireFile lowered = do
           , compiledCircuitMetadata = metadataValue
           }
   -- The artifact and the circuit are derived from the same lowering fragment
-  -- through parallel paths; gating on the binding checker turns that shared
-  -- derivation into an enforced invariant instead of a refactor hazard.
-  case admissionArtifactBindsCompiledCircuit admission compiled of
-    Right () -> pure compiled
-    Left bindingError ->
+  -- through parallel paths; gating on the admission bundle turns that shared
+  -- derivation into one enforced boundary instead of a refactor hazard.
+  case admitWireAdmissionBundle finalizedAdmission compiled of
+    Right _bundle -> pure compiled
+    Left bundleError ->
       Left
         ( WireCore.WireParseError
-            ( "internal Wire admission artifact does not bind to the compiled circuit: "
-                <> T.pack (show bindingError)
+            ( "internal Wire admission bundle was rejected: "
+                <> renderAdmissionBundleError bundleError
             )
         )
 
-validateWireAdmissionArtifact
-  :: WireAdmissionArtifact -> Either WireCore.WireError WireAdmissionArtifact
-validateWireAdmissionArtifact admission
-  | wireAdmissionArtifactValidatorReady admission =
-      Right admission
-  | otherwise =
-      Left
-        ( WireCore.WireParseError
-            "internal Wire admission artifact failed validator-ready checks"
-        )
+renderAdmissionBundleError :: AdmissionBundleError -> Text
+renderAdmissionBundleError = \case
+  AdmissionBundleArtifactNotValidatorReady ->
+    "artifact failed validator-ready checks"
+  AdmissionBundleCircuitBindingFailed bindingError ->
+    "artifact does not bind to the compiled circuit: " <> T.pack (show bindingError)
 
 attachAdmissionMetadata :: Maybe Aeson.Value -> WireAdmissionArtifact -> Aeson.Value
 attachAdmissionMetadata maybeMetadata admission =

--- a/test/Cortex/Wire/CompileSpec.hs
+++ b/test/Cortex/Wire/CompileSpec.hs
@@ -68,6 +68,11 @@ import Cortex.Wire.AdmissionBinding
   ( AdmissionBindingError (..)
   , admissionArtifactBindsCompiledCircuit
   )
+import Cortex.Wire.AdmissionBundle
+  ( AdmissionBundleError (..)
+  , WireAdmissionBundle (..)
+  , admitWireAdmissionBundle
+  )
 import Cortex.Wire.Circuit.Artifact
   ( CircuitConditionNode (..)
   , CompiledCircuit (..)
@@ -3799,6 +3804,29 @@ spec = describe "Cortex.Wire.Compile" $ do
       compileWireText source `shouldSatisfy` isRight
 
   describe "admission artifact circuit binding" $ do
+    it "admits a validator-ready artifact bound to its compiled circuit as a bundle" $ do
+      compiled <- requireRight (compileWireText simpleChainSourceText)
+      expectAdmissionBundle compiled
+
+    it "rejects validator-stale artifacts before circuit binding" $ do
+      compiled <- requireRight (compileWireText simpleChainSourceText)
+      artifact <- requireWireAdmissionArtifact compiled
+      let staleArtifact =
+            artifact {wireAdmissionEndpointUses = emptyAdmissionEndpointUseWitness}
+      admitWireAdmissionBundle
+        staleArtifact
+        (patchAdmissionMetadata staleArtifact compiled)
+        `shouldBe` Left AdmissionBundleArtifactNotValidatorReady
+
+    it "rejects circuit-binding drift through the unified bundle gate" $ do
+      compiled <- requireRight (compileWireText simpleChainSourceText)
+      artifact <- requireWireAdmissionArtifact compiled
+      let metadataDrift =
+            compiled {compiledCircuitMetadata = Aeson.object ["format" Aeson..= ("drift" :: T.Text)]}
+      admitWireAdmissionBundle artifact metadataDrift
+        `shouldBe` Left
+          (AdmissionBundleCircuitBindingFailed BindingMetadataMissingAdmissionKey)
+
     it "binds the labeled chain artifact to its compiled circuit" $ do
       compiled <- requireRight (compileWireText simpleChainSourceText)
       expectArtifactBindsCircuit compiled
@@ -5517,6 +5545,16 @@ expectArtifactBindsCircuit :: CompiledCircuit -> Expectation
 expectArtifactBindsCircuit compiled = do
   artifact <- requireWireAdmissionArtifact compiled
   admissionArtifactBindsCompiledCircuit artifact compiled `shouldBe` Right ()
+
+expectAdmissionBundle :: CompiledCircuit -> Expectation
+expectAdmissionBundle compiled = do
+  artifact <- requireWireAdmissionArtifact compiled
+  admitWireAdmissionBundle artifact compiled
+    `shouldBe` Right
+      WireAdmissionBundle
+        { wireAdmissionBundleSchemaVersion = wireAdmissionCurrentSchemaVersion
+        , wireAdmissionBundleArtifact = artifact
+        }
 
 expectBindingFailure
   :: (AdmissionBindingError -> Bool)


### PR DESCRIPTION
## Summary

Define the first concrete unified Wire admission boundary: Haskell still emits the artifact/circuit candidate, but compiler output now passes through one named bundle gate that joins artifact validator readiness with artifact-to-circuit binding.

## Changes

- add `Cortex.Wire.AdmissionBundle` with `WireAdmissionBundle` and `admitWireAdmissionBundle`
- route Wire compilation through the bundle gate instead of separate validator/binding calls
- cover success, validator-stale, and circuit-binding-drift cases in `CompileSpec`
- update `proof-status.md` to name the new Haskell-side join point without claiming Lean runtime validation yet

## Validation

- [x] `just docs-lint`
- [x] `just test-match "admission artifact circuit binding"`
- [x] `just lint`
- [x] commit hooks passed

## Remaining follow-up

This PR creates the explicit replacement point for #361. Later slices can put a Lean runtime checker behind this boundary, add a richer serialized bundle shape, and strengthen the proof-facing contract.

## Issue

Closes #361
