### PR TITLE
feat(wire): add compatible one-record executor substrate

### DIFF
--- a/docs/ADRs/0060-filesystem-package-and-binding-manifests.md
+++ b/docs/ADRs/0060-filesystem-package-and-binding-manifests.md
@@ -133,6 +133,12 @@ Future hardening slices may add manifest versioning, dependency declarations, co
 and direct TOML syntax for ADR 0053 requirement slots. Those fields remain inert package data when
 they are added.
 
+**2026-07-19 compatibility amendment.** ADR 0095 introduces `argument_shape` as the canonical
+one-record ingress schema key. During the epic migration the loader accepts either the existing
+`config_shape` key or `argument_shape`, maps both to the same projection, and rejects a manifest
+that supplies both. The example above intentionally remains a valid legacy manifest until the final
+breaking Wire migration.
+
 ### Capability registration model
 
 Capabilities enter the manifest system through executor catalog metadata, not through Wire syntax.

--- a/docs/ADRs/0095-wire-single-record-executor-boundary.md
+++ b/docs/ADRs/0095-wire-single-record-executor-boundary.md
@@ -1,0 +1,86 @@
+---
+title: "ADR 0095 - Wire Single-Record Executor Boundary"
+description:
+  "Introduces a compatibility-first one-record executor ingress ABI while keeping static node
+  metadata distinct from runtime argument evaluation."
+sidebar:
+  label: "0095. Wire executor boundary"
+  order: 95
+status: proposed
+date: 2026-07-19
+superseded_by: null
+related:
+  - docs/ADRs/0024-typed-executor-node-interface.md
+  - docs/ADRs/0025-configured-executor-values.md
+  - docs/ADRs/0053-executor-catalog-manifests-and-pulse-bindings.md
+  - docs/ADRs/0060-filesystem-package-and-binding-manifests.md
+  - docs/ADRs/0096-certified-native-pure-region-compilation.md
+---
+
+# ADR 0095 - Wire Single-Record Executor Boundary
+
+## Status
+
+Proposed and partially implemented. The runtime, registry, manifest, capability, and compiled
+metadata substrate exists additively. Existing authored calls, `config_shape`, config-facing APIs,
+host wrappers, and compiled `config` metadata remain supported. The compatible source surface and
+the final breaking removal are separate later slices.
+
+## Context
+
+The existing executor boundary splits configuration from a parenthesized source value and also mixes
+compiler controls into the configuration record. A single runtime record is easier to validate,
+bind, version, and lower. That simplification must not collapse two evaluation phases: graph
+admission needs static compiler facts, while an executor argument may depend on values that do not
+exist until the node consumes its inputs.
+
+## Decision
+
+The canonical executor ABI is one record. `payload` is the automatic scalar wrapper field and `cfg`
+is the conventional location for executor-specific configuration. This normalization is a
+compile-time structural decision, but the resulting CorePure expression is evaluated at node
+ingress.
+
+The phases are intentionally distinct:
+
+- compiler metadata is statically evaluable and affects graph admission, scheduling, retries,
+  budgets, memory, routing, and other compiler-owned policy;
+- executor arguments are runtime ingress data and may reference consumed ports, module-level
+  CorePure bindings, and node `where` fields;
+- after ingress evaluation, the runtime requires an object, validates it against `argument_shape`,
+  and passes that exact value to the host binding.
+
+The compatibility slice dual-reads `config_shape` and `argument_shape`, rejecting a manifest that
+defines both. Public config-named projection and capability records remain as storage-compatible
+views with argument-named adapters. Admission projection v1 continues to round-trip with
+`configSchemaRef`; v2 uses `argumentShapeRef`.
+
+Compiled executor tasks dual-write their unchanged legacy `config` envelope and a normalized
+`argument` envelope. The latter contains `value`, optional module `bindings`, and optional `where`.
+Legacy split calls normalize as follows:
+
+- empty configuration plus `null` input becomes `{}`;
+- a non-null input contributes `payload`;
+- executor configuration contributes fields below `cfg`;
+- both contributions share the same record.
+
+The old `wrapWireStageDefinition` remains available. The additive
+`wrapWireStageDefinitionWithArgument` supplies evaluate, validate, exact-delivery semantics. No
+authored grammar changes are part of this slice.
+
+## Consequences
+
+- Static evaluation and PureWire runtime evaluation remain separate concepts; a constant executor
+  argument is still ingress data, not node metadata.
+- Hosts can migrate bindings independently while existing integrations continue to run.
+- Conflicting old/new manifest keys fail rather than silently selecting one schema.
+- The final migration can remove aliases and legacy envelopes without redesigning the runtime ABI.
+
+## Traceability
+
+- Feature key: `wire.single_record_executor_boundary`
+- Production: `src/Cortex/Wire/{Compile,Executor,Pure,Runtime}.hs`
+- Package and capability: `src/Cortex/Wire/Package/Manifest.hs`,
+  `src/Cortex/Capability/{Executor,Catalog/AdmissionProjection}.hs`
+- Tests: `test/Cortex/Wire/{Compile,Package,Runtime}Spec.hs`,
+  `test/Cortex/Capability/CatalogSpec.hs`

--- a/docs/ADRs/index.md
+++ b/docs/ADRs/index.md
@@ -109,6 +109,7 @@ documentation lifecycle; ADR 0063 governs feature traceability and feature-statu
 | [0092](0092-circuit-engine-runtime-host-boundary.md)               | Circuit Engine and Runtime-Host Boundary                                   | accepted   |
 | [0093](0093-versioned-circuit-state-event-control-protocol.md)     | Versioned Circuit State, Event, and Control Protocol                       | accepted   |
 | [0094](0094-hosted-x86-64-linux-executable-profile.md)             | Hosted x86_64 Linux Executable Profile                                     | accepted   |
+| [0095](0095-wire-single-record-executor-boundary.md)               | Wire Single-Record Executor Boundary                                       | proposed   |
 | [0096](0096-certified-native-pure-region-compilation.md)           | Certified NativePure Compilation                                           | proposed   |
 
 ## By category
@@ -141,6 +142,7 @@ is shown here.
   [0092](0092-circuit-engine-runtime-host-boundary.md),
   [0093](0093-versioned-circuit-state-event-control-protocol.md),
   [0094](0094-hosted-x86-64-linux-executable-profile.md),
+  [0095](0095-wire-single-record-executor-boundary.md),
   [0096](0096-certified-native-pure-region-compilation.md)
 - **Rewrite admission & budget** (8):
   [0005](0005-budgeted-rewrite-admission-and-materialization.md),

--- a/src/Cortex/Capability/Catalog/AdmissionProjection.hs
+++ b/src/Cortex/Capability/Catalog/AdmissionProjection.hs
@@ -24,19 +24,26 @@ module Cortex.Capability.Catalog.AdmissionProjection
   , ProjectionVersion (..)
   , ContentDigest (..)
   , ConfigSchemaRef (..)
+  , ArgumentShapeRef (..)
   , RequirementSlot (..)
+  , currentProjectionVersion
+  , apArgumentShapeRef
+  , admissionProjectionWithArgumentShapeRef
+  , rsArgumentSelector
   , admissionProjectionDigest
   , encodeWirePorts
   , decodeWirePorts
   )
 where
 
+import Control.Monad (when)
 import Crypto.Hash (SHA256, hashlazy)
 import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.!=), (.:), (.:?), (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.Types (Parser)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
@@ -75,6 +82,31 @@ data ConfigSchemaRef
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
+{- | Canonical name for the schema/decoder reference at the one-record ingress
+boundary. The config-named representation remains stored for v1 callers.
+-}
+data ArgumentShapeRef
+  = ArgumentShapeNone
+  | ArgumentShapeDigest ContentDigest
+  | ArgumentShapeName Text
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+currentProjectionVersion :: ProjectionVersion
+currentProjectionVersion = ProjectionVersion "2"
+
+argumentShapeRefFromConfig :: ConfigSchemaRef -> ArgumentShapeRef
+argumentShapeRefFromConfig = \case
+  ConfigSchemaNone -> ArgumentShapeNone
+  ConfigSchemaDigest digest -> ArgumentShapeDigest digest
+  ConfigSchemaName name -> ArgumentShapeName name
+
+configSchemaRefFromArgument :: ArgumentShapeRef -> ConfigSchemaRef
+configSchemaRefFromArgument = \case
+  ArgumentShapeNone -> ConfigSchemaNone
+  ArgumentShapeDigest digest -> ConfigSchemaDigest digest
+  ArgumentShapeName name -> ConfigSchemaName name
+
 {- | A declared requirement the binding layer must satisfy: a capability kind, the
 local binding name the host resolves, an optional config selector path, and the
 required permission class. Inert — declaring a requirement does not grant it.
@@ -87,6 +119,9 @@ data RequirementSlot = RequirementSlot
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
+
+rsArgumentSelector :: RequirementSlot -> Maybe Text
+rsArgumentSelector = rsConfigSelector
 
 data AdmissionProjection = AdmissionProjection
   { apExecutorId :: !WireExecutorId
@@ -101,27 +136,57 @@ data AdmissionProjection = AdmissionProjection
   }
   deriving stock (Eq, Show, Generic)
 
+apArgumentShapeRef :: AdmissionProjection -> ArgumentShapeRef
+apArgumentShapeRef = argumentShapeRefFromConfig . apConfigSchemaRef
+
+admissionProjectionWithArgumentShapeRef
+  :: ArgumentShapeRef -> AdmissionProjection -> AdmissionProjection
+admissionProjectionWithArgumentShapeRef shapeRef projection =
+  projection
+    { apProjectionVersion = currentProjectionVersion
+    , apConfigSchemaRef = configSchemaRefFromArgument shapeRef
+    }
+
 instance ToJSON AdmissionProjection where
   toJSON p =
     object
-      [ "executorId" .= unWireExecutorId (apExecutorId p)
-      , "projectionVersion" .= apProjectionVersion p
-      , "ports" .= encodeWirePorts (apPorts p)
-      , "configSchemaRef" .= apConfigSchemaRef p
-      , "requirementSlots" .= apRequirementSlots p
-      , "replayClass" .= apReplayClass p
-      , "isolationExpectation" .= apIsolationExpectation p
-      , "effect" .= effectText (apEffect p)
-      , "awaitStrategy" .= apAwaitStrategy p
-      ]
+      ( [ "executorId" .= unWireExecutorId (apExecutorId p)
+        , "projectionVersion" .= apProjectionVersion p
+        , "ports" .= encodeWirePorts (apPorts p)
+        , "requirementSlots" .= apRequirementSlots p
+        , "replayClass" .= apReplayClass p
+        , "isolationExpectation" .= apIsolationExpectation p
+        , "effect" .= effectText (apEffect p)
+        , "awaitStrategy" .= apAwaitStrategy p
+        ]
+          <> if apProjectionVersion p == currentProjectionVersion
+            then ["argumentShapeRef" .= apArgumentShapeRef p]
+            else ["configSchemaRef" .= apConfigSchemaRef p]
+      )
 
 instance FromJSON AdmissionProjection where
-  parseJSON = withObject "AdmissionProjection" $ \o ->
+  parseJSON = withObject "AdmissionProjection" $ \o -> do
+    version <- o .: "projectionVersion"
+    legacyRef <- o .:? "configSchemaRef"
+    argumentRef <- o .:? "argumentShapeRef"
+    when (isJust legacyRef && isJust argumentRef) $
+      fail "admission projection cannot define both configSchemaRef and argumentShapeRef"
+    storedRef <-
+      case version of
+        ProjectionVersion "2" ->
+          maybe
+            (fail "version 2 admission projection is missing argumentShapeRef")
+            (pure . configSchemaRefFromArgument)
+            argumentRef
+        ProjectionVersion "1" ->
+          maybe (fail "version 1 admission projection is missing configSchemaRef") pure legacyRef
+        ProjectionVersion unknown ->
+          fail ("unsupported admission projection version " <> T.unpack unknown)
     AdmissionProjection . WireExecutorId
       <$> o .: "executorId"
-      <*> o .: "projectionVersion"
+      <*> pure version
       <*> (o .: "ports" >>= decodeWirePorts)
-      <*> o .: "configSchemaRef"
+      <*> pure storedRef
       <*> o .:? "requirementSlots" .!= []
       <*> o .: "replayClass"
       <*> o .: "isolationExpectation"
@@ -138,7 +203,9 @@ admissionProjectionDigest p =
           ( unWireExecutorId (apExecutorId p)
           , unProjectionVersion (apProjectionVersion p)
           , canonicalPorts (apPorts p)
-          , toJSON (apConfigSchemaRef p)
+          , if apProjectionVersion p == currentProjectionVersion
+              then toJSON (apArgumentShapeRef p)
+              else toJSON (apConfigSchemaRef p)
           , toJSON (apRequirementSlots p)
           , toJSON (apReplayClass p)
           , toJSON (apIsolationExpectation p)

--- a/src/Cortex/Capability/Executor.hs
+++ b/src/Cortex/Capability/Executor.hs
@@ -15,6 +15,9 @@ Cortex substrate modules stay consumer-neutral and keep downstream product polic
 module Cortex.Capability.Executor
   ( ExecutorSpec (..)
   , ExecutorConfigDecoder (..)
+  , ExecutorArgumentDecoder (..)
+  , executorSpecArgumentDecoder
+  , executorSpecWithArgumentDecoder
   , ExecutorRequirement (..)
   , ExecutorCodecBoundary (..)
   , ExecutorBindingAuthority (..)
@@ -42,6 +45,29 @@ data ExecutorConfigDecoder
   | ExecutorConfigJsonSchema Aeson.Value
   | ExecutorConfigDecoderName Text
   deriving stock (Eq, Show, Generic)
+
+data ExecutorArgumentDecoder
+  = ExecutorArgumentUnchecked
+  | ExecutorArgumentJsonSchema Aeson.Value
+  | ExecutorArgumentDecoderName Text
+  deriving stock (Eq, Show, Generic)
+
+executorSpecArgumentDecoder :: ExecutorSpec -> ExecutorArgumentDecoder
+executorSpecArgumentDecoder spec =
+  case spec.executorSpecConfigDecoder of
+    ExecutorConfigUnchecked -> ExecutorArgumentUnchecked
+    ExecutorConfigJsonSchema schema -> ExecutorArgumentJsonSchema schema
+    ExecutorConfigDecoderName name -> ExecutorArgumentDecoderName name
+
+executorSpecWithArgumentDecoder :: ExecutorArgumentDecoder -> ExecutorSpec -> ExecutorSpec
+executorSpecWithArgumentDecoder decoder spec =
+  spec
+    { executorSpecConfigDecoder =
+        case decoder of
+          ExecutorArgumentUnchecked -> ExecutorConfigUnchecked
+          ExecutorArgumentJsonSchema schema -> ExecutorConfigJsonSchema schema
+          ExecutorArgumentDecoderName name -> ExecutorConfigDecoderName name
+    }
 
 data ExecutorRequirement
   = ExecutorRequiresTool Text
@@ -77,13 +103,13 @@ executorProjection spec =
   (executorSpecPorts spec)
     { wireExecutorProjectionId = executorSpecId spec
     , wireExecutorProjectionEffect = executorSpecEffect spec
-    , wireExecutorProjectionConfigShape = configShape (executorSpecConfigDecoder spec)
+    , wireExecutorProjectionConfigShape = configShape (executorSpecArgumentDecoder spec)
     }
   where
     configShape = \case
-      ExecutorConfigUnchecked -> WireExecutorConfigUnchecked
-      ExecutorConfigJsonSchema schema -> WireExecutorConfigSchema schema
-      ExecutorConfigDecoderName _ -> WireExecutorConfigUnchecked
+      ExecutorArgumentUnchecked -> WireExecutorConfigUnchecked
+      ExecutorArgumentJsonSchema schema -> WireExecutorConfigSchema schema
+      ExecutorArgumentDecoderName _ -> WireExecutorConfigUnchecked
 
 executorProjectionRegistry :: [ExecutorSpec] -> WireExecutorRegistry
 executorProjectionRegistry specs =

--- a/src/Cortex/Wire.hs
+++ b/src/Cortex/Wire.hs
@@ -46,6 +46,8 @@ module Cortex.Wire
   , wrapWireStageOutputs
   , wrapWireStageResult
   , wrapWireStageDefinition
+  , wrapWireStageDefinitionWithArgument
+  , validateWireExecutorArgument
   , emptyWireCompileEnv
   , wireCompileEnvWithContractRegistry
   , wireCompileEnvWithExecutorRegistry
@@ -140,9 +142,11 @@ import Cortex.Wire.Runtime
   ( WireInputBundle (..)
   , unwrapWireStageInputs
   , unwrapWireStageValue
+  , validateWireExecutorArgument
   , wireInputBundleFromStageInputs
   , wireInputBundlePromptSummary
   , wrapWireStageDefinition
+  , wrapWireStageDefinitionWithArgument
   , wrapWireStageOutput
   , wrapWireStageOutputs
   , wrapWireStageResult

--- a/src/Cortex/Wire/Compile.hs
+++ b/src/Cortex/Wire/Compile.hs
@@ -157,6 +157,7 @@ import Cortex.Wire.Pure
   , corePureStaticContextFromBindings
   , corePureWhereStaticFields
   , renderPureEvalError
+  , validateCorePureExpr
   , validatePureTaskConfig
   , validatePureVariantTaskConfig
   )
@@ -3072,6 +3073,8 @@ loweredNodeFromExecutorCall compileEnv st nodeRef ports whereExpr executorCallVa
                 lookupMaybeTextField "instructions" exactFields
                   <|> lookupMaybeTextField "prompt" exactFields
               configValue = executorConfigValue genericFields whereExpr inputExpr
+              argumentExpr = normalizeLegacyExecutorArgument genericFields inputExpr
+              argumentValue = executorArgumentValue st.lsPureBindings whereExpr argumentExpr
               normalForm =
                 executorNodeBoundaryNormalForm
                   nodeRef
@@ -3082,6 +3085,8 @@ loweredNodeFromExecutorCall compileEnv st nodeRef ports whereExpr executorCallVa
                   configValue
           mapLeft (WireCore.WireInvalidPorts nodeRef) $
             validateNodeBoundaryNormalForm normalForm
+          mapLeft (WireCore.WireInvalidPorts nodeRef . renderPureEvalError) $
+            validateCorePureExpr argumentExpr
           validateExecutorProjection compileEnv nodeRef executor (normalFormPorts normalForm)
           tools <- maybe (Right []) evalTools (Map.lookup ("tools" :| []) exactFields)
           memoryStrategy <- traverse evalMemoryStrategy (Map.lookup ("memory" :| []) exactFields)
@@ -3091,21 +3096,25 @@ loweredNodeFromExecutorCall compileEnv st nodeRef ports whereExpr executorCallVa
                 { circuitTaskNodeRef = nodeRef
                 , circuitTaskNodeLabel = defaultNodeLabel nodeRef label
                 , circuitTaskNodeMetadata =
-                    actMetadata
-                      nodeRef
-                      executor
-                      label
-                      instructionsText
-                      configValue
-                      tools
-                      (normalFormPorts normalForm)
-                      (lookupMaybeInt32Field "timeout" exactFields)
-                      (lookupMaybeInt32Field "retry" exactFields)
-                      (lookupMaybeInt32Field "stepBudget" exactFields)
-                      (lookupMaybeInt32Field "toolLoopMinSteps" exactFields)
-                      (lookupMaybeInt32Field "maxOutputTokens" exactFields)
-                      (lookupMaybeBoolField "reasoningEnabled" exactFields)
-                      memoryStrategy
+                    insertMetadataValue
+                      "argument"
+                      argumentValue
+                      ( actMetadata
+                          nodeRef
+                          executor
+                          label
+                          instructionsText
+                          configValue
+                          tools
+                          (normalFormPorts normalForm)
+                          (lookupMaybeInt32Field "timeout" exactFields)
+                          (lookupMaybeInt32Field "retry" exactFields)
+                          (lookupMaybeInt32Field "stepBudget" exactFields)
+                          (lookupMaybeInt32Field "toolLoopMinSteps" exactFields)
+                          (lookupMaybeInt32Field "maxOutputTokens" exactFields)
+                          (lookupMaybeBoolField "reasoningEnabled" exactFields)
+                          memoryStrategy
+                      )
                 }
   Right
     LoweredNode
@@ -3171,6 +3180,59 @@ executorConfigValue fields whereExpr inputExpr =
             ]
         Nothing ->
           KeyMap.singleton (Key.fromText "input") inputValue
+
+{- | Compatibility normalization for the legacy split config/input call. This
+creates the same one-record runtime boundary that the new syntax will target
+later, while leaving the legacy compiled config envelope untouched.
+-}
+normalizeLegacyExecutorArgument
+  :: Map (NonEmpty Text) EvalValue -> CorePureExpr -> CorePureExpr
+normalizeLegacyExecutorArgument fields inputExpr =
+  CorePureRecord (payloadField <> configFields)
+  where
+    payloadField =
+      case inputExpr of
+        CorePureLit CorePureNull -> []
+        _ -> [CorePureField ("payload" :| []) inputExpr]
+    configFields =
+      [ CorePureField ("cfg" :| NE.toList path) (aesonValueToCorePureExpr (evalValueToAeson value))
+      | (path, value) <- Map.toAscList fields
+      ]
+
+aesonValueToCorePureExpr :: Aeson.Value -> CorePureExpr
+aesonValueToCorePureExpr = \case
+  Aeson.Null -> CorePureLit CorePureNull
+  Aeson.Bool value -> CorePureLit (CorePureBool value)
+  Aeson.Number value -> CorePureLit (CorePureNumber value)
+  Aeson.String value -> CorePureLit (CorePureString value)
+  Aeson.Array values -> CorePureList (fmap aesonValueToCorePureExpr (Vector.toList values))
+  Aeson.Object object ->
+    CorePureRecord
+      [ CorePureField (Key.toText key :| []) (aesonValueToCorePureExpr value)
+      | (key, value) <- KeyMap.toList object
+      ]
+
+executorArgumentValue
+  :: [CorePureBinding]
+  -> Maybe CorePureExpr
+  -> CorePureExpr
+  -> Aeson.Value
+executorArgumentValue topLevelBindings whereExpr argumentExpr =
+  Aeson.Object $
+    insertMaybeJson
+      "where"
+      whereExpr
+      ( KeyMap.fromList $
+          (Key.fromText "value", Aeson.toJSON argumentExpr)
+            : [ (Key.fromText "bindings", Aeson.toJSON topLevelBindings)
+              | not (null topLevelBindings)
+              ]
+      )
+
+insertMetadataValue :: Text -> Aeson.Value -> Aeson.Value -> Aeson.Value
+insertMetadataValue key value = \case
+  Aeson.Object object -> Aeson.Object (KeyMap.insert (Key.fromText key) value object)
+  other -> other
 
 insertMaybeJson
   :: Aeson.ToJSON a => Text -> Maybe a -> KeyMap.KeyMap Aeson.Value -> KeyMap.KeyMap Aeson.Value

--- a/src/Cortex/Wire/Executor.hs
+++ b/src/Cortex/Wire/Executor.hs
@@ -19,8 +19,13 @@ module Cortex.Wire.Executor
   , wireExecutorIdFromWireExecutor
   , WireExecutorEffect (..)
   , WireExecutorConfigShape (..)
+  , WireExecutorArgumentShape (..)
+  , wireExecutorArgumentShapeFromConfigShape
+  , wireExecutorConfigShapeFromArgumentShape
   , WireExecutorPortPolicy (..)
   , WireExecutorProjection (..)
+  , wireExecutorProjectionArgumentShape
+  , wireExecutorProjectionWithArgumentShape
   , wireExecutorProjectionFromPorts
   , wireContractsFromPorts
   , WireExecutorRegistry (..)
@@ -69,6 +74,24 @@ data WireExecutorConfigShape
   | WireExecutorConfigSchema Aeson.Value
   deriving stock (Eq, Show, Generic)
 
+{- | Canonical one-record executor ingress shape. The config-named type remains
+as a compatibility view until the final Wire migration.
+-}
+data WireExecutorArgumentShape
+  = WireExecutorArgumentUnchecked
+  | WireExecutorArgumentSchema Aeson.Value
+  deriving stock (Eq, Show, Generic)
+
+wireExecutorArgumentShapeFromConfigShape :: WireExecutorConfigShape -> WireExecutorArgumentShape
+wireExecutorArgumentShapeFromConfigShape = \case
+  WireExecutorConfigUnchecked -> WireExecutorArgumentUnchecked
+  WireExecutorConfigSchema schema -> WireExecutorArgumentSchema schema
+
+wireExecutorConfigShapeFromArgumentShape :: WireExecutorArgumentShape -> WireExecutorConfigShape
+wireExecutorConfigShapeFromArgumentShape = \case
+  WireExecutorArgumentUnchecked -> WireExecutorConfigUnchecked
+  WireExecutorArgumentSchema schema -> WireExecutorConfigSchema schema
+
 data WireExecutorPortPolicy
   = WireExecutorFixedPorts
   | WireExecutorAuthorDeclaredPorts
@@ -83,6 +106,20 @@ data WireExecutorProjection = WireExecutorProjection
   , wireExecutorProjectionPortPolicy :: !WireExecutorPortPolicy
   }
   deriving stock (Eq, Show, Generic)
+
+{- | Canonical argument-facing view of a projection. It is computed from the
+retained config field so existing record construction remains source-compatible.
+-}
+wireExecutorProjectionArgumentShape :: WireExecutorProjection -> WireExecutorArgumentShape
+wireExecutorProjectionArgumentShape =
+  wireExecutorArgumentShapeFromConfigShape . wireExecutorProjectionConfigShape
+
+wireExecutorProjectionWithArgumentShape
+  :: WireExecutorArgumentShape -> WireExecutorProjection -> WireExecutorProjection
+wireExecutorProjectionWithArgumentShape shape projection =
+  projection
+    { wireExecutorProjectionConfigShape = wireExecutorConfigShapeFromArgumentShape shape
+    }
 
 wireExecutorProjectionFromPorts
   :: WireExecutorId

--- a/src/Cortex/Wire/Package/Manifest.hs
+++ b/src/Cortex/Wire/Package/Manifest.hs
@@ -45,11 +45,13 @@ import Cortex.Wire.AST
   )
 import Cortex.Wire.Contract (WireContractSpec (..))
 import Cortex.Wire.Executor
-  ( WireExecutorConfigShape (..)
+  ( WireExecutorArgumentShape (..)
+  , WireExecutorConfigShape (..)
   , WireExecutorEffect (..)
   , WireExecutorId (..)
   , WireExecutorPortPolicy (..)
   , WireExecutorProjection (..)
+  , wireExecutorConfigShapeFromArgumentShape
   )
 import Cortex.Wire.NativePure.Shape (NativeShapeProjection)
 import Cortex.Wire.Package (NamespaceEntry (..), WirePackage (..))
@@ -208,12 +210,27 @@ instance Toml.FromValue WireExecutorProjection where
   fromValue = Toml.parseTableFromValue $ do
     rawId <- Toml.reqKey "id"
     rawVocabulary <- optionalList "vocabulary"
-    WireExecutorProjection (WireExecutorId rawId)
-      <$> optionalValue "ports" emptyPorts
-      <*> pure (Set.fromList rawVocabulary)
-      <*> Toml.reqKey "effect"
-      <*> optionalValue "config_shape" WireExecutorConfigUnchecked
-      <*> optionalValue "port_policy" WireExecutorFixedPorts
+    ports <- optionalValue "ports" emptyPorts
+    effect <- Toml.reqKey "effect"
+    legacyShape <- Toml.optKey "config_shape"
+    argumentShape <- Toml.optKey "argument_shape"
+    storedShape <-
+      case (legacyShape, argumentShape) of
+        (Just _legacy, Just _argument) ->
+          fail "executor manifest cannot define both config_shape and argument_shape"
+        (Just legacy, Nothing) -> pure legacy
+        (Nothing, Just argument) -> pure (wireExecutorConfigShapeFromArgumentShape argument)
+        (Nothing, Nothing) -> pure WireExecutorConfigUnchecked
+    portPolicy <- optionalValue "port_policy" WireExecutorFixedPorts
+    pure
+      WireExecutorProjection
+        { wireExecutorProjectionId = WireExecutorId rawId
+        , wireExecutorProjectionPorts = ports
+        , wireExecutorProjectionVocabulary = Set.fromList rawVocabulary
+        , wireExecutorProjectionEffect = effect
+        , wireExecutorProjectionConfigShape = storedShape
+        , wireExecutorProjectionPortPolicy = portPolicy
+        }
 
 newtype TomlNativeShape = TomlNativeShape
   { unTomlNativeShape :: NativeShapeProjection
@@ -268,6 +285,19 @@ instance Toml.FromValue WireExecutorConfigShape where
       parseSchema =
         Toml.parseTableFromValue $
           WireExecutorConfigSchema . unTomlJsonValue <$> Toml.reqKey "schema"
+
+instance Toml.FromValue WireExecutorArgumentShape where
+  fromValue rawValue = parseUnchecked rawValue <|> parseSchema rawValue
+    where
+      parseUnchecked value = do
+        raw <- Toml.fromValue value
+        case T.toCaseFold (T.strip raw) of
+          "unchecked" -> pure WireExecutorArgumentUnchecked
+          other -> fail ("unknown Wire executor argument shape: " <> T.unpack other)
+
+      parseSchema =
+        Toml.parseTableFromValue $
+          WireExecutorArgumentSchema . unTomlJsonValue <$> Toml.reqKey "schema"
 
 instance Toml.FromValue WirePorts where
   fromValue =

--- a/src/Cortex/Wire/Pure.hs
+++ b/src/Cortex/Wire/Pure.hs
@@ -21,6 +21,7 @@ module Cortex.Wire.Pure
   , PreparedPureTask
   , renderPureEvalError
   , validatePurePorts
+  , validateCorePureExpr
   , validatePureTaskConfig
   , validatePureVariantTaskConfig
   , preparePureTaskOutputs
@@ -30,17 +31,21 @@ module Cortex.Wire.Pure
   , evaluatePureTaskOutputs
   , evaluatePureTaskVariant
   , evaluatePreparedPureTaskOutputs
+  , WireExecutorArgumentSpec (..)
+  , wireExecutorArgumentSpecFromMetadata
+  , evaluateWireExecutorArgument
   , corePureBuiltinSignature
   , corePureBuiltinAuthorityReport
   , corePureBuiltinAuthorityFree
   , pureWireExecutorId
   , pureWireExecutorProjection
   , pureExecutorConfigSchema
+  , pureExecutorArgumentSchema
   , canonicalJson
   )
 where
 
-import Control.Monad (foldM, (>=>))
+import Control.Monad (foldM, unless, (>=>))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KeyMap
@@ -555,13 +560,33 @@ bindPreparedPureInputValues
   -> [PreparedPureInput]
   -> WireInputBundle
   -> Either PureEvalError (Map Text value)
-bindPreparedPureInputValues wrapValue preparedInputs inputBundle =
+bindPreparedPureInputValues =
+  bindPreparedInputValuesWith wireValueJson
+
+{- | Executor ingress accepts every payload carrier already validated by the
+Wire boundary. The JSON-only restriction remains specific to pure nodes.
+-}
+bindPreparedExecutorInputValues
+  :: (Aeson.Value -> value)
+  -> [PreparedPureInput]
+  -> WireInputBundle
+  -> Either PureEvalError (Map Text value)
+bindPreparedExecutorInputValues =
+  bindPreparedInputValuesWith (\_portName wireValue -> Right wireValue.wireValueValue)
+
+bindPreparedInputValuesWith
+  :: (Text -> WireValue -> Either PureEvalError Aeson.Value)
+  -> (Aeson.Value -> value)
+  -> [PreparedPureInput]
+  -> WireInputBundle
+  -> Either PureEvalError (Map Text value)
+bindPreparedInputValuesWith extractValue wrapValue preparedInputs inputBundle =
   Map.fromList <$> traverse bindInputPort preparedInputs
   where
     bindInputPort preparedInput = do
       let portName = preparedInput.preparedPureInputPortName
       wireValue <- singleMatchedValue preparedInput
-      value <- wireValueJson portName wireValue
+      value <- extractValue portName wireValue
       Right (portName, wrapValue value)
 
     singleMatchedValue preparedInput =
@@ -643,6 +668,80 @@ evaluateVariantResult labels env = \case
         payload <- evaluateCorePureExpr env payloadExpr >>= corePureValueToJson
         pure (label, payload)
   _ -> Left (PureVariantConstructorExpected labels)
+
+{- | Runtime-evaluated executor argument plus every lexical scope required to
+evaluate it after compilation.
+-}
+data WireExecutorArgumentSpec = WireExecutorArgumentSpec
+  { wireExecutorArgumentExpr :: !CorePureExpr
+  , wireExecutorArgumentBindings :: ![CorePureBinding]
+  , wireExecutorArgumentWhere :: !(Maybe CorePureExpr)
+  }
+  deriving stock (Eq, Show)
+
+wireExecutorArgumentSpecFromMetadata :: Aeson.Value -> Either Text WireExecutorArgumentSpec
+wireExecutorArgumentSpecFromMetadata metadataValue = do
+  metadataObject <- expectObject "executor task metadata" metadataValue
+  argumentValue <-
+    maybe
+      (Left "executor task metadata is missing the argument envelope")
+      Right
+      (KeyMap.lookup "argument" metadataObject)
+  argumentObject <- expectObject "executor argument envelope" argumentValue
+  let unknownKeys =
+        [ keyText
+        | key <- KeyMap.keys argumentObject
+        , let keyText = Key.toText key
+        , keyText `notElem` ["value", "bindings", "where"]
+        ]
+  unless (null unknownKeys) $
+    Left ("unsupported executor argument envelope fields: " <> T.intercalate ", " unknownKeys)
+  exprValue <-
+    maybe
+      (Left "executor argument envelope is missing the value field")
+      Right
+      (KeyMap.lookup "value" argumentObject)
+  argumentExpr <- decodeEnvelopeField "executor argument value" exprValue
+  bindings <-
+    maybe
+      (Right [])
+      (decodeEnvelopeField "executor argument bindings")
+      (KeyMap.lookup "bindings" argumentObject)
+  whereExpr <-
+    traverse
+      (decodeEnvelopeField "executor argument where")
+      (KeyMap.lookup "where" argumentObject)
+  Right
+    WireExecutorArgumentSpec
+      { wireExecutorArgumentExpr = argumentExpr
+      , wireExecutorArgumentBindings = bindings
+      , wireExecutorArgumentWhere = whereExpr
+      }
+  where
+    expectObject label = \case
+      Aeson.Object object -> Right object
+      _ -> Left (label <> " must be a JSON object")
+    decodeEnvelopeField :: Aeson.FromJSON a => Text -> Aeson.Value -> Either Text a
+    decodeEnvelopeField label value =
+      case Aeson.fromJSON value of
+        Aeson.Success decoded -> Right decoded
+        Aeson.Error err -> Left (label <> ": " <> T.pack err)
+
+-- | Evaluate normalized argument data at node ingress, after port values exist.
+evaluateWireExecutorArgument
+  :: WirePorts
+  -> WireExecutorArgumentSpec
+  -> WireInputBundle
+  -> Either PureEvalError Aeson.Value
+evaluateWireExecutorArgument ports spec inputBundle = do
+  preparedInputs <- preparePureInputs ports
+  inputEnv <- bindPreparedExecutorInputValues CorePureJson preparedInputs inputBundle
+  outerEnv <-
+    bindCorePureBindings
+      (corePureEnvFromInputValues inputEnv)
+      spec.wireExecutorArgumentBindings
+  env <- bindCorePureWhere outerEnv spec.wireExecutorArgumentWhere
+  evaluateCorePureExpr env spec.wireExecutorArgumentExpr >>= corePureValueToJson
 
 evaluatePreparedPureTaskOutputs
   :: PreparedPureTask
@@ -2401,3 +2500,7 @@ pureExecutorConfigSchema =
                 ]
           ]
     ]
+
+-- | Canonical name for the retained pure executor schema.
+pureExecutorArgumentSchema :: Aeson.Value
+pureExecutorArgumentSchema = pureExecutorConfigSchema

--- a/src/Cortex/Wire/Runtime.hs
+++ b/src/Cortex/Wire/Runtime.hs
@@ -20,6 +20,8 @@ module Cortex.Wire.Runtime
   , wrapWireStageOutputs
   , wrapWireStageResult
   , wrapWireStageDefinition
+  , wrapWireStageDefinitionWithArgument
+  , validateWireExecutorArgument
   )
 where
 
@@ -34,11 +36,17 @@ import Data.UUID (UUID)
 
 import Cortex.Pulse.Node (NodeId (..))
 import Cortex.Pulse.Plan
-  ( StageContext (..)
+  ( StageAction
+  , StageContext (..)
   , StageDefinition (..)
   , StageResult (..)
   )
 import Cortex.Wire.Contract (WireContractRegistry)
+import Cortex.Wire.ContractValidation
+  ( renderWireContractValidationError
+  , validateJsonValueAgainstSchema
+  )
+import Cortex.Wire.Executor (WireExecutorArgumentShape (..))
 import Cortex.Wire.NodeBoundary
   ( BoundaryEgressContext (..)
   , wrapNodeBoundaryOutput
@@ -147,6 +155,56 @@ wrapWireStageDefinition maybeRegistry ports stageDef =
           -- failure (ADR 0062), not an untyped stage exception.
           Left errText -> pure (StageFail "executor_output_validation_failure" errText)
     }
+
+{- | Additive one-record executor boundary. Unlike the legacy wrapper above,
+this evaluates argument data at ingress, validates it, and gives the exact
+validated record to the host binding before applying the common egress path.
+-}
+wrapWireStageDefinitionWithArgument
+  :: Maybe WireContractRegistry
+  -> WireExecutorArgumentShape
+  -> (WireInputBundle -> Either Text Aeson.Value)
+  -> WirePorts
+  -> (Aeson.Value -> StageAction NodeId)
+  -> StageDefinition NodeId
+  -> StageDefinition NodeId
+wrapWireStageDefinitionWithArgument maybeRegistry argumentShape evaluateArgument ports bindingAction stageDef =
+  stageDef
+    { sdAction = \ctx -> do
+        let inputBundle = wireInputBundleFromStageInputs ctx.scInputs
+        case evaluateArgument inputBundle >>= validateWireExecutorArgument argumentShape of
+          Left errText ->
+            pure (StageFail "executor_argument_validation_failure" errText)
+          Right validatedArgument -> do
+            let unwrappedCtx =
+                  ctx
+                    { scInputs = inputBundle.wireInputBundleUnwrappedInputs
+                    }
+            stageResult <- bindingAction validatedArgument unwrappedCtx
+            case wrapWireStageResult maybeRegistry ctx.scNodeId ctx.scRunId ports stageResult of
+              Right wrappedResult -> pure wrappedResult
+              Left errText -> pure (StageFail "executor_output_validation_failure" errText)
+    }
+
+{- | Validate and return the same normalized record that will be delivered to
+the binding. No post-evaluation wrapping or rebuilding occurs here.
+-}
+validateWireExecutorArgument
+  :: WireExecutorArgumentShape -> Aeson.Value -> Either Text Aeson.Value
+validateWireExecutorArgument shape argument = do
+  case argument of
+    Aeson.Object _ -> Right ()
+    _ -> Left "Wire executor argument must be a normalized JSON object"
+  case shape of
+    WireExecutorArgumentUnchecked -> Right argument
+    WireExecutorArgumentSchema schema ->
+      case validateJsonValueAgainstSchema "executor argument" schema argument of
+        Right () -> Right argument
+        Left validationError ->
+          Left
+            ( "Wire executor argument validation: "
+                <> renderWireContractValidationError validationError
+            )
 
 wrapWireStageResult
   :: Maybe WireContractRegistry

--- a/test/Cortex/Capability/CatalogSpec.hs
+++ b/test/Cortex/Capability/CatalogSpec.hs
@@ -12,6 +12,7 @@ determinism, and the runtime binding record.
 module Cortex.Capability.CatalogSpec (spec) where
 
 import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.ByteString.Lazy (ByteString)
 import Test.Hspec
 
@@ -76,6 +77,19 @@ spec = do
       roundTrips SubmitParkResume
       roundTrips IdempotentWithKey
       roundTrips SubprocessSandbox
+    it "retains v1 config projections while emitting v2 argument projections" $ do
+      let v2Projection =
+            admissionProjectionWithArgumentShapeRef
+              (ArgumentShapeName "braket-argument")
+              sampleProjection
+      roundTrips v2Projection
+      apProjectionVersion v2Projection `shouldBe` currentProjectionVersion
+      apArgumentShapeRef v2Projection `shouldBe` ArgumentShapeName "braket-argument"
+      case Aeson.toJSON v2Projection of
+        Aeson.Object object -> do
+          KeyMap.member "argumentShapeRef" object `shouldBe` True
+          KeyMap.member "configSchemaRef" object `shouldBe` False
+        other -> expectationFailure ("expected projection object, got " <> show other)
 
   describe "admissionProjectionDigest" $ do
     it "is deterministic for the same projection" $

--- a/test/Cortex/Wire/CompileSpec.hs
+++ b/test/Cortex/Wire/CompileSpec.hs
@@ -16,6 +16,7 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Foldable qualified as Foldable
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map.Strict qualified as Map
 import Data.Maybe (isJust, mapMaybe)
 import Data.Scientific (Scientific, floatingOrInteger)
@@ -120,7 +121,11 @@ import Cortex.Wire.LeanFixture
   , renderEmittedUmbrellaModule
   , renderFixtureModuleText
   )
