### PR TITLE
feat(wire): resolve package-owned modules

### DIFF
--- a/app/wire/Main.hs
+++ b/app/wire/Main.hs
@@ -105,7 +105,7 @@ import Cortex.Wire.Compile
   )
 import Cortex.Wire.Contract (WireCompileEnv (..), emptyWireCompileEnv)
 import Cortex.Wire.EndpointUse qualified as EndpointUse
-import Cortex.Wire.Import (loadWireModuleClosure, renderWireImportError)
+import Cortex.Wire.Import (loadWireModuleClosureWithEnv, renderWireImportError)
 import Cortex.Wire.Include (expandWireSourceIncludes)
 import Cortex.Wire.LeanFixture
   ( EmittedFixture (..)
@@ -119,10 +119,9 @@ import Cortex.Wire.LeanFixture
   )
 import Cortex.Wire.Package
   ( NamespaceRegistry
-  , packageConflicts
   , renderPackageConflict
   , stdOnlyRegistry
-  , wireCompileEnvWithPackages
+  , wireCompileEnvWithPackagesChecked
   )
 import Cortex.Wire.Package.Manifest
   ( loadWirePackageManifests
@@ -300,7 +299,7 @@ usageText =
 buildWire :: [FilePath] -> Maybe Text -> FilePath -> IO ()
 buildWire packagePaths maybeSelectedReturn path = do
   compileEnv <- loadCliWireCompileEnv packagePaths
-  modules <- loadWireModules path
+  modules <- loadWireModules compileEnv path
   let compile =
         maybe
           (compileWireModules compileEnv)
@@ -310,9 +309,9 @@ buildWire packagePaths maybeSelectedReturn path = do
   BSL.putStr (AesonPretty.encodePretty compiled)
   BSL.putStr "\n"
 
-loadWireModules :: FilePath -> IO (NonEmpty WireModule)
-loadWireModules path =
-  loadWireModuleClosure path
+loadWireModules :: WireCompileEnv -> FilePath -> IO (NonEmpty WireModule)
+loadWireModules compileEnv path =
+  loadWireModuleClosureWithEnv compileEnv path
     >>= either (dieText . renderWireImportError) pure
 
 {- | Inspect the endpoint-use / closure accounting of a compiled Wire file
@@ -324,7 +323,7 @@ it does not execute.
 frontierWire :: [FilePath] -> FrontierCommand -> IO ()
 frontierWire packagePaths frontierCommand = do
   compileEnv <- loadCliWireCompileEnv packagePaths
-  modules <- loadWireModules frontierCommand.frontierCommandFile
+  modules <- loadWireModules compileEnv frontierCommand.frontierCommandFile
   let compile =
         maybe
           (compileWireModules compileEnv)
@@ -440,7 +439,7 @@ fmtWireFile mode path = do
 runWire :: [FilePath] -> FilePath -> IO ()
 runWire packagePaths path = do
   compileEnv <- loadCliWireCompileEnv packagePaths
-  modules <- loadWireModules path
+  modules <- loadWireModules compileEnv path
   let namespaceRegistry =
         fromMaybe stdOnlyRegistry compileEnv.wireCompileEnvNamespaceRegistry
   let rootFile = (NE.last modules).wireModuleFile
@@ -497,9 +496,9 @@ loadCliWireCompileEnv explicitPaths = do
   manifestPaths <- cliWirePackageManifestPaths explicitPaths
   loadedPackages <- loadWirePackageManifests manifestPaths
   packages <- either (dieText . renderWirePackageManifestError) pure loadedPackages
-  case packageConflicts packages of
-    [] -> pure (wireCompileEnvWithPackages packages emptyWireCompileEnv)
-    conflicts ->
+  case wireCompileEnvWithPackagesChecked packages emptyWireCompileEnv of
+    Right compileEnv -> pure compileEnv
+    Left conflicts ->
       dieText
         ( "conflicting Wire packages:\n"
             <> T.intercalate "\n" (fmap (("  - " <>) . renderPackageConflict) conflicts)

--- a/docs/ADRs/0060-filesystem-package-and-binding-manifests.md
+++ b/docs/ADRs/0060-filesystem-package-and-binding-manifests.md
@@ -68,14 +68,15 @@ A Wire package manifest is compile-time, inert data. The shape loaded today cont
 - namespace mappings from source contract names to canonical contract ids;
 - executor projections — the inert `WireExecutorProjection` (identity, ports, vocabulary, effect,
   config shape, port policy);
-- contract specs.
+- contract specs;
+- package-owned Wire module sources.
 
-Reserved for later slices, and not loaded by the current implementation: package dependencies,
-executor capability requirement slots (the ADR 0053 `RequirementSlot` data), and package-owned Wire
-module paths. When they are added they remain inert package data. The leaner
-`WireExecutorProjection` loaded today is deliberately distinct from the richer ADR 0053
-`AdmissionProjection`; only the latter carries projection version, requirement slots, replay class,
-isolation expectation, and await strategy, and Wire compilation never loads it.
+Reserved for later slices, and not loaded by the current implementation: package dependencies and
+executor capability requirement slots (the ADR 0053 `RequirementSlot` data). When they are added
+they remain inert package data. The leaner `WireExecutorProjection` loaded today is deliberately
+distinct from the richer ADR 0053 `AdmissionProjection`; only the latter carries projection version,
+requirement slots, replay class, isolation expectation, and await strategy, and Wire compilation
+never loads it.
 
 Loading a Wire package manifest never grants runtime authority. It only extends the namespace,
 contract, and executor-projection registries used by Wire compilation. Once requirement slots are
@@ -120,11 +121,17 @@ description = "Input accepted by the review analyzer."
 id = "example.ReviewReport"
 payload_kind = "json"
 description = "Report emitted by the review analyzer."
+
+[[module]]
+path = "example.review/helpers.wire"
+source = '''
+export let normalize = pure(x) { x };
+'''
 ```
 
 Future hardening slices may add manifest versioning, dependency declarations, conflict diagnostics,
-package-owned Wire module paths, and direct TOML syntax for ADR 0053 requirement slots. Those fields
-remain inert package data when they are added.
+and direct TOML syntax for ADR 0053 requirement slots. Those fields remain inert package data when
+they are added.
 
 ### Capability registration model
 
@@ -333,9 +340,23 @@ diagnostics for duplicate package ids, namespaces, executor ids, and contract id
 external manifests must reject a non-empty `packageConflicts` result before compilation.
 
 This discharges the earlier "future hardening" note for conflict diagnostics. Manifest versioning,
-dependency declarations, package-owned Wire module paths, and direct TOML syntax for future binding
-requirements remain deferred.
+dependency declarations, and direct TOML syntax for future binding requirements remain deferred.
 
 Traceability: `PackageConflict`, `packageConflicts`, and `renderPackageConflict` live in
 `src/Cortex/Wire/Package.hs`; the `wire` CLI rejects conflicts before constructing `WireCompileEnv`;
 coverage includes `test/Cortex/Wire/PackageSpec.hs` and `test/Cortex/Wire/QuantumPackageSpec.hs`.
+
+## Amendment - package-owned Wire modules (2026-06-30)
+
+Wire package manifests may include `[[module]]` entries. Each entry gives a logical package module
+`path` and a literal Wire `source` body. These modules are inert compile-time source: they do not
+grant runtime authority, do not imply filesystem access, and are loaded only when the selected
+compile environment contains the manifest. Because package modules do not imply filesystem access,
+the loader rejects `include_str` and `include_dir` forms inside package-owned module source.
+
+Package composition rejects duplicate module paths, matching the duplicate-package/namespace/id
+conflict policy above. File imports still resolve existing filesystem paths first. If an import path
+does not exist on disk and matches a package module path in the compile environment, the loader
+reads the package-owned source and gives it a package-module identity in the dependency closure.
+Missing package-style paths produce package-module diagnostics rather than pretending to be missing
+local files.

--- a/docs/Usage/06-package-manifests-and-extensions.md
+++ b/docs/Usage/06-package-manifests-and-extensions.md
@@ -24,6 +24,30 @@ nix run .#wire -- \
 
 Repeat the flag when an example needs more than one package.
 
+## Package-Owned Modules
+
+A package can also publish helper Wire source through `[[module]]` entries:
+
+```toml
+[package]
+id = "example.review"
+
+[[module]]
+path = "example.review/helpers.wire"
+source = '''
+export let normalize = pure(x) { x };
+'''
+```
+
+Wire files compiled with that manifest can import the package module by its manifest path:
+
+```wire
+import { normalize } from "example.review/helpers.wire";
+```
+
+Package modules are compile-time source only. Loading a manifest does not grant runtime authority or
+filesystem access. Package-owned modules therefore cannot use `include_str` or `include_dir`.
+
 ## Environment Search Path
 
 If no `--wire-package` flags are present, the CLI reads `CORTEX_WIRE_PACKAGE_MANIFESTS` as a search

--- a/extensions/quantum/src/Cortex/Quantum/Compile.hs
+++ b/extensions/quantum/src/Cortex/Quantum/Compile.hs
@@ -24,7 +24,7 @@ import System.Environment (lookupEnv)
 import Cortex.Wire (CompiledCircuit, renderWireError)
 import Cortex.Wire.Compile (compileWireModules, compileWireModulesWithReturn)
 import Cortex.Wire.Contract (WireCompileEnv, emptyWireCompileEnv)
-import Cortex.Wire.Import (loadWireModuleClosure, renderWireImportError)
+import Cortex.Wire.Import (loadWireModuleClosureWithEnv, renderWireImportError)
 import Cortex.Wire.Package
   ( packageConflicts
   , renderPackageConflict
@@ -63,7 +63,7 @@ packageManifestPaths = do
 -}
 compileExport :: WireCompileEnv -> Maybe Text -> FilePath -> IO (Either Text CompiledCircuit)
 compileExport env selectedReturn path = do
-  closure <- loadWireModuleClosure path
+  closure <- loadWireModuleClosureWithEnv env path
   pure $ case closure of
     Left err -> Left (renderWireImportError err)
     Right modules ->

--- a/src/Cortex/Wire/Compile.hs
+++ b/src/Cortex/Wire/Compile.hs
@@ -23,6 +23,7 @@ module Cortex.Wire.Compile
   , compileWireTextWithReturnAndEnv
   , compileWireFragmentText
   , compileWireFragmentTextWithEnv
+  , WireModuleId (..)
   , WireModule (..)
   , WireModuleExports
   , compileWireModules
@@ -304,18 +305,23 @@ ordering are IO concerns owned by "Cortex.Wire.Import"; the compiler consumes
 an already-ordered closure purely (dependencies first, root last).
 -}
 data WireModule = WireModule
-  { wireModulePath :: !FilePath
-  -- ^ Canonical identity of the module file; unique within a closure.
+  { wireModulePath :: !WireModuleId
+  -- ^ Canonical identity of the module; unique within a closure.
   , wireModuleDisplayPath :: !Text
   -- ^ Path used in diagnostics.
   , wireModuleParseInfo :: !WireParseInfo
   , wireModuleFile :: !WireFile
-  , wireModuleImportPaths :: !(Map Text FilePath)
+  , wireModuleImportPaths :: !(Map Text WireModuleId)
   {- ^ Import path text as written in this module, resolved to the canonical
   path of the target module.
   -}
   }
   deriving stock (Eq, Show)
+
+data WireModuleId
+  = WireFileModule !FilePath
+  | WirePackageModule !Text
+  deriving stock (Eq, Ord, Show)
 
 -- | The importable surface of a lowered module.
 data WireModuleExports = WireModuleExports
@@ -391,16 +397,16 @@ compileModulesInternal maybeSelectedReturn compileEnv modules = do
 
 addModuleExports
   :: WireCompileEnv
-  -> Map FilePath WireModuleExports
+  -> Map WireModuleId WireModuleExports
   -> WireModule
-  -> Either WireCore.WireError (Map FilePath WireModuleExports)
+  -> Either WireCore.WireError (Map WireModuleId WireModuleExports)
 addModuleExports compileEnv exportsByPath wireModule = do
   importCtx <- moduleImportContext exportsByPath wireModule
   moduleExports <- lowerModuleExports compileEnv importCtx wireModule
   Right (Map.insert wireModule.wireModulePath moduleExports exportsByPath)
 
 moduleImportContext
-  :: Map FilePath WireModuleExports
+  :: Map WireModuleId WireModuleExports
   -> WireModule
   -> Either WireCore.WireError (Map Text WireModuleExports)
 moduleImportContext exportsByPath wireModule =

--- a/src/Cortex/Wire/Contracts.hs
+++ b/src/Cortex/Wire/Contracts.hs
@@ -88,6 +88,7 @@ data WireCompileEnv = WireCompileEnv
   , wireCompileEnvProjectionMode :: WireProjectionMode
   , wireCompileEnvContractRegistry :: Maybe WireContractRegistry
   , wireCompileEnvNamespaceRegistry :: !(Maybe NamespaceRegistry)
+  , wireCompileEnvPackageModules :: !(Map Text Text)
   }
   deriving stock (Eq, Show)
 
@@ -103,6 +104,7 @@ emptyWireCompileEnv =
     , wireCompileEnvProjectionMode = WireProjectionPermissive
     , wireCompileEnvContractRegistry = Nothing
     , wireCompileEnvNamespaceRegistry = Nothing
+    , wireCompileEnvPackageModules = Map.empty
     }
 
 wireCompileEnvWithContractRegistry :: WireContractRegistry -> WireCompileEnv
@@ -120,6 +122,7 @@ strictWireCompileEnv executorRegistry contractRegistry =
     , wireCompileEnvProjectionMode = WireProjectionStrict
     , wireCompileEnvContractRegistry = Just contractRegistry
     , wireCompileEnvNamespaceRegistry = Nothing
+    , wireCompileEnvPackageModules = Map.empty
     }
 
 portsMetadataValue :: WirePorts -> Aeson.Value

--- a/src/Cortex/Wire/Import.hs
+++ b/src/Cortex/Wire/Import.hs
@@ -19,6 +19,7 @@ full requesting context.
 module Cortex.Wire.Import
   ( WireImportError (..)
   , loadWireModuleClosure
+  , loadWireModuleClosureWithEnv
   , renderWireImportError
   )
 where
@@ -34,8 +35,9 @@ import Data.Text.IO qualified as TIO
 import System.Directory (canonicalizePath, doesFileExist)
 import System.FilePath (isAbsolute, normalise, takeDirectory, (</>))
 
-import Cortex.Wire.Compile (WireModule (..))
-import Cortex.Wire.Include (expandWireSourceIncludes)
+import Cortex.Wire.Compile (WireModule (..), WireModuleId (..))
+import Cortex.Wire.Contract (WireCompileEnv (..), emptyWireCompileEnv)
+import Cortex.Wire.Include (expandWireSourceIncludes, wireSourceIncludesPresent)
 import Cortex.Wire.Parser (WireParseInfo, parseWireFileWithInfo, renderParseError)
 import Cortex.Wire.Syntax (ImportSpec (..), TopForm (..), WireFile (..))
 
@@ -44,11 +46,13 @@ data WireImportError
     the missing file is not the root itself.
     -}
     WireImportFileNotFound !FilePath !(Maybe FilePath)
+  | WireImportPackageModuleNotFound !Text !(Maybe FilePath)
   | WireImportReadError !FilePath !Text
   | WireImportIncludeError !FilePath !Text
+  | WireImportPackageModuleIncludeError !Text
   | WireImportModuleParseError !FilePath !Text
   | -- | Import chain from the root to the repeated module, root first.
-    WireImportCycle ![FilePath]
+    WireImportCycle ![Text]
   deriving stock (Eq, Show)
 
 renderWireImportError :: WireImportError -> Text
@@ -57,17 +61,25 @@ renderWireImportError = \case
     "imported Wire file not found: "
       <> T.pack path
       <> maybe "" (\importer -> " (imported from " <> T.pack importer <> ")") requestedBy
+  WireImportPackageModuleNotFound path requestedBy ->
+    "package Wire module not found: "
+      <> path
+      <> maybe "" (\importer -> " (imported from " <> T.pack importer <> ")") requestedBy
   WireImportReadError path err ->
     "failed to read Wire file " <> T.pack path <> ": " <> err
   WireImportIncludeError path err ->
     "failed to expand includes in " <> T.pack path <> ": " <> err
+  WireImportPackageModuleIncludeError modulePath ->
+    "package Wire module "
+      <> modulePath
+      <> " uses include_str/include_dir, which are not allowed in package-owned modules"
   WireImportModuleParseError path err ->
     "failed to parse imported Wire file " <> T.pack path <> ":\n" <> err
   WireImportCycle chain ->
-    "Wire import cycle: " <> T.intercalate " -> " (fmap T.pack chain)
+    "Wire import cycle: " <> T.intercalate " -> " chain
 
 data LoadState = LoadState
-  { loadVisited :: !(Map FilePath WireModule)
+  { loadVisited :: !(Map WireModuleId WireModule)
   , loadOrdered :: ![WireModule]
   -- ^ Reverse dependency order; reversed once at the end.
   }
@@ -77,8 +89,13 @@ list is dependency-ordered with the root module last, ready for
 'Cortex.Wire.Compile.compileWireModules'.
 -}
 loadWireModuleClosure :: FilePath -> IO (Either WireImportError (NonEmpty WireModule))
-loadWireModuleClosure rootPath = do
-  result <- loadModule [] emptyLoadState Nothing rootPath
+loadWireModuleClosure =
+  loadWireModuleClosureWithEnv emptyWireCompileEnv
+
+loadWireModuleClosureWithEnv
+  :: WireCompileEnv -> FilePath -> IO (Either WireImportError (NonEmpty WireModule))
+loadWireModuleClosureWithEnv compileEnv rootPath = do
+  result <- loadFileModule compileEnv [] emptyLoadState Nothing rootPath
   pure $ do
     finalState <- result
     case NE.nonEmpty (reverse finalState.loadOrdered) of
@@ -88,32 +105,36 @@ loadWireModuleClosure rootPath = do
   where
     emptyLoadState = LoadState {loadVisited = Map.empty, loadOrdered = []}
 
-loadModule
-  :: [FilePath]
+loadFileModule
+  :: WireCompileEnv
+  -> [WireModuleId]
   -> LoadState
   -> Maybe FilePath
   -> FilePath
   -> IO (Either WireImportError LoadState)
-loadModule stack state requestedBy rawPath = do
+loadFileModule compileEnv stack state requestedBy rawPath = do
   exists <- doesFileExist rawPath
   if not exists
     then pure (Left (WireImportFileNotFound (normalise rawPath) requestedBy))
     else do
       path <- canonicalizePath rawPath
-      if Map.member path state.loadVisited
+      let moduleId = WireFileModule path
+      if Map.member moduleId state.loadVisited
         then pure (Right state)
         else
-          if path `elem` stack
-            then pure (Left (WireImportCycle (reverse (path : stack))))
-            else loadNewModule stack state path (normalise rawPath)
+          if moduleId `elem` stack
+            then
+              pure (Left (WireImportCycle (reverse (wireModuleIdText moduleId : fmap wireModuleIdText stack))))
+            else loadNewFileModule compileEnv stack state path (normalise rawPath)
 
-loadNewModule
-  :: [FilePath]
+loadNewFileModule
+  :: WireCompileEnv
+  -> [WireModuleId]
   -> LoadState
   -> FilePath
   -> FilePath
   -> IO (Either WireImportError LoadState)
-loadNewModule stack state path displayPath = do
+loadNewFileModule compileEnv stack state path displayPath = do
   sourceResult <- try @IOException (TIO.readFile path)
   case sourceResult of
     Left ioError' -> pure (Left (WireImportReadError displayPath (T.pack (show ioError'))))
@@ -125,23 +146,58 @@ loadNewModule stack state path displayPath = do
             Left parseError ->
               pure (Left (WireImportModuleParseError displayPath (renderParseError parseError)))
             Right (parseInfo, wireFile) ->
-              loadImports stack state path displayPath parseInfo wireFile
+              loadImports compileEnv stack state (WireFileModule path) path displayPath parseInfo wireFile
+
+loadPackageModule
+  :: WireCompileEnv
+  -> [WireModuleId]
+  -> LoadState
+  -> Maybe FilePath
+  -> Text
+  -> Text
+  -> IO (Either WireImportError LoadState)
+loadPackageModule compileEnv stack state _requestedBy modulePath source =
+  let moduleId = WirePackageModule modulePath
+   in if Map.member moduleId state.loadVisited
+        then pure (Right state)
+        else
+          if moduleId `elem` stack
+            then
+              pure (Left (WireImportCycle (reverse (wireModuleIdText moduleId : fmap wireModuleIdText stack))))
+            else
+              if wireSourceIncludesPresent source
+                then pure (Left (WireImportPackageModuleIncludeError modulePath))
+                else case parseWireFileWithInfo (T.unpack modulePath) source of
+                  Left parseError ->
+                    pure (Left (WireImportModuleParseError (T.unpack modulePath) (renderParseError parseError)))
+                  Right (parseInfo, wireFile) ->
+                    loadImports
+                      compileEnv
+                      stack
+                      state
+                      moduleId
+                      (T.unpack modulePath)
+                      (T.unpack modulePath)
+                      parseInfo
+                      wireFile
 
 loadImports
-  :: [FilePath]
+  :: WireCompileEnv
+  -> [WireModuleId]
   -> LoadState
+  -> WireModuleId
   -> FilePath
   -> FilePath
   -> WireParseInfo
   -> WireFile
   -> IO (Either WireImportError LoadState)
-loadImports stack state path displayPath parseInfo wireFile =
+loadImports compileEnv stack state moduleId path displayPath parseInfo wireFile =
   go state (importPathTexts wireFile) Map.empty
   where
     go currentState [] resolvedPaths =
       let wireModule =
             WireModule
-              { wireModulePath = path
+              { wireModulePath = moduleId
               , wireModuleDisplayPath = T.pack displayPath
               , wireModuleParseInfo = parseInfo
               , wireModuleFile = wireFile
@@ -150,18 +206,67 @@ loadImports stack state path displayPath parseInfo wireFile =
        in pure
             ( Right
                 currentState
-                  { loadVisited = Map.insert path wireModule currentState.loadVisited
+                  { loadVisited = Map.insert moduleId wireModule currentState.loadVisited
                   , loadOrdered = wireModule : currentState.loadOrdered
                   }
             )
     go currentState (pathText : rest) resolvedPaths = do
       let targetRaw = resolveImportPath path pathText
-      loadModule (path : stack) currentState (Just displayPath) targetRaw >>= \case
-        Left err -> pure (Left err)
-        Right nextState -> do
-          targetCanonical <- canonicalizePath targetRaw
-          go nextState rest (Map.insert pathText targetCanonical resolvedPaths)
+      resolveImportedModule
+        compileEnv
+        (moduleId : stack)
+        currentState
+        (Just displayPath)
+        moduleId
+        targetRaw
+        pathText
+        >>= \case
+          Left err -> pure (Left err)
+          Right (nextState, resolvedId) ->
+            go nextState rest (Map.insert pathText resolvedId resolvedPaths)
 
+resolveImportedModule
+  :: WireCompileEnv
+  -> [WireModuleId]
+  -> LoadState
+  -> Maybe FilePath
+  -> WireModuleId
+  -> FilePath
+  -> Text
+  -> IO (Either WireImportError (LoadState, WireModuleId))
+resolveImportedModule compileEnv stack currentState requestedBy importerId targetRaw pathText =
+  case importerId of
+    WirePackageModule _ ->
+      resolvePackageModule
+    WireFileModule _ -> do
+      exists <- doesFileExist targetRaw
+      if exists
+        then do
+          loaded <- loadFileModule compileEnv stack currentState requestedBy targetRaw
+          case loaded of
+            Left err -> pure (Left err)
+            Right nextState -> do
+              targetCanonical <- canonicalizePath targetRaw
+              pure (Right (nextState, WireFileModule targetCanonical))
+        else
+          if looksLikePackageModuleRef packageLookupPath
+            then resolvePackageModule
+            else pure (Left (WireImportFileNotFound (normalise targetRaw) requestedBy))
+  where
+    packageLookupPath =
+      if T.isPrefixOf "./" pathText || T.isPrefixOf "../" pathText
+        then T.pack (normalise targetRaw)
+        else pathText
+
+    resolvePackageModule =
+      case Map.lookup packageLookupPath compileEnv.wireCompileEnvPackageModules of
+        Just source -> do
+          loaded <- loadPackageModule compileEnv stack currentState requestedBy packageLookupPath source
+          pure $ case loaded of
+            Left err -> Left err
+            Right nextState -> Right (nextState, WirePackageModule packageLookupPath)
+        Nothing ->
+          pure (Left (WireImportPackageModuleNotFound packageLookupPath requestedBy))
 importPathTexts :: WireFile -> [Text]
 importPathTexts wireFile =
   [ importSpecPathText importSpec
@@ -179,3 +284,15 @@ resolveImportPath importerPath pathText =
    in if isAbsolute target
         then target
         else takeDirectory importerPath </> target
+
+looksLikePackageModuleRef :: Text -> Bool
+looksLikePackageModuleRef pathText =
+  not (T.isPrefixOf "./" pathText)
+    && not (T.isPrefixOf "../" pathText)
+    && not (T.isPrefixOf "/" pathText)
+    && T.any (== '/') pathText
+
+wireModuleIdText :: WireModuleId -> Text
+wireModuleIdText = \case
+  WireFileModule path -> T.pack path
+  WirePackageModule modulePath -> modulePath

--- a/src/Cortex/Wire/Include.hs
+++ b/src/Cortex/Wire/Include.hs
@@ -13,6 +13,7 @@ CorePure literals.
 -}
 module Cortex.Wire.Include
   ( expandWireSourceIncludes
+  , wireSourceIncludesPresent
   , wireSourceIncludeNames
   )
 where
@@ -60,6 +61,33 @@ expandWireSourceIncludes sourcePath sourceText =
     Right expanded -> pure (Right expanded)
   where
     baseDir = takeDirectory sourcePath
+
+-- | Detect source include forms outside comments and string literals.
+wireSourceIncludesPresent :: Text -> Bool
+wireSourceIncludesPresent sourceText =
+  case T.uncons sourceText of
+    Nothing ->
+      False
+    Just ('#', _) ->
+      scanAfter "\n" sourceText
+    Just ('"', _) ->
+      wireSourceIncludesPresent (snd (spanWireString sourceText))
+    Just ('/', _)
+      | "/*" `T.isPrefixOf` sourceText ->
+          scanAfter "*/" sourceText
+    Just ('\'', _)
+      | "''" `T.isPrefixOf` sourceText ->
+          scanAfter "''" (T.drop 2 sourceText)
+    _
+      | Just {} <- parseIncludeCall sourceText ->
+          True
+      | otherwise ->
+          wireSourceIncludesPresent (T.drop 1 sourceText)
+  where
+    scanAfter marker text =
+      let rest = snd (T.breakOn marker text)
+       in not (T.null rest)
+            && wireSourceIncludesPresent (T.drop (T.length marker) rest)
 
 expandSourceText :: FilePath -> Text -> IO Text
 expandSourceText baseDir sourceText =

--- a/src/Cortex/Wire/Package.hs
+++ b/src/Cortex/Wire/Package.hs
@@ -27,7 +27,9 @@ module Cortex.Wire.Package
   , stdOnlyRegistry
   , WirePackage (..)
   , packageNamespaceRegistry
+  , packageModuleSources
   , wireCompileEnvWithPackages
+  , wireCompileEnvWithPackagesChecked
   , PackageConflict (..)
   , packageConflicts
   , renderPackageConflict
@@ -72,6 +74,8 @@ data WirePackage = WirePackage
   , wpNamespaceEntries :: ![NamespaceEntry]
   , wpExecutorProjections :: ![WireExecutorProjection]
   , wpContractSpecs :: ![WireContractSpec]
+  , wpModuleSources :: !(Map.Map Text Text)
+  , wpModulePaths :: ![Text]
   }
 
 -- | Compose @std.io@ with the given Wire packages into one registry.
@@ -79,9 +83,15 @@ packageNamespaceRegistry :: [WirePackage] -> NamespaceRegistry
 packageNamespaceRegistry packages =
   namespaceRegistryFromEntries (stdNamespaceEntry : concatMap wpNamespaceEntries packages)
 
+-- | Package-owned Wire module sources keyed by stable import path.
+packageModuleSources :: [WirePackage] -> Map.Map Text Text
+packageModuleSources packages =
+  firstWins (concatMap (Map.toList . wpModuleSources) packages)
+
 {- | Add inert Wire packages to a compile environment. This supplies the `use`
 namespace registry and makes package contracts/executor projections available to
-strict compilation, but it grants no runtime authority.
+strict compilation, plus package-owned Wire module sources for import loading.
+It grants no runtime authority.
 -}
 wireCompileEnvWithPackages :: [WirePackage] -> WireCompileEnv -> WireCompileEnv
 wireCompileEnvWithPackages packages env =
@@ -96,6 +106,8 @@ wireCompileEnvWithPackages packages env =
         mergeExecutorRegistry env.wireCompileEnvExecutorRegistry packageExecutorRegistry
     , wireCompileEnvContractRegistry =
         Just (mergeContractRegistry env.wireCompileEnvContractRegistry packageContractRegistry)
+    , wireCompileEnvPackageModules =
+        env.wireCompileEnvPackageModules <> packageModuleSources packages
     }
   where
     packageNamespaceRegistry' =
@@ -114,6 +126,16 @@ wireCompileEnvWithPackages packages env =
             | spec <- concatMap wpContractSpecs packages
             ]
         )
+
+{- | Checked package composition for callers that load independent manifests.
+Conflicts are reported before the left-biased registries choose a winner.
+-}
+wireCompileEnvWithPackagesChecked
+  :: [WirePackage] -> WireCompileEnv -> Either [PackageConflict] WireCompileEnv
+wireCompileEnvWithPackagesChecked packages env =
+  case packageConflicts packages of
+    [] -> Right (wireCompileEnvWithPackages packages env)
+    conflicts -> Left conflicts
 
 {- | Keep the first binding for a duplicate key, matching the namespace registry's
 @Map.fromListWith (\\_ existing -> existing)@. Composition uses one precedence
@@ -143,6 +165,7 @@ data PackageConflict
   | DuplicateNamespace !Text
   | DuplicateExecutorId !Text
   | DuplicateContractId !Text
+  | DuplicateModulePath !Text
   deriving stock (Eq, Show)
 
 renderPackageConflict :: PackageConflict -> Text
@@ -151,6 +174,7 @@ renderPackageConflict = \case
   DuplicateNamespace namespace -> "duplicate namespace " <> namespace
   DuplicateExecutorId executorId -> "duplicate executor id " <> executorId
   DuplicateContractId contractId -> "duplicate contract id " <> contractId
+  DuplicateModulePath modulePath -> "duplicate package module path " <> modulePath
 
 {- | Every identifier claimed by more than one package among @packages@: package ids,
 exported namespaces, executor projection ids, and contract ids. An empty result means
@@ -170,7 +194,14 @@ packageConflicts packages =
           ]
     , DuplicateContractId
         <$> duplicates [spec.wireContractSpecId | package <- packages, spec <- package.wpContractSpecs]
+    , DuplicateModulePath
+        <$> duplicates [modulePath | package <- packages, modulePath <- packageModulePaths package]
     ]
   where
+    packageModulePaths package =
+      case package.wpModulePaths of
+        [] -> Map.keys package.wpModuleSources
+        paths -> paths
+
     duplicates :: Eq a => [a] -> [a]
     duplicates xs = nub [x | x <- xs, length (filter (== x) xs) > 1]

--- a/src/Cortex/Wire/Package/Manifest.hs
+++ b/src/Cortex/Wire/Package/Manifest.hs
@@ -114,6 +114,7 @@ data WirePackageManifest = WirePackageManifest
   , wpmNamespaces :: ![NamespaceManifest]
   , wpmExecutorProjections :: ![WireExecutorProjection]
   , wpmContracts :: ![WireContractSpec]
+  , wpmModules :: ![ModuleManifest]
   }
   deriving stock (Eq, Show)
 
@@ -125,6 +126,7 @@ instance Toml.FromValue WirePackageManifest where
         <*> optionalList "namespace"
         <*> optionalList "executor"
         <*> optionalList "contract"
+        <*> optionalList "module"
 
 data PackageManifest = PackageManifest
   { pmId :: !Text
@@ -159,7 +161,24 @@ manifestToWirePackage manifest =
     , wpNamespaceEntries = fmap namespaceManifestEntry manifest.wpmNamespaces
     , wpExecutorProjections = manifest.wpmExecutorProjections
     , wpContractSpecs = manifest.wpmContracts
+    , wpModuleSources =
+        Map.fromList
+          [(packageModule.modulePath, packageModule.moduleSource) | packageModule <- manifest.wpmModules]
+    , wpModulePaths = fmap (.modulePath) manifest.wpmModules
     }
+
+data ModuleManifest = ModuleManifest
+  { modulePath :: !Text
+  , moduleSource :: !Text
+  }
+  deriving stock (Eq, Show)
+
+instance Toml.FromValue ModuleManifest where
+  fromValue =
+    Toml.parseTableFromValue $
+      ModuleManifest
+        <$> Toml.reqKey "path"
+        <*> Toml.reqKey "source"
 
 namespaceManifestEntry :: NamespaceManifest -> NamespaceEntry
 namespaceManifestEntry manifest =

--- a/test/Cortex/Wire/ImportSpec.hs
+++ b/test/Cortex/Wire/ImportSpec.hs
@@ -13,32 +13,40 @@ Tests may import the surface they exercise, but they do not define downstream pr
 module Cortex.Wire.ImportSpec (spec) where
 
 import Data.Bifunctor (first)
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
-import System.Directory (createDirectoryIfMissing)
+import System.Directory (createDirectoryIfMissing, withCurrentDirectory)
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
+import Cortex.Quantum.Compile (compileExport)
 import Cortex.Wire (CircuitNodeRef (..), CompiledCircuit (..), renderWireError)
 import Cortex.Wire.Compile (compileWireModules)
-import Cortex.Wire.Contract (emptyWireCompileEnv)
+import Cortex.Wire.Contract (WireCompileEnv, emptyWireCompileEnv)
 import Cortex.Wire.Import
   ( WireImportError (..)
   , loadWireModuleClosure
+  , loadWireModuleClosureWithEnv
   , renderWireImportError
   )
+import Cortex.Wire.Package (WirePackage (..), wireCompileEnvWithPackages)
 
 {- | Load the import closure of a root file and compile it; both load and
 compile failures surface as rendered text so specs can match messages.
 -}
 compileAtPath :: FilePath -> IO (Either Text CompiledCircuit)
-compileAtPath path =
-  loadWireModuleClosure path >>= \case
+compileAtPath =
+  compileAtPathWithEnv emptyWireCompileEnv
+
+compileAtPathWithEnv :: WireCompileEnv -> FilePath -> IO (Either Text CompiledCircuit)
+compileAtPathWithEnv compileEnv path =
+  loadWireModuleClosureWithEnv compileEnv path >>= \case
     Left importError -> pure (Left (renderWireImportError importError))
     Right modules ->
-      pure (first renderWireError (compileWireModules emptyWireCompileEnv modules))
+      pure (first renderWireError (compileWireModules compileEnv modules))
 
 -- | Each spec gets its own scratch directory for fixture files.
 itInTempDir :: String -> (FilePath -> IO ()) -> Spec
@@ -98,6 +106,171 @@ spec = do
         Right compiled -> do
           fmap (.unCircuitNodeRef) compiled.compiledCircuitEntryNodes `shouldBe` ["greet_source"]
           fmap (.unCircuitNodeRef) compiled.compiledCircuitExitNodes `shouldBe` ["emit"]
+
+    itInTempDir "compiles an explicit import from a package-owned module" $ \dir -> do
+      let package =
+            WirePackage
+              { wpId = "example.pkg"
+              , wpNamespaceEntries = []
+              , wpExecutorProjections = []
+              , wpContractSpecs = []
+              , wpModuleSources =
+                  Map.singleton
+                    "example.pkg/helpers.wire"
+                    (T.unlines helperLibrary)
+              , wpModulePaths = ["example.pkg/helpers.wire"]
+              }
+          compileEnv = wireCompileEnvWithPackages [package] emptyWireCompileEnv
+      writeFixture
+        (dir </> "main.wire")
+        (importerBody "import { greeting, greeter } from \"example.pkg/helpers.wire\";")
+      result <- compileAtPathWithEnv compileEnv (dir </> "main.wire")
+      case result of
+        Left err -> expectationFailure (T.unpack err)
+        Right compiled -> do
+          fmap (.unCircuitNodeRef) compiled.compiledCircuitEntryNodes `shouldBe` ["greet_source"]
+          fmap (.unCircuitNodeRef) compiled.compiledCircuitExitNodes `shouldBe` ["emit"]
+
+    itInTempDir "passes package modules through the quantum compile helper" $ \dir -> do
+      let package =
+            WirePackage
+              { wpId = "example.pkg"
+              , wpNamespaceEntries = []
+              , wpExecutorProjections = []
+              , wpContractSpecs = []
+              , wpModuleSources =
+                  Map.singleton
+                    "example.pkg/helpers.wire"
+                    (T.unlines helperLibrary)
+              , wpModulePaths = ["example.pkg/helpers.wire"]
+              }
+          compileEnv = wireCompileEnvWithPackages [package] emptyWireCompileEnv
+      writeFixture
+        (dir </> "main.wire")
+        [ "import { greeter } from \"example.pkg/helpers.wire\";"
+        , ""
+        , "greeter"
+        ]
+      result <- compileExport compileEnv Nothing (dir </> "main.wire")
+      case result of
+        Left err -> expectationFailure (T.unpack err)
+        Right compiled ->
+          fmap (.unCircuitNodeRef) compiled.compiledCircuitEntryNodes `shouldBe` ["greet_source"]
+
+    itInTempDir "resolves package module relative imports against the package path" $ \dir -> do
+      let helperModule =
+            [ "use std.io.{@stdin};"
+            , ""
+            , "import { politeness } from \"./shared.wire\";"
+            , ""
+            , "contract GreetingText;"
+            , ""
+            , "export let greeting = name: \"hello ${name}, ${politeness}\";"
+            , ""
+            , "node greet_source"
+            , "  -> message: GreetingText = @stdin { prompt = \"Name: \"; } (null);"
+            , ""
+            , "export let greeter = greet_source;"
+            ]
+          package =
+            WirePackage
+              { wpId = "example.pkg"
+              , wpNamespaceEntries = []
+              , wpExecutorProjections = []
+              , wpContractSpecs = []
+              , wpModuleSources =
+                  Map.fromList
+                    [ ("example.pkg/helpers.wire", T.unlines helperModule)
+                    , ("example.pkg/shared.wire", "export let politeness = \"please\";")
+                    ]
+              , wpModulePaths = ["example.pkg/helpers.wire", "example.pkg/shared.wire"]
+              }
+          compileEnv = wireCompileEnvWithPackages [package] emptyWireCompileEnv
+      writeFixture
+        (dir </> "main.wire")
+        (importerBody "import { greeting, greeter } from \"example.pkg/helpers.wire\";")
+      result <- compileAtPathWithEnv compileEnv (dir </> "main.wire")
+      case result of
+        Left err -> expectationFailure (T.unpack err)
+        Right compiled -> do
+          fmap (.unCircuitNodeRef) compiled.compiledCircuitEntryNodes `shouldBe` ["greet_source"]
+          fmap (.unCircuitNodeRef) compiled.compiledCircuitExitNodes `shouldBe` ["emit"]
+
+    itInTempDir "does not probe cwd for package module relative imports" $ \dir -> do
+      let helperModule =
+            [ "use std.io.{@stdin};"
+            , ""
+            , "import { politeness } from \"./shared.wire\";"
+            , ""
+            , "contract GreetingText;"
+            , ""
+            , "export let greeting = name: \"hello ${name}, ${politeness}\";"
+            , ""
+            , "node greet_source"
+            , "  -> message: GreetingText = @stdin { prompt = \"Name: \"; } (null);"
+            , ""
+            , "export let greeter = greet_source;"
+            ]
+          package =
+            WirePackage
+              { wpId = "example.pkg"
+              , wpNamespaceEntries = []
+              , wpExecutorProjections = []
+              , wpContractSpecs = []
+              , wpModuleSources =
+                  Map.fromList
+                    [ ("example.pkg/helpers.wire", T.unlines helperModule)
+                    , ("example.pkg/shared.wire", "export let politeness = \"please\";")
+                    ]
+              , wpModulePaths = ["example.pkg/helpers.wire", "example.pkg/shared.wire"]
+              }
+          compileEnv = wireCompileEnvWithPackages [package] emptyWireCompileEnv
+      createDirectoryIfMissing True (dir </> "example.pkg")
+      writeFixture
+        (dir </> "example.pkg" </> "shared.wire")
+        [ "let politeness = \"from filesystem\";"
+        ]
+      writeFixture
+        (dir </> "main.wire")
+        (importerBody "import { greeting, greeter } from \"example.pkg/helpers.wire\";")
+      result <- withCurrentDirectory dir (compileAtPathWithEnv compileEnv "main.wire")
+      case result of
+        Left err -> expectationFailure (T.unpack err)
+        Right compiled -> do
+          fmap (.unCircuitNodeRef) compiled.compiledCircuitEntryNodes `shouldBe` ["greet_source"]
+          fmap (.unCircuitNodeRef) compiled.compiledCircuitExitNodes `shouldBe` ["emit"]
+
+    itInTempDir "does not load absolute filesystem imports from package modules" $ \dir -> do
+      let secretPath = dir </> "secret.wire"
+          helperModule =
+            [ "import { payload } from \"" <> T.pack secretPath <> "\";"
+            , ""
+            , "export let exposed = payload;"
+            ]
+          package =
+            WirePackage
+              { wpId = "example.pkg"
+              , wpNamespaceEntries = []
+              , wpExecutorProjections = []
+              , wpContractSpecs = []
+              , wpModuleSources =
+                  Map.singleton "example.pkg/helpers.wire" (T.unlines helperModule)
+              , wpModulePaths = ["example.pkg/helpers.wire"]
+              }
+          compileEnv = wireCompileEnvWithPackages [package] emptyWireCompileEnv
+      writeFixture secretPath ["export let payload = \"from filesystem\";"]
+      writeFixture
+        (dir </> "main.wire")
+        [ "import { exposed } from \"example.pkg/helpers.wire\";"
+        , ""
+        , "exposed"
+        ]
+      result <- compileAtPathWithEnv compileEnv (dir </> "main.wire")
+      case result of
+        Left err -> do
+          err `shouldSatisfy` T.isInfixOf "package Wire module not found"
+          err `shouldSatisfy` T.isInfixOf (T.pack secretPath)
+        Right _compiled -> expectationFailure "expected package module absolute import rejection"
 
     itInTempDir "compiles a file-return import through the named form" $ \dir -> do
       writeFixture
@@ -178,12 +351,63 @@ spec = do
         Left err -> expectationFailure (T.unpack err)
         Right _compiled -> pure ()
 
+    itInTempDir "rejects include_str inside a package-owned module" $ \dir -> do
+      let package =
+            WirePackage
+              { wpId = "example.pkg"
+              , wpNamespaceEntries = []
+              , wpExecutorProjections = []
+              , wpContractSpecs = []
+              , wpModuleSources =
+                  Map.singleton
+                    "example.pkg/helpers.wire"
+                    "export let payload = include_str(\"/etc/passwd\");"
+              , wpModulePaths = ["example.pkg/helpers.wire"]
+              }
+          compileEnv = wireCompileEnvWithPackages [package] emptyWireCompileEnv
+      writeFixture
+        (dir </> "main.wire")
+        [ "import { payload } from \"example.pkg/helpers.wire\";"
+        , ""
+        , "payload"
+        ]
+      result <- compileAtPathWithEnv compileEnv (dir </> "main.wire")
+      case result of
+        Left err -> do
+          err `shouldSatisfy` T.isInfixOf "include_str/include_dir"
+          err `shouldSatisfy` T.isInfixOf "package-owned modules"
+        Right _compiled -> expectationFailure "expected package module include rejection"
+
     itInTempDir "rejects importing a name that exists but is not exported" $ \dir -> do
       writeFixture (dir </> "helpers.wire") helperLibrary
       writeFixture
         (dir </> "main.wire")
         (importerBody "import { politeness, greeting, greeter } from \"./helpers.wire\";")
       result <- compileAtPath (dir </> "main.wire")
+      case result of
+        Left err -> do
+          err `shouldSatisfy` T.isInfixOf "does not export it"
+          err `shouldSatisfy` T.isInfixOf "politeness"
+        Right _compiled -> expectationFailure "expected a visibility error"
+
+    itInTempDir "rejects importing a private name from a package-owned module" $ \dir -> do
+      let package =
+            WirePackage
+              { wpId = "example.pkg"
+              , wpNamespaceEntries = []
+              , wpExecutorProjections = []
+              , wpContractSpecs = []
+              , wpModuleSources =
+                  Map.singleton
+                    "example.pkg/helpers.wire"
+                    (T.unlines helperLibrary)
+              , wpModulePaths = ["example.pkg/helpers.wire"]
+              }
+          compileEnv = wireCompileEnvWithPackages [package] emptyWireCompileEnv
+      writeFixture
+        (dir </> "main.wire")
+        (importerBody "import { politeness, greeting, greeter } from \"example.pkg/helpers.wire\";")
+      result <- compileAtPathWithEnv compileEnv (dir </> "main.wire")
       case result of
         Left err -> do
           err `shouldSatisfy` T.isInfixOf "does not export it"
@@ -212,6 +436,19 @@ spec = do
         Left otherError ->
           expectationFailure ("unexpected error: " <> T.unpack (renderWireImportError otherError))
         Right _modules -> expectationFailure "expected a missing-file error"
+
+    itInTempDir "rejects a missing package module distinctly from a missing file" $ \dir -> do
+      writeFixture
+        (dir </> "main.wire")
+        (importerBody "import { greeting, greeter } from \"example.pkg/absent.wire\";")
+      result <- loadWireModuleClosureWithEnv emptyWireCompileEnv (dir </> "main.wire")
+      case result of
+        Left (WireImportPackageModuleNotFound missingPath (Just requestedBy)) -> do
+          missingPath `shouldBe` "example.pkg/absent.wire"
+          requestedBy `shouldSatisfy` \path -> "main.wire" == T.unpack (T.takeWhileEnd (/= '/') (T.pack path))
+        Left otherError ->
+          expectationFailure ("unexpected error: " <> T.unpack (renderWireImportError otherError))
+        Right _modules -> expectationFailure "expected a missing package module error"
 
     itInTempDir "rejects a local binding that collides with an imported name" $ \dir -> do
       writeFixture (dir </> "helpers.wire") helperLibrary

--- a/test/Cortex/Wire/PackageSpec.hs
+++ b/test/Cortex/Wire/PackageSpec.hs
@@ -15,10 +15,12 @@ module Cortex.Wire.PackageSpec (spec) where
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
+import Data.Text qualified as T
 import Test.Hspec
 
 import Cortex.Wire.Contract (WireCompileEnv (..), emptyWireCompileEnv)
 import Cortex.Wire.Package
+import Cortex.Wire.Package.Manifest (decodeWirePackageManifest, renderWirePackageManifestError)
 import Cortex.Wire.Syntax (QName (..), UseItem (..), UseSpec (..))
 import Cortex.Wire.Use
 
@@ -86,6 +88,17 @@ useBeta =
 notTaken :: Text -> Bool
 notTaken = const False
 
+testPackage :: Text -> [NamespaceEntry] -> WirePackage
+testPackage packageId namespaceEntries =
+  WirePackage
+    { wpId = packageId
+    , wpNamespaceEntries = namespaceEntries
+    , wpExecutorProjections = []
+    , wpContractSpecs = []
+    , wpModuleSources = Map.empty
+    , wpModulePaths = []
+    }
+
 spec :: Spec
 spec = do
   describe "applyWireUseSpecs against a composed registry" $ do
@@ -114,7 +127,7 @@ spec = do
         `shouldBe` Left (WireUseUnknownItem "quantum.core" "@teleport")
 
   describe "packageNamespaceRegistry" . it "composes std.io with package namespaces" $ do
-    let reg = packageNamespaceRegistry [WirePackage "quantum" [quantumCore] [] []]
+    let reg = packageNamespaceRegistry [testPackage "quantum" [quantumCore]]
     namespaceRegistryNamespaces reg `shouldMatchList` ["std.io", "quantum.core"]
 
   describe "wireCompileEnvWithPackages"
@@ -122,11 +135,11 @@ spec = do
     $ do
       let envWithAlpha =
             wireCompileEnvWithPackages
-              [WirePackage "alpha" [alphaCore] [] []]
+              [testPackage "alpha" [alphaCore]]
               emptyWireCompileEnv
           envWithAlphaBeta =
             wireCompileEnvWithPackages
-              [WirePackage "beta" [betaCore] [] []]
+              [testPackage "beta" [betaCore]]
               envWithAlpha
 
       case envWithAlphaBeta.wireCompileEnvNamespaceRegistry of
@@ -144,11 +157,45 @@ spec = do
 
   describe "packageConflicts" $ do
     it "is empty for packages with disjoint ids and namespaces" $
-      packageConflicts [WirePackage "alpha" [alphaCore] [] [], WirePackage "beta" [betaCore] [] []]
+      packageConflicts [testPackage "alpha" [alphaCore], testPackage "beta" [betaCore]]
         `shouldBe` []
 
     it "reports duplicate package ids and namespaces" $ do
       let conflicts =
-            packageConflicts [WirePackage "dup" [alphaCore] [] [], WirePackage "dup" [alphaCore] [] []]
+            packageConflicts [testPackage "dup" [alphaCore], testPackage "dup" [alphaCore]]
       conflicts `shouldContain` [DuplicatePackageId "dup"]
       conflicts `shouldContain` [DuplicateNamespace "alpha.core"]
+
+    it "reports duplicate package module paths" $ do
+      let packageWithModule packageId =
+            (testPackage packageId [])
+              { wpModuleSources = Map.singleton "example/helpers.wire" "export let value = 1;"
+              , wpModulePaths = ["example/helpers.wire"]
+              }
+      packageConflicts [packageWithModule "alpha", packageWithModule "beta"]
+        `shouldContain` [DuplicateModulePath "example/helpers.wire"]
+
+    it "reports duplicate package module paths preserved from a single manifest" $ do
+      let package =
+            (testPackage "alpha" [])
+              { wpModuleSources = Map.singleton "example/helpers.wire" "export let value = 1;"
+              , wpModulePaths = ["example/helpers.wire", "example/helpers.wire"]
+              }
+      packageConflicts [package] `shouldContain` [DuplicateModulePath "example/helpers.wire"]
+
+    it "reports duplicate package module paths decoded from one manifest" $ do
+      let source =
+            "[package]\n\
+            \id = \"alpha\"\n\
+            \\n\
+            \[[module]]\n\
+            \path = \"example/helpers.wire\"\n\
+            \source = \"export let value = 1;\"\n\
+            \\n\
+            \[[module]]\n\
+            \path = \"example/helpers.wire\"\n\
+            \source = \"export let value = 2;\"\n"
+      case decodeWirePackageManifest "cortex.toml" source of
+        Left err -> expectationFailure (T.unpack (renderWirePackageManifestError err))
+        Right package ->
+          packageConflicts [package] `shouldContain` [DuplicateModulePath "example/helpers.wire"]


### PR DESCRIPTION
## Summary
- Adds package-owned Wire module sources to `WirePackage` and `cortex.toml` via `[[module]]` entries.
- Adds deterministic checked package composition for duplicate package ids, namespaces, executor ids, contract ids, and module paths.
- Teaches the Wire import loader/CLI to resolve package-backed modules from the selected `WireCompileEnv`, including relative package-module imports and missing-package-module diagnostics.
- Updates ADR/usage docs for the implemented manifest module surface.

## Verification
- `nix build .#cortex --print-build-logs`
- `just fmt`
- `just test-match "Wire file imports"`
- `just test-match "package"`
- `just docs-lint`
- `just check-commit-provenance origin/main..HEAD`

## Issue
Closes #280