### PR TITLE
feat(wire): model hosted process protocol

### DIFF
--- a/cortex.cabal
+++ b/cortex.cabal
@@ -215,6 +215,7 @@ library
         Cortex.Wire.Circuit.Compiled
         Cortex.Wire.Circuit.Compiler
         Cortex.Wire.Circuit.Engine
+        Cortex.Wire.Circuit.HostProtocol
         Cortex.Wire.Circuit.Hosted
         Cortex.Wire.Circuit.IR
         Cortex.Wire.Circuit.Lower
@@ -453,6 +454,7 @@ test-suite cortex-test
         Cortex.Pulse.TypesSpec
         Cortex.Wire.Circuit.CompilerSpec
         Cortex.Wire.Circuit.EngineSpec
+        Cortex.Wire.Circuit.HostProtocolSpec
         Cortex.Wire.Circuit.HostedSpec
         Cortex.Wire.Circuit.IRSpec
         Cortex.Wire.Cli.FrontierSpec

--- a/docs/Reference/Wire/hosted-execution.md
+++ b/docs/Reference/Wire/hosted-execution.md
@@ -145,11 +145,18 @@ lifecycle is a separate state machine:
 - `Cortex.Wire.Circuit.HostedSpec` refines the policy against real pipes, workers, cancellation, and
   child processes through scripted engines.
 
-TLC checks atomic worker registration, acknowledgement before successor work, buffered-completion
-gating, terminal-checkpoint authority, cancellation liveness after interruption, independent
-non-extending deadlines, committed terminal precedence over abnormal exit, and the prohibition on
-forwarding completions after cancellation. Run both the Wire host model and the existing Pulse
-run-terminal signal model with:
+TLC checks acknowledgement before successor work, buffered-completion gating, successful-terminal
+quiescence, operator and interruption-driven cancellation liveness, crossing-checkpoint deadline
+preservation, unrelated-traffic deadline stability, terminal precedence after child exit, and the
+prohibition on forwarding direct or buffered completions after cancellation or terminal authority.
+Four expected-failure configurations remove one protection at a time, including post-terminal
+completion dropping, so those completion and deadline properties exercise a reachable violation.
+
+The proof boundary is deliberate: Lean proves that an accepted engine completion cannot unlock
+successor drive before the checkpoint gate, while TLA+ proves the host lifecycle ordering around
+workers, acknowledgements, cancellation, clocks, and child exit. Neither model is described as
+proving the other's state space. Run both the Wire host model and the existing Pulse run-terminal
+signal model with:
 
 ```sh
 just tla-check

--- a/docs/Reference/Wire/hosted-execution.md
+++ b/docs/Reference/Wire/hosted-execution.md
@@ -134,6 +134,27 @@ Checkpoint order is load-bearing:
 Ready effects may execute concurrently. A host serializes completion delivery and checkpoint
 acknowledgements and may buffer workers that finish while another checkpoint is pending.
 
+### Host-protocol assurance boundary
+
+The Lean engine model proves snapshot validity, whole-drive classification, and the checkpoint gate;
+it intentionally carries no process handles, workers, queues, or clocks. The concurrent host
+lifecycle is a separate state machine:
+
+- `Cortex.Wire.Circuit.HostProtocol` is the pure executable policy used by the IO event loop;
+- `formal/HostedProtocol.tla` is its bounded concurrency model; and
+- `Cortex.Wire.Circuit.HostedSpec` refines the policy against real pipes, workers, cancellation, and
+  child processes through scripted engines.
+
+TLC checks atomic worker registration, acknowledgement before successor work, buffered-completion
+gating, terminal-checkpoint authority, cancellation liveness after interruption, independent
+non-extending deadlines, committed terminal precedence over abnormal exit, and the prohibition on
+forwarding completions after cancellation. Run both the Wire host model and the existing Pulse
+run-terminal signal model with:
+
+```sh
+just tla-check
+```
+
 The repository records transport overhead with an opt-in Criterion suite:
 
 ```sh

--- a/formal/HostedProtocol.cfg
+++ b/formal/HostedProtocol.cfg
@@ -1,13 +1,21 @@
 CONSTANT Timeout = 2
 CONSTANT MaxClock = 6
+CONSTANT DropBufferedAfterCancellation = TRUE
+CONSTANT DropCompletionAfterTerminal = TRUE
+CONSTANT PreserveCrossingDeadline = TRUE
+CONSTANT StableDeadlineUnderTraffic = TRUE
 SPECIFICATION Spec
 INVARIANT TypeOK
 INVARIANT AcknowledgementBeforeSuccessor
 INVARIANT WorkerRegistrationAtomic
 INVARIANT TerminalCheckpointAuthority
+INVARIANT TerminalCheckpointQuiescence
 INVARIANT NoCompletionAfterCancellation
+INVARIANT NoCompletionAfterTerminal
+INVARIANT CrossingCheckpointDeadlinePreserved
 INVARIANT EngineDeadlineNotExtended
+INVARIANT DeadlineStableUnderUnrelatedTraffic
 INVARIANT CancellationDeadlineIndependent
 INVARIANT BufferedCompletionIsGated
 INVARIANT CommittedTerminalSurvivesAbnormalExit
-PROPERTY CancellationLivenessAfterInterruption
+PROPERTY CancellationLiveness

--- a/formal/HostedProtocol.cfg
+++ b/formal/HostedProtocol.cfg
@@ -1,0 +1,13 @@
+CONSTANT Timeout = 2
+CONSTANT MaxClock = 6
+SPECIFICATION Spec
+INVARIANT TypeOK
+INVARIANT AcknowledgementBeforeSuccessor
+INVARIANT WorkerRegistrationAtomic
+INVARIANT TerminalCheckpointAuthority
+INVARIANT NoCompletionAfterCancellation
+INVARIANT EngineDeadlineNotExtended
+INVARIANT CancellationDeadlineIndependent
+INVARIANT BufferedCompletionIsGated
+INVARIANT CommittedTerminalSurvivesAbnormalExit
+PROPERTY CancellationLivenessAfterInterruption

--- a/formal/HostedProtocol.tla
+++ b/formal/HostedProtocol.tla
@@ -1,18 +1,22 @@
 ------------------------------ MODULE HostedProtocol ------------------------------
 (*******************************************************************************)
-(* Bounded model of the Wire process-host protocol around the circuit engine.   *)
-(* The engine snapshot semantics live in Lean; this model covers host-owned      *)
-(* concurrency: atomic worker registration, serialized completions, checkpoint   *)
-(* acknowledgement, cancellation, independent watchdogs, terminal authority,    *)
-(* and child exit.  The vocabulary mirrors Cortex.Wire.Circuit.HostProtocol.     *)
+(* Bounded model of the Wire process-host protocol. Lean proves engine snapshot  *)
+(* semantics and checkpoint acceptance; this model covers host-owned workers,     *)
+(* serialized completions, cancellation, independent deadlines, terminal          *)
+(* precedence, and child exit. Three constants deliberately weaken race handling   *)
+(* in negative configurations so the principal invariants are non-vacuous.         *)
 (*******************************************************************************)
 EXTENDS Naturals, FiniteSets, TLC
 
-CONSTANTS Timeout, MaxClock
+CONSTANTS Timeout, MaxClock,
+          DropBufferedAfterCancellation,
+          DropCompletionAfterTerminal,
+          PreserveCrossingDeadline,
+          StableDeadlineUnderTraffic
 
 Workers == {"w1", "w2"}
-Terminals == {"active", "succeeded", "cancelled"}
-Outcomes == {"none", "fault", "succeeded", "cancelled"}
+Terminals == {"active", "succeeded", "failed", "cancelled"}
+Outcomes == {"none", "fault", "succeeded", "failed", "cancelled"}
 
 VARIABLES
   checkpointPending,
@@ -24,8 +28,12 @@ VARIABLES
   workerRegistered,
   interrupted,
   buffered,
+  operatorCancelPending,
   cancelSent,
   completionAfterCancellation,
+  completionAfterTerminal,
+  crossingDeadlineLost,
+  deadlineExtendedByTraffic,
   engineObligation,
   engineStarted,
   engineDeadline,
@@ -47,8 +55,12 @@ vars == <<
   workerRegistered,
   interrupted,
   buffered,
+  operatorCancelPending,
   cancelSent,
   completionAfterCancellation,
+  completionAfterTerminal,
+  crossingDeadlineLost,
+  deadlineExtendedByTraffic,
   engineObligation,
   engineStarted,
   engineDeadline,
@@ -71,8 +83,12 @@ TypeOK ==
   /\ workerRegistered \subseteq Workers
   /\ interrupted \subseteq Workers
   /\ buffered \subseteq Workers
+  /\ operatorCancelPending \in BOOLEAN
   /\ cancelSent \in BOOLEAN
   /\ completionAfterCancellation \in BOOLEAN
+  /\ completionAfterTerminal \in BOOLEAN
+  /\ crossingDeadlineLost \in BOOLEAN
+  /\ deadlineExtendedByTraffic \in BOOLEAN
   /\ engineObligation \in BOOLEAN
   /\ engineStarted \in 0..MaxClock
   /\ engineDeadline \in 0..(MaxClock + Timeout)
@@ -94,8 +110,12 @@ Init ==
   /\ workerRegistered = {}
   /\ interrupted = {}
   /\ buffered = {}
+  /\ operatorCancelPending \in BOOLEAN
   /\ cancelSent = FALSE
   /\ completionAfterCancellation = FALSE
+  /\ completionAfterTerminal = FALSE
+  /\ crossingDeadlineLost = FALSE
+  /\ deadlineExtendedByTraffic = FALSE
   /\ engineObligation = TRUE
   /\ engineStarted = 0
   /\ engineDeadline = Timeout
@@ -108,6 +128,7 @@ Init ==
   /\ traffic = 0
 
 ReceiveInitialCheckpoint ==
+  \E terminal \in Terminals:
   /\ outcome = "none"
   /\ terminalSeen = "none"
   /\ ~checkpointAcknowledged
@@ -115,14 +136,16 @@ ReceiveInitialCheckpoint ==
   /\ engineObligation
   /\ checkpointPending' = TRUE
   /\ awaitingCheckpoint' = TRUE
-  /\ committedTerminal' = "active"
+  /\ committedTerminal' = terminal
   /\ engineObligation' = FALSE
   /\ UNCHANGED <<
        checkpointAcknowledged, terminalSeen, workerRunning, workerRegistered,
-       interrupted, buffered, cancelSent, completionAfterCancellation,
-       engineStarted, engineDeadline, cancellationObligation,
-       cancellationStarted, cancellationDeadline, childExited, outcome,
-       clock, traffic
+       interrupted, buffered, operatorCancelPending, cancelSent,
+       completionAfterCancellation, completionAfterTerminal,
+       crossingDeadlineLost, deadlineExtendedByTraffic,
+       engineStarted, engineDeadline,
+       cancellationObligation, cancellationStarted, cancellationDeadline,
+       childExited, outcome, clock, traffic
      >>
 
 StartSuccessor ==
@@ -137,11 +160,20 @@ StartSuccessor ==
     /\ worker \notin workerRunning
     /\ workerRunning' = workerRunning \cup {worker}
     /\ workerRegistered' = workerRegistered \cup {worker}
-    /\ engineObligation' = FALSE
+    /\ IF awaitingCheckpoint /\ engineObligation
+          THEN IF PreserveCrossingDeadline
+            THEN /\ engineObligation' = engineObligation
+                 /\ crossingDeadlineLost' = crossingDeadlineLost
+            ELSE /\ engineObligation' = FALSE
+                 /\ crossingDeadlineLost' = TRUE
+          ELSE /\ engineObligation' = FALSE
+               /\ crossingDeadlineLost' = crossingDeadlineLost
     /\ UNCHANGED <<
          checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
-         committedTerminal, terminalSeen, interrupted, buffered, cancelSent,
-         completionAfterCancellation, engineStarted, engineDeadline,
+         committedTerminal, terminalSeen, interrupted, buffered,
+         operatorCancelPending, cancelSent, completionAfterCancellation,
+         completionAfterTerminal, deadlineExtendedByTraffic,
+         engineStarted, engineDeadline,
          cancellationObligation, cancellationStarted, cancellationDeadline,
          childExited, outcome, clock, traffic
        >>
@@ -151,13 +183,19 @@ FinishWorker ==
     /\ outcome = "none"
     /\ workerRunning' = workerRunning \ {worker}
     /\ workerRegistered' = workerRegistered \ {worker}
-    /\ IF cancelSent \/ interrupted # {}
+    /\ IF committedTerminal # "active" \/ terminalSeen # "none" \/ cancelSent \/ interrupted # {}
           THEN /\ buffered' = buffered
                /\ awaitingCheckpoint' = awaitingCheckpoint
                /\ engineObligation' = engineObligation
                /\ engineStarted' = engineStarted
                /\ engineDeadline' = engineDeadline
                /\ completionAfterCancellation' = completionAfterCancellation
+               /\ completionAfterTerminal' =
+                    IF committedTerminal # "active" \/ terminalSeen # "none"
+                      THEN IF DropCompletionAfterTerminal
+                        THEN completionAfterTerminal
+                        ELSE TRUE
+                      ELSE completionAfterTerminal
           ELSE IF awaitingCheckpoint
             THEN /\ buffered' = buffered \cup {worker}
                  /\ awaitingCheckpoint' = awaitingCheckpoint
@@ -165,23 +203,27 @@ FinishWorker ==
                  /\ engineStarted' = engineStarted
                  /\ engineDeadline' = engineDeadline
                  /\ completionAfterCancellation' = completionAfterCancellation
+                 /\ completionAfterTerminal' = completionAfterTerminal
             ELSE /\ buffered' = buffered
                  /\ awaitingCheckpoint' = TRUE
                  /\ engineObligation' = TRUE
                  /\ engineStarted' = clock
                  /\ engineDeadline' = clock + Timeout
-                 /\ completionAfterCancellation' =
-                      completionAfterCancellation \/ cancelSent
+                 /\ completionAfterCancellation' = completionAfterCancellation \/ cancelSent
+                 /\ completionAfterTerminal' = completionAfterTerminal \/ committedTerminal # "active" \/ terminalSeen # "none"
     /\ UNCHANGED <<
          checkpointPending, checkpointAcknowledged, committedTerminal,
-         terminalSeen, interrupted, cancelSent, cancellationObligation,
-         cancellationStarted, cancellationDeadline, childExited, outcome,
-         clock, traffic
+         terminalSeen, interrupted, operatorCancelPending, cancelSent,
+         crossingDeadlineLost, deadlineExtendedByTraffic,
+         cancellationObligation, cancellationStarted, cancellationDeadline,
+         childExited, outcome, clock, traffic
        >>
 
 InterruptWorker ==
   \E worker \in workerRunning:
     /\ outcome = "none"
+    /\ committedTerminal = "active"
+    /\ terminalSeen = "none"
     /\ ~cancelSent
     /\ workerRunning' = workerRunning \ {worker}
     /\ workerRegistered' = workerRegistered \ {worker}
@@ -194,15 +236,20 @@ InterruptWorker ==
                /\ cancellationDeadline' = clock + Timeout
     /\ UNCHANGED <<
          checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
-         committedTerminal, terminalSeen, buffered, cancelSent,
-         completionAfterCancellation, engineObligation, engineStarted,
-         engineDeadline, childExited, outcome, clock, traffic
+         committedTerminal, terminalSeen, buffered, operatorCancelPending,
+         cancelSent, completionAfterCancellation, completionAfterTerminal,
+         crossingDeadlineLost, deadlineExtendedByTraffic,
+         engineObligation, engineStarted, engineDeadline,
+         childExited, outcome, clock, traffic
        >>
 
 SendCancellation ==
   /\ outcome = "none"
-  /\ interrupted # {}
+  /\ committedTerminal = "active"
+  /\ terminalSeen = "none"
+  /\ operatorCancelPending \/ interrupted # {}
   /\ ~cancelSent
+  /\ operatorCancelPending' = FALSE
   /\ cancelSent' = TRUE
   /\ cancellationObligation' = FALSE
   /\ IF engineObligation
@@ -216,19 +263,20 @@ SendCancellation ==
        checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
        committedTerminal, terminalSeen, workerRunning, workerRegistered,
        interrupted, buffered, completionAfterCancellation,
-       cancellationStarted, cancellationDeadline, childExited, outcome,
-       clock, traffic
+       completionAfterTerminal, crossingDeadlineLost,
+       deadlineExtendedByTraffic, cancellationStarted,
+       cancellationDeadline, childExited, outcome, clock, traffic
      >>
 
 ReceiveActiveCheckpoint ==
   /\ outcome = "none"
   /\ terminalSeen = "none"
+  /\ committedTerminal = "active"
   /\ checkpointAcknowledged
   /\ ~checkpointPending
   /\ engineObligation
   /\ checkpointPending' = TRUE
   /\ awaitingCheckpoint' = TRUE
-  /\ committedTerminal' = "active"
   /\ IF cancelSent
         THEN /\ engineObligation' = engineObligation
              /\ engineStarted' = engineStarted
@@ -237,20 +285,23 @@ ReceiveActiveCheckpoint ==
              /\ engineStarted' = engineStarted
              /\ engineDeadline' = engineDeadline
   /\ UNCHANGED <<
-       checkpointAcknowledged, terminalSeen, workerRunning, workerRegistered,
-       interrupted, buffered, cancelSent, completionAfterCancellation,
-       cancellationObligation, cancellationStarted, cancellationDeadline,
-       childExited, outcome, clock, traffic
+       checkpointAcknowledged, committedTerminal, terminalSeen,
+       workerRunning, workerRegistered, interrupted, buffered,
+       operatorCancelPending, cancelSent, completionAfterCancellation,
+       completionAfterTerminal, crossingDeadlineLost,
+       deadlineExtendedByTraffic, cancellationObligation,
+       cancellationStarted, cancellationDeadline, childExited,
+       outcome, clock, traffic
      >>
 
 ReceiveTerminalCheckpoint ==
-  \E terminal \in {"succeeded", "cancelled"}:
+  \E terminal \in {"succeeded", "failed", "cancelled"}:
     /\ outcome = "none"
     /\ terminalSeen = "none"
+    /\ committedTerminal = "active"
     /\ checkpointAcknowledged
     /\ ~checkpointPending
     /\ engineObligation
-    /\ IF terminal = "cancelled" THEN cancelSent ELSE ~cancelSent
     /\ IF terminal = "succeeded"
           THEN workerRunning = {} /\ interrupted = {} /\ buffered = {}
           ELSE TRUE
@@ -258,12 +309,15 @@ ReceiveTerminalCheckpoint ==
     /\ awaitingCheckpoint' = TRUE
     /\ committedTerminal' = terminal
     /\ engineObligation' = FALSE
+    /\ cancellationObligation' = FALSE
     /\ UNCHANGED <<
          checkpointAcknowledged, terminalSeen, workerRunning,
-         workerRegistered, interrupted, buffered, cancelSent,
-         completionAfterCancellation, engineStarted, engineDeadline,
-         cancellationObligation, cancellationStarted, cancellationDeadline,
-         childExited, outcome, clock, traffic
+         workerRegistered, interrupted, buffered, operatorCancelPending,
+         cancelSent, completionAfterCancellation, completionAfterTerminal,
+         crossingDeadlineLost, deadlineExtendedByTraffic,
+         engineStarted, engineDeadline,
+         cancellationStarted, cancellationDeadline, childExited,
+         outcome, clock, traffic
        >>
 
 AcknowledgeCheckpoint ==
@@ -271,32 +325,70 @@ AcknowledgeCheckpoint ==
   /\ checkpointPending
   /\ checkpointPending' = FALSE
   /\ checkpointAcknowledged' = TRUE
-  /\ IF cancelSent /\ buffered # {}
+  /\ IF committedTerminal # "active"
         THEN /\ buffered' = {}
              /\ awaitingCheckpoint' = FALSE
              /\ engineObligation' = TRUE
-             /\ engineStarted' = engineStarted
-             /\ engineDeadline' = engineDeadline
-        ELSE IF buffered # {}
-          THEN /\ buffered' = buffered \ {CHOOSE worker \in buffered: TRUE}
-               /\ awaitingCheckpoint' = TRUE
-               /\ engineObligation' = TRUE
-               /\ engineStarted' = clock
-               /\ engineDeadline' = clock + Timeout
-          ELSE /\ buffered' = buffered
+             /\ engineStarted' = clock
+             /\ engineDeadline' = clock + Timeout
+             /\ completionAfterCancellation' =
+                  IF DropBufferedAfterCancellation
+                    THEN completionAfterCancellation
+                    ELSE completionAfterCancellation \/ (cancelSent /\ buffered # {})
+             /\ completionAfterTerminal' = completionAfterTerminal
+        ELSE IF cancelSent /\ buffered # {}
+          THEN /\ buffered' = {}
                /\ awaitingCheckpoint' = FALSE
                /\ engineObligation' = TRUE
-               /\ engineStarted' = clock
-               /\ engineDeadline' = clock + Timeout
+               /\ engineStarted' = engineStarted
+               /\ engineDeadline' = engineDeadline
+               /\ completionAfterCancellation' =
+                    IF DropBufferedAfterCancellation
+                      THEN completionAfterCancellation
+                      ELSE TRUE
+               /\ completionAfterTerminal' = completionAfterTerminal
+          ELSE IF buffered # {}
+            THEN /\ buffered' = buffered \ {CHOOSE worker \in buffered: TRUE}
+                 /\ awaitingCheckpoint' = TRUE
+                 /\ engineObligation' = TRUE
+                 /\ engineStarted' = clock
+                 /\ engineDeadline' = clock + Timeout
+                 /\ completionAfterCancellation' = completionAfterCancellation \/ cancelSent
+                 /\ completionAfterTerminal' = completionAfterTerminal \/ committedTerminal # "active"
+            ELSE IF cancelSent
+              THEN /\ buffered' = buffered
+                   /\ awaitingCheckpoint' = FALSE
+                   /\ engineObligation' = TRUE
+                   /\ engineStarted' = engineStarted
+                   /\ engineDeadline' = engineDeadline
+                   /\ completionAfterCancellation' = completionAfterCancellation
+                   /\ completionAfterTerminal' = completionAfterTerminal
+              ELSE IF workerRunning # {} \/ interrupted # {}
+                THEN /\ buffered' = buffered
+                     /\ awaitingCheckpoint' = FALSE
+                     /\ engineObligation' = FALSE
+                     /\ engineStarted' = engineStarted
+                     /\ engineDeadline' = engineDeadline
+                     /\ completionAfterCancellation' = completionAfterCancellation
+                     /\ completionAfterTerminal' = completionAfterTerminal
+                ELSE /\ buffered' = buffered
+                     /\ awaitingCheckpoint' = FALSE
+                     /\ engineObligation' = TRUE
+                     /\ engineStarted' = clock
+                     /\ engineDeadline' = clock + Timeout
+                     /\ completionAfterCancellation' = completionAfterCancellation
+                     /\ completionAfterTerminal' = completionAfterTerminal
   /\ UNCHANGED <<
        committedTerminal, terminalSeen, workerRunning, workerRegistered,
-       interrupted, cancelSent, completionAfterCancellation,
+       interrupted, operatorCancelPending, cancelSent,
+       crossingDeadlineLost, deadlineExtendedByTraffic,
        cancellationObligation, cancellationStarted, cancellationDeadline,
        childExited, outcome, clock, traffic
      >>
 
 ObserveTerminal ==
   /\ outcome = "none"
+  /\ terminalSeen = "none"
   /\ committedTerminal # "active"
   /\ checkpointAcknowledged
   /\ ~checkpointPending
@@ -312,25 +404,30 @@ ObserveTerminal ==
   /\ engineObligation' = TRUE
   /\ engineStarted' = clock
   /\ engineDeadline' = clock + Timeout
+  /\ cancellationObligation' = FALSE
   /\ UNCHANGED <<
        checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
-       committedTerminal, cancelSent, completionAfterCancellation,
-       cancellationObligation, cancellationStarted, cancellationDeadline,
-       childExited, outcome, clock, traffic
+       committedTerminal, operatorCancelPending, cancelSent,
+       completionAfterCancellation, completionAfterTerminal,
+       crossingDeadlineLost, deadlineExtendedByTraffic,
+       cancellationStarted, cancellationDeadline, childExited,
+       outcome, clock, traffic
      >>
 
 AbnormalChildExit ==
   /\ outcome = "none"
-  /\ terminalSeen # "none"
   /\ childExited' = TRUE
-  /\ outcome' = terminalSeen
+  /\ outcome' = IF terminalSeen # "none" THEN terminalSeen ELSE "fault"
   /\ engineObligation' = FALSE
   /\ UNCHANGED <<
        checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
        committedTerminal, terminalSeen, workerRunning, workerRegistered,
-       interrupted, buffered, cancelSent, completionAfterCancellation,
-       engineStarted, engineDeadline, cancellationObligation,
-       cancellationStarted, cancellationDeadline, clock, traffic
+       interrupted, buffered, operatorCancelPending, cancelSent,
+       completionAfterCancellation, completionAfterTerminal,
+       crossingDeadlineLost, deadlineExtendedByTraffic,
+       engineStarted, engineDeadline,
+       cancellationObligation, cancellationStarted,
+       cancellationDeadline, clock, traffic
      >>
 
 EngineTimeout ==
@@ -342,9 +439,12 @@ EngineTimeout ==
   /\ UNCHANGED <<
        checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
        committedTerminal, terminalSeen, workerRunning, workerRegistered,
-       interrupted, buffered, cancelSent, completionAfterCancellation,
-       engineStarted, engineDeadline, cancellationObligation,
-       cancellationStarted, cancellationDeadline, childExited, clock, traffic
+       interrupted, buffered, operatorCancelPending, cancelSent,
+       completionAfterCancellation, completionAfterTerminal,
+       crossingDeadlineLost, deadlineExtendedByTraffic,
+       engineStarted, engineDeadline,
+       cancellationObligation, cancellationStarted,
+       cancellationDeadline, childExited, clock, traffic
      >>
 
 CancellationTimeout ==
@@ -356,8 +456,11 @@ CancellationTimeout ==
   /\ UNCHANGED <<
        checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
        committedTerminal, terminalSeen, workerRunning, workerRegistered,
-       interrupted, buffered, cancelSent, completionAfterCancellation,
-       engineObligation, engineStarted, engineDeadline, cancellationStarted,
+       interrupted, buffered, operatorCancelPending, cancelSent,
+       completionAfterCancellation, completionAfterTerminal,
+       crossingDeadlineLost, deadlineExtendedByTraffic,
+       engineObligation, engineStarted, engineDeadline,
+       cancellationStarted,
        cancellationDeadline, childExited, clock, traffic
      >>
 
@@ -368,22 +471,33 @@ Tick ==
   /\ UNCHANGED <<
        checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
        committedTerminal, terminalSeen, workerRunning, workerRegistered,
-       interrupted, buffered, cancelSent, completionAfterCancellation,
+       interrupted, buffered, operatorCancelPending, cancelSent,
+       completionAfterCancellation, completionAfterTerminal,
+       crossingDeadlineLost, deadlineExtendedByTraffic,
        engineObligation, engineStarted, engineDeadline,
-       cancellationObligation, cancellationStarted, cancellationDeadline,
-       childExited, outcome, traffic
+       cancellationObligation,
+       cancellationStarted, cancellationDeadline, childExited,
+       outcome, traffic
      >>
 
 UnrelatedTraffic ==
   /\ outcome = "none"
   /\ traffic' = 1 - traffic
+  /\ IF ~StableDeadlineUnderTraffic /\ engineObligation
+        THEN /\ engineStarted' = clock
+             /\ engineDeadline' = clock + Timeout
+             /\ deadlineExtendedByTraffic' = TRUE
+        ELSE /\ engineStarted' = engineStarted
+             /\ engineDeadline' = engineDeadline
+             /\ deadlineExtendedByTraffic' = deadlineExtendedByTraffic
   /\ UNCHANGED <<
        checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
        committedTerminal, terminalSeen, workerRunning, workerRegistered,
-       interrupted, buffered, cancelSent, completionAfterCancellation,
-       engineObligation, engineStarted, engineDeadline,
-       cancellationObligation, cancellationStarted, cancellationDeadline,
-       childExited, outcome, clock
+       interrupted, buffered, operatorCancelPending, cancelSent,
+       completionAfterCancellation, completionAfterTerminal,
+       crossingDeadlineLost, engineObligation,
+       cancellationObligation, cancellationStarted,
+       cancellationDeadline, childExited, outcome, clock
      >>
 
 Done ==
@@ -409,14 +523,15 @@ Next ==
 
 Fairness ==
   /\ WF_vars(SendCancellation)
+  /\ WF_vars(AcknowledgeCheckpoint)
+  /\ WF_vars(ObserveTerminal)
   /\ WF_vars(EngineTimeout)
   /\ WF_vars(CancellationTimeout)
 
 Spec == Init /\ [][Next]_vars /\ Fairness
 
 (************************ Model-checked host obligations ************************)
-AcknowledgementBeforeSuccessor ==
-  workerRunning # {} => checkpointAcknowledged
+AcknowledgementBeforeSuccessor == workerRunning # {} => checkpointAcknowledged
 
 WorkerRegistrationAtomic == workerRunning \subseteq workerRegistered
 
@@ -424,10 +539,20 @@ TerminalCheckpointAuthority ==
   terminalSeen # "none" =>
     terminalSeen = committedTerminal /\ checkpointAcknowledged /\ ~checkpointPending
 
+TerminalCheckpointQuiescence ==
+  committedTerminal = "succeeded" =>
+    workerRunning = {} /\ interrupted = {} /\ buffered = {}
+
 NoCompletionAfterCancellation == ~completionAfterCancellation
+
+NoCompletionAfterTerminal == ~completionAfterTerminal
+
+CrossingCheckpointDeadlinePreserved == ~crossingDeadlineLost
 
 EngineDeadlineNotExtended ==
   engineObligation => engineDeadline = engineStarted + Timeout
+
+DeadlineStableUnderUnrelatedTraffic == ~deadlineExtendedByTraffic
 
 CancellationDeadlineIndependent ==
   cancellationObligation => cancellationDeadline = cancellationStarted + Timeout
@@ -435,9 +560,10 @@ CancellationDeadlineIndependent ==
 BufferedCompletionIsGated == buffered # {} => awaitingCheckpoint
 
 CommittedTerminalSurvivesAbnormalExit ==
-  childExited => outcome = committedTerminal
+  childExited /\ terminalSeen # "none" => outcome = committedTerminal
 
-CancellationLivenessAfterInterruption ==
-  [](interrupted # {} => <>(cancelSent \/ outcome # "none"))
+CancellationLiveness ==
+  []( (operatorCancelPending \/ interrupted # {})
+      => <>(cancelSent \/ committedTerminal # "active" \/ outcome # "none") )
 
 =============================================================================

--- a/formal/HostedProtocol.tla
+++ b/formal/HostedProtocol.tla
@@ -1,0 +1,443 @@
+------------------------------ MODULE HostedProtocol ------------------------------
+(*******************************************************************************)
+(* Bounded model of the Wire process-host protocol around the circuit engine.   *)
+(* The engine snapshot semantics live in Lean; this model covers host-owned      *)
+(* concurrency: atomic worker registration, serialized completions, checkpoint   *)
+(* acknowledgement, cancellation, independent watchdogs, terminal authority,    *)
+(* and child exit.  The vocabulary mirrors Cortex.Wire.Circuit.HostProtocol.     *)
+(*******************************************************************************)
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS Timeout, MaxClock
+
+Workers == {"w1", "w2"}
+Terminals == {"active", "succeeded", "cancelled"}
+Outcomes == {"none", "fault", "succeeded", "cancelled"}
+
+VARIABLES
+  checkpointPending,
+  checkpointAcknowledged,
+  awaitingCheckpoint,
+  committedTerminal,
+  terminalSeen,
+  workerRunning,
+  workerRegistered,
+  interrupted,
+  buffered,
+  cancelSent,
+  completionAfterCancellation,
+  engineObligation,
+  engineStarted,
+  engineDeadline,
+  cancellationObligation,
+  cancellationStarted,
+  cancellationDeadline,
+  childExited,
+  outcome,
+  clock,
+  traffic
+
+vars == <<
+  checkpointPending,
+  checkpointAcknowledged,
+  awaitingCheckpoint,
+  committedTerminal,
+  terminalSeen,
+  workerRunning,
+  workerRegistered,
+  interrupted,
+  buffered,
+  cancelSent,
+  completionAfterCancellation,
+  engineObligation,
+  engineStarted,
+  engineDeadline,
+  cancellationObligation,
+  cancellationStarted,
+  cancellationDeadline,
+  childExited,
+  outcome,
+  clock,
+  traffic
+>>
+
+TypeOK ==
+  /\ checkpointPending \in BOOLEAN
+  /\ checkpointAcknowledged \in BOOLEAN
+  /\ awaitingCheckpoint \in BOOLEAN
+  /\ committedTerminal \in Terminals
+  /\ terminalSeen \in Terminals \cup {"none"}
+  /\ workerRunning \subseteq Workers
+  /\ workerRegistered \subseteq Workers
+  /\ interrupted \subseteq Workers
+  /\ buffered \subseteq Workers
+  /\ cancelSent \in BOOLEAN
+  /\ completionAfterCancellation \in BOOLEAN
+  /\ engineObligation \in BOOLEAN
+  /\ engineStarted \in 0..MaxClock
+  /\ engineDeadline \in 0..(MaxClock + Timeout)
+  /\ cancellationObligation \in BOOLEAN
+  /\ cancellationStarted \in 0..MaxClock
+  /\ cancellationDeadline \in 0..(MaxClock + Timeout)
+  /\ childExited \in BOOLEAN
+  /\ outcome \in Outcomes
+  /\ clock \in 0..MaxClock
+  /\ traffic \in 0..1
+
+Init ==
+  /\ checkpointPending = FALSE
+  /\ checkpointAcknowledged = FALSE
+  /\ awaitingCheckpoint = FALSE
+  /\ committedTerminal = "active"
+  /\ terminalSeen = "none"
+  /\ workerRunning = {}
+  /\ workerRegistered = {}
+  /\ interrupted = {}
+  /\ buffered = {}
+  /\ cancelSent = FALSE
+  /\ completionAfterCancellation = FALSE
+  /\ engineObligation = TRUE
+  /\ engineStarted = 0
+  /\ engineDeadline = Timeout
+  /\ cancellationObligation = FALSE
+  /\ cancellationStarted = 0
+  /\ cancellationDeadline = 0
+  /\ childExited = FALSE
+  /\ outcome = "none"
+  /\ clock = 0
+  /\ traffic = 0
+
+ReceiveInitialCheckpoint ==
+  /\ outcome = "none"
+  /\ terminalSeen = "none"
+  /\ ~checkpointAcknowledged
+  /\ ~checkpointPending
+  /\ engineObligation
+  /\ checkpointPending' = TRUE
+  /\ awaitingCheckpoint' = TRUE
+  /\ committedTerminal' = "active"
+  /\ engineObligation' = FALSE
+  /\ UNCHANGED <<
+       checkpointAcknowledged, terminalSeen, workerRunning, workerRegistered,
+       interrupted, buffered, cancelSent, completionAfterCancellation,
+       engineStarted, engineDeadline, cancellationObligation,
+       cancellationStarted, cancellationDeadline, childExited, outcome,
+       clock, traffic
+     >>
+
+StartSuccessor ==
+  \E worker \in Workers:
+    /\ outcome = "none"
+    /\ checkpointAcknowledged
+    /\ ~checkpointPending
+    /\ committedTerminal = "active"
+    /\ terminalSeen = "none"
+    /\ ~cancelSent
+    /\ interrupted = {}
+    /\ worker \notin workerRunning
+    /\ workerRunning' = workerRunning \cup {worker}
+    /\ workerRegistered' = workerRegistered \cup {worker}
+    /\ engineObligation' = FALSE
+    /\ UNCHANGED <<
+         checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
+         committedTerminal, terminalSeen, interrupted, buffered, cancelSent,
+         completionAfterCancellation, engineStarted, engineDeadline,
+         cancellationObligation, cancellationStarted, cancellationDeadline,
+         childExited, outcome, clock, traffic
+       >>
+
+FinishWorker ==
+  \E worker \in workerRunning:
+    /\ outcome = "none"
+    /\ workerRunning' = workerRunning \ {worker}
+    /\ workerRegistered' = workerRegistered \ {worker}
+    /\ IF cancelSent \/ interrupted # {}
+          THEN /\ buffered' = buffered
+               /\ awaitingCheckpoint' = awaitingCheckpoint
+               /\ engineObligation' = engineObligation
+               /\ engineStarted' = engineStarted
+               /\ engineDeadline' = engineDeadline
+               /\ completionAfterCancellation' = completionAfterCancellation
+          ELSE IF awaitingCheckpoint
+            THEN /\ buffered' = buffered \cup {worker}
+                 /\ awaitingCheckpoint' = awaitingCheckpoint
+                 /\ engineObligation' = engineObligation
+                 /\ engineStarted' = engineStarted
+                 /\ engineDeadline' = engineDeadline
+                 /\ completionAfterCancellation' = completionAfterCancellation
+            ELSE /\ buffered' = buffered
+                 /\ awaitingCheckpoint' = TRUE
+                 /\ engineObligation' = TRUE
+                 /\ engineStarted' = clock
+                 /\ engineDeadline' = clock + Timeout
+                 /\ completionAfterCancellation' =
+                      completionAfterCancellation \/ cancelSent
+    /\ UNCHANGED <<
+         checkpointPending, checkpointAcknowledged, committedTerminal,
+         terminalSeen, interrupted, cancelSent, cancellationObligation,
+         cancellationStarted, cancellationDeadline, childExited, outcome,
+         clock, traffic
+       >>
+
+InterruptWorker ==
+  \E worker \in workerRunning:
+    /\ outcome = "none"
+    /\ ~cancelSent
+    /\ workerRunning' = workerRunning \ {worker}
+    /\ workerRegistered' = workerRegistered \ {worker}
+    /\ interrupted' = interrupted \cup {worker}
+    /\ cancellationObligation' = TRUE
+    /\ IF cancellationObligation
+          THEN /\ cancellationStarted' = cancellationStarted
+               /\ cancellationDeadline' = cancellationDeadline
+          ELSE /\ cancellationStarted' = clock
+               /\ cancellationDeadline' = clock + Timeout
+    /\ UNCHANGED <<
+         checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
+         committedTerminal, terminalSeen, buffered, cancelSent,
+         completionAfterCancellation, engineObligation, engineStarted,
+         engineDeadline, childExited, outcome, clock, traffic
+       >>
+
+SendCancellation ==
+  /\ outcome = "none"
+  /\ interrupted # {}
+  /\ ~cancelSent
+  /\ cancelSent' = TRUE
+  /\ cancellationObligation' = FALSE
+  /\ IF engineObligation
+        THEN /\ engineObligation' = engineObligation
+             /\ engineStarted' = engineStarted
+             /\ engineDeadline' = engineDeadline
+        ELSE /\ engineObligation' = TRUE
+             /\ engineStarted' = clock
+             /\ engineDeadline' = clock + Timeout
+  /\ UNCHANGED <<
+       checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
+       committedTerminal, terminalSeen, workerRunning, workerRegistered,
+       interrupted, buffered, completionAfterCancellation,
+       cancellationStarted, cancellationDeadline, childExited, outcome,
+       clock, traffic
+     >>
+
+ReceiveActiveCheckpoint ==
+  /\ outcome = "none"
+  /\ terminalSeen = "none"
+  /\ checkpointAcknowledged
+  /\ ~checkpointPending
+  /\ engineObligation
+  /\ checkpointPending' = TRUE
+  /\ awaitingCheckpoint' = TRUE
+  /\ committedTerminal' = "active"
+  /\ IF cancelSent
+        THEN /\ engineObligation' = engineObligation
+             /\ engineStarted' = engineStarted
+             /\ engineDeadline' = engineDeadline
+        ELSE /\ engineObligation' = FALSE
+             /\ engineStarted' = engineStarted
+             /\ engineDeadline' = engineDeadline
+  /\ UNCHANGED <<
+       checkpointAcknowledged, terminalSeen, workerRunning, workerRegistered,
+       interrupted, buffered, cancelSent, completionAfterCancellation,
+       cancellationObligation, cancellationStarted, cancellationDeadline,
+       childExited, outcome, clock, traffic
+     >>
+
+ReceiveTerminalCheckpoint ==
+  \E terminal \in {"succeeded", "cancelled"}:
+    /\ outcome = "none"
+    /\ terminalSeen = "none"
+    /\ checkpointAcknowledged
+    /\ ~checkpointPending
+    /\ engineObligation
+    /\ IF terminal = "cancelled" THEN cancelSent ELSE ~cancelSent
+    /\ IF terminal = "succeeded"
+          THEN workerRunning = {} /\ interrupted = {} /\ buffered = {}
+          ELSE TRUE
+    /\ checkpointPending' = TRUE
+    /\ awaitingCheckpoint' = TRUE
+    /\ committedTerminal' = terminal
+    /\ engineObligation' = FALSE
+    /\ UNCHANGED <<
+         checkpointAcknowledged, terminalSeen, workerRunning,
+         workerRegistered, interrupted, buffered, cancelSent,
+         completionAfterCancellation, engineStarted, engineDeadline,
+         cancellationObligation, cancellationStarted, cancellationDeadline,
+         childExited, outcome, clock, traffic
+       >>
+
+AcknowledgeCheckpoint ==
+  /\ outcome = "none"
+  /\ checkpointPending
+  /\ checkpointPending' = FALSE
+  /\ checkpointAcknowledged' = TRUE
+  /\ IF cancelSent /\ buffered # {}
+        THEN /\ buffered' = {}
+             /\ awaitingCheckpoint' = FALSE
+             /\ engineObligation' = TRUE
+             /\ engineStarted' = engineStarted
+             /\ engineDeadline' = engineDeadline
+        ELSE IF buffered # {}
+          THEN /\ buffered' = buffered \ {CHOOSE worker \in buffered: TRUE}
+               /\ awaitingCheckpoint' = TRUE
+               /\ engineObligation' = TRUE
+               /\ engineStarted' = clock
+               /\ engineDeadline' = clock + Timeout
+          ELSE /\ buffered' = buffered
+               /\ awaitingCheckpoint' = FALSE
+               /\ engineObligation' = TRUE
+               /\ engineStarted' = clock
+               /\ engineDeadline' = clock + Timeout
+  /\ UNCHANGED <<
+       committedTerminal, terminalSeen, workerRunning, workerRegistered,
+       interrupted, cancelSent, completionAfterCancellation,
+       cancellationObligation, cancellationStarted, cancellationDeadline,
+       childExited, outcome, clock, traffic
+     >>
+
+ObserveTerminal ==
+  /\ outcome = "none"
+  /\ committedTerminal # "active"
+  /\ checkpointAcknowledged
+  /\ ~checkpointPending
+  /\ ~awaitingCheckpoint
+  /\ IF committedTerminal = "succeeded"
+        THEN workerRunning = {} /\ interrupted = {} /\ buffered = {}
+        ELSE TRUE
+  /\ terminalSeen' = committedTerminal
+  /\ workerRunning' = {}
+  /\ workerRegistered' = {}
+  /\ interrupted' = {}
+  /\ buffered' = {}
+  /\ engineObligation' = TRUE
+  /\ engineStarted' = clock
+  /\ engineDeadline' = clock + Timeout
+  /\ UNCHANGED <<
+       checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
+       committedTerminal, cancelSent, completionAfterCancellation,
+       cancellationObligation, cancellationStarted, cancellationDeadline,
+       childExited, outcome, clock, traffic
+     >>
+
+AbnormalChildExit ==
+  /\ outcome = "none"
+  /\ terminalSeen # "none"
+  /\ childExited' = TRUE
+  /\ outcome' = terminalSeen
+  /\ engineObligation' = FALSE
+  /\ UNCHANGED <<
+       checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
+       committedTerminal, terminalSeen, workerRunning, workerRegistered,
+       interrupted, buffered, cancelSent, completionAfterCancellation,
+       engineStarted, engineDeadline, cancellationObligation,
+       cancellationStarted, cancellationDeadline, clock, traffic
+     >>
+
+EngineTimeout ==
+  /\ outcome = "none"
+  /\ engineObligation
+  /\ clock >= engineDeadline
+  /\ outcome' = IF terminalSeen # "none" THEN terminalSeen ELSE "fault"
+  /\ engineObligation' = FALSE
+  /\ UNCHANGED <<
+       checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
+       committedTerminal, terminalSeen, workerRunning, workerRegistered,
+       interrupted, buffered, cancelSent, completionAfterCancellation,
+       engineStarted, engineDeadline, cancellationObligation,
+       cancellationStarted, cancellationDeadline, childExited, clock, traffic
+     >>
+
+CancellationTimeout ==
+  /\ outcome = "none"
+  /\ cancellationObligation
+  /\ clock >= cancellationDeadline
+  /\ outcome' = "fault"
+  /\ cancellationObligation' = FALSE
+  /\ UNCHANGED <<
+       checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
+       committedTerminal, terminalSeen, workerRunning, workerRegistered,
+       interrupted, buffered, cancelSent, completionAfterCancellation,
+       engineObligation, engineStarted, engineDeadline, cancellationStarted,
+       cancellationDeadline, childExited, clock, traffic
+     >>
+
+Tick ==
+  /\ outcome = "none"
+  /\ clock < MaxClock
+  /\ clock' = clock + 1
+  /\ UNCHANGED <<
+       checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
+       committedTerminal, terminalSeen, workerRunning, workerRegistered,
+       interrupted, buffered, cancelSent, completionAfterCancellation,
+       engineObligation, engineStarted, engineDeadline,
+       cancellationObligation, cancellationStarted, cancellationDeadline,
+       childExited, outcome, traffic
+     >>
+
+UnrelatedTraffic ==
+  /\ outcome = "none"
+  /\ traffic' = 1 - traffic
+  /\ UNCHANGED <<
+       checkpointPending, checkpointAcknowledged, awaitingCheckpoint,
+       committedTerminal, terminalSeen, workerRunning, workerRegistered,
+       interrupted, buffered, cancelSent, completionAfterCancellation,
+       engineObligation, engineStarted, engineDeadline,
+       cancellationObligation, cancellationStarted, cancellationDeadline,
+       childExited, outcome, clock
+     >>
+
+Done ==
+  /\ outcome # "none"
+  /\ UNCHANGED vars
+
+Next ==
+  \/ ReceiveInitialCheckpoint
+  \/ StartSuccessor
+  \/ FinishWorker
+  \/ InterruptWorker
+  \/ SendCancellation
+  \/ ReceiveActiveCheckpoint
+  \/ ReceiveTerminalCheckpoint
+  \/ AcknowledgeCheckpoint
+  \/ ObserveTerminal
+  \/ AbnormalChildExit
+  \/ EngineTimeout
+  \/ CancellationTimeout
+  \/ Tick
+  \/ UnrelatedTraffic
+  \/ Done
+
+Fairness ==
+  /\ WF_vars(SendCancellation)
+  /\ WF_vars(EngineTimeout)
+  /\ WF_vars(CancellationTimeout)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(************************ Model-checked host obligations ************************)
+AcknowledgementBeforeSuccessor ==
+  workerRunning # {} => checkpointAcknowledged
+
+WorkerRegistrationAtomic == workerRunning \subseteq workerRegistered
+
+TerminalCheckpointAuthority ==
+  terminalSeen # "none" =>
+    terminalSeen = committedTerminal /\ checkpointAcknowledged /\ ~checkpointPending
+
+NoCompletionAfterCancellation == ~completionAfterCancellation
+
+EngineDeadlineNotExtended ==
+  engineObligation => engineDeadline = engineStarted + Timeout
+
+CancellationDeadlineIndependent ==
+  cancellationObligation => cancellationDeadline = cancellationStarted + Timeout
+
+BufferedCompletionIsGated == buffered # {} => awaitingCheckpoint
+
+CommittedTerminalSurvivesAbnormalExit ==
+  childExited => outcome = committedTerminal
+
+CancellationLivenessAfterInterruption ==
+  [](interrupted # {} => <>(cancelSent \/ outcome # "none"))
+
+=============================================================================

--- a/formal/HostedProtocolExtendDeadline.cfg
+++ b/formal/HostedProtocolExtendDeadline.cfg
@@ -1,0 +1,8 @@
+CONSTANT Timeout = 2
+CONSTANT MaxClock = 6
+CONSTANT DropBufferedAfterCancellation = TRUE
+CONSTANT DropCompletionAfterTerminal = TRUE
+CONSTANT PreserveCrossingDeadline = TRUE
+CONSTANT StableDeadlineUnderTraffic = FALSE
+SPECIFICATION Spec
+INVARIANT DeadlineStableUnderUnrelatedTraffic

--- a/formal/HostedProtocolForwardAfterCancel.cfg
+++ b/formal/HostedProtocolForwardAfterCancel.cfg
@@ -1,0 +1,8 @@
+CONSTANT Timeout = 2
+CONSTANT MaxClock = 6
+CONSTANT DropBufferedAfterCancellation = FALSE
+CONSTANT DropCompletionAfterTerminal = TRUE
+CONSTANT PreserveCrossingDeadline = TRUE
+CONSTANT StableDeadlineUnderTraffic = TRUE
+SPECIFICATION Spec
+INVARIANT NoCompletionAfterCancellation

--- a/formal/HostedProtocolForwardAfterTerminal.cfg
+++ b/formal/HostedProtocolForwardAfterTerminal.cfg
@@ -1,0 +1,10 @@
+CONSTANT Timeout = 2
+CONSTANT MaxClock = 6
+CONSTANT DropBufferedAfterCancellation = TRUE
+CONSTANT DropCompletionAfterTerminal = FALSE
+CONSTANT PreserveCrossingDeadline = TRUE
+CONSTANT StableDeadlineUnderTraffic = TRUE
+
+SPECIFICATION Spec
+
+INVARIANT NoCompletionAfterTerminal

--- a/formal/HostedProtocolLoseCrossingDeadline.cfg
+++ b/formal/HostedProtocolLoseCrossingDeadline.cfg
@@ -1,0 +1,8 @@
+CONSTANT Timeout = 2
+CONSTANT MaxClock = 6
+CONSTANT DropBufferedAfterCancellation = TRUE
+CONSTANT DropCompletionAfterTerminal = TRUE
+CONSTANT PreserveCrossingDeadline = FALSE
+CONSTANT StableDeadlineUnderTraffic = TRUE
+SPECIFICATION Spec
+INVARIANT CrossingCheckpointDeadlinePreserved

--- a/formal/README.md
+++ b/formal/README.md
@@ -22,6 +22,19 @@ the protocol shape:
 The negative config (`Split.cfg`) is expected to fail; `scripts/check-tla.sh` asserts it reproduces
 its documented violation, so the model cannot vacuously pass.
 
+### `HostedProtocol.tla` — the Wire process-host lifecycle
+
+This model covers the concurrency owned by the process host rather than the engine value semantics:
+atomic worker registration, checkpoint acknowledgement, direct and buffered completions, operator
+and interruption-driven cancellation, independent deadline identities, completed/failed/cancelled
+terminal precedence, and abnormal child exit. Lean separately proves snapshot validity and the
+engine checkpoint gate.
+
+The positive `HostedProtocol.cfg` checks the production policy. Three expected-failure configs prove
+the central race checks are non-vacuous by respectively forwarding a buffered completion after
+cancellation, clearing a deadline when a successor request crosses a completion, and replacing an
+outstanding deadline on unrelated traffic.
+
 ## Note on multi-await lock ordering (no model required)
 
 An earlier draft modelled `SELECT … FOR SHARE` acquisition ordering for deadlock-avoidance. That was

--- a/justfile
+++ b/justfile
@@ -195,9 +195,9 @@ lean-check:
     @echo "🔍 Checking Cortex theory through Nix..."
     nix run .#_check-theory
 
-# Model-check the Pulse run-terminal signal protocol (TLC) through the flake surface
+# Model-check the Pulse and Wire hosted protocols (TLC) through the flake surface
 tla-check:
-    @echo "🔍 Model-checking the run-terminal signal protocol (TLC)..."
+    @echo "🔍 Model-checking the Pulse and Wire hosted protocols (TLC)..."
     nix run .#_check-tla
 
 # Run the test suite against an ephemeral Postgres with the Pulse schema fixture.

--- a/nix/ci/default.nix
+++ b/nix/ci/default.nix
@@ -301,7 +301,7 @@
       _check-tla = {
         type = "app";
         program = "${check-tla}/bin/check-tla";
-        meta.description = "Model-check the Pulse run-terminal signal protocol with TLC";
+        meta.description = "Model-check the Pulse and Wire hosted protocols with TLC";
       };
 
       check-haskell-format = {

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Model-check the Pulse run-terminal signal protocol with TLC.
+# Model-check the Pulse signal and Wire process-host protocols with TLC.
 #
 # Positive specs must verify. The two NEGATIVE specs must reproduce the bug they
 # document (lost wakeup / deadlock) -- proving the models actually catch the bug
@@ -46,6 +46,7 @@ expect_violation() { # $1 cfg, $2 spec, $3 needle
 
 echo "TLA+ positive checks (must verify):"
 expect_pass Atomic.cfg RunTerminalSignal.tla
+expect_pass HostedProtocol.cfg HostedProtocol.tla
 
 echo "TLA+ negative checks (must reproduce the documented bug):"
 expect_violation Split.cfg RunTerminalSignal.tla "NoStuckWaiter is violated"

--- a/scripts/check-tla.sh
+++ b/scripts/check-tla.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Model-check the Pulse signal and Wire process-host protocols with TLC.
 #
-# Positive specs must verify. The two NEGATIVE specs must reproduce the bug they
-# document (lost wakeup / deadlock) -- proving the models actually catch the bug
-# class rather than vacuously passing. Requires `tlc` on PATH (nixpkgs#tlaplus).
+# Positive specs must verify. NEGATIVE specs deliberately weaken one protocol
+# rule and must reproduce the named invariant violation, proving the checks are
+# not vacuous. Requires `tlc` on PATH (nixpkgs#tlaplus).
 set -euo pipefail
 
 cd "$(dirname "$0")/../formal"
@@ -50,6 +50,10 @@ expect_pass HostedProtocol.cfg HostedProtocol.tla
 
 echo "TLA+ negative checks (must reproduce the documented bug):"
 expect_violation Split.cfg RunTerminalSignal.tla "NoStuckWaiter is violated"
+expect_violation HostedProtocolForwardAfterCancel.cfg HostedProtocol.tla "NoCompletionAfterCancellation is violated"
+expect_violation HostedProtocolForwardAfterTerminal.cfg HostedProtocol.tla "NoCompletionAfterTerminal is violated"
+expect_violation HostedProtocolLoseCrossingDeadline.cfg HostedProtocol.tla "CrossingCheckpointDeadlinePreserved is violated"
+expect_violation HostedProtocolExtendDeadline.cfg HostedProtocol.tla "DeadlineStableUnderUnrelatedTraffic is violated"
 
 if [ "$fail" -ne 0 ]; then
   echo "TLA+ protocol checks FAILED." >&2

--- a/src/Cortex/Wire/Circuit/HostProtocol.hs
+++ b/src/Cortex/Wire/Circuit/HostProtocol.hs
@@ -1,0 +1,185 @@
+{- |
+Module      : Cortex.Wire.Circuit.HostProtocol
+Description : Pure lifecycle policy for the hosted Wire process protocol.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+The hosted engine owns circuit scheduling, but the process host owns a second
+state machine: checkpoint acknowledgement, worker completion serialization,
+cancellation, watchdogs, terminal authority, and child exit.  Keeping those
+decisions as a pure transition policy makes the concurrency crossings
+reviewable and gives the TLA+ model in @formal/HostedProtocol.tla@ a concrete
+implementation target.
+
+This module deliberately carries no handles, callbacks, timers, or worker
+payloads.  'ProtocolView' is the lifecycle projection of the IO loop and
+'transition' selects its next authoritative action.  The caller performs that
+action and then projects its new state before the next transition.
+-}
+module Cortex.Wire.Circuit.HostProtocol
+  ( ChildExitKind (..)
+  , DeadlineUpdate (..)
+  , ProtocolAction (..)
+  , ProtocolEvent (..)
+  , ProtocolView (..)
+  , transition
+  )
+where
+
+import Data.Text (Text)
+
+import Cortex.Wire.Circuit.Engine
+  ( EngineTerminalState (..)
+  )
+
+{- | Whether process exit itself was successful.  Terminal authority is
+intentionally separate: once terminal is committed and observed, either
+exit kind finishes with that committed result.
+-}
+data ChildExitKind
+  = ChildExitSuccess
+  | ChildExitAbnormal
+  deriving stock (Eq, Show)
+
+-- | How an IO-backed deadline changes across one pure protocol transition.
+data DeadlineUpdate
+  = KeepDeadline
+  | ClearDeadline
+  | ArmFreshDeadline
+  | EnsureDeadline
+  deriving stock (Eq, Show)
+
+-- | Race-relevant lifecycle facts projected from the process loop.
+data ProtocolView = ProtocolView
+  { protocolCommittedTerminal :: !(Maybe EngineTerminalState)
+  , protocolAwaitingCheckpoint :: !Bool
+  , protocolWorkerCount :: !Int
+  , protocolInterruptedCount :: !Int
+  , protocolBufferedCompletionCount :: !Int
+  , protocolTerminalSeen :: !(Maybe EngineTerminalState)
+  , protocolCancellationSent :: !Bool
+  }
+  deriving stock (Eq, Show)
+
+-- | Inputs whose disposition previously lived in interleaved IO branches.
+data ProtocolEvent
+  = CancellationRequested
+  | SuccessorRequested
+  | ResolvedCompletionArrived
+  | InterruptedCompletionArrived !Bool
+  | CheckpointReceived !EngineTerminalState
+  | CheckpointAcknowledged !EngineTerminalState
+  | TerminalReceived !EngineTerminalState
+  | ChildExited !ChildExitKind
+  | EngineDeadlineExpired
+  | CancellationDeadlineExpired
+  deriving stock (Eq, Show)
+
+-- | Authoritative next action selected by the pure host protocol.
+data ProtocolAction
+  = IgnoreInput
+  | SendCancellation !DeadlineUpdate !DeadlineUpdate
+  | StartSuccessor !DeadlineUpdate
+  | SuppressSuccessor
+  | ForwardCompletion !DeadlineUpdate
+  | BufferCompletion
+  | DropCompletion
+  | AwaitCancellation !DeadlineUpdate
+  | CommitCheckpoint !DeadlineUpdate
+  | DispatchBufferedCompletion
+  | DropBufferedCompletions
+  | AwaitTerminal !DeadlineUpdate
+  | AwaitCancellationCheckpoint !DeadlineUpdate
+  | AwaitEngineProgress !DeadlineUpdate
+  | AwaitWorkers
+  | SendShutdown
+  | CancelWorkersAndSendShutdown
+  | FinishCommittedTerminal
+  | ProtocolFault !Text
+  deriving stock (Eq, Show)
+
+-- | Pure transition policy for host-owned lifecycle decisions.
+transition :: ProtocolView -> ProtocolEvent -> ProtocolAction
+transition state = \case
+  CancellationRequested
+    | terminalObserved -> IgnoreInput
+    | state.protocolCancellationSent -> IgnoreInput
+    | otherwise -> SendCancellation EnsureDeadline ClearDeadline
+  SuccessorRequested
+    | not hasCommittedCheckpoint ->
+        ProtocolFault "engine requested an effect before its initial checkpoint was committed"
+    | terminalObserved -> ProtocolFault "engine requested an effect after terminal"
+    | state.protocolCancellationSent -> SuppressSuccessor
+    | state.protocolInterruptedCount /= 0 -> SuppressSuccessor
+    | otherwise ->
+        StartSuccessor
+          ( if state.protocolAwaitingCheckpoint
+              then KeepDeadline
+              else ClearDeadline
+          )
+  ResolvedCompletionArrived
+    | state.protocolCancellationSent -> DropCompletion
+    | state.protocolInterruptedCount /= 0 -> DropCompletion
+    | state.protocolAwaitingCheckpoint -> BufferCompletion
+    | otherwise -> ForwardCompletion ArmFreshDeadline
+  InterruptedCompletionArrived cancellationWatcherInstalled
+    | state.protocolCancellationSent -> DropCompletion
+    | not cancellationWatcherInstalled ->
+        ProtocolFault "effect reported interruption but no cancellation watcher is installed"
+    | otherwise -> AwaitCancellation EnsureDeadline
+  CheckpointReceived terminal ->
+    CommitCheckpoint
+      ( if state.protocolCancellationSent && terminal == EngineActive
+          then KeepDeadline
+          else ClearDeadline
+      )
+  CheckpointAcknowledged terminal
+    | state.protocolCancellationSent
+        && state.protocolBufferedCompletionCount /= 0 ->
+        DropBufferedCompletions
+    | state.protocolBufferedCompletionCount /= 0 -> DispatchBufferedCompletion
+    | terminal /= EngineActive -> AwaitTerminal ArmFreshDeadline
+    | state.protocolCancellationSent -> AwaitCancellationCheckpoint EnsureDeadline
+    | state.protocolWorkerCount == 0
+        && state.protocolInterruptedCount == 0 ->
+        AwaitEngineProgress ArmFreshDeadline
+    | otherwise -> AwaitWorkers
+  TerminalReceived terminal ->
+    case state.protocolCommittedTerminal of
+      Nothing -> ProtocolFault "engine emitted terminal before a committed checkpoint"
+      Just committedTerminal
+        | committedTerminal /= terminal ->
+            ProtocolFault "terminal event disagrees with the committed checkpoint"
+        | state.protocolAwaitingCheckpoint ->
+            ProtocolFault "engine emitted terminal before checkpoint acknowledgement"
+        | terminal == EngineCancelled && state.protocolCancellationSent ->
+            CancelWorkersAndSendShutdown
+        | state.protocolWorkerCount /= 0 ->
+            ProtocolFault "engine emitted terminal with effects still running"
+        | state.protocolInterruptedCount /= 0 ->
+            ProtocolFault "engine emitted terminal with interrupted effects outstanding"
+        | state.protocolBufferedCompletionCount /= 0 ->
+            ProtocolFault "engine emitted terminal with buffered completions"
+        | otherwise -> SendShutdown
+  ChildExited exitKind
+    | terminalObserved -> FinishCommittedTerminal
+    | exitKind == ChildExitSuccess ->
+        ProtocolFault "hosted engine exited before a terminal event"
+    | otherwise -> ProtocolFault "hosted engine exited unexpectedly"
+  EngineDeadlineExpired
+    | terminalObserved -> FinishCommittedTerminal
+    | otherwise ->
+        ProtocolFault
+          "hosted engine unresponsive: mandated protocol output did not arrive within the response deadline"
+  CancellationDeadlineExpired ->
+    ProtocolFault
+      "host cancellation did not follow an interrupted effect within the response deadline"
+  where
+    hasCommittedCheckpoint = case state.protocolCommittedTerminal of
+      Nothing -> False
+      Just _terminal -> True
+    terminalObserved = case state.protocolTerminalSeen of
+      Nothing -> False
+      Just _terminal -> True

--- a/src/Cortex/Wire/Circuit/HostProtocol.hs
+++ b/src/Cortex/Wire/Circuit/HostProtocol.hs
@@ -8,50 +8,82 @@ Stability   : experimental
 
 The hosted engine owns circuit scheduling, but the process host owns a second
 state machine: checkpoint acknowledgement, worker completion serialization,
-cancellation, watchdogs, terminal authority, and child exit.  Keeping those
-decisions as a pure transition policy makes the concurrency crossings
-reviewable and gives the TLA+ model in @formal/HostedProtocol.tla@ a concrete
-implementation target.
+cancellation, watchdogs, terminal authority, and child exit. Keeping those
+decisions pure makes concurrency crossings reviewable and gives the TLA+ model
+in @formal/HostedProtocol.tla@ a concrete implementation target.
 
-This module deliberately carries no handles, callbacks, timers, or worker
-payloads.  'ProtocolView' is the lifecycle projection of the IO loop and
-'transition' selects its next authoritative action.  The caller performs that
-action and then projects its new state before the next transition.
+Each input has its own result type. The IO loop therefore handles every legal
+decision exhaustively instead of recovering from an impossible action at
+runtime.
 -}
 module Cortex.Wire.Circuit.HostProtocol
-  ( ChildExitKind (..)
-  , DeadlineUpdate (..)
-  , ProtocolAction (..)
-  , ProtocolEvent (..)
+  ( CancellationDeadlineUpdate (..)
+  , CancellationDeadlines (..)
+  , CancellationDecision (..)
+  , CheckpointAcknowledgementDecision (..)
+  , CheckpointDeadlines (..)
+  , CheckpointDecision (..)
+  , ChildExitDecision (..)
+  , CompletionDropReason (..)
+  , DeadlineKind (..)
+  , DeadlineDecision (..)
+  , EngineDeadlineUpdate (..)
+  , InterruptedCompletionDecision (..)
   , ProtocolView (..)
-  , transition
+  , ResolvedCompletionDecision (..)
+  , ShutdownDeadlines (..)
+  , SuccessorDecision (..)
+  , TerminalDecision (..)
+  , decideCancellation
+  , decideCheckpoint
+  , decideCheckpointAcknowledgement
+  , decideChildExit
+  , decideDeadline
+  , decideInterruptedCompletion
+  , decideResolvedCompletion
+  , decideSuccessor
+  , decideTerminal
   )
 where
 
 import Data.Text (Text)
+import System.Exit (ExitCode (..))
 
 import Cortex.Wire.Circuit.Engine
   ( EngineTerminalState (..)
   )
 
-{- | Whether process exit itself was successful.  Terminal authority is
-intentionally separate: once terminal is committed and observed, either
-exit kind finishes with that committed result.
--}
-data ChildExitKind
-  = ChildExitSuccess
-  | ChildExitAbnormal
+data EngineDeadlineUpdate
+  = KeepEngineDeadline
+  | ClearEngineDeadline
+  | ArmFreshEngineDeadline
+  | EnsureEngineDeadline
   deriving stock (Eq, Show)
 
--- | How an IO-backed deadline changes across one pure protocol transition.
-data DeadlineUpdate
-  = KeepDeadline
-  | ClearDeadline
-  | ArmFreshDeadline
-  | EnsureDeadline
+data CancellationDeadlineUpdate
+  = KeepCancellationDeadline
+  | ClearCancellationDeadline
+  | EnsureCancellationDeadline
   deriving stock (Eq, Show)
 
--- | Race-relevant lifecycle facts projected from the process loop.
+data CancellationDeadlines = CancellationDeadlines
+  { cancellationEngineDeadline :: !EngineDeadlineUpdate
+  , cancellationFollowUpDeadline :: !CancellationDeadlineUpdate
+  }
+  deriving stock (Eq, Show)
+
+data CheckpointDeadlines = CheckpointDeadlines
+  { checkpointEngineDeadline :: !EngineDeadlineUpdate
+  , checkpointCancellationDeadline :: !CancellationDeadlineUpdate
+  }
+  deriving stock (Eq, Show)
+
+data ShutdownDeadlines = ShutdownDeadlines
+  { shutdownEngineDeadline :: !EngineDeadlineUpdate
+  , shutdownCancellationDeadline :: !CancellationDeadlineUpdate
+  }
+  deriving stock (Eq, Show)
+
 data ProtocolView = ProtocolView
   { protocolCommittedTerminal :: !(Maybe EngineTerminalState)
   , protocolAwaitingCheckpoint :: !Bool
@@ -63,123 +95,207 @@ data ProtocolView = ProtocolView
   }
   deriving stock (Eq, Show)
 
--- | Inputs whose disposition previously lived in interleaved IO branches.
-data ProtocolEvent
-  = CancellationRequested
-  | SuccessorRequested
-  | ResolvedCompletionArrived
-  | InterruptedCompletionArrived !Bool
-  | CheckpointReceived !EngineTerminalState
-  | CheckpointAcknowledged !EngineTerminalState
-  | TerminalReceived !EngineTerminalState
-  | ChildExited !ChildExitKind
-  | EngineDeadlineExpired
-  | CancellationDeadlineExpired
+data CompletionDropReason
+  = DroppedAfterCancellation
+  | DroppedAfterTerminalCheckpoint
+  | DroppedDuringInterruption
   deriving stock (Eq, Show)
 
--- | Authoritative next action selected by the pure host protocol.
-data ProtocolAction
-  = IgnoreInput
-  | SendCancellation !DeadlineUpdate !DeadlineUpdate
-  | StartSuccessor !DeadlineUpdate
+data CancellationDecision
+  = IgnoreCancellation
+  | SendCancellation !CancellationDeadlines
+  deriving stock (Eq, Show)
+
+data SuccessorDecision
+  = SuccessorFault !Text
   | SuppressSuccessor
-  | ForwardCompletion !DeadlineUpdate
-  | BufferCompletion
-  | DropCompletion
-  | AwaitCancellation !DeadlineUpdate
-  | CommitCheckpoint !DeadlineUpdate
-  | DispatchBufferedCompletion
-  | DropBufferedCompletions
-  | AwaitTerminal !DeadlineUpdate
-  | AwaitCancellationCheckpoint !DeadlineUpdate
-  | AwaitEngineProgress !DeadlineUpdate
-  | AwaitWorkers
-  | SendShutdown
-  | CancelWorkersAndSendShutdown
-  | FinishCommittedTerminal
-  | ProtocolFault !Text
+  | StartSuccessor !EngineDeadlineUpdate
   deriving stock (Eq, Show)
 
--- | Pure transition policy for host-owned lifecycle decisions.
-transition :: ProtocolView -> ProtocolEvent -> ProtocolAction
-transition state = \case
-  CancellationRequested
-    | terminalObserved -> IgnoreInput
-    | state.protocolCancellationSent -> IgnoreInput
-    | otherwise -> SendCancellation EnsureDeadline ClearDeadline
-  SuccessorRequested
-    | not hasCommittedCheckpoint ->
-        ProtocolFault "engine requested an effect before its initial checkpoint was committed"
-    | terminalObserved -> ProtocolFault "engine requested an effect after terminal"
+data ResolvedCompletionDecision
+  = DropResolvedCompletion !CompletionDropReason
+  | BufferResolvedCompletion
+  | ForwardResolvedCompletion !EngineDeadlineUpdate
+  deriving stock (Eq, Show)
+
+data InterruptedCompletionDecision
+  = DropInterruptedCompletion !CompletionDropReason
+  | InterruptedCompletionFault !Text
+  | AwaitCancellation !CancellationDeadlineUpdate
+  deriving stock (Eq, Show)
+
+data CheckpointDecision
+  = CheckpointFault !Text
+  | CommitCheckpoint !CheckpointDeadlines
+  deriving stock (Eq, Show)
+
+data CheckpointAcknowledgementDecision
+  = DropBufferedCompletions !CompletionDropReason
+  | DispatchBufferedCompletion !EngineDeadlineUpdate
+  | AwaitEngineOutput !EngineDeadlineUpdate
+  | AwaitWorkers
+  deriving stock (Eq, Show)
+
+data TerminalDecision
+  = TerminalFault !Text
+  | SendShutdown !ShutdownDeadlines
+  | CancelWorkersAndSendShutdown !ShutdownDeadlines
+  deriving stock (Eq, Show)
+
+data ChildExitDecision
+  = FinishCommittedTerminal
+  | ChildExitFault !Text
+  deriving stock (Eq, Show)
+
+data DeadlineDecision
+  = FinishDeadlineTerminal
+  | DeadlineFault !Text
+  deriving stock (Eq, Show)
+
+data DeadlineKind
+  = EngineDeadline
+  | CancellationDeadline
+  deriving stock (Eq, Show)
+
+decideCancellation :: ProtocolView -> CancellationDecision
+decideCancellation state
+  | terminalObserved state = IgnoreCancellation
+  | committedTerminal state = IgnoreCancellation
+  | state.protocolCancellationSent = IgnoreCancellation
+  | otherwise =
+      SendCancellation
+        CancellationDeadlines
+          { cancellationEngineDeadline = EnsureEngineDeadline
+          , cancellationFollowUpDeadline = ClearCancellationDeadline
+          }
+
+decideSuccessor :: ProtocolView -> SuccessorDecision
+decideSuccessor state = case state.protocolCommittedTerminal of
+  Nothing -> SuccessorFault "engine requested an effect before its initial checkpoint was committed"
+  Just terminal
+    | terminal /= EngineActive ->
+        SuccessorFault "engine requested an effect after a terminal checkpoint was committed"
     | state.protocolCancellationSent -> SuppressSuccessor
     | state.protocolInterruptedCount /= 0 -> SuppressSuccessor
     | otherwise ->
         StartSuccessor
           ( if state.protocolAwaitingCheckpoint
-              then KeepDeadline
-              else ClearDeadline
+              then KeepEngineDeadline
+              else ClearEngineDeadline
           )
-  ResolvedCompletionArrived
-    | state.protocolCancellationSent -> DropCompletion
-    | state.protocolInterruptedCount /= 0 -> DropCompletion
-    | state.protocolAwaitingCheckpoint -> BufferCompletion
-    | otherwise -> ForwardCompletion ArmFreshDeadline
-  InterruptedCompletionArrived cancellationWatcherInstalled
-    | state.protocolCancellationSent -> DropCompletion
-    | not cancellationWatcherInstalled ->
-        ProtocolFault "effect reported interruption but no cancellation watcher is installed"
-    | otherwise -> AwaitCancellation EnsureDeadline
-  CheckpointReceived terminal ->
-    CommitCheckpoint
-      ( if state.protocolCancellationSent && terminal == EngineActive
-          then KeepDeadline
-          else ClearDeadline
-      )
-  CheckpointAcknowledged terminal
-    | state.protocolCancellationSent
-        && state.protocolBufferedCompletionCount /= 0 ->
-        DropBufferedCompletions
-    | state.protocolBufferedCompletionCount /= 0 -> DispatchBufferedCompletion
-    | terminal /= EngineActive -> AwaitTerminal ArmFreshDeadline
-    | state.protocolCancellationSent -> AwaitCancellationCheckpoint EnsureDeadline
-    | state.protocolWorkerCount == 0
-        && state.protocolInterruptedCount == 0 ->
-        AwaitEngineProgress ArmFreshDeadline
-    | otherwise -> AwaitWorkers
-  TerminalReceived terminal ->
-    case state.protocolCommittedTerminal of
-      Nothing -> ProtocolFault "engine emitted terminal before a committed checkpoint"
-      Just committedTerminal
-        | committedTerminal /= terminal ->
-            ProtocolFault "terminal event disagrees with the committed checkpoint"
-        | state.protocolAwaitingCheckpoint ->
-            ProtocolFault "engine emitted terminal before checkpoint acknowledgement"
-        | terminal == EngineCancelled && state.protocolCancellationSent ->
-            CancelWorkersAndSendShutdown
-        | state.protocolWorkerCount /= 0 ->
-            ProtocolFault "engine emitted terminal with effects still running"
-        | state.protocolInterruptedCount /= 0 ->
-            ProtocolFault "engine emitted terminal with interrupted effects outstanding"
-        | state.protocolBufferedCompletionCount /= 0 ->
-            ProtocolFault "engine emitted terminal with buffered completions"
-        | otherwise -> SendShutdown
-  ChildExited exitKind
-    | terminalObserved -> FinishCommittedTerminal
-    | exitKind == ChildExitSuccess ->
-        ProtocolFault "hosted engine exited before a terminal event"
-    | otherwise -> ProtocolFault "hosted engine exited unexpectedly"
-  EngineDeadlineExpired
-    | terminalObserved -> FinishCommittedTerminal
-    | otherwise ->
-        ProtocolFault
-          "hosted engine unresponsive: mandated protocol output did not arrive within the response deadline"
-  CancellationDeadlineExpired ->
-    ProtocolFault
-      "host cancellation did not follow an interrupted effect within the response deadline"
+
+decideResolvedCompletion :: ProtocolView -> ResolvedCompletionDecision
+decideResolvedCompletion state
+  | committedTerminal state = DropResolvedCompletion DroppedAfterTerminalCheckpoint
+  | state.protocolCancellationSent = DropResolvedCompletion DroppedAfterCancellation
+  | state.protocolInterruptedCount /= 0 = DropResolvedCompletion DroppedDuringInterruption
+  | state.protocolAwaitingCheckpoint = BufferResolvedCompletion
+  | otherwise = ForwardResolvedCompletion ArmFreshEngineDeadline
+
+decideInterruptedCompletion :: ProtocolView -> Bool -> InterruptedCompletionDecision
+decideInterruptedCompletion state cancellationWatcherInstalled
+  | not cancellationWatcherInstalled =
+      InterruptedCompletionFault
+        "effect reported interruption but no cancellation watcher is installed"
+  | committedTerminal state = DropInterruptedCompletion DroppedAfterTerminalCheckpoint
+  | state.protocolCancellationSent = DropInterruptedCompletion DroppedAfterCancellation
+  | otherwise = AwaitCancellation EnsureCancellationDeadline
+
+decideCheckpoint :: ProtocolView -> EngineTerminalState -> CheckpointDecision
+decideCheckpoint state terminal
+  | terminalObserved state = CheckpointFault "engine emitted a checkpoint after terminal"
+  | committedTerminal state =
+      CheckpointFault "engine emitted a checkpoint after a terminal checkpoint was committed"
+  | terminal == EngineSucceeded && outstanding /= 0 =
+      CheckpointFault "engine emitted a succeeded checkpoint with host effects still outstanding"
+  | otherwise =
+      CommitCheckpoint
+        CheckpointDeadlines
+          { checkpointEngineDeadline =
+              if state.protocolCancellationSent && terminal == EngineActive
+                then KeepEngineDeadline
+                else ClearEngineDeadline
+          , checkpointCancellationDeadline =
+              if terminal == EngineActive
+                then KeepCancellationDeadline
+                else ClearCancellationDeadline
+          }
   where
-    hasCommittedCheckpoint = case state.protocolCommittedTerminal of
-      Nothing -> False
-      Just _terminal -> True
-    terminalObserved = case state.protocolTerminalSeen of
-      Nothing -> False
-      Just _terminal -> True
+    outstanding =
+      state.protocolWorkerCount
+        + state.protocolInterruptedCount
+        + state.protocolBufferedCompletionCount
+
+decideCheckpointAcknowledgement
+  :: ProtocolView
+  -> EngineTerminalState
+  -> CheckpointAcknowledgementDecision
+decideCheckpointAcknowledgement state terminal
+  | terminal /= EngineActive && state.protocolBufferedCompletionCount /= 0 =
+      DropBufferedCompletions DroppedAfterTerminalCheckpoint
+  | terminal /= EngineActive = AwaitEngineOutput ArmFreshEngineDeadline
+  | state.protocolInterruptedCount /= 0
+      && state.protocolBufferedCompletionCount /= 0 =
+      DropBufferedCompletions DroppedDuringInterruption
+  | state.protocolCancellationSent && state.protocolBufferedCompletionCount /= 0 =
+      DropBufferedCompletions DroppedAfterCancellation
+  | state.protocolBufferedCompletionCount /= 0 =
+      DispatchBufferedCompletion ArmFreshEngineDeadline
+  | state.protocolCancellationSent = AwaitEngineOutput EnsureEngineDeadline
+  | state.protocolWorkerCount == 0 && state.protocolInterruptedCount == 0 =
+      AwaitEngineOutput ArmFreshEngineDeadline
+  | otherwise = AwaitWorkers
+
+decideTerminal :: ProtocolView -> EngineTerminalState -> TerminalDecision
+decideTerminal state terminal
+  | terminalObserved state = TerminalFault "engine emitted duplicate terminal"
+  | terminal == EngineActive = TerminalFault "engine emitted an active terminal event"
+  | otherwise = case state.protocolCommittedTerminal of
+      Nothing -> TerminalFault "engine emitted terminal before a committed checkpoint"
+      Just committed
+        | committed /= terminal ->
+            TerminalFault "terminal event disagrees with the committed checkpoint"
+        | state.protocolAwaitingCheckpoint ->
+            TerminalFault "engine emitted terminal before checkpoint acknowledgement"
+        | terminal == EngineSucceeded && outstanding /= 0 ->
+            TerminalFault "engine emitted succeeded terminal with host effects still outstanding"
+        | terminal /= EngineSucceeded && outstanding /= 0 ->
+            CancelWorkersAndSendShutdown shutdownDeadlines
+        | otherwise -> SendShutdown shutdownDeadlines
+  where
+    outstanding =
+      state.protocolWorkerCount
+        + state.protocolInterruptedCount
+        + state.protocolBufferedCompletionCount
+    shutdownDeadlines =
+      ShutdownDeadlines
+        { shutdownEngineDeadline = ArmFreshEngineDeadline
+        , shutdownCancellationDeadline = ClearCancellationDeadline
+        }
+
+decideChildExit :: ProtocolView -> ExitCode -> ChildExitDecision
+decideChildExit state exitKind
+  | terminalObserved state = FinishCommittedTerminal
+  | ExitSuccess <- exitKind = ChildExitFault "hosted engine exited before a terminal event"
+  | ExitFailure _ <- exitKind = ChildExitFault "hosted engine exited unexpectedly"
+
+decideDeadline :: DeadlineKind -> ProtocolView -> DeadlineDecision
+decideDeadline deadlineKind state
+  | terminalObserved state = FinishDeadlineTerminal
+  | otherwise =
+      DeadlineFault
+        ( case deadlineKind of
+            EngineDeadline ->
+              "hosted engine unresponsive: mandated protocol output did not arrive within the response deadline"
+            CancellationDeadline ->
+              "host cancellation did not follow an interrupted effect within the response deadline"
+        )
+
+terminalObserved :: ProtocolView -> Bool
+terminalObserved state = case state.protocolTerminalSeen of
+  Nothing -> False
+  Just _terminal -> True
+
+committedTerminal :: ProtocolView -> Bool
+committedTerminal ProtocolView {protocolCommittedTerminal = Just terminal} = terminal /= EngineActive
+committedTerminal _state = False

--- a/src/Cortex/Wire/Circuit/Hosted.hs
+++ b/src/Cortex/Wire/Circuit/Hosted.hs
@@ -33,7 +33,7 @@ module Cortex.Wire.Circuit.Hosted
   )
 where
 
-import Control.Concurrent (threadDelay)
+import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.Async (Async, AsyncCancelled, asyncWithUnmask, cancel, withAsync)
 import Control.Concurrent.STM
   ( TQueue
@@ -64,7 +64,7 @@ import Control.Exception
   , throwIO
   , try
   )
-import Control.Monad (forM_, unless)
+import Control.Monad (forM_, unless, void)
 import Data.ByteString qualified as BS
 import Data.Char (isAlphaNum)
 import Data.Map.Strict (Map)
@@ -77,6 +77,8 @@ import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
 import Data.Text.Encoding.Error (lenientDecode)
 import Data.Word (Word32, Word64)
+import Debug.Trace (traceEventIO)
+import GHC.Clock (getMonotonicTimeNSec)
 import System.Exit (ExitCode (..))
 import System.IO
   ( BufferMode (NoBuffering)
@@ -226,13 +228,23 @@ data LoopState = LoopState
   , loopBufferedCompletions :: !(Map Word64 (Word32, Either Text EffectResolution))
   , loopTerminalSeen :: !(Maybe EngineTerminalState)
   , loopCancellationSent :: !Bool
-  , loopEngineDeadline :: !(Maybe (TVar Bool))
-  , loopCancellationDeadline :: !(Maybe (TVar Bool))
+  , loopEngineDeadline :: !(Maybe ResponseDeadline)
+  , loopCancellationDeadline :: !(Maybe ResponseDeadline)
   {- ^ Engine output and cancellation follow-up are independent obligations.
   Keeping separate timers prevents an unrelated checkpoint from clearing or
   extending the promise that an interrupted effect will be followed by an
   authorized run-level cancel.
   -}
+  }
+
+data ResponseDeadline = ResponseDeadline
+  { responseDeadlineExpired :: !(TVar Bool)
+  , responseDeadlineAtNanos :: !Word64
+  }
+
+data PausedResponseDeadlines = PausedResponseDeadlines
+  { pausedEngineDeadlineMicros :: !(Maybe Int)
+  , pausedCancellationDeadlineMicros :: !(Maybe Int)
   }
 
 initialLoopState :: Maybe EngineState -> LoopState
@@ -271,7 +283,7 @@ protocolView state =
 -- | Start a fresh deadline for a newly-created response obligation.
 armFreshEngineDeadline :: Int -> LoopState -> IO LoopState
 armFreshEngineDeadline responseTimeoutMicros state = do
-  deadline <- registerDelay responseTimeoutMicros
+  deadline <- newResponseDeadline responseTimeoutMicros
   pure state {loopEngineDeadline = Just deadline}
 
 {- | Ensure an engine-response deadline exists without extending an
@@ -287,32 +299,82 @@ ensureCancellationDeadline :: Int -> LoopState -> IO LoopState
 ensureCancellationDeadline responseTimeoutMicros state = case state.loopCancellationDeadline of
   Just _existing -> pure state
   Nothing -> do
-    deadline <- registerDelay responseTimeoutMicros
+    deadline <- newResponseDeadline responseTimeoutMicros
     pure state {loopCancellationDeadline = Just deadline}
+
+newResponseDeadline :: Int -> IO ResponseDeadline
+newResponseDeadline timeoutMicros = do
+  expired <- registerDelay timeoutMicros
+  now <- getMonotonicTimeNSec
+  pure
+    ResponseDeadline
+      { responseDeadlineExpired = expired
+      , responseDeadlineAtNanos = now + fromIntegral timeoutMicros * 1000
+      }
+
+pauseResponseDeadlines :: LoopState -> IO (LoopState, PausedResponseDeadlines)
+pauseResponseDeadlines state = do
+  now <- getMonotonicTimeNSec
+  let paused =
+        PausedResponseDeadlines
+          { pausedEngineDeadlineMicros = remainingMicros now state.loopEngineDeadline
+          , pausedCancellationDeadlineMicros = remainingMicros now state.loopCancellationDeadline
+          }
+  pure
+    ( state
+        { loopEngineDeadline = Nothing
+        , loopCancellationDeadline = Nothing
+        }
+    , paused
+    )
+  where
+    remainingMicros current = fmap $ \deadline ->
+      fromIntegral
+        ( max
+            1
+            ( ( (if responseDeadlineAtNanos deadline > current then responseDeadlineAtNanos deadline - current else 0)
+                  + 999
+              )
+                `div` 1000
+            )
+        )
+
+resumeResponseDeadlines :: PausedResponseDeadlines -> LoopState -> IO LoopState
+resumeResponseDeadlines paused state = do
+  engineResumed <-
+    resume
+      paused.pausedEngineDeadlineMicros
+      (\deadline -> state {loopEngineDeadline = Just deadline})
+      state
+  resume
+    paused.pausedCancellationDeadlineMicros
+    (\deadline -> engineResumed {loopCancellationDeadline = Just deadline})
+    engineResumed
+  where
+    resume maybeMicros setDeadline unchanged = case maybeMicros of
+      Nothing -> pure unchanged
+      Just micros -> newResponseDeadline micros >>= \deadline -> pure (setDeadline deadline)
 
 applyEngineDeadlineUpdate
   :: Int
-  -> HostProtocol.DeadlineUpdate
+  -> HostProtocol.EngineDeadlineUpdate
   -> LoopState
   -> IO LoopState
 applyEngineDeadlineUpdate responseTimeoutMicros = \case
-  HostProtocol.KeepDeadline -> pure
-  HostProtocol.ClearDeadline -> \state -> pure state {loopEngineDeadline = Nothing}
-  HostProtocol.ArmFreshDeadline -> armFreshEngineDeadline responseTimeoutMicros
-  HostProtocol.EnsureDeadline -> ensureEngineDeadline responseTimeoutMicros
+  HostProtocol.KeepEngineDeadline -> pure
+  HostProtocol.ClearEngineDeadline -> \state -> pure state {loopEngineDeadline = Nothing}
+  HostProtocol.ArmFreshEngineDeadline -> armFreshEngineDeadline responseTimeoutMicros
+  HostProtocol.EnsureEngineDeadline -> ensureEngineDeadline responseTimeoutMicros
 
 applyCancellationDeadlineUpdate
   :: Int
-  -> HostProtocol.DeadlineUpdate
+  -> HostProtocol.CancellationDeadlineUpdate
   -> LoopState
   -> IO LoopState
 applyCancellationDeadlineUpdate responseTimeoutMicros = \case
-  HostProtocol.KeepDeadline -> pure
-  HostProtocol.ClearDeadline -> \state -> pure state {loopCancellationDeadline = Nothing}
-  HostProtocol.ArmFreshDeadline -> \state -> do
-    deadline <- registerDelay responseTimeoutMicros
-    pure state {loopCancellationDeadline = Just deadline}
-  HostProtocol.EnsureDeadline -> ensureCancellationDeadline responseTimeoutMicros
+  HostProtocol.KeepCancellationDeadline -> pure
+  HostProtocol.ClearCancellationDeadline -> \state -> pure state {loopCancellationDeadline = Nothing}
+  HostProtocol.EnsureCancellationDeadline -> ensureCancellationDeadline responseTimeoutMicros
 
 runHostedProgram
   :: HostedProgramArtifact
@@ -444,7 +506,14 @@ withMaybeAsync = \case
   Just action -> \use -> withAsync action (use . Just)
 
 cancelRegisteredWorkers :: TVar (Map Word64 (Async ())) -> IO ()
-cancelRegisteredWorkers workerRegistry = readTVarIO workerRegistry >>= mapM_ cancel
+cancelRegisteredWorkers workerRegistry =
+  readTVarIO workerRegistry >>= mapM_ requestWorkerCancellation
+
+requestWorkerCancellation :: Async () -> IO ()
+requestWorkerCancellation worker =
+  void . forkIO $ do
+    _ <- try @SomeException (cancel worker)
+    pure ()
 
 validateRunId :: Text -> Either Text ()
 validateRunId runId
@@ -595,8 +664,8 @@ a continuously-writing child cannot starve an already-expired watchdog.
 -}
 readLoopInput
   :: TQueue HostInput
-  -> Maybe (TVar Bool)
-  -> Maybe (TVar Bool)
+  -> Maybe ResponseDeadline
+  -> Maybe ResponseDeadline
   -> IO LoopWaitResult
 readLoopInput queue engineDeadline cancellationDeadline =
   atomically $
@@ -607,7 +676,7 @@ readLoopInput queue engineDeadline cancellationDeadline =
     awaitDeadline maybeDeadline expired =
       case maybeDeadline of
         Nothing -> retry
-        Just deadline -> readTVar deadline >>= check >> pure expired
+        Just deadline -> readTVar deadline.responseDeadlineExpired >>= check >> pure expired
 
 awaitHello
   :: Int
@@ -654,25 +723,21 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
       case loopInput of
         CancellationDeadlineExpired ->
           enactTerminalDecision state $
-            HostProtocol.transition
-              (protocolView state)
-              HostProtocol.CancellationDeadlineExpired
+            HostProtocol.decideDeadline HostProtocol.CancellationDeadline (protocolView state)
         EngineDeadlineExpired ->
           enactTerminalDecision state $
-            HostProtocol.transition
-              (protocolView state)
-              HostProtocol.EngineDeadlineExpired
+            HostProtocol.decideDeadline HostProtocol.EngineDeadline (protocolView state)
         LoopInput input -> dispatch state input
 
     dispatch state = \case
-      HostEngineEvent (Left message) -> failWith state message
+      HostEngineEvent (Left message) -> finishOrFail state message
       HostEngineEvent (Right event) -> handleEvent state event
       HostEffectFinished sequenceNumber nodeId resolution ->
         handleCompletion state sequenceNumber nodeId resolution
       HostCancellationRequested reason -> do
-        case HostProtocol.transition (protocolView state) HostProtocol.CancellationRequested of
-          HostProtocol.IgnoreInput -> go state
-          HostProtocol.SendCancellation engineUpdate cancellationUpdate -> do
+        case HostProtocol.decideCancellation (protocolView state) of
+          HostProtocol.IgnoreCancellation -> go state
+          HostProtocol.SendCancellation deadlines -> do
             commandResult <- try @IOException (writeCommand childInput (HostCancel runId reason))
             case commandResult of
               Left err -> failWith state ("sending cancellation: " <> exceptionText err)
@@ -680,29 +745,23 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
                 cancellationUpdated <-
                   applyCancellationDeadlineUpdate
                     responseTimeoutMicros
-                    cancellationUpdate
+                    deadlines.cancellationFollowUpDeadline
                     state
                 armed <-
                   applyEngineDeadlineUpdate
                     responseTimeoutMicros
-                    engineUpdate
+                    deadlines.cancellationEngineDeadline
                     cancellationUpdated
                 go armed {loopCancellationSent = True}
-          decision -> unexpectedDecision state "cancellation" decision
-      HostRuntimeFailed message -> failWith state ("host runtime failed: " <> message)
+      HostRuntimeFailed message -> finishOrFail state ("host runtime failed: " <> message)
       HostChildExited exitCode ->
-        case HostProtocol.transition
+        case HostProtocol.decideChildExit
           (protocolView state)
-          ( HostProtocol.ChildExited $
-              if exitCode == ExitSuccess
-                then HostProtocol.ChildExitSuccess
-                else HostProtocol.ChildExitAbnormal
-          ) of
+          exitCode of
           HostProtocol.FinishCommittedTerminal -> finish state
-          HostProtocol.ProtocolFault message
+          HostProtocol.ChildExitFault message
             | exitCode == ExitSuccess -> failWith state message
             | otherwise -> failWith state (message <> ": " <> T.pack (show exitCode))
-          decision -> unexpectedDecision state "child exit" decision
 
     handleEvent state = \case
       EngineHello {} -> failWith state "hosted engine emitted duplicate hello"
@@ -725,37 +784,45 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
           case expectedCheckpoint state snapshot.esCheckpointSequence of
             Left message -> failWith state message
             Right () ->
-              case HostProtocol.transition
-                (protocolView state)
-                (HostProtocol.CheckpointReceived snapshot.esTerminal) of
-                HostProtocol.CommitCheckpoint deadlineUpdate -> do
+              case HostProtocol.decideCheckpoint (protocolView state) snapshot.esTerminal of
+                HostProtocol.CheckpointFault message -> failWith state message
+                HostProtocol.CommitCheckpoint deadlines -> do
+                  cancellationUpdated <-
+                    applyCancellationDeadlineUpdate
+                      responseTimeoutMicros
+                      deadlines.checkpointCancellationDeadline
+                      state
                   checkpointReceived <-
-                    applyEngineDeadlineUpdate responseTimeoutMicros deadlineUpdate state
+                    applyEngineDeadlineUpdate
+                      responseTimeoutMicros
+                      deadlines.checkpointEngineDeadline
+                      cancellationUpdated
                   commitCheckpoint checkpointReceived snapshot
-                decision -> unexpectedDecision state "checkpoint" decision
 
     commitCheckpoint checkpointReceived snapshot = do
+      (persistenceState, pausedDeadlines) <- pauseResponseDeadlines checkpointReceived
       commitResult <- trySynchronous (runtimeHost.hostedCommitCheckpoint snapshot)
       case commitResult of
-        Left err -> failWith checkpointReceived ("checkpoint host threw: " <> exceptionText err)
+        Left err -> failWith persistenceState ("checkpoint host threw: " <> exceptionText err)
         Right (CheckpointCommitRejected message) ->
-          failWith checkpointReceived ("checkpoint commit failed: " <> message)
-        Right (CheckpointCommitAbortRun message) -> abortWith checkpointReceived message
+          failWith persistenceState ("checkpoint commit failed: " <> message)
+        Right (CheckpointCommitAbortRun message) -> abortWith persistenceState message
         Right CheckpointCommitAccepted -> do
+          resumedState <- resumeResponseDeadlines pausedDeadlines checkpointReceived
+          let committedState =
+                resumedState
+                  { loopLastCommitted = Just snapshot
+                  , loopLastCheckpointSequence = Just snapshot.esCheckpointSequence
+                  , loopAwaitingCheckpoint = False
+                  }
           writeResult <-
             try @IOException $
               writeCommand
                 childInput
                 (HostCheckpointCommitted runId snapshot.esCheckpointSequence)
           case writeResult of
-            Left err -> failWith checkpointReceived ("acknowledging checkpoint: " <> exceptionText err)
-            Right () ->
-              dispatchBuffered
-                checkpointReceived
-                  { loopLastCommitted = Just snapshot
-                  , loopLastCheckpointSequence = Just snapshot.esCheckpointSequence
-                  , loopAwaitingCheckpoint = False
-                  }
+            Left err -> failWith committedState ("acknowledging checkpoint: " <> exceptionText err)
+            Right () -> dispatchBuffered committedState
 
     handleRequest state sequenceNumber nodeId
       | nodeId >= nodeCount = failWith state "engine requested an out-of-range node"
@@ -765,15 +832,14 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
           || nodeId `Set.member` state.loopInterruptedNodes =
           failWith state "engine requested a node already in flight"
       | otherwise =
-          case HostProtocol.transition (protocolView state) HostProtocol.SuccessorRequested of
-            HostProtocol.ProtocolFault message -> failWith state message
+          case HostProtocol.decideSuccessor (protocolView state) of
+            HostProtocol.SuccessorFault message -> failWith state message
             HostProtocol.SuppressSuccessor ->
               -- The request crossed cancellation or interruption. Track its
               -- sequence, but do not start authority-bearing work.
               go state {loopNextRequestSequence = sequenceNumber + 1}
             HostProtocol.StartSuccessor deadlineUpdate -> do
               startSuccessor state deadlineUpdate sequenceNumber nodeId
-            decision -> unexpectedDecision state "successor request" decision
 
     startSuccessor state deadlineUpdate sequenceNumber nodeId = do
       -- Spawn-and-register is masked so an async exception cannot leave
@@ -802,7 +868,13 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
     handleCompletion state sequenceNumber nodeId resolution =
       case Map.lookup sequenceNumber state.loopWorkers of
         Nothing
-          | state.loopCancellationSent -> go state
+          | isJust state.loopTerminalSeen -> do
+              traceDroppedCompletion
+                HostProtocol.DroppedAfterTerminalCheckpoint
+                sequenceNumber
+                nodeId
+                resolution
+              go state
         Nothing -> failWith state "received an unknown or duplicate effect completion"
         Just (expectedNodeId, _worker)
           | expectedNodeId /= nodeId -> failWith state "effect completion node mismatch"
@@ -814,8 +886,8 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
                       , loopActiveNodes = Set.delete nodeId state.loopActiveNodes
                       }
               case resolution of
-                Right (EffectInterrupted _reason) ->
-                  handleInterruptedCompletion completedState nodeId
+                Right interrupted@EffectInterrupted {} ->
+                  handleInterruptedCompletion completedState sequenceNumber nodeId (Right interrupted)
                 Left message ->
                   handleResolvedCompletion
                     completedState
@@ -829,14 +901,14 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
                     nodeId
                     (Right (EffectResolved completion))
 
-    handleInterruptedCompletion state nodeId =
-      case HostProtocol.transition
+    handleInterruptedCompletion state sequenceNumber nodeId resolution =
+      case HostProtocol.decideInterruptedCompletion
         (protocolView state)
-        ( HostProtocol.InterruptedCompletionArrived $
-            isJust runtimeHost.hostedAwaitCancellation
-        ) of
-        HostProtocol.DropCompletion -> go state
-        HostProtocol.ProtocolFault message -> failWith state message
+        (isJust runtimeHost.hostedAwaitCancellation) of
+        HostProtocol.DropInterruptedCompletion reason -> do
+          traceDroppedCompletion reason sequenceNumber nodeId resolution
+          go state
+        HostProtocol.InterruptedCompletionFault message -> failWith state message
         HostProtocol.AwaitCancellation deadlineUpdate -> do
           -- The run-level cancel that interrupted the worker is in flight;
           -- the engine keeps the node running until cancellation resets it.
@@ -849,12 +921,16 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
                     Set.insert nodeId state.loopInterruptedNodes
                 }
           go deadlineUpdated
-        decision -> unexpectedDecision state "interrupted completion" decision
 
     handleResolvedCompletion state sequenceNumber nodeId resolution =
-      case HostProtocol.transition (protocolView state) HostProtocol.ResolvedCompletionArrived of
-        HostProtocol.DropCompletion -> go state
-        HostProtocol.BufferCompletion ->
+      case HostProtocol.decideResolvedCompletion (protocolView state) of
+        HostProtocol.DropResolvedCompletion reason -> do
+          -- Cancellation and terminal checkpoints supersede both successful
+          -- completions and buffered host exceptions. The pure decision keeps
+          -- that otherwise silent precedence explicit and testable.
+          traceDroppedCompletion reason sequenceNumber nodeId resolution
+          go state
+        HostProtocol.BufferResolvedCompletion ->
           go
             state
               { loopBufferedCompletions =
@@ -863,9 +939,8 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
                     (nodeId, resolution)
                     state.loopBufferedCompletions
               }
-        HostProtocol.ForwardCompletion deadlineUpdate ->
+        HostProtocol.ForwardResolvedCompletion deadlineUpdate ->
           sendCompletion state deadlineUpdate sequenceNumber nodeId resolution
-        decision -> unexpectedDecision state "resolved completion" decision
 
     sendCompletion state deadlineUpdate sequenceNumber nodeId = \case
       Left message -> failWith state ("effect host threw: " <> message)
@@ -890,52 +965,55 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
       case state.loopLastCommitted of
         Nothing -> failWith state "checkpoint acknowledgement lost committed authority"
         Just snapshot ->
-          case HostProtocol.transition
+          case HostProtocol.decideCheckpointAcknowledgement
             (protocolView state)
-            (HostProtocol.CheckpointAcknowledged snapshot.esTerminal) of
-            HostProtocol.DropBufferedCompletions ->
-              -- Cancellation supersedes completions buffered before the
-              -- cancelled checkpoint was acknowledged.
+            snapshot.esTerminal of
+            HostProtocol.DropBufferedCompletions reason -> do
+              -- Cancellation or a terminal checkpoint supersedes completions
+              -- (including host exceptions) buffered before acknowledgement.
+              forM_ (Map.toList state.loopBufferedCompletions) $ \(sequenceNumber, (nodeId, resolution)) ->
+                traceDroppedCompletion reason sequenceNumber nodeId resolution
               dispatchBuffered state {loopBufferedCompletions = Map.empty}
-            HostProtocol.DispatchBufferedCompletion ->
+            HostProtocol.DispatchBufferedCompletion deadlineUpdate ->
               case Map.minViewWithKey state.loopBufferedCompletions of
                 Nothing -> failWith state "protocol selected an absent buffered completion"
                 Just ((sequenceNumber, (nodeId, resolution)), remaining) ->
                   sendCompletion
                     state {loopBufferedCompletions = remaining}
-                    HostProtocol.ArmFreshDeadline
+                    deadlineUpdate
                     sequenceNumber
                     nodeId
                     resolution
-            HostProtocol.AwaitTerminal deadlineUpdate ->
-              applyEngineDeadlineUpdate responseTimeoutMicros deadlineUpdate state >>= go
-            HostProtocol.AwaitCancellationCheckpoint deadlineUpdate ->
-              applyEngineDeadlineUpdate responseTimeoutMicros deadlineUpdate state >>= go
-            HostProtocol.AwaitEngineProgress deadlineUpdate ->
+            HostProtocol.AwaitEngineOutput deadlineUpdate ->
               applyEngineDeadlineUpdate responseTimeoutMicros deadlineUpdate state >>= go
             HostProtocol.AwaitWorkers -> go state
-            decision -> unexpectedDecision state "checkpoint acknowledgement" decision
 
     handleTerminal state terminal =
-      case HostProtocol.transition
-        (protocolView state)
-        (HostProtocol.TerminalReceived terminal) of
-        HostProtocol.ProtocolFault message -> failWith state message
-        HostProtocol.CancelWorkersAndSendShutdown -> do
+      case HostProtocol.decideTerminal (protocolView state) terminal of
+        HostProtocol.TerminalFault message -> failWith state message
+        HostProtocol.CancelWorkersAndSendShutdown deadlines -> do
           cancelledState <- cancelLiveWorkers state
-          writeShutdown cancelledState terminal
-        HostProtocol.SendShutdown -> writeShutdown state terminal
-        decision -> unexpectedDecision state "terminal" decision
+          writeShutdown cancelledState deadlines terminal
+        HostProtocol.SendShutdown deadlines -> writeShutdown state deadlines terminal
 
-    writeShutdown state terminal = do
+    writeShutdown state deadlines terminal = do
       writeResult <- try @IOException (writeCommand childInput (HostShutdown runId))
       case writeResult of
         Left err -> failWith state ("sending hosted shutdown: " <> exceptionText err)
-        Right () ->
-          armFreshEngineDeadline responseTimeoutMicros (state {loopTerminalSeen = Just terminal}) >>= go
+        Right () -> do
+          cancellationUpdated <-
+            applyCancellationDeadlineUpdate
+              responseTimeoutMicros
+              deadlines.shutdownCancellationDeadline
+              state {loopTerminalSeen = Just terminal}
+          applyEngineDeadlineUpdate
+            responseTimeoutMicros
+            deadlines.shutdownEngineDeadline
+            cancellationUpdated
+            >>= go
 
     cancelLiveWorkers state = do
-      forM_ (Map.elems state.loopWorkers) (cancel . snd)
+      forM_ (Map.elems state.loopWorkers) (requestWorkerCancellation . snd)
       let workerKeys = Map.keys state.loopWorkers
       atomically $
         modifyTVar' workerRegistry (\registry -> foldr Map.delete registry workerKeys)
@@ -948,18 +1026,28 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
           }
 
     enactTerminalDecision state = \case
-      HostProtocol.FinishCommittedTerminal -> finish state
-      HostProtocol.ProtocolFault message -> failWith state message
-      decision -> unexpectedDecision state "terminal decision" decision
+      HostProtocol.FinishDeadlineTerminal -> finish state
+      HostProtocol.DeadlineFault message -> failWith state message
 
-    unexpectedDecision state crossing decision =
-      failWith
-        state
-        ( "host protocol policy returned an invalid "
-            <> crossing
-            <> " action: "
-            <> T.pack (show decision)
-        )
+    finishOrFail state message
+      | isJust state.loopTerminalSeen = finish state
+      | otherwise = failWith state message
+
+    traceDroppedCompletion reason sequenceNumber nodeId resolution =
+      traceEventIO $
+        "cortex.hosted.completion_dropped reason="
+          <> show reason
+          <> " kind="
+          <> completionKind resolution
+          <> " sequence="
+          <> show sequenceNumber
+          <> " node="
+          <> show nodeId
+
+    completionKind = \case
+      Left _message -> "host_exception"
+      Right EffectInterrupted {} -> "interrupted"
+      Right EffectResolved {} -> "resolved"
 
     expectedCheckpoint state actual =
       case state.loopLastCheckpointSequence of

--- a/src/Cortex/Wire/Circuit/Hosted.hs
+++ b/src/Cortex/Wire/Circuit/Hosted.hs
@@ -69,7 +69,7 @@ import Data.ByteString qualified as BS
 import Data.Char (isAlphaNum)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (catMaybes, isJust, isNothing)
+import Data.Maybe (catMaybes, isJust)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -116,6 +116,7 @@ import Cortex.Wire.Circuit.Engine
   , validateEngineState
   , validateRestorableEngineState
   )
+import Cortex.Wire.Circuit.HostProtocol qualified as HostProtocol
 
 maxProtocolLineBytes :: Int
 maxProtocolLineBytes = 2 * 1024 * 1024
@@ -252,6 +253,21 @@ initialLoopState maybeRestore =
     , loopCancellationDeadline = Nothing
     }
 
+{- | Forget IO payloads and project only the lifecycle facts consumed by the
+pure host-protocol transition policy.
+-}
+protocolView :: LoopState -> HostProtocol.ProtocolView
+protocolView state =
+  HostProtocol.ProtocolView
+    { protocolCommittedTerminal = (.esTerminal) <$> state.loopLastCommitted
+    , protocolAwaitingCheckpoint = state.loopAwaitingCheckpoint
+    , protocolWorkerCount = Map.size state.loopWorkers
+    , protocolInterruptedCount = Set.size state.loopInterruptedNodes
+    , protocolBufferedCompletionCount = Map.size state.loopBufferedCompletions
+    , protocolTerminalSeen = state.loopTerminalSeen
+    , protocolCancellationSent = state.loopCancellationSent
+    }
+
 -- | Start a fresh deadline for a newly-created response obligation.
 armFreshEngineDeadline :: Int -> LoopState -> IO LoopState
 armFreshEngineDeadline responseTimeoutMicros state = do
@@ -273,6 +289,30 @@ ensureCancellationDeadline responseTimeoutMicros state = case state.loopCancella
   Nothing -> do
     deadline <- registerDelay responseTimeoutMicros
     pure state {loopCancellationDeadline = Just deadline}
+
+applyEngineDeadlineUpdate
+  :: Int
+  -> HostProtocol.DeadlineUpdate
+  -> LoopState
+  -> IO LoopState
+applyEngineDeadlineUpdate responseTimeoutMicros = \case
+  HostProtocol.KeepDeadline -> pure
+  HostProtocol.ClearDeadline -> \state -> pure state {loopEngineDeadline = Nothing}
+  HostProtocol.ArmFreshDeadline -> armFreshEngineDeadline responseTimeoutMicros
+  HostProtocol.EnsureDeadline -> ensureEngineDeadline responseTimeoutMicros
+
+applyCancellationDeadlineUpdate
+  :: Int
+  -> HostProtocol.DeadlineUpdate
+  -> LoopState
+  -> IO LoopState
+applyCancellationDeadlineUpdate responseTimeoutMicros = \case
+  HostProtocol.KeepDeadline -> pure
+  HostProtocol.ClearDeadline -> \state -> pure state {loopCancellationDeadline = Nothing}
+  HostProtocol.ArmFreshDeadline -> \state -> do
+    deadline <- registerDelay responseTimeoutMicros
+    pure state {loopCancellationDeadline = Just deadline}
+  HostProtocol.EnsureDeadline -> ensureCancellationDeadline responseTimeoutMicros
 
 runHostedProgram
   :: HostedProgramArtifact
@@ -613,18 +653,15 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
           state.loopCancellationDeadline
       case loopInput of
         CancellationDeadlineExpired ->
-          failWith
-            state
-            "host cancellation did not follow an interrupted effect within the response deadline"
-        EngineDeadlineExpired
-          -- After the terminal handshake only child exit remains; a child
-          -- that never exits is torn down by process cleanup, and the run's
-          -- committed terminal snapshot stands.
-          | isJust state.loopTerminalSeen -> finish state
-          | otherwise ->
-              failWith
-                state
-                "hosted engine unresponsive: mandated protocol output did not arrive within the response deadline"
+          enactTerminalDecision state $
+            HostProtocol.transition
+              (protocolView state)
+              HostProtocol.CancellationDeadlineExpired
+        EngineDeadlineExpired ->
+          enactTerminalDecision state $
+            HostProtocol.transition
+              (protocolView state)
+              HostProtocol.EngineDeadlineExpired
         LoopInput input -> dispatch state input
 
     dispatch state = \case
@@ -632,32 +669,40 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
       HostEngineEvent (Right event) -> handleEvent state event
       HostEffectFinished sequenceNumber nodeId resolution ->
         handleCompletion state sequenceNumber nodeId resolution
-      HostCancellationRequested _reason
-        | isJust state.loopTerminalSeen -> go state
-      HostCancellationRequested _reason
-        | state.loopCancellationSent -> go state
       HostCancellationRequested reason -> do
-        commandResult <- try @IOException (writeCommand childInput (HostCancel runId reason))
-        case commandResult of
-          Left err -> failWith state ("sending cancellation: " <> exceptionText err)
-          Right () -> do
-            -- A cancelled checkpoint is now mandated. If another checkpoint
-            -- is already outstanding, cancellation is deferred behind it and
-            -- inherits its earlier deadline.
-            armed <-
-              ensureEngineDeadline
-                responseTimeoutMicros
-                state {loopCancellationDeadline = Nothing}
-            go armed {loopCancellationSent = True}
+        case HostProtocol.transition (protocolView state) HostProtocol.CancellationRequested of
+          HostProtocol.IgnoreInput -> go state
+          HostProtocol.SendCancellation engineUpdate cancellationUpdate -> do
+            commandResult <- try @IOException (writeCommand childInput (HostCancel runId reason))
+            case commandResult of
+              Left err -> failWith state ("sending cancellation: " <> exceptionText err)
+              Right () -> do
+                cancellationUpdated <-
+                  applyCancellationDeadlineUpdate
+                    responseTimeoutMicros
+                    cancellationUpdate
+                    state
+                armed <-
+                  applyEngineDeadlineUpdate
+                    responseTimeoutMicros
+                    engineUpdate
+                    cancellationUpdated
+                go armed {loopCancellationSent = True}
+          decision -> unexpectedDecision state "cancellation" decision
       HostRuntimeFailed message -> failWith state ("host runtime failed: " <> message)
-      HostChildExited ExitSuccess ->
-        case state.loopTerminalSeen of
-          Just _terminal -> finish state
-          Nothing -> failWith state "hosted engine exited before a terminal event"
-      HostChildExited _exitCode
-        | isJust state.loopTerminalSeen -> finish state
       HostChildExited exitCode ->
-        failWith state ("hosted engine exited unexpectedly: " <> T.pack (show exitCode))
+        case HostProtocol.transition
+          (protocolView state)
+          ( HostProtocol.ChildExited $
+              if exitCode == ExitSuccess
+                then HostProtocol.ChildExitSuccess
+                else HostProtocol.ChildExitAbnormal
+          ) of
+          HostProtocol.FinishCommittedTerminal -> finish state
+          HostProtocol.ProtocolFault message
+            | exitCode == ExitSuccess -> failWith state message
+            | otherwise -> failWith state (message <> ": " <> T.pack (show exitCode))
+          decision -> unexpectedDecision state "child exit" decision
 
     handleEvent state = \case
       EngineHello {} -> failWith state "hosted engine emitted duplicate hello"
@@ -679,88 +724,80 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
         Right () ->
           case expectedCheckpoint state snapshot.esCheckpointSequence of
             Left message -> failWith state message
-            Right () -> do
-              let checkpointReceived =
-                    state
-                      { loopEngineDeadline =
-                          if state.loopCancellationSent
-                            && snapshot.esTerminal == EngineActive
-                            then state.loopEngineDeadline
-                            else Nothing
-                      }
-              commitResult <- trySynchronous (runtimeHost.hostedCommitCheckpoint snapshot)
-              case commitResult of
-                Left err -> failWith checkpointReceived ("checkpoint host threw: " <> exceptionText err)
-                Right (CheckpointCommitRejected message) ->
-                  failWith checkpointReceived ("checkpoint commit failed: " <> message)
-                Right (CheckpointCommitAbortRun message) -> abortWith checkpointReceived message
-                Right CheckpointCommitAccepted -> do
-                  writeResult <-
-                    try @IOException $
-                      writeCommand
-                        childInput
-                        (HostCheckpointCommitted runId snapshot.esCheckpointSequence)
-                  case writeResult of
-                    Left err -> failWith checkpointReceived ("acknowledging checkpoint: " <> exceptionText err)
-                    Right () ->
-                      dispatchBuffered
-                        checkpointReceived
-                          { loopLastCommitted = Just snapshot
-                          , loopLastCheckpointSequence = Just snapshot.esCheckpointSequence
-                          , loopAwaitingCheckpoint = False
-                          }
+            Right () ->
+              case HostProtocol.transition
+                (protocolView state)
+                (HostProtocol.CheckpointReceived snapshot.esTerminal) of
+                HostProtocol.CommitCheckpoint deadlineUpdate -> do
+                  checkpointReceived <-
+                    applyEngineDeadlineUpdate responseTimeoutMicros deadlineUpdate state
+                  commitCheckpoint checkpointReceived snapshot
+                decision -> unexpectedDecision state "checkpoint" decision
+
+    commitCheckpoint checkpointReceived snapshot = do
+      commitResult <- trySynchronous (runtimeHost.hostedCommitCheckpoint snapshot)
+      case commitResult of
+        Left err -> failWith checkpointReceived ("checkpoint host threw: " <> exceptionText err)
+        Right (CheckpointCommitRejected message) ->
+          failWith checkpointReceived ("checkpoint commit failed: " <> message)
+        Right (CheckpointCommitAbortRun message) -> abortWith checkpointReceived message
+        Right CheckpointCommitAccepted -> do
+          writeResult <-
+            try @IOException $
+              writeCommand
+                childInput
+                (HostCheckpointCommitted runId snapshot.esCheckpointSequence)
+          case writeResult of
+            Left err -> failWith checkpointReceived ("acknowledging checkpoint: " <> exceptionText err)
+            Right () ->
+              dispatchBuffered
+                checkpointReceived
+                  { loopLastCommitted = Just snapshot
+                  , loopLastCheckpointSequence = Just snapshot.esCheckpointSequence
+                  , loopAwaitingCheckpoint = False
+                  }
 
     handleRequest state sequenceNumber nodeId
       | nodeId >= nodeCount = failWith state "engine requested an out-of-range node"
-      | isNothing state.loopLastCommitted =
-          failWith state "engine requested an effect before its initial checkpoint was committed"
       | sequenceNumber /= state.loopNextRequestSequence =
           failWith state "engine effect request sequence is not monotonic"
       | nodeId `Set.member` state.loopActiveNodes
           || nodeId `Set.member` state.loopInterruptedNodes =
           failWith state "engine requested a node already in flight"
-      | isJust state.loopTerminalSeen =
-          failWith state "engine requested an effect after terminal"
-      | state.loopCancellationSent =
-          -- The engine wrote this request before it read the cancel; the
-          -- cancelled checkpoint will reset the node. Track the sequence so
-          -- monotonicity still holds, but start no work. The engine deadline is
-          -- untouched: the cancelled checkpoint is still due.
-          go state {loopNextRequestSequence = sequenceNumber + 1}
-      | not (Set.null state.loopInterruptedNodes) =
-          -- A run-level cancel is required after an interruption. Requests
-          -- already emitted by the engine are left running in its state and
-          -- will be reset by that cancel; no new host work starts meanwhile.
-          go state {loopNextRequestSequence = sequenceNumber + 1}
-      | otherwise = do
-          -- Spawn-and-register is masked so an async exception cannot leave
-          -- a live worker outside the registry; the worker body itself runs
-          -- unmasked so it stays promptly cancellable.
-          worker <- mask_ $ do
-            spawned <- asyncWithUnmask $ \unmask -> do
-              resolution <-
-                trySynchronous (unmask (runtimeHost.hostedExecuteEffect nodeId))
-              atomically $
-                writeTQueue
-                  queue
-                  (HostEffectFinished sequenceNumber nodeId (firstException resolution))
-            atomically (modifyTVar' workerRegistry (Map.insert sequenceNumber spawned))
-            pure spawned
-          -- A valid effect request satisfies the engine-progress obligation
-          -- only when no completion checkpoint is already outstanding. A
-          -- request can cross an effect completion in the host queue; in
-          -- that case the completion's checkpoint remains mandatory and its
-          -- original deadline must survive while this worker runs.
-          go
+      | otherwise =
+          case HostProtocol.transition (protocolView state) HostProtocol.SuccessorRequested of
+            HostProtocol.ProtocolFault message -> failWith state message
+            HostProtocol.SuppressSuccessor ->
+              -- The request crossed cancellation or interruption. Track its
+              -- sequence, but do not start authority-bearing work.
+              go state {loopNextRequestSequence = sequenceNumber + 1}
+            HostProtocol.StartSuccessor deadlineUpdate -> do
+              startSuccessor state deadlineUpdate sequenceNumber nodeId
+            decision -> unexpectedDecision state "successor request" decision
+
+    startSuccessor state deadlineUpdate sequenceNumber nodeId = do
+      -- Spawn-and-register is masked so an async exception cannot leave
+      -- a live worker outside the registry; the worker body itself runs
+      -- unmasked so it stays promptly cancellable.
+      worker <- mask_ $ do
+        spawned <- asyncWithUnmask $ \unmask -> do
+          resolution <-
+            trySynchronous (unmask (runtimeHost.hostedExecuteEffect nodeId))
+          atomically $
+            writeTQueue
+              queue
+              (HostEffectFinished sequenceNumber nodeId (firstException resolution))
+        atomically (modifyTVar' workerRegistry (Map.insert sequenceNumber spawned))
+        pure spawned
+      let registered =
             state
               { loopNextRequestSequence = sequenceNumber + 1
               , loopWorkers = Map.insert sequenceNumber (nodeId, worker) state.loopWorkers
               , loopActiveNodes = Set.insert nodeId state.loopActiveNodes
-              , loopEngineDeadline =
-                  if state.loopAwaitingCheckpoint
-                    then state.loopEngineDeadline
-                    else Nothing
               }
+      deadlineUpdated <-
+        applyEngineDeadlineUpdate responseTimeoutMicros deadlineUpdate registered
+      go deadlineUpdated
 
     handleCompletion state sequenceNumber nodeId resolution =
       case Map.lookup sequenceNumber state.loopWorkers of
@@ -777,24 +814,8 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
                       , loopActiveNodes = Set.delete nodeId state.loopActiveNodes
                       }
               case resolution of
-                Right (EffectInterrupted _reason)
-                  | completedState.loopCancellationSent -> go completedState
-                  | isNothing runtimeHost.hostedAwaitCancellation ->
-                      failWith
-                        completedState
-                        "effect reported interruption but no cancellation watcher is installed"
-                  | otherwise ->
-                      -- The run-level cancel that interrupted the worker is
-                      -- in flight; the engine keeps the node running until
-                      -- that cancel resets it to pending.
-                      ensureCancellationDeadline
-                        responseTimeoutMicros
-                        ( completedState
-                            { loopInterruptedNodes =
-                                Set.insert nodeId completedState.loopInterruptedNodes
-                            }
-                        )
-                        >>= go
+                Right (EffectInterrupted _reason) ->
+                  handleInterruptedCompletion completedState nodeId
                 Left message ->
                   handleResolvedCompletion
                     completedState
@@ -808,10 +829,32 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
                     nodeId
                     (Right (EffectResolved completion))
 
-    handleResolvedCompletion state sequenceNumber nodeId resolution
-      | state.loopCancellationSent = go state
-      | not (Set.null state.loopInterruptedNodes) = go state
-      | state.loopAwaitingCheckpoint =
+    handleInterruptedCompletion state nodeId =
+      case HostProtocol.transition
+        (protocolView state)
+        ( HostProtocol.InterruptedCompletionArrived $
+            isJust runtimeHost.hostedAwaitCancellation
+        ) of
+        HostProtocol.DropCompletion -> go state
+        HostProtocol.ProtocolFault message -> failWith state message
+        HostProtocol.AwaitCancellation deadlineUpdate -> do
+          -- The run-level cancel that interrupted the worker is in flight;
+          -- the engine keeps the node running until cancellation resets it.
+          deadlineUpdated <-
+            applyCancellationDeadlineUpdate
+              responseTimeoutMicros
+              deadlineUpdate
+              state
+                { loopInterruptedNodes =
+                    Set.insert nodeId state.loopInterruptedNodes
+                }
+          go deadlineUpdated
+        decision -> unexpectedDecision state "interrupted completion" decision
+
+    handleResolvedCompletion state sequenceNumber nodeId resolution =
+      case HostProtocol.transition (protocolView state) HostProtocol.ResolvedCompletionArrived of
+        HostProtocol.DropCompletion -> go state
+        HostProtocol.BufferCompletion ->
           go
             state
               { loopBufferedCompletions =
@@ -820,9 +863,11 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
                     (nodeId, resolution)
                     state.loopBufferedCompletions
               }
-      | otherwise = sendCompletion state sequenceNumber nodeId resolution
+        HostProtocol.ForwardCompletion deadlineUpdate ->
+          sendCompletion state deadlineUpdate sequenceNumber nodeId resolution
+        decision -> unexpectedDecision state "resolved completion" decision
 
-    sendCompletion state sequenceNumber nodeId = \case
+    sendCompletion state deadlineUpdate sequenceNumber nodeId = \case
       Left message -> failWith state ("effect host threw: " <> message)
       Right (EffectInterrupted _reason) ->
         -- Unreachable: interruptions are intercepted before buffering, and
@@ -837,53 +882,50 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
         case writeResult of
           Left err -> failWith state ("sending effect completion: " <> exceptionText err)
           Right () -> do
-            armed <- armFreshEngineDeadline responseTimeoutMicros state
+            armed <-
+              applyEngineDeadlineUpdate responseTimeoutMicros deadlineUpdate state
             go armed {loopAwaitingCheckpoint = True}
 
-    dispatchBuffered state
-      -- Completions buffered before the cancel was sent must not reach an
-      -- engine that has already processed the cancel; the cancelled
-      -- checkpoint supersedes them.
-      | state.loopCancellationSent && not (Map.null state.loopBufferedCompletions) =
-          continueAfterCheckpoint state {loopBufferedCompletions = Map.empty}
-      | otherwise =
-          case Map.minViewWithKey state.loopBufferedCompletions of
-            Nothing -> continueAfterCheckpoint state
-            Just ((sequenceNumber, (nodeId, resolution)), remaining) ->
-              sendCompletion
-                state {loopBufferedCompletions = remaining}
-                sequenceNumber
-                nodeId
-                resolution
-
-    continueAfterCheckpoint state
-      | maybe False (\snapshot -> snapshot.esTerminal /= EngineActive) state.loopLastCommitted =
-          armFreshEngineDeadline responseTimeoutMicros state >>= go
-      | state.loopCancellationSent =
-          ensureEngineDeadline responseTimeoutMicros state >>= go
-      | Map.null state.loopWorkers
-          && Set.null state.loopInterruptedNodes =
-          armFreshEngineDeadline responseTimeoutMicros state >>= go
-      | otherwise = go state
+    dispatchBuffered state =
+      case state.loopLastCommitted of
+        Nothing -> failWith state "checkpoint acknowledgement lost committed authority"
+        Just snapshot ->
+          case HostProtocol.transition
+            (protocolView state)
+            (HostProtocol.CheckpointAcknowledged snapshot.esTerminal) of
+            HostProtocol.DropBufferedCompletions ->
+              -- Cancellation supersedes completions buffered before the
+              -- cancelled checkpoint was acknowledged.
+              dispatchBuffered state {loopBufferedCompletions = Map.empty}
+            HostProtocol.DispatchBufferedCompletion ->
+              case Map.minViewWithKey state.loopBufferedCompletions of
+                Nothing -> failWith state "protocol selected an absent buffered completion"
+                Just ((sequenceNumber, (nodeId, resolution)), remaining) ->
+                  sendCompletion
+                    state {loopBufferedCompletions = remaining}
+                    HostProtocol.ArmFreshDeadline
+                    sequenceNumber
+                    nodeId
+                    resolution
+            HostProtocol.AwaitTerminal deadlineUpdate ->
+              applyEngineDeadlineUpdate responseTimeoutMicros deadlineUpdate state >>= go
+            HostProtocol.AwaitCancellationCheckpoint deadlineUpdate ->
+              applyEngineDeadlineUpdate responseTimeoutMicros deadlineUpdate state >>= go
+            HostProtocol.AwaitEngineProgress deadlineUpdate ->
+              applyEngineDeadlineUpdate responseTimeoutMicros deadlineUpdate state >>= go
+            HostProtocol.AwaitWorkers -> go state
+            decision -> unexpectedDecision state "checkpoint acknowledgement" decision
 
     handleTerminal state terminal =
-      case state.loopLastCommitted of
-        Nothing -> failWith state "engine emitted terminal before a committed checkpoint"
-        Just snapshot
-          | snapshot.esTerminal /= terminal ->
-              failWith state "terminal event disagrees with the committed checkpoint"
-          | state.loopAwaitingCheckpoint ->
-              failWith state "engine emitted terminal before checkpoint acknowledgement"
-          | terminal == EngineCancelled && state.loopCancellationSent -> do
-              cancelledState <- cancelLiveWorkers state
-              writeShutdown cancelledState terminal
-          | not (Map.null state.loopWorkers) ->
-              failWith state "engine emitted terminal with effects still running"
-          | not (Set.null state.loopInterruptedNodes) ->
-              failWith state "engine emitted terminal with interrupted effects outstanding"
-          | not (Map.null state.loopBufferedCompletions) ->
-              failWith state "engine emitted terminal with buffered completions"
-          | otherwise -> writeShutdown state terminal
+      case HostProtocol.transition
+        (protocolView state)
+        (HostProtocol.TerminalReceived terminal) of
+        HostProtocol.ProtocolFault message -> failWith state message
+        HostProtocol.CancelWorkersAndSendShutdown -> do
+          cancelledState <- cancelLiveWorkers state
+          writeShutdown cancelledState terminal
+        HostProtocol.SendShutdown -> writeShutdown state terminal
+        decision -> unexpectedDecision state "terminal" decision
 
     writeShutdown state terminal = do
       writeResult <- try @IOException (writeCommand childInput (HostShutdown runId))
@@ -904,6 +946,20 @@ eventLoop responseTimeoutMicros runId programIdentity nodeCount childInput queue
           , loopInterruptedNodes = Set.empty
           , loopBufferedCompletions = Map.empty
           }
+
+    enactTerminalDecision state = \case
+      HostProtocol.FinishCommittedTerminal -> finish state
+      HostProtocol.ProtocolFault message -> failWith state message
+      decision -> unexpectedDecision state "terminal decision" decision
+
+    unexpectedDecision state crossing decision =
+      failWith
+        state
+        ( "host protocol policy returned an invalid "
+            <> crossing
+            <> " action: "
+            <> T.pack (show decision)
+        )
 
     expectedCheckpoint state actual =
       case state.loopLastCheckpointSequence of

--- a/test/Cortex/Wire/Circuit/HostProtocolSpec.hs
+++ b/test/Cortex/Wire/Circuit/HostProtocolSpec.hs
@@ -1,0 +1,106 @@
+{- |
+Module      : Cortex.Wire.Circuit.HostProtocolSpec
+Description : Exhaustive finite checks for the pure hosted protocol policy.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+Exhaustively exercises the finite lifecycle decisions that the IO-backed
+hosted event loop delegates to the pure protocol policy.
+-}
+module Cortex.Wire.Circuit.HostProtocolSpec (spec) where
+
+import Test.Hspec
+
+import Cortex.Wire.Circuit.Engine
+  ( EngineTerminalState (..)
+  )
+import Cortex.Wire.Circuit.HostProtocol
+
+spec :: Spec
+spec = describe "hosted process protocol policy" $ do
+  it "never forwards a completion after cancellation" $
+    mapM_
+      ( \candidateState ->
+          transition candidateState ResolvedCompletionArrived
+            `shouldBe` DropCompletion
+      )
+      [ state
+          { protocolCancellationSent = True
+          , protocolAwaitingCheckpoint = awaiting
+          , protocolInterruptedCount = interrupted
+          }
+      | awaiting <- [False, True]
+      , interrupted <- [0, 1]
+      ]
+
+  it "preserves an outstanding engine deadline across unrelated traffic" $ do
+    transition
+      state {protocolAwaitingCheckpoint = True}
+      SuccessorRequested
+      `shouldBe` StartSuccessor KeepDeadline
+    transition
+      state {protocolCancellationSent = True}
+      (CheckpointReceived EngineActive)
+      `shouldBe` CommitCheckpoint KeepDeadline
+
+  it "keeps cancellation and engine deadlines as separate obligations" $
+    transition state (InterruptedCompletionArrived True)
+      `shouldBe` AwaitCancellation EnsureDeadline
+
+  it "requires committed checkpoint authority before terminal" $ do
+    transition
+      state {protocolCommittedTerminal = Nothing}
+      (TerminalReceived EngineSucceeded)
+      `shouldBe` ProtocolFault "engine emitted terminal before a committed checkpoint"
+    transition
+      state {protocolCommittedTerminal = Just EngineCancelled}
+      (TerminalReceived EngineSucceeded)
+      `shouldBe` ProtocolFault "terminal event disagrees with the committed checkpoint"
+
+  it "lets a committed terminal survive either child exit kind" $
+    mapM_
+      ( \exitKind ->
+          transition
+            state {protocolTerminalSeen = Just EngineSucceeded}
+            (ChildExited exitKind)
+            `shouldBe` FinishCommittedTerminal
+      )
+      [ChildExitSuccess, ChildExitAbnormal]
+
+  it "drops buffered completions when cancellation crosses checkpoint acknowledgement" $
+    transition
+      state
+        { protocolCancellationSent = True
+        , protocolBufferedCompletionCount = 2
+        }
+      (CheckpointAcknowledged EngineActive)
+      `shouldBe` DropBufferedCompletions
+
+  it "suppresses successors after cancellation or interruption" $ do
+    transition
+      state
+        { protocolCommittedTerminal = Just EngineActive
+        , protocolCancellationSent = True
+        }
+      SuccessorRequested
+      `shouldBe` SuppressSuccessor
+    transition
+      state
+        { protocolCommittedTerminal = Just EngineActive
+        , protocolInterruptedCount = 1
+        }
+      SuccessorRequested
+      `shouldBe` SuppressSuccessor
+  where
+    state =
+      ProtocolView
+        { protocolCommittedTerminal = Just EngineActive
+        , protocolAwaitingCheckpoint = False
+        , protocolWorkerCount = 0
+        , protocolInterruptedCount = 0
+        , protocolBufferedCompletionCount = 0
+        , protocolTerminalSeen = Nothing
+        , protocolCancellationSent = False
+        }

--- a/test/Cortex/Wire/Circuit/HostProtocolSpec.hs
+++ b/test/Cortex/Wire/Circuit/HostProtocolSpec.hs
@@ -6,11 +6,12 @@ License     : Apache-2.0
 Maintainer  : julius.koskela@digimuoto.com
 Stability   : experimental
 
-Exhaustively exercises the finite lifecycle decisions that the IO-backed
-hosted event loop delegates to the pure protocol policy.
+Exercises the race-relevant decisions exported by the pure host lifecycle
+policy without involving process handles, timers, or worker payloads.
 -}
 module Cortex.Wire.Circuit.HostProtocolSpec (spec) where
 
+import System.Exit (ExitCode (..))
 import Test.Hspec
 
 import Cortex.Wire.Circuit.Engine
@@ -20,79 +21,128 @@ import Cortex.Wire.Circuit.HostProtocol
 
 spec :: Spec
 spec = describe "hosted process protocol policy" $ do
-  it "never forwards a completion after cancellation" $
+  it "never forwards a completion after cancellation or terminal authority" $ do
+    decideResolvedCompletion state {protocolCancellationSent = True}
+      `shouldBe` DropResolvedCompletion DroppedAfterCancellation
+    decideResolvedCompletion state {protocolCommittedTerminal = Just EngineTerminalFailed}
+      `shouldBe` DropResolvedCompletion DroppedAfterTerminalCheckpoint
+    decideInterruptedCompletion
+      state {protocolCommittedTerminal = Just EngineCancelled}
+      True
+      `shouldBe` DropInterruptedCompletion DroppedAfterTerminalCheckpoint
+
+  it "still faults an interrupted worker without a cancellation watcher after terminal authority" $
+    decideInterruptedCompletion
+      state {protocolCommittedTerminal = Just EngineTerminalFailed}
+      False
+      `shouldBe` InterruptedCompletionFault
+        "effect reported interruption but no cancellation watcher is installed"
+
+  it "requires active committed authority before starting a successor" $ do
+    decideSuccessor state {protocolCommittedTerminal = Nothing}
+      `shouldBe` SuccessorFault "engine requested an effect before its initial checkpoint was committed"
+    decideSuccessor state {protocolCommittedTerminal = Just EngineSucceeded}
+      `shouldBe` SuccessorFault "engine requested an effect after a terminal checkpoint was committed"
+    decideSuccessor state {protocolAwaitingCheckpoint = True}
+      `shouldBe` StartSuccessor KeepEngineDeadline
+
+  it "rejects checkpoints and duplicate terminal events after terminal authority" $ do
+    decideCheckpoint
+      state {protocolTerminalSeen = Just EngineSucceeded}
+      EngineSucceeded
+      `shouldBe` CheckpointFault "engine emitted a checkpoint after terminal"
+    decideCheckpoint
+      state {protocolCommittedTerminal = Just EngineSucceeded}
+      EngineSucceeded
+      `shouldBe` CheckpointFault "engine emitted a checkpoint after a terminal checkpoint was committed"
+    decideTerminal
+      state {protocolTerminalSeen = Just EngineSucceeded}
+      EngineSucceeded
+      `shouldBe` TerminalFault "engine emitted duplicate terminal"
+
+  it "requires succeeded checkpoints to be host-quiescent" $
     mapM_
-      ( \candidateState ->
-          transition candidateState ResolvedCompletionArrived
-            `shouldBe` DropCompletion
+      ( \candidate ->
+          decideCheckpoint candidate EngineSucceeded
+            `shouldBe` CheckpointFault "engine emitted a succeeded checkpoint with host effects still outstanding"
       )
-      [ state
-          { protocolCancellationSent = True
-          , protocolAwaitingCheckpoint = awaiting
-          , protocolInterruptedCount = interrupted
-          }
-      | awaiting <- [False, True]
-      , interrupted <- [0, 1]
+      [ state {protocolWorkerCount = 1}
+      , state {protocolInterruptedCount = 1}
+      , state {protocolBufferedCompletionCount = 1}
       ]
 
-  it "preserves an outstanding engine deadline across unrelated traffic" $ do
-    transition
-      state {protocolAwaitingCheckpoint = True}
-      SuccessorRequested
-      `shouldBe` StartSuccessor KeepDeadline
-    transition
-      state {protocolCancellationSent = True}
-      (CheckpointReceived EngineActive)
-      `shouldBe` CommitCheckpoint KeepDeadline
-
-  it "keeps cancellation and engine deadlines as separate obligations" $
-    transition state (InterruptedCompletionArrived True)
-      `shouldBe` AwaitCancellation EnsureDeadline
-
-  it "requires committed checkpoint authority before terminal" $ do
-    transition
-      state {protocolCommittedTerminal = Nothing}
-      (TerminalReceived EngineSucceeded)
-      `shouldBe` ProtocolFault "engine emitted terminal before a committed checkpoint"
-    transition
-      state {protocolCommittedTerminal = Just EngineCancelled}
-      (TerminalReceived EngineSucceeded)
-      `shouldBe` ProtocolFault "terminal event disagrees with the committed checkpoint"
-
-  it "lets a committed terminal survive either child exit kind" $
+  it "cancels outstanding host work for failed and cancelled terminals" $
     mapM_
-      ( \exitKind ->
-          transition
-            state {protocolTerminalSeen = Just EngineSucceeded}
-            (ChildExited exitKind)
-            `shouldBe` FinishCommittedTerminal
+      ( \terminal ->
+          decideTerminal
+            state
+              { protocolCommittedTerminal = Just terminal
+              , protocolWorkerCount = 1
+              }
+            terminal
+            `shouldBe` CancelWorkersAndSendShutdown shutdownDeadlines
       )
-      [ChildExitSuccess, ChildExitAbnormal]
+      [EngineTerminalFailed, EngineCancelled]
 
-  it "drops buffered completions when cancellation crosses checkpoint acknowledgement" $
-    transition
+  it "never dispatches buffered completions beyond a terminal checkpoint" $ do
+    decideCheckpointAcknowledgement
+      state {protocolBufferedCompletionCount = 2}
+      EngineTerminalFailed
+      `shouldBe` DropBufferedCompletions DroppedAfterTerminalCheckpoint
+    decideCheckpointAcknowledgement state EngineTerminalFailed
+      `shouldBe` AwaitEngineOutput ArmFreshEngineDeadline
+
+  it "drops buffered completions when an interruption is pending" $
+    decideCheckpointAcknowledgement
+      state
+        { protocolInterruptedCount = 1
+        , protocolBufferedCompletionCount = 1
+        }
+      EngineActive
+      `shouldBe` DropBufferedCompletions DroppedDuringInterruption
+
+  it "returns explicit deadline policy for buffer dispatch and shutdown" $ do
+    decideCheckpointAcknowledgement
+      state {protocolBufferedCompletionCount = 1}
+      EngineActive
+      `shouldBe` DispatchBufferedCompletion ArmFreshEngineDeadline
+    decideTerminal
+      state {protocolCommittedTerminal = Just EngineSucceeded}
+      EngineSucceeded
+      `shouldBe` SendShutdown shutdownDeadlines
+
+  it "keeps cancellation and engine deadlines separate and named" $ do
+    decideCancellation state
+      `shouldBe` SendCancellation
+        CancellationDeadlines
+          { cancellationEngineDeadline = EnsureEngineDeadline
+          , cancellationFollowUpDeadline = ClearCancellationDeadline
+          }
+    decideInterruptedCompletion state True
+      `shouldBe` AwaitCancellation EnsureCancellationDeadline
+    decideCheckpoint state {protocolCancellationSent = True} EngineActive
+      `shouldBe` CommitCheckpoint
+        CheckpointDeadlines
+          { checkpointEngineDeadline = KeepEngineDeadline
+          , checkpointCancellationDeadline = KeepCancellationDeadline
+          }
+
+  it "lets a committed terminal survive either child exit code and watchdog" $ do
+    let observed = state {protocolTerminalSeen = Just EngineTerminalFailed}
+    mapM_
+      (\exitCode -> decideChildExit observed exitCode `shouldBe` FinishCommittedTerminal)
+      [ExitSuccess, ExitFailure 1]
+    decideDeadline EngineDeadline observed `shouldBe` FinishDeadlineTerminal
+    decideDeadline CancellationDeadline observed `shouldBe` FinishDeadlineTerminal
+
+  it "drops buffered completions when cancellation crosses acknowledgement" $
+    decideCheckpointAcknowledgement
       state
         { protocolCancellationSent = True
         , protocolBufferedCompletionCount = 2
         }
-      (CheckpointAcknowledged EngineActive)
-      `shouldBe` DropBufferedCompletions
-
-  it "suppresses successors after cancellation or interruption" $ do
-    transition
-      state
-        { protocolCommittedTerminal = Just EngineActive
-        , protocolCancellationSent = True
-        }
-      SuccessorRequested
-      `shouldBe` SuppressSuccessor
-    transition
-      state
-        { protocolCommittedTerminal = Just EngineActive
-        , protocolInterruptedCount = 1
-        }
-      SuccessorRequested
-      `shouldBe` SuppressSuccessor
+      EngineActive
+      `shouldBe` DropBufferedCompletions DroppedAfterCancellation
   where
     state =
       ProtocolView
@@ -103,4 +153,9 @@ spec = describe "hosted process protocol policy" $ do
         , protocolBufferedCompletionCount = 0
         , protocolTerminalSeen = Nothing
         , protocolCancellationSent = False
+        }
+    shutdownDeadlines =
+      ShutdownDeadlines
+        { shutdownEngineDeadline = ArmFreshEngineDeadline
+        , shutdownCancellationDeadline = ClearCancellationDeadline
         }

--- a/test/Cortex/Wire/Circuit/HostedSpec.hs
+++ b/test/Cortex/Wire/Circuit/HostedSpec.hs
@@ -15,8 +15,9 @@ example, an effect completion after cancellation).
 -}
 module Cortex.Wire.Circuit.HostedSpec (spec) where
 
-import Control.Concurrent.MVar (newEmptyMVar, putMVar, readMVar)
-import Control.Exception (AsyncException (ThreadKilled), throwIO)
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, readMVar, tryTakeMVar)
+import Control.Exception (AsyncException (ThreadKilled), finally, throwIO)
 import Data.Aeson qualified as Aeson
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
@@ -331,6 +332,147 @@ spec = describe "Cortex.Wire.Circuit.Hosted" $ do
         Left err ->
           T.unpack err.hostedRunErrorMessage
             `shouldContain` "mandated protocol output did not arrive"
+
+  it "rejects successor work after a terminal checkpoint without executing it" $ do
+    let steps =
+          [ Emit hello
+          , Await -- start
+          , Emit (checkpoint (engineState 1 EngineSucceeded [EngineCompleted, EngineCompleted] [7, 9]))
+          , Await -- ack 1
+          , Emit (effectRequested 1 0)
+          , Await -- host tears the child down
+          ]
+    withFakeEngine steps $ \artifact -> do
+      executed <- newEmptyMVar
+      let runtimeHost =
+            succeedingHost
+              { hostedExecuteEffect = \_nodeId -> do
+                  putMVar executed ()
+                  pure (EffectResolved EffectSkipped)
+              }
+      result <- runHost runtimeHost artifact
+      case result of
+        Right _state -> expectationFailure "expected a post-terminal-checkpoint protocol fault"
+        Left err ->
+          T.unpack err.hostedRunErrorMessage
+            `shouldContain` "after a terminal checkpoint"
+      tryTakeMVar executed `shouldReturn` Nothing
+
+  it "rejects checkpoints after the terminal event without replacing authority" $ do
+    let committed = engineState 1 EngineSucceeded [EngineCompleted, EngineCompleted] [7, 9]
+        extra = engineState 2 EngineSucceeded [EngineCompleted, EngineCompleted] [7, 9]
+        steps =
+          [ Emit hello
+          , Await -- start
+          , Emit (checkpoint committed)
+          , Await -- ack 1
+          , Emit (terminalEvent EngineSucceeded)
+          , Await -- shutdown
+          , Emit (checkpoint extra)
+          , Await -- host tears the child down
+          ]
+    withFakeEngine steps $ \artifact -> do
+      result <- runHost succeedingHost artifact
+      case result of
+        Right _state -> expectationFailure "expected a post-terminal checkpoint fault"
+        Left err -> do
+          T.unpack err.hostedRunErrorMessage `shouldContain` "checkpoint after terminal"
+          (.esCheckpointSequence) <$> err.hostedRunLastCommitted `shouldBe` Just 1
+
+  it "rejects duplicate terminal events without indefinitely refreshing shutdown" $ do
+    let steps =
+          [ Emit hello
+          , Await -- start
+          , Emit (checkpoint (engineState 1 EngineSucceeded [EngineCompleted, EngineCompleted] [7, 9]))
+          , Await -- ack 1
+          , Emit (terminalEvent EngineSucceeded)
+          , Await -- shutdown
+          , Emit (terminalEvent EngineSucceeded)
+          , Await -- host tears the child down
+          ]
+    withFakeEngine steps $ \artifact -> do
+      result <- runHost succeedingHost artifact
+      case result of
+        Right _state -> expectationFailure "expected a duplicate terminal fault"
+        Left err -> T.unpack err.hostedRunErrorMessage `shouldContain` "duplicate terminal"
+
+  it "honors failed terminal authority and cancels a still-running sibling" $ do
+    let steps =
+          [ Emit hello
+          , Await -- start
+          , Emit (checkpoint (engineState 1 EngineActive [EnginePending, EnginePending] [0, 0]))
+          , Await -- ack 1
+          , Emit (effectRequested 1 0)
+          , Emit (effectRequested 2 1)
+          , Await -- failed completion for node 0
+          , Emit (checkpoint (engineState 2 EngineTerminalFailed [EngineFailed, EngineRunning] [0, 0]))
+          , Await -- ack 2
+          , Emit (terminalEvent EngineTerminalFailed)
+          , Await -- shutdown
+          ]
+    withFakeEngine steps $ \artifact -> do
+      releasePrimary <- newEmptyMVar
+      neverResolves <- newEmptyMVar
+      siblingStarted <- newEmptyMVar
+      siblingCancelled <- newEmptyMVar
+      let runtimeHost =
+            succeedingHost
+              { hostedExecuteEffect = \case
+                  0 -> do
+                    readMVar releasePrimary
+                    pure (EffectResolved (EffectFailed "primary failed"))
+                  _otherNode ->
+                    do
+                      putMVar siblingStarted ()
+                      readMVar neverResolves
+                        `finally` putMVar siblingCancelled ()
+              }
+      result <- withAsync (runHost runtimeHost artifact) $ \running -> do
+        readMVar siblingStarted
+        putMVar releasePrimary ()
+        wait running
+      case result of
+        Left err -> expectationFailure ("expected committed failure, got: " <> show err)
+        Right finalState -> finalState.esTerminal `shouldBe` EngineTerminalFailed
+      timeout 1000000 (readMVar siblingCancelled) `shouldReturn` Just ()
+
+  it "intentionally drops a host exception once cancellation wins" $ do
+    let steps =
+          [ Emit hello
+          , Await -- start
+          , Emit (checkpoint (engineState 1 EngineActive [EnginePending, EnginePending] [0, 0]))
+          , Await -- ack 1
+          , Emit (effectRequested 1 0)
+          , AwaitNotCompletion -- cancel, never the host exception
+          , Emit (checkpoint (engineState 2 EngineCancelled [EnginePending, EnginePending] [0, 0]))
+          , Await -- ack 2
+          , Emit (terminalEvent EngineCancelled)
+          , Await -- shutdown
+          ]
+    withFakeEngine steps $ \artifact -> do
+      effectStarted <- newEmptyMVar
+      cancellationIssued <- newEmptyMVar
+      releaseException <- newEmptyMVar
+      let runtimeHost =
+            HostedRuntimeHost
+              { hostedCommitCheckpoint = \_state -> pure CheckpointCommitAccepted
+              , hostedExecuteEffect = \_nodeId -> do
+                  putMVar effectStarted ()
+                  readMVar releaseException
+                  ioError (userError "host exception after cancellation")
+              , hostedAwaitCancellation =
+                  Just $ do
+                    readMVar effectStarted
+                    putMVar cancellationIssued ()
+                    pure (Right "operator cancellation")
+              }
+      result <- withAsync (runHost runtimeHost artifact) $ \running -> do
+        readMVar cancellationIssued
+        putMVar releaseException ()
+        wait running
+      case result of
+        Left err -> expectationFailure ("expected cancellation authority, got: " <> show err)
+        Right finalState -> finalState.esTerminal `shouldBe` EngineCancelled
 
   it "fails closed when an interrupted effect is not followed by an authorized cancel" $ do
     let steps =