-import Cortex.Wire.Pure (pureWireExecutorProjection)
+import Cortex.Wire.Pure
+  ( WireExecutorArgumentSpec (..)
+  , pureWireExecutorProjection
+  , wireExecutorArgumentSpecFromMetadata
+  )
 import Cortex.Wire.Std
   ( stdIoReadFileShapeMessage
   , stdIoStdoutShapeMessage
@@ -3170,8 +3175,20 @@ spec = describe "Cortex.Wire.Compile" $ do
   it "compiles a configured executor value applied in a node body" $ do
     compiled <- requireRight (compileWireText configuredExecutorSourceText)
     case Map.lookup (CircuitNodeRef "analyst") compiled.compiledCircuitNodes of
-      Just (CompiledCircuitTask taskNode) ->
+      Just (CompiledCircuitTask taskNode) -> do
         taskNode.circuitTaskNodeMetadata `shouldSatisfy` metadataConfigHasNumber "temperature" 0.2
+        case wireExecutorArgumentSpecFromMetadata taskNode.circuitTaskNodeMetadata of
+          Left err -> expectationFailure ("normalized argument did not decode: " <> T.unpack err)
+          Right argumentSpec -> do
+            argumentSpec.wireExecutorArgumentExpr
+              `shouldBe` Syntax.CorePureRecord
+                [ Syntax.CorePureField
+                    ("payload" :| [])
+                    (Syntax.CorePureIdent "plan")
+                , Syntax.CorePureField
+                    ("cfg" :| ["temperature"])
+                    (Syntax.CorePureLit (Syntax.CorePureNumber 0.2))
+                ]
       other ->
         expectationFailure ("expected task node, got: " <> show other)
 
@@ -3201,8 +3218,13 @@ spec = describe "Cortex.Wire.Compile" $ do
   it "evaluates top-level pure-data lets in executor config" $ do
     compiled <- requireRight (compileWireText topLevelLetConfigSourceText)
     case Map.lookup (CircuitNodeRef "analyst") compiled.compiledCircuitNodes of
-      Just (CompiledCircuitTask taskNode) ->
+      Just (CompiledCircuitTask taskNode) -> do
         taskNode.circuitTaskNodeMetadata `shouldSatisfy` metadataHasInstructions "Audit now"
+        case wireExecutorArgumentSpecFromMetadata taskNode.circuitTaskNodeMetadata of
+          Left err -> expectationFailure ("normalized argument did not decode: " <> T.unpack err)
+          Right argumentSpec ->
+            fmap Syntax.corePureBindingName argumentSpec.wireExecutorArgumentBindings
+              `shouldContain` ["analyst_instructions"]
       other ->
         expectationFailure ("expected task node, got: " <> show other)
 

--- a/test/Cortex/Wire/NativePureAdmissionSpec.hs
+++ b/test/Cortex/Wire/NativePureAdmissionSpec.hs
@@ -5,6 +5,9 @@ Copyright   : (c) 2026 Digimuoto Oy
 License     : Apache-2.0
 Maintainer  : julius.koskela@digimuoto.com
 Stability   : experimental
+
+These specs pin the ephemeral admission model used before normalized artifacts
+and maximal fusion are introduced by later NativePure epic slices.
 -}
 module Cortex.Wire.NativePureAdmissionSpec (spec) where
 

--- a/test/Cortex/Wire/PackageSpec.hs
+++ b/test/Cortex/Wire/PackageSpec.hs
@@ -26,9 +26,11 @@ import Cortex.Wire
   , NativeShapeProjection (..)
   , WireContractRegistry
   , WireContractSpec (..)
+  , WireExecutorArgumentShape (..)
   , WireOutputPort (..)
   , WirePorts (..)
   , wireContractRegistryFromList
+  , wireExecutorProjectionArgumentShape
   , wrapWireStageOutput
   )
 import Cortex.Wire.Contract (WireCompileEnv (..), emptyWireCompileEnv)
@@ -212,6 +214,32 @@ spec = do
         Left err -> expectationFailure (T.unpack (renderWirePackageManifestError err))
         Right package ->
           packageConflicts [package] `shouldContain` [DuplicateModulePath "example/helpers.wire"]
+
+  describe "compatible executor shape manifests" $ do
+    let manifest shapeField =
+          "[package]\nid = \"shape-test\"\n[[executor]]\nid = \"review\"\neffect = \"model\"\n"
+            <> shapeField
+            <> "\n"
+        decodedShape shapeField = do
+          package <- decodeWirePackageManifest "cortex.toml" (manifest shapeField)
+          case package.wpExecutorProjections of
+            [projection] -> Right (wireExecutorProjectionArgumentShape projection)
+            _ -> Left (error "expected one executor projection")
+
+    it "dual-reads legacy config_shape and canonical argument_shape" $ do
+      decodedShape "config_shape = \"unchecked\""
+        `shouldBe` Right WireExecutorArgumentUnchecked
+      decodedShape "argument_shape = \"unchecked\""
+        `shouldBe` Right WireExecutorArgumentUnchecked
+
+    it "rejects conflicting legacy and canonical shape keys" $
+      case decodeWirePackageManifest
+        "cortex.toml"
+        (manifest "config_shape = \"unchecked\"\nargument_shape = \"unchecked\"") of
+        Left err ->
+          renderWirePackageManifestError err
+            `shouldSatisfy` T.isInfixOf "both config_shape and argument_shape"
+        Right _ -> expectationFailure "conflicting executor shape keys unexpectedly decoded"
 
   describe "native contract shape manifests" $ do
     it "decodes scalar and bounded native_shape projections" $ do