### PR DESCRIPTION
## Summary

- derive the hosted IO event loop from exhaustive, event-specific pure protocol decisions
- enforce terminal-checkpoint authority across successors, completions, cancellation, worker cleanup, deadlines, and child exit
- model the concurrent host lifecycle in TLA+, including failed terminals, operator cancellation, buffered dispatch, and deadline identity
- add expected-failure TLC configurations proving the completion and deadline properties are non-vacuous
- harden the follow-up implementation against stream-failure, shutdown, acknowledgement, and timing races

## Why

Lean models the target-independent engine snapshot and checkpoint gate, but the late lifecycle races were in the concurrent process-host protocol. The original host model left several real crossings either unguarded or abstracted away: post-terminal checkpoints and successors, failed terminal states with live siblings, buffered completion dispatch after cancellation, and unrelated traffic refreshing watchdogs.

This change gives each host input a typed pure decision surface, applies all deadline policy through named directives, and aligns the executable loop, TLA+ model, process tests, and assurance documentation.

## Guarantees

- successor effects require a committed active checkpoint
- checkpoints and duplicate terminal events are rejected after terminal authority
- successful terminals require host quiescence; failed and cancelled terminals request cancellation of live siblings
- direct and buffered completions never reach the engine after cancellation or terminal checkpoints
- engine and cancellation obligations are independent; checkpoint persistence pauses and later resumes their remaining budgets
- a terminal observed before child exit retains authority; an earlier abnormal exit is a host fault
- stream and runtime failures after a terminal event preserve the committed result
- intentionally discarded completions emit a redacted cortex.hosted.completion_dropped eventlog marker
- Lean proves engine checkpoint acceptance; TLA+ separately checks bounded host lifecycle ordering and liveness

## Model non-vacuity

just tla-check verifies the production model and requires four weakened host configurations to reproduce their named violations:

- buffered completion forwarding after cancellation
- completion forwarding after terminal authority
- checkpoint deadline loss when a successor request crosses a completion
- deadline extension by unrelated traffic

## Validation

- just test — 1,213 examples, 0 failures, 164 existing pending
- just tla-check
- just fmt
- just lint
- all commit hooks: docs lint, formatter, HLint, Lean lint, and style