--- a/test/Cortex/Wire/RuntimeSpec.hs
+++ b/test/Cortex/Wire/RuntimeSpec.hs
@@ -12,17 +12,128 @@ node-boundary normal-form module, but these tests intentionally assert only publ
 module Cortex.Wire.RuntimeSpec (spec) where
 
 import Data.Aeson qualified as Aeson
+import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.UUID qualified as UUID
 import Test.Hspec
 
+import Cortex.Pulse.Memory (defaultMemoryStrategy, discardMemoryHandle)
 import Cortex.Pulse.Node (NodeId (..))
+import Cortex.Pulse.Plan
+  ( StageActionId (..)
+  , StageContext (..)
+  , StageDefinition (..)
+  , StageReplaySafety (..)
+  , StageResult (..)
+  , stageTemplateId
+  )
+import Cortex.Pulse.Rewrite (BudgetContext (..))
+import Cortex.Pulse.Types (defaultRewriteBudget)
 import Cortex.Wire
 
 spec :: Spec
 spec = describe "Cortex.Wire runtime egress" $ do
+  describe "compatible one-record executor argument boundary" $ do
+    let schema =
+          WireExecutorArgumentSchema $
+            Aeson.object
+              [ "type" Aeson..= ("object" :: Text)
+              , "required" Aeson..= ["payload" :: Text]
+              , "additionalProperties" Aeson..= False
+              , "properties"
+                  Aeson..= Aeson.object
+                    ["payload" Aeson..= Aeson.object ["type" Aeson..= ("string" :: Text)]]
+              ]
+
+    it "returns the evaluated record unchanged after schema validation" $ do
+      let argument = Aeson.object ["payload" Aeson..= ("hello" :: Text)]
+      validateWireExecutorArgument schema argument `shouldBe` Right argument
+
+    it "rejects non-record values even for unchecked projections" $
+      validateWireExecutorArgument WireExecutorArgumentUnchecked (Aeson.String "raw")
+        `shouldBeLeftContaining` "must be a normalized JSON object"
+
+    it "evaluates port, module-binding, and where values only at ingress" $ do
+      let bundle = wireInputBundleFromStageInputs topicStageInputs
+      evaluateWireExecutorArgument topicPorts topicArgumentSpec bundle
+        `shouldBe` Right
+          ( Aeson.object
+              [ "payload" Aeson..= ("hello" :: Text)
+              , "cfg" Aeson..= Aeson.object ["mode" Aeson..= ("safe" :: Text)]
+              , "tag" Aeson..= ("r-1" :: Text)
+              ]
+          )
+
+    it "passes non-JSON payload carriers through executor ingress unchanged" $ do
+      let bundle = wireInputBundleFromStageInputs textStageInputs
+      evaluateWireExecutorArgument textNodePorts textArgumentSpec bundle
+        `shouldBe` Right (Aeson.object ["payload" Aeson..= ("plain body" :: Text)])
+
+    it "round-trips the compiled argument envelope" $ do
+      let metadata =
+            Aeson.object
+              [ "argument"
+                  Aeson..= Aeson.object
+                    [ "value" Aeson..= topicArgumentSpec.wireExecutorArgumentExpr
+                    , "bindings" Aeson..= topicArgumentSpec.wireExecutorArgumentBindings
+                    , "where" Aeson..= topicArgumentSpec.wireExecutorArgumentWhere
+                    ]
+              ]
+      wireExecutorArgumentSpecFromMetadata metadata `shouldBe` Right topicArgumentSpec
+
+    it "delivers the validated record to the binding unchanged" $ do
+      received <- newIORef ([] :: [Aeson.Value])
+      let stageDef =
+            wrapWireStageDefinitionWithArgument
+              (Just topicRegistry)
+              schema
+              (const (Right expectedArgument))
+              topicNodePorts
+              ( \argument _ctx -> do
+                  modifyIORef' received (argument :)
+                  pure (StageComplete (Aeson.object ["score" Aeson..= (1 :: Int)]))
+              )
+              baseTopicStageDefinition
+          expectedArgument = Aeson.object ["payload" Aeson..= ("hello" :: Text)]
+      result <- stageDef.sdAction topicStageContext
+      case result of
+        StageComplete _value -> pure ()
+        other -> expectationFailure ("expected StageComplete, got " <> showStageResult other)
+      readIORef received `shouldReturn` [expectedArgument]
+
+    it "blocks host invocation when ingress validation fails" $ do
+      invoked <- newIORef (0 :: Int)
+      let rejectingSchema =
+            WireExecutorArgumentSchema $
+              Aeson.object
+                [ "type" Aeson..= ("object" :: Text)
+                , "required" Aeson..= ["payload" :: Text]
+                , "properties"
+                    Aeson..= Aeson.object
+                      ["payload" Aeson..= Aeson.object ["type" Aeson..= ("integer" :: Text)]]
+                ]
+          stageDef =
+            wrapWireStageDefinitionWithArgument
+              (Just topicRegistry)
+              rejectingSchema
+              topicArgumentEvaluator
+              topicNodePorts
+              ( \_argument _ctx -> do
+                  modifyIORef' invoked (+ 1)
+                  pure (StageComplete (Aeson.object ["score" Aeson..= (1 :: Int)]))
+              )
+              baseTopicStageDefinition
+      result <- stageDef.sdAction topicStageContext
+      case result of
+        StageFail errType message -> do
+          errType `shouldBe` "executor_argument_validation_failure"
+          message `shouldSatisfy` T.isInfixOf "expected integer at $.payload"
+        other -> expectationFailure ("expected StageFail, got " <> showStageResult other)
+      readIORef invoked `shouldReturn` 0
+
   it "wraps raw single-output JSON through the declared output port" $ do
     result <-
       requireRight $
@@ -235,6 +346,156 @@ spec = describe "Cortex.Wire runtime egress" $ do
                 }
       wrapWireStageOutput (Just scoreRegistry) producer runId mixedVariantPorts emitted
         `shouldBeLeftContaining` "must not mix an exclusive output group with ordinary outputs"
+
+topicNodePorts :: WirePorts
+topicNodePorts =
+  WirePorts
+    { wirePortsInputs = Map.singleton "topic" topicInputPort
+    , wirePortsOutputs = Map.singleton "score" (WireOutputPort "Score" Nothing)
+    }
+
+topicPorts :: WirePorts
+topicPorts = topicNodePorts {wirePortsOutputs = Map.empty}
+
+topicInputPort :: WireInputPort
+topicInputPort =
+  WireInputPort
+    { wireInputPortAccepts = ["Topic"]
+    , wireInputPortCardinality = WireInputCardinalityOne
+    , wireInputPortRequired = True
+    }
+
+topicArgumentSpec :: WireExecutorArgumentSpec
+topicArgumentSpec =
+  WireExecutorArgumentSpec
+    { wireExecutorArgumentExpr =
+        CorePureRecord
+          [ CorePureField ("payload" :| []) (CorePureIdent "topic")
+          , CorePureField ("cfg" :| []) (CorePureIdent "base")
+          , CorePureField ("tag" :| []) (CorePureIdent "run_tag")
+          ]
+    , wireExecutorArgumentBindings =
+        [ CorePureBinding
+            "base"
+            (CorePureRecord [CorePureField ("mode" :| []) (CorePureLit (CorePureString "safe"))])
+        ]
+    , wireExecutorArgumentWhere =
+        Just
+          (CorePureRecord [CorePureField ("run_tag" :| []) (CorePureLit (CorePureString "r-1"))])
+    }
+
+topicArgumentEvaluator :: WireInputBundle -> Either Text Aeson.Value
+topicArgumentEvaluator bundle =
+  case evaluateWireExecutorArgument topicNodePorts topicArgumentSpec bundle of
+    Left evalError -> Left (renderPureEvalError evalError)
+    Right value -> Right value
+
+topicStageInputs :: Map.Map NodeId Aeson.Value
+topicStageInputs =
+  Map.singleton
+    (NodeId "source")
+    ( Aeson.toJSON $
+        (mkWireValue "Topic" WirePayloadJson (Just "source") (Aeson.String "hello"))
+          { wireValuePort = Just "topic"
+          }
+    )
+
+textNodePorts :: WirePorts
+textNodePorts =
+  WirePorts
+    { wirePortsInputs =
+        Map.singleton
+          "message"
+          WireInputPort
+            { wireInputPortAccepts = ["Message"]
+            , wireInputPortCardinality = WireInputCardinalityOne
+            , wireInputPortRequired = True
+            }
+    , wirePortsOutputs = Map.empty
+    }
+
+textArgumentSpec :: WireExecutorArgumentSpec
+textArgumentSpec =
+  WireExecutorArgumentSpec
+    { wireExecutorArgumentExpr =
+        CorePureRecord [CorePureField ("payload" :| []) (CorePureIdent "message")]
+    , wireExecutorArgumentBindings = []
+    , wireExecutorArgumentWhere = Nothing
+    }
+
+textStageInputs :: Map.Map NodeId Aeson.Value
+textStageInputs =
+  Map.singleton
+    (NodeId "source")
+    ( Aeson.toJSON $
+        (mkWireValue "Message" WirePayloadText (Just "source") (Aeson.String "plain body"))
+          { wireValuePort = Just "message"
+          }
+    )
+
+topicStageContext :: StageContext
+topicStageContext =
+  StageContext
+    { scRunId = UUID.fromWords 0 0 0 0
+    , scNodeId = NodeId "score"
+    , scInputs = topicStageInputs
+    , scAttempt = 1
+    , scBudgetContext =
+        BudgetContext
+          { bcInitialBudget = defaultRewriteBudget
+          , bcRemainingBudget = defaultRewriteBudget
+          }
+    , scRewriteRejection = Nothing
+    , scRetryFailure = Nothing
+    , scMemory = discardMemoryHandle
+    , scMemoryStrategy = defaultMemoryStrategy
+    }
+
+baseTopicStageDefinition :: StageDefinition NodeId
+baseTopicStageDefinition =
+  StageDefinition
+    { sdStageId = NodeId "score"
+    , sdTemplateId = stageTemplateId (NodeId "score")
+    , sdActionId = StageActionId "wire.test.topic-score"
+    , sdReplaySafety = SafeToReplay
+    , sdReplayPolicyOverride = Nothing
+    , sdTimeoutSeconds = Nothing
+    , sdRetryPolicy = Nothing
+    , sdAction = \_ctx -> pure (StageFail "unbound" "base action must be superseded")
+    , sdMemoryStrategy = defaultMemoryStrategy
+    }
+
+topicRegistry :: WireContractRegistry
+topicRegistry =
+  wireContractRegistryFromList
+    [ WireContractSpec
+        { wireContractSpecId = "Topic"
+        , wireContractSpecPayloadKind = WirePayloadJson
+        , wireContractSpecDescription = "Topic payload."
+        , wireContractSpecRecordFields = Nothing
+        , wireContractSpecSchema = Nothing
+        , wireContractSpecNativeShape = Nothing
+        , wireContractSpecExamples = []
+        }
+    , WireContractSpec
+        { wireContractSpecId = "Score"
+        , wireContractSpecPayloadKind = WirePayloadJson
+        , wireContractSpecDescription = "Score payload."
+        , wireContractSpecRecordFields = Nothing
+        , wireContractSpecSchema = Nothing
+        , wireContractSpecNativeShape = Nothing
+        , wireContractSpecExamples = []
+        }
+    ]
+
+showStageResult :: StageResult NodeId -> String
+showStageResult = \case
+  StageComplete {} -> "StageComplete"
+  StageSuspend {} -> "StageSuspend"
+  StageRewrite {} -> "StageRewrite"
+  StageLoopStep {} -> "StageLoopStep"
+  StageRejectRewrite {} -> "StageRejectRewrite"
+  StageFail {} -> "StageFail"
 
 producer :: NodeId
 producer = NodeId "classifier"


### PR DESCRIPTION
## Epic slice

Focused PR 06 of #383. Targets the NativePure epic branch; it does not target `main`.

## What this adds

- canonical one-record executor argument shapes and capability/projection adapters
- dual-read `config_shape` / `argument_shape` manifests, with conflicting keys rejected
- v1 admission projection compatibility plus v2 `argumentShapeRef`
- dual-written compiled executor metadata: unchanged legacy `config` plus normalized `argument`
- ingress evaluation over consumed ports, module CorePure bindings, and node `where`
- pre-invocation schema validation and exact validated-record delivery
- payload-kind separation: executor ingress accepts every already-validated Wire carrier while pure-node evaluation remains JSON-only
- ADR 0095 in proposed/partial status, explicitly separating static node metadata from runtime argument data

All legacy authored syntax, configured-executor values, config-facing APIs, host wrappers, and compiled metadata remain supported. No grammar change is included.

## Validation

- full Haskell suite: 1,250 examples, 0 failures (164 DB-dependent pending)
- focused runtime boundary: 7 examples, 0 failures
- focused manifest, compiled-envelope, and projection compatibility tests: green
- HLint: no hints
- formatter and commit hooks: green
- docs lint: 217 artifacts
- docs site build: green
- signed and signed-off provenance: green

## Epic checklist

- [x] PR 06 compatible one-record executor substrate
- [ ] Full epic checkpoint after merge
- [ ] PR 14 compatible authoring surface
- [ ] PR 15 final breaking removal

Refs #382. Supersedes the corresponding substrate hunks in donor #378.