### PR TITLE
feat(wire): lower NativePure regions to C

### DIFF
--- a/docs/ADRs/0096-certified-native-pure-region-compilation.md
+++ b/docs/ADRs/0096-certified-native-pure-region-compilation.md
@@ -41,8 +41,14 @@ module representation. A separate validated C11 translation-unit model now deriv
 source, header, export inventory, layout/resource manifest, and static assertions from one
 structured representation. The production StaticC v1 backend now constructs that representation
 directly; a whitespace-only compatibility layout preserves its published source and header bytes
-without admitting raw C tokens. This is not yet the NativePure execution profile: artifact decoding
-in Lean, concrete region/frame lowering, v2 scheduling, and target gates remain later epic slices.
+without admitting raw C tokens. The concrete NativePure slice now consumes that shared semantic IR,
+constructs fixed input/output/checkpoint frames, emits explicit aggregate padding and typed
+tagged-sum payload unions, propagates checked-i64 overflow through a status result, and derives C,
+headers, exports, layouts, resource manifests, and static assertions from the validated C11 unit.
+Executable construction checks cover scalar and exclusive-sum kernels, and strict local host
+compilation confirms the emitted functions have no unresolved host, heap, worker, or Lean-runtime
+symbols. This is not yet the NativePure execution profile: normalized-plan decoding in Lean, v2
+scheduling, the hermetic target matrix, and three-way differential closure remain later epic slices.
 
 ## Context
 
@@ -170,9 +176,12 @@ worker registration, cancellation, deadline, and terminal-authority invariants r
   modules construct the production StaticC v1 translation unit while preserving its artifact bytes;
   `theory/Cortex/Wire/NativePure.lean` defines the source kernel, total lowering into that IR,
   structural/checked-i64 refinement, canonical-label discipline, padding-aware layouts, resource
-  evidence, and read/write-region well-formedness; and `theory/Cortex/Wire/StaticC.lean` lowers
-  topology-specialized readiness functions into the same semantic module. Binary64 is explicitly
-  excluded from certified refinement evidence.
+  evidence, and read/write-region well-formedness; `theory/Cortex/Wire/NativePure/C.lean` lowers the
+  shared semantic IR into concrete authority-free frame functions and validated C11 artifacts, while
+  `theory/Cortex/Wire/NativePure/C/Unit.lean` checks scalar, overflow, layout, and tagged-sum
+  construction; and `theory/Cortex/Wire/StaticC.lean` lowers topology-specialized readiness
+  functions into the same semantic module. Binary64 is explicitly excluded from certified refinement
+  evidence.
 
 ## Tracking
 
@@ -180,8 +189,9 @@ worker registration, cancellation, deadline, and terminal-authority invariants r
   admission, normalized realization artifacts, maximal fusion, and the Haskell plan validator are
   implemented)
 - Current executable evidence: `test/Cortex/Wire/NativeShapeSpec.hs`, the `native_shape` manifest
-  cases in `test/Cortex/Wire/PackageSpec.hs`, `test/Cortex/Wire/NativePureAdmissionSpec.hs`, and the
-  906-job Lean build containing `Cortex.Wire.NativePure`
-- Planned public surface: normalized-plan decoding in Lean, semantic-IR-to-C11 lowering, concrete
-  NativePure frames/functions, and additive v2 runtime/target interfaces
+  cases in `test/Cortex/Wire/PackageSpec.hs`, `test/Cortex/Wire/NativePureAdmissionSpec.hs`, the
+  Lean construction checks in `Cortex.Wire.NativePure.C.Unit`, and strict host compilation of the
+  emitted increment and tagged-classifier fixtures
+- Planned public surface: normalized-plan decoding in Lean, hermetic host/bare-target and
+  differential gates, and additive v2 runtime/target interfaces
 - Implementation tracker: GitHub issue #382 and the NativePure epic PR

--- a/test/fixtures/wire/native-pure-c/classify-harness.c
+++ b/test/fixtures/wire/native-pure-c/classify-harness.c
@@ -1,0 +1,18 @@
+#include "classify.h"
+
+#include <stdint.h>
+
+int main(void) {
+  classify_input input = {.field_0 = -7};
+  classify_output output = {0};
+  if (classify_run(&input, &output) != CORTEX_NP_OK ||
+      output.value.tag != 1 || output.value.payload.variant_1 != -7) {
+    return 1;
+  }
+  input.field_0 = 9;
+  if (classify_run(&input, &output) != CORTEX_NP_OK ||
+      output.value.tag != 0 || output.value.payload.variant_0 != 9) {
+    return 2;
+  }
+  return 0;
+}

--- a/test/fixtures/wire/native-pure-c/increment-harness.c
+++ b/test/fixtures/wire/native-pure-c/increment-harness.c
@@ -1,0 +1,17 @@
+#include "increment.h"
+
+#include <limits.h>
+#include <stdint.h>
+
+int main(void) {
+  increment_input input = {.field_0 = 41};
+  increment_output output = {0};
+  if (increment_run(&input, &output) != CORTEX_NP_OK || output.value != 42) {
+    return 1;
+  }
+  input.field_0 = INT64_MAX;
+  if (increment_run(&input, &output) != CORTEX_NP_ARITHMETIC_OVERFLOW) {
+    return 2;
+  }
+  return 0;
+}

--- a/theory/Cortex.lean
+++ b/theory/Cortex.lean
@@ -25,6 +25,8 @@ import Cortex.Wire.StaticCEmitter
 import Cortex.Wire.StaticCEmitter.Layout
 import Cortex.Wire.StaticCEmitter.Unit
 import Cortex.Wire.NativePure
+import Cortex.Wire.NativePure.C
+import Cortex.Wire.NativePure.C.Unit
 import Cortex.Wire.Registry
 import Cortex.Wire.Rewrite
 import Cortex.Wire.Admission

--- a/theory/Cortex/Wire/C11.lean
+++ b/theory/Cortex/Wire/C11.lean
@@ -90,6 +90,7 @@ inductive Expr where
   | parenthesized (value : Expr)
   | sizeof (ty : CType)
   | alignof (ty : CType)
+  | offsetof (ty : CType) (field : Name)
   deriving Repr
 
 structure Local where
@@ -146,6 +147,15 @@ structure StructDecl where
   emitTag : Bool := false
   deriving Repr
 
+/-- A fixed C union. NativePure tagged sums use this rather than a byte blob so
+the generated payload remains typed while retaining max-variant layout. -/
+structure UnionDecl where
+  name : Name
+  fields : List Field
+  visibility : Visibility := .internal
+  emitTag : Bool := false
+  deriving Repr
+
 structure EnumMember where
   name : Name
   value : Int
@@ -177,6 +187,7 @@ inductive TypeDecl where
   | functionAlias (declaration : FunctionTypedef)
   | enumeration (declaration : EnumDecl)
   | structure (declaration : StructDecl)
+  | union (declaration : UnionDecl)
   deriving Repr
 
 inductive Initializer where
@@ -250,6 +261,7 @@ structure TranslationUnit where
   functionTypedefs : List FunctionTypedef := []
   enums : List EnumDecl := []
   structs : List StructDecl := []
+  unions : List UnionDecl := []
   globals : List Global := []
   functions : List CFunction := []
   assertions : List StaticAssert := []
@@ -312,6 +324,7 @@ private def exprValidFuel : Nat → Expr → Bool
       | .postIncrement value => valid value
       | .parenthesized value => valid value
       | .sizeof ty | .alignof ty => typeValid ty
+      | .offsetof ty field => typeValid ty && validIdentifier field
 
 private def exprValid (expression : Expr) : Bool :=
   exprValidFuel (reprStr expression).length expression
@@ -384,9 +397,10 @@ private def declaredNames (unit : TranslationUnit) : List Name :=
     | .alias declaration => declaration.name
     | .functionAlias declaration => declaration.name
     | .enumeration declaration => declaration.name
-    | .structure declaration => declaration.name) ++
+    | .structure declaration => declaration.name
+    | .union declaration => declaration.name) ++
   unit.typedefs.map (·.name) ++ unit.functionTypedefs.map (·.name) ++
-    unit.enums.map (·.name) ++ unit.structs.map (·.name) ++
+    unit.enums.map (·.name) ++ unit.structs.map (·.name) ++ unit.unions.map (·.name) ++
       unit.globals.map (·.name) ++ unit.functions.map (·.name)
 
 private def safeInclude (header : String) : Bool :=
@@ -415,6 +429,10 @@ def validate (unit : TranslationUnit) : Except String ValidatedTranslationUnit :
   if !unit.structs.all (fieldNamesValid ·.fields) then throw "invalid or duplicate struct field"
   if !unit.structs.all (fun declaration => declaration.fields.all (typeValid ·.ty)) then
     throw "invalid struct field type"
+  if !unit.unions.all (fieldNamesValid ·.fields) then throw "invalid or duplicate union field"
+  if !unit.unions.all (fun declaration =>
+      !declaration.fields.isEmpty && declaration.fields.all (typeValid ·.ty)) then
+    throw "invalid union field type"
   if !unit.enums.all (fun declaration =>
       !declaration.members.isEmpty &&
         declaration.members.all (validIdentifier ·.name) &&
@@ -464,6 +482,10 @@ def validate (unit : TranslationUnit) : Except String ValidatedTranslationUnit :
     | .structure declaration =>
         if !fieldNamesValid declaration.fields || !declaration.fields.all (typeValid ·.ty) then
           throw "invalid ordered struct declaration"
+    | .union declaration =>
+        if declaration.fields.isEmpty || !fieldNamesValid declaration.fields ||
+            !declaration.fields.all (typeValid ·.ty) then
+          throw "invalid ordered union declaration"
   if !unique (exportedNames unit) then throw "duplicate exported symbol"
   if !unit.layouts.all layoutValid then
     throw "invalid layout metadata"
@@ -643,7 +665,7 @@ private def exprPrecedence : Expr → Nat
   | .unary _ _ | .cast _ _ => 14
   | .ident _ | .signed _ | .unsigned _ | .bool _ | .string _ | .character _ | .null |
     .call _ _ | .field _ _ | .pointerField _ _ | .index _ _ | .postIncrement _ |
-    .parenthesized _ | .sizeof _ | .alignof _ => 15
+    .parenthesized _ | .sizeof _ | .alignof _ | .offsetof _ _ => 15
 
 private def renderExprFuel : Nat → Nat → Expr → String
   | 0, _, _ => ""
@@ -680,6 +702,8 @@ private def renderExprFuel : Nat → Nat → Expr → String
         | .parenthesized value => "(" ++ renderAt 0 value ++ ")"
         | .sizeof ty => "sizeof(" ++ renderDeclaration ty "" ++ ")"
         | .alignof ty => "_Alignof(" ++ renderDeclaration ty "" ++ ")"
+        | .offsetof ty field =>
+            "offsetof(" ++ renderDeclaration ty "" ++ ", " ++ field ++ ")"
       if precedence < parent then "(" ++ rendered ++ ")" else rendered
 
 def renderExpr (expression : Expr) : String :=
@@ -762,6 +786,12 @@ private def renderStruct (decl : StructDecl) : String :=
       "  " ++ renderDeclaration field.ty field.name ++ ";\n") ++
     "} " ++ decl.name ++ ";\n\n"
 
+private def renderUnion (decl : UnionDecl) : String :=
+  "typedef union" ++ (if decl.emitTag then " " ++ decl.name else "") ++ " {\n" ++
+    String.join (decl.fields.map fun field =>
+      "  " ++ renderDeclaration field.ty field.name ++ ";\n") ++
+    "} " ++ decl.name ++ ";\n\n"
+
 private def renderEnum (decl : EnumDecl) : String :=
   "typedef enum" ++ (if decl.emitTag then " " ++ decl.name else "") ++ " {\n" ++
     String.intercalate ",\n" (decl.members.map fun member =>
@@ -780,6 +810,7 @@ private def typeDeclVisibility : TypeDecl → Visibility
   | .functionAlias declaration => declaration.visibility
   | .enumeration declaration => declaration.visibility
   | .structure declaration => declaration.visibility
+  | .union declaration => declaration.visibility
 
 private def renderTypeDecl : TypeDecl → String
   | .define name value => "#define " ++ name ++ " " ++ renderExpr value ++ "\n\n"
@@ -787,6 +818,7 @@ private def renderTypeDecl : TypeDecl → String
   | .functionAlias declaration => renderFunctionTypedef declaration
   | .enumeration declaration => renderEnum declaration
   | .structure declaration => renderStruct declaration
+  | .union declaration => renderUnion declaration
 
 private def renderPrototype (function : CFunction) : String :=
   String.join (function.headerComments.map fun comment => "/* " ++ comment ++ " */\n") ++
@@ -834,7 +866,9 @@ private def renderTypeDecls (unit : TranslationUnit) (publicOnly : Bool) : Strin
       String.join ((unit.enums.filter fun declaration =>
         visible declaration.visibility).map renderEnum) ++
       String.join ((unit.structs.filter fun declaration =>
-        visible declaration.visibility).map renderStruct)
+        visible declaration.visibility).map renderStruct) ++
+      String.join ((unit.unions.filter fun declaration =>
+        visible declaration.visibility).map renderUnion)
   else
     String.join ((unit.orderedTypes.filter fun declaration =>
       visible (typeDeclVisibility declaration)).map renderTypeDecl)

--- a/theory/Cortex/Wire/NativePure.lean
+++ b/theory/Cortex/Wire/NativePure.lean
@@ -12,8 +12,10 @@ PureWire node yields one `CertifiedKernel`; cross-node fusion is deliberately
 deferred. Values are immutable. The only storage classification introduced
 after lowering is `read` for inputs and `write` for fresh outputs.
 
-The kernel lowers into the shared semantic C IR. The printable C AST remains a
-separate later layer outside this theorem boundary. `lower` is total and
+The kernel lowers into the shared semantic C IR. Concrete frame lowering and
+the printable C AST are separate layers outside this theorem boundary; the
+former consumes `CertifiedKernel.target`, not this source expression again.
+`lower` is total and
 `lower_refines` proves executable semantic preservation
 only for expressions carrying structural/checked-i64 basis evidence. Binary64
 values remain representable, but expressions containing them are explicitly

--- a/theory/Cortex/Wire/NativePure/C.lean
+++ b/theory/Cortex/Wire/NativePure/C.lean
@@ -1,0 +1,600 @@
+import Cortex.Wire.NativePure
+import Cortex.Wire.C11
+
+/-!
+## Concrete NativePure region lowering
+
+This is the concrete, authority-free lowering below the certified NativePure
+kernel and above the shared printable C11 layer.  It fixes every aggregate
+layout, inserts named padding, represents exclusive sums as a tag plus a typed
+payload union, and emits one total status-returning frame function.
+
+The scheduler is deliberately absent.  A generated function can read only its
+input frame and write only its output frame; checked operations return a typed
+failure status.  PR 12 may schedule these functions, but cannot give them a
+host context or worker authority because neither exists in this ABI.
+-/
+
+namespace Cortex.Wire.NativePure.C
+
+open Cortex.Wire.NativePure
+open Cortex.Wire.C11
+
+inductive Status where
+  | ok
+  | typeMismatch
+  | arithmeticOverflow
+  | bounds
+  | capacity
+  | invalidTag
+  deriving DecidableEq, Repr
+
+def Status.code : Status → Nat
+  | .ok => 0
+  | .typeMismatch => 1
+  | .arithmeticOverflow => 2
+  | .bounds => 3
+  | .capacity => 4
+  | .invalidTag => 5
+
+/-- C-safe names are construction-owned. Authored labels remain manifest
+metadata and never become identifiers. -/
+private def typeName (index : Nat) : Name := s!"cortex_np_type_{index}"
+private def payloadName (index : Nat) : Name := s!"cortex_np_type_{index}_payload"
+private def fieldName (index : Nat) : Name := s!"field_{index}"
+private def variantName (index : Nat) : Name := s!"variant_{index}"
+private def paddingName (index : Nat) : Name := s!"padding_{index}"
+
+private def insertTy (types : List Ty) (ty : Ty) : List Ty :=
+  if types.contains ty then types else types ++ [ty]
+
+/-- Fuelled implementation makes nested record/sum traversal visibly total to
+Lean even though recursive children occur below lists of labelled fields. -/
+private def collectTyFuel : Nat → Ty → List Ty → List Ty
+  | 0, _, types => types
+  | _fuel + 1, .text capacity, types => insertTy types (.text capacity)
+  | fuel + 1, .vector capacity element, types =>
+      insertTy (collectTyFuel fuel element types) (.vector capacity element)
+  | fuel + 1, .record fields, types =>
+      let children := fields.foldl
+        (fun acc field => collectTyFuel fuel field.2 acc) types
+      insertTy children (.record fields)
+  | fuel + 1, .sum variants, types =>
+      let children := variants.foldl
+        (fun acc variant => collectTyFuel fuel variant.2 acc) types
+      insertTy children (.sum variants)
+  | _ + 1, _, types => types
+
+/-- Children precede their containing aggregate. This is also the C
+declaration order, so no forward declaration is required. -/
+def collectTy (ty : Ty) (types : List Ty) : List Ty :=
+  collectTyFuel (reprStr ty).length ty types
+
+mutual
+  def collectExpr : SemanticC.Expr context ty → List Ty → List Ty
+    | .load _, types => collectTy ty types
+    | .read _, types => collectTy ty types
+    | .unit, types => types
+    | .bool _, types => types
+    | .u8 _, types => types
+    | .u32 _, types => types
+    | .i64 _, types => types
+    | .u64 _, types => types
+    | .f64 _, types => types
+    | .text _ _, types => collectTy ty types
+    | .bind bound body, types => collectExpr body (collectExpr bound types)
+    | .branch condition thenExpr elseExpr, types =>
+        collectExpr elseExpr (collectExpr thenExpr (collectExpr condition types))
+    | .not value, types => collectExpr value types
+    | .and left right, types | .or left right, types | .checkedAdd left right, types
+    | .checkedSub left right, types | .checkedMul left right, types
+    | .eqU8 left right, types | .eqU32 left right, types | .eqU64 left right, types
+    | .eqI64 left right, types | .ltU64 left right, types | .ltI64 left right, types =>
+        collectExpr right (collectExpr left types)
+    | .struct fields, types => collectRecord fields (collectTy ty types)
+    | .field record _, types => collectTy ty (collectExpr record types)
+    | .vector values, types => collectVector values (collectTy ty types)
+    | .index vector index, types => collectTy ty (collectExpr index (collectExpr vector types))
+    | .tagged _ payload, types => collectExpr payload (collectTy ty types)
+    | .call _ args, types => collectArgs args (collectTy ty types)
+
+  def collectRecord : SemanticC.RecordExpr context fields → List Ty → List Ty
+    | .nil, types => types
+    | .cons _ field rest, types => collectRecord rest (collectExpr field types)
+
+  def collectVector : SemanticC.VectorExpr context element capacity → List Ty → List Ty
+    | .nil, types => types
+    | .cons head tail, types => collectVector tail (collectExpr head types)
+
+  def collectArgs : SemanticC.Args context params → List Ty → List Ty
+    | .nil, types => types
+    | .cons head tail, types => collectArgs tail (collectExpr head types)
+end
+
+private def tyIndex (types : List Ty) (ty : Ty) : Nat :=
+  (types.findIdx? (· == ty)).getD types.length
+
+def ctype (types : List Ty) : Ty → CType
+  | .unit => .u8
+  | .bool => .bool
+  | .u8 => .u8
+  | .u32 => .u32
+  | .i64 => .i64
+  | .u64 => .u64
+  | .f64 => .f64
+  | ty@(.text _) | ty@(.vector _ _) | ty@(.record _) | ty@(.sum _) =>
+      .named (typeName (tyIndex types ty))
+
+structure ConcreteField where
+  sourceLabel : Name
+  cName : Name
+  ty : Ty
+  ctype : CType
+  offset : Nat
+  size : Nat
+  deriving Repr
+
+structure ConcreteAggregate where
+  name : Name
+  size : Nat
+  alignment : Nat
+  fields : List ConcreteField
+  declaration : TypeDecl
+  deriving Repr
+
+private structure FieldBuild where
+  declarations : List Field := []
+  metadata : List ConcreteField := []
+  offset : Nat := 0
+  padding : Nat := 0
+
+private def addPadding (target : Nat) (state : FieldBuild) : FieldBuild :=
+  if state.offset < target then
+    { state with
+      declarations := state.declarations ++
+        [{ name := paddingName state.padding, ty := .array (target - state.offset) .u8 }]
+      offset := target
+      padding := state.padding + 1 }
+  else state
+
+private def addField
+    (types : List Ty) (sourceLabel : Name) (index : Nat) (ty : Ty)
+    (state : FieldBuild) : FieldBuild :=
+  let (size, alignment) := layout ty
+  let placed := addPadding (alignUp state.offset alignment) state
+  let cName := fieldName index
+  { placed with
+    declarations := placed.declarations ++ [{ name := cName, ty := ctype types ty }]
+    metadata := placed.metadata ++
+      [{ sourceLabel, cName, ty, ctype := ctype types ty, offset := placed.offset, size }]
+    offset := placed.offset + size }
+
+private def finishFields (size : Nat) (state : FieldBuild) : FieldBuild :=
+  addPadding size state
+
+private def recordAggregate
+    (types : List Ty) (index : Nat) (fields : List (Name × Ty)) : ConcreteAggregate :=
+  let built := fields.zipIdx.foldl
+    (fun state entry => addField types entry.1.1 entry.2 entry.1.2 state) {}
+  let (size, alignment) := layout (.record fields)
+  let finished := finishFields size built
+  let name := typeName index
+  { name, size, alignment, fields := finished.metadata
+  , declaration := .structure { name, fields := finished.declarations, visibility := .exported } }
+
+private def textAggregate (index capacity : Nat) : ConcreteAggregate :=
+  let name := typeName index
+  let (size, alignment) := layout (.text capacity)
+  let raw : List Field :=
+    [{ name := "length", ty := .u32 }, { name := "bytes", ty := .array capacity .u8 }]
+  let used := 4 + capacity
+  let fields :=
+    if used < size then raw ++ [{ name := "padding_0", ty := .array (size - used) .u8 }]
+    else raw
+  { name, size, alignment
+  , fields :=
+      [ { sourceLabel := "length", cName := "length", ty := .u32, ctype := .u32
+        , offset := 0, size := 4 }
+      , { sourceLabel := "bytes", cName := "bytes", ty := .vector capacity .u8
+        , ctype := .array capacity .u8, offset := 4, size := capacity }
+      ]
+  , declaration := .structure { name, fields, visibility := .exported } }
+
+private def vectorAggregate
+    (types : List Ty) (index capacity : Nat) (element : Ty) : ConcreteAggregate :=
+  let name := typeName index
+  let (elementSize, elementAlignment) := layout element
+  let payloadOffset := alignUp 4 elementAlignment
+  let (size, alignment) := layout (.vector capacity element)
+  let before :=
+    if 4 < payloadOffset then [{ name := "padding_0", ty := .array (payloadOffset - 4) .u8 }]
+    else []
+  let used := payloadOffset + capacity * elementSize
+  let after :=
+    if used < size then [{ name := "padding_1", ty := .array (size - used) .u8 }]
+    else []
+  { name, size, alignment
+  , fields :=
+      [ { sourceLabel := "length", cName := "length", ty := .u32, ctype := .u32
+        , offset := 0, size := 4 }
+      , { sourceLabel := "items", cName := "items", ty := .vector capacity element
+        , ctype := .array capacity (ctype types element), offset := payloadOffset
+        , size := capacity * elementSize }
+      ]
+  , declaration := .structure
+      { name, visibility := .exported
+      , fields := [{ name := "length", ty := .u32 }] ++ before ++
+          [{ name := "items", ty := .array capacity (ctype types element) }] ++ after } }
+
+private def sumAggregates
+    (types : List Ty) (index : Nat) (variants : List (Name × Ty)) : List ConcreteAggregate :=
+  let sumName := typeName index
+  let unionName := payloadName index
+  let unionFields := variants.zipIdx.map fun entry : (Name × Ty) × Nat =>
+    { name := variantName entry.2, ty := ctype types entry.1.2 : Field }
+  let (payloadSize, payloadAlignment) := sumLayout variants
+  let payloadAggregate : ConcreteAggregate :=
+    { name := unionName, size := payloadSize, alignment := payloadAlignment, fields := []
+    , declaration := .union
+        { name := unionName, fields := unionFields, visibility := .exported } }
+  let payloadOffset := alignUp 4 payloadAlignment
+  let (size, alignment) := layout (.sum variants)
+  let before :=
+    if 4 < payloadOffset then [{ name := "padding_0", ty := .array (payloadOffset - 4) .u8 }]
+    else []
+  let used := payloadOffset + payloadSize
+  let after :=
+    if used < size then [{ name := "padding_1", ty := .array (size - used) .u8 }]
+    else []
+  let sumAggregate : ConcreteAggregate :=
+    { name := sumName, size, alignment
+    , fields :=
+        [ { sourceLabel := "tag", cName := "tag", ty := .u32, ctype := .u32
+          , offset := 0, size := 4 }
+        , { sourceLabel := "payload", cName := "payload", ty := .sum variants
+          , ctype := .named unionName, offset := payloadOffset, size := payloadSize }
+        ]
+    , declaration := .structure
+        { name := sumName, visibility := .exported
+        , fields := [{ name := "tag", ty := .u32 }] ++ before ++
+            [{ name := "payload", ty := .named unionName }] ++ after } }
+  [payloadAggregate, sumAggregate]
+
+def aggregateDeclarations (types : List Ty) : List ConcreteAggregate :=
+  types.zipIdx.flatMap fun entry =>
+    match entry.1 with
+    | .text capacity => [textAggregate entry.2 capacity]
+    | .vector capacity element => [vectorAggregate types entry.2 capacity element]
+    | .record fields => [recordAggregate types entry.2 fields]
+    | .sum variants => sumAggregates types entry.2 variants
+    | .unit | .bool | .u8 | .u32 | .i64 | .u64 | .f64 => []
+
+private def varIndex : Var context ty → Nat
+  | .zero => 0
+  | .succ rest => 1 + varIndex rest
+
+private def memberIndex : Member name ty fields → Nat
+  | .head => 0
+  | .tail rest => 1 + memberIndex rest
+
+private structure Emitted where
+  statements : List Stmt
+  value : Cortex.Wire.C11.Expr
+  next : Nat
+
+private def temporary (next : Nat) : Name := s!"value_{next}"
+
+private def emitRecordWith
+    (emit : ∀ {fieldTy}, Nat → SemanticC.Expr context fieldTy → Except String Emitted)
+    (target : Name) : (index next : Nat) → SemanticC.RecordExpr context fields →
+    Except String (List Stmt × Nat)
+  | _, next, .nil => pure ([], next)
+  | index, next, .cons _ field rest => do
+      let fieldValue ← emit next field
+      let restValue ← emitRecordWith emit target (index + 1) fieldValue.next rest
+      pure
+        (fieldValue.statements ++
+          [.assign (.field (.ident target) (fieldName index)) fieldValue.value] ++ restValue.1,
+         restValue.2)
+
+private def emitExprFuel
+    (fuel : Nat)
+    (types : List Ty) (env : List Cortex.Wire.C11.Expr) (next : Nat)
+    (expr : SemanticC.Expr context ty) : Except String Emitted :=
+  match fuel with
+  | 0 => throw "NativePure C lowering exhausted structural fuel"
+  | fuel + 1 =>
+    let emitBinary {operand : Ty}
+        (op : BinaryOp) (left right : SemanticC.Expr context operand) := do
+      let leftValue ← emitExprFuel fuel types env next left
+      let rightValue ← emitExprFuel fuel types env leftValue.next right
+      pure
+        { statements := leftValue.statements ++ rightValue.statements
+        , value := .binary op leftValue.value rightValue.value
+        , next := rightValue.next }
+    let emitChecked
+        (builtin : Name) (left right : SemanticC.Expr context .i64) := do
+      let leftValue ← emitExprFuel fuel types env next left
+      let rightValue ← emitExprFuel fuel types env leftValue.next right
+      let resultName := temporary rightValue.next
+      pure
+        { statements := leftValue.statements ++ rightValue.statements ++
+            [ .local { name := resultName, ty := .i64 }
+            , .branch
+                (.call (.ident builtin)
+                  [leftValue.value, rightValue.value, .unary .address (.ident resultName)])
+                [.returnValue (.unsigned Status.arithmeticOverflow.code)] []
+            ]
+        , value := .ident resultName
+        , next := rightValue.next + 1 }
+    match expr with
+    | .load slot =>
+        match env[varIndex slot]? with
+        | some value => pure { statements := [], value, next }
+        | none => throw "NativePure C lowering lost a typed input binding"
+    | .read _ => throw "NativePure region lowering forbids ambient storage reads"
+    | .unit => pure { statements := [], value := .unsigned 0, next }
+    | .bool value => pure { statements := [], value := .bool value, next }
+    | .u8 value => pure { statements := [], value := .unsigned value.value, next }
+    | .u32 value => pure { statements := [], value := .unsigned value.value, next }
+    | .i64 value => pure { statements := [], value := .signed value.value, next }
+    | .u64 value => pure { statements := [], value := .unsigned value.value, next }
+    | .f64 _ => throw "binary64 concrete literals remain in the PR 13 validation slice"
+    | .text value _ => do
+        let resultName := temporary next
+        let bytes := value.toUTF8.toList
+        let assignments := bytes.zipIdx.map fun entry : UInt8 × Nat =>
+          .assign (.index (.field (.ident resultName) "bytes") (.unsigned entry.2))
+            (.unsigned entry.1.toNat)
+        pure
+          { statements :=
+              [.local { name := resultName, ty := ctype types ty }]
+              ++ [.assign (.field (.ident resultName) "length") (.unsigned bytes.length)]
+              ++ assignments
+          , value := .ident resultName, next := next + 1 }
+    | .bind bound body => do
+        let boundValue ← emitExprFuel fuel types env next bound
+        let bodyValue ← emitExprFuel fuel types (boundValue.value :: env) boundValue.next body
+        pure
+          { statements := boundValue.statements ++ bodyValue.statements
+          , value := bodyValue.value, next := bodyValue.next }
+    | .branch condition thenExpr elseExpr => do
+        let conditionValue ← emitExprFuel fuel types env next condition
+        let resultName := temporary conditionValue.next
+        let thenValue ← emitExprFuel fuel types env (conditionValue.next + 1) thenExpr
+        let elseValue ← emitExprFuel fuel types env thenValue.next elseExpr
+        pure
+          { statements := conditionValue.statements ++
+              [.local { name := resultName, ty := ctype types ty }] ++
+              [.branch conditionValue.value
+                (thenValue.statements ++ [.assign (.ident resultName) thenValue.value])
+                (elseValue.statements ++ [.assign (.ident resultName) elseValue.value])]
+          , value := .ident resultName, next := elseValue.next }
+    | .not value => do
+        let emitted ← emitExprFuel fuel types env next value
+        pure { emitted with value := .unary .logicalNot emitted.value }
+    | .and left right => emitBinary .logicalAnd left right
+    | .or left right => emitBinary .logicalOr left right
+    | .checkedAdd left right => emitChecked "__builtin_add_overflow" left right
+    | .checkedSub left right => emitChecked "__builtin_sub_overflow" left right
+    | .checkedMul left right => emitChecked "__builtin_mul_overflow" left right
+    | .eqU8 left right => emitBinary .equal left right
+    | .eqU32 left right => emitBinary .equal left right
+    | .eqU64 left right => emitBinary .equal left right
+    | .eqI64 left right => emitBinary .equal left right
+    | .ltU64 left right => emitBinary .less left right
+    | .ltI64 left right => emitBinary .less left right
+    | .struct fields => do
+        let resultName := temporary next
+        let fieldsValue ←
+          emitRecordWith (fun fieldNext field => emitExprFuel fuel types env fieldNext field)
+            resultName 0 (next + 1) fields
+        pure
+          { statements := [.local { name := resultName, ty := ctype types ty }] ++ fieldsValue.1
+          , value := .ident resultName, next := fieldsValue.2 }
+    | .field record member => do
+        let recordValue ← emitExprFuel fuel types env next record
+        pure { recordValue with value := .field recordValue.value (fieldName (memberIndex member)) }
+    | .vector _ =>
+        throw "bounded vector construction awaits the PR 13 differential closure"
+    | .index vector index => do
+        let vectorValue ← emitExprFuel fuel types env next vector
+        let indexValue ← emitExprFuel fuel types env vectorValue.next index
+        pure
+          { statements := vectorValue.statements ++ indexValue.statements ++
+              [ .branch
+                  (.binary .greaterEqual indexValue.value
+                    (.field vectorValue.value "length"))
+                  [.returnValue (.unsigned Status.bounds.code)] []
+              ]
+          , value := .index (.field vectorValue.value "items") indexValue.value
+          , next := indexValue.next }
+    | .tagged member payload => do
+        let payloadValue ← emitExprFuel fuel types env next payload
+        let resultName := temporary payloadValue.next
+        let index := memberIndex member
+        pure
+          { statements := payloadValue.statements ++
+              [ .local { name := resultName, ty := ctype types ty }
+              , .assign (.field (.ident resultName) "tag") (.unsigned index)
+              , .assign
+                  (.field (.field (.ident resultName) "payload") (variantName index))
+                  payloadValue.value
+              ]
+          , value := .ident resultName, next := payloadValue.next + 1 }
+    | .call _ _ => throw "NativePure region lowering forbids semantic function calls"
+termination_by fuel
+
+/-- Total constructive lowering. `steps` is a structural upper bound for the
+admitted expression tree; the extra unit covers the root dispatch. -/
+private def emitExpr
+    (types : List Ty) (env : List Cortex.Wire.C11.Expr) (next : Nat)
+    (fuel : Nat) (expr : SemanticC.Expr context ty) : Except String Emitted :=
+  emitExprFuel (fuel + 1) types env next expr
+
+structure Region where
+  name : Name
+  inputLabels : List Name
+  kernel : CertifiedKernel
+
+private def regionTypes (region : Region) : List Ty :=
+  let inputs := region.kernel.inputs.foldl (fun types ty => collectTy ty types) []
+  collectExpr region.kernel.target (collectTy region.kernel.output inputs)
+
+private def frameFields
+    (types : List Ty) (labels : List Name) (values : List Ty) : FieldBuild :=
+  values.zipIdx.foldl (fun state entry =>
+    addField types (labels[entry.2]?.getD s!"input_{entry.2}") entry.2 entry.1 state) {}
+
+private def inputFrame (region : Region) (types : List Ty) : ConcreteAggregate :=
+  let name := region.name ++ "_input"
+  let built := frameFields types region.inputLabels region.kernel.inputs
+  let calculatedSize :=
+    alignUp built.offset (region.kernel.inputs.foldl (fun acc ty => max acc (alignOf ty)) 1)
+  let size := max 1 calculatedSize
+  let finished := finishFields size built
+  { name, size, alignment := region.kernel.inputs.foldl (fun acc ty => max acc (alignOf ty)) 1
+  , fields := finished.metadata
+  , declaration := .structure
+      { name, fields := if finished.declarations.isEmpty then [{ name := "empty", ty := .u8 }]
+        else finished.declarations, visibility := .exported } }
+
+private def outputFrame (region : Region) (types : List Ty) : ConcreteAggregate :=
+  let name := region.name ++ "_output"
+  let (size, alignment) := layout region.kernel.output
+  { name, size, alignment
+  , fields :=
+      [{ sourceLabel := "value", cName := "value", ty := region.kernel.output
+       , ctype := ctype types region.kernel.output, offset := 0, size }]
+  , declaration := .structure
+      { name, fields := [{ name := "value", ty := ctype types region.kernel.output }]
+      , visibility := .exported } }
+
+private def effectFrame
+    (region : Region) (input output : ConcreteAggregate) : ConcreteAggregate :=
+  let name := region.name ++ "_effect_frame"
+  let hasInput := !region.kernel.inputs.isEmpty
+  let inputOffset := 0
+  let outputOffset := if hasInput then alignUp (inputOffset + input.size) output.alignment else 0
+  let alignment := if hasInput then max input.alignment output.alignment else output.alignment
+  let size := alignUp (outputOffset + output.size) alignment
+  let beforeOutput :=
+    if hasInput && inputOffset + input.size < outputOffset then
+      [{ name := "padding_1", ty := .array (outputOffset - inputOffset - input.size) .u8 }]
+    else []
+  let trailing :=
+    if outputOffset + output.size < size then
+      [{ name := "padding_2", ty := .array (size - outputOffset - output.size) .u8 }]
+    else []
+  { name, size, alignment
+  , fields :=
+      (if hasInput then
+        [ { sourceLabel := "input", cName := "input", ty := .unit
+          , ctype := .named input.name, offset := inputOffset, size := input.size }]
+      else []) ++
+      [ { sourceLabel := "output", cName := "output", ty := region.kernel.output
+        , ctype := .named output.name, offset := outputOffset, size := output.size }
+      ]
+  , declaration := .structure
+      { name, visibility := .exported
+      , fields := (if hasInput then [{ name := "input", ty := .named input.name }] else []) ++
+          beforeOutput ++
+          [{ name := "output", ty := .named output.name }] ++ trailing } }
+
+private def aggregateLayout (aggregate : ConcreteAggregate) : Layout :=
+  { name := aggregate.name, size := aggregate.size, alignment := aggregate.alignment
+  , fields := aggregate.fields.map fun field =>
+      { name := field.cName, offset := field.offset, size := field.size } }
+
+private def aggregateAssertions (aggregate : ConcreteAggregate) : List StaticAssert :=
+  [ { condition := .binary .equal (.sizeof (.named aggregate.name)) (.unsigned aggregate.size)
+    , message := aggregate.name ++ " size" }
+  , { condition := .binary .equal (.alignof (.named aggregate.name)) (.unsigned aggregate.alignment)
+    , message := aggregate.name ++ " alignment" }
+  ] ++ aggregate.fields.map fun field =>
+    { condition := .binary .equal (.offsetof (.named aggregate.name) field.cName)
+        (.unsigned field.offset)
+    , message := aggregate.name ++ "." ++ field.cName ++ " offset" }
+
+private def regionFunction
+    (region : Region) (types : List Ty) (input output : ConcreteAggregate) :
+    Except String CFunction := do
+  if !validIdentifier region.name then throw "NativePure region C name is not a valid identifier"
+  if region.inputLabels.length != region.kernel.inputs.length then
+    throw "NativePure region input labels do not match its typed boundary"
+  let environment := region.kernel.inputs.zipIdx.map fun entry =>
+    .pointerField (.ident "input") (fieldName entry.2)
+  let emitted ←
+    emitExpr types environment 0 region.kernel.bounds.maxSteps region.kernel.target
+  pure
+    { name := region.name ++ "_run"
+    , result := .u32
+    , params :=
+        [ { name := "input", ty := .pointer (.named input.name) true }
+        , { name := "output", ty := .pointer (.named output.name) false }
+        ]
+    , body := some (emitted.statements ++
+        [ .assign (.pointerField (.ident "output") "value") emitted.value
+        , .returnValue (.unsigned Status.ok.code)
+        ])
+    , visibility := .exported
+    , comments :=
+        ["Synchronous, heap-free and authority-free NativePure region."] }
+
+def translationUnit (identity : String) (region : Region) : Except String TranslationUnit := do
+  if identity.isEmpty then throw "NativePure program identity must not be empty"
+  let types := regionTypes region
+  let nativeAggregates := aggregateDeclarations types
+  let input := inputFrame region types
+  let output := outputFrame region types
+  let effect := effectFrame region input output
+  let aggregates := nativeAggregates ++ [input, output, effect]
+  let function ← regionFunction region types input output
+  if output.size > region.kernel.bounds.outputBytes then
+    throw "NativePure output frame exceeds its certified bound"
+  if effect.size > region.kernel.bounds.checkpointBytes then
+    throw "NativePure effect frame exceeds its certified checkpoint bound"
+  pure
+    { schema := "cortex.wire.native-pure-c/v1"
+    , identity
+    , headerGuard := region.name ++ "_NATIVE_PURE_C_V1_H"
+    , localHeader := region.name ++ ".h"
+    , orderedTypes :=
+        [ .enumeration
+            { name := "cortex_np_status", visibility := .exported
+            , members :=
+                [ { name := "CORTEX_NP_OK", value := Status.ok.code }
+                , { name := "CORTEX_NP_TYPE_MISMATCH", value := Status.typeMismatch.code }
+                , { name := "CORTEX_NP_ARITHMETIC_OVERFLOW"
+                  , value := Status.arithmeticOverflow.code }
+                , { name := "CORTEX_NP_BOUNDS", value := Status.bounds.code }
+                , { name := "CORTEX_NP_CAPACITY", value := Status.capacity.code }
+                , { name := "CORTEX_NP_INVALID_TAG", value := Status.invalidTag.code }
+                ] }
+        ] ++ aggregates.map (·.declaration)
+    , functions := [function]
+    , assertions := aggregates.flatMap aggregateAssertions ++
+        [ { condition := .binary .lessEqual (.sizeof (.named output.name))
+              (.unsigned region.kernel.bounds.outputBytes)
+          , message := "NativePure output bound" }
+        , { condition := .binary .lessEqual (.sizeof (.named effect.name))
+              (.unsigned region.kernel.bounds.checkpointBytes)
+          , message := "NativePure checkpoint bound" }
+        ]
+    , layouts := aggregates.map aggregateLayout
+    , resources :=
+        [ { name := "stack_bytes", value := region.kernel.bounds.stackBytes }
+        , { name := "static_bytes", value := region.kernel.bounds.staticBytes }
+        , { name := "output_bytes", value := region.kernel.bounds.outputBytes }
+        , { name := "checkpoint_bytes", value := region.kernel.bounds.checkpointBytes }
+        , { name := "max_steps", value := region.kernel.bounds.maxSteps }
+        ] }
+
+def compile (identity : String) (region : Region) : Except String ValidatedTranslationUnit := do
+  let unit ← translationUnit identity region
+  C11.validate unit
+
+def render (identity : String) (region : Region) : Except String RenderedArtifacts := do
+  renderArtifacts <$> compile identity region
+
+end Cortex.Wire.NativePure.C

--- a/theory/Cortex/Wire/NativePure/C/Unit.lean
+++ b/theory/Cortex/Wire/NativePure/C/Unit.lean
@@ -1,0 +1,224 @@
+import Cortex.Wire.NativePure.C
+
+/-! Executable construction checks for the concrete NativePure C lowering. -/
+
+namespace Cortex.Wire.NativePure.C.Unit
+
+open Cortex.Wire.NativePure
+open Cortex.Wire.NativePure.C
+
+private def one : I64 :=
+  { value := 1, lower := by decide, upper := by decide }
+
+private def incrementBody : Expr [.i64] .i64 :=
+  .add (.var .zero) (.i64 one)
+
+private def bounds : ResourceBounds :=
+  { stackBytes := 24
+  , staticBytes := 0
+  , outputBytes := 8
+  , checkpointBytes := 16
+  , maxSteps := 3
+  , checkpointWithinHostedCeiling := by decide
+  }
+
+private def kernel : CertifiedKernel :=
+  { sourceNode := "increment"
+  , inputs := [.i64]
+  , output := .i64
+  , body := incrementBody
+  , bounds
+  , regions :=
+      [ { name := "input.score", access := .read, capacity := 8, alignment := 8 }
+      , { name := "output.result", access := .write, capacity := 8, alignment := 8 }
+      ]
+  , regionsWellFormed := by simp [RegionsWellFormed]
+  , inputsWellFormed := by simp [WellFormedTy]
+  , outputWellFormed := by simp [WellFormedTy]
+  , refinementBasis := by simp [incrementBody, RefinementExpr, RefinementTy]
+  , stepsSound := by native_decide
+  , outputSound := by native_decide
+  }
+
+private def region : Region :=
+  { name := "increment", inputLabels := ["score"], kernel }
+
+private def renderedResult := render "native-pure-unit" region
+
+example : renderedResult.toOption.isSome = true := by native_decide
+
+def rendered : Cortex.Wire.C11.RenderedArtifacts :=
+  renderedResult.toOption.get (by native_decide)
+
+example : rendered.source.contains "__builtin_add_overflow" = true := by native_decide
+example : rendered.source.contains "malloc" = false := by native_decide
+example : rendered.source.contains "pthread" = false := by native_decide
+example : rendered.header.contains "increment_run" = true := by native_decide
+example : rendered.manifest.contains "checkpoint_bytes" = true := by native_decide
+example : rendered.manifest.contains "increment_effect_frame" = true := by native_decide
+
+private abbrev Decision : Ty :=
+  Ty.sum [("accepted", .i64), ("rejected", .i64)]
+
+private def acceptedMember :
+    Member "accepted" .i64 [("accepted", .i64), ("rejected", .i64)] := .head
+
+private def rejectedMember :
+    Member "rejected" .i64 [("accepted", .i64), ("rejected", .i64)] := .tail .head
+
+private def zero : I64 :=
+  { value := 0, lower := by decide, upper := by decide }
+
+private def classifyBody : Expr [.i64] Decision :=
+  .ifE
+    (.ltI64 (.var .zero) (.i64 zero))
+    (.inject rejectedMember (.var .zero))
+    (.inject acceptedMember (.var .zero))
+
+private def classifyKernel : CertifiedKernel :=
+  { sourceNode := "classify"
+  , inputs := [.i64]
+  , output := Decision
+  , body := classifyBody
+  , bounds :=
+      { stackBytes := 40
+      , staticBytes := 0
+      , outputBytes := 16
+      , checkpointBytes := 24
+      , maxSteps := 6
+      , checkpointWithinHostedCeiling := by decide
+      }
+  , regions :=
+      [ { name := "input.score", access := .read, capacity := 8, alignment := 8 }
+      , { name := "output.variant", access := .write, capacity := 16, alignment := 8 }
+      ]
+  , regionsWellFormed := by simp [RegionsWellFormed]
+  , inputsWellFormed := by simp [WellFormedTy]
+  , outputWellFormed := by
+      simp [WellFormedTy, WellFormedFields, LabelsCanonical]
+      native_decide
+  , refinementBasis := by
+      simp [classifyBody, Decision, RefinementExpr, RefinementTy, RefinementFields]
+  , stepsSound := by native_decide
+  , outputSound := by native_decide
+  }
+
+private def classifyRegion : Region :=
+  { name := "classify", inputLabels := ["score"], kernel := classifyKernel }
+
+private def classifyRenderedResult := render "native-pure-sum-unit" classifyRegion
+
+example : classifyRenderedResult.toOption.isSome = true := by native_decide
+
+def classifyRendered : Cortex.Wire.C11.RenderedArtifacts :=
+  classifyRenderedResult.toOption.get (by native_decide)
+
+example : classifyRendered.header.contains "typedef union" = true := by native_decide
+example : classifyRendered.header.contains "uint32_t tag" = true := by native_decide
+example : classifyRendered.header.contains "variant_1" = true := by native_decide
+example : classifyRendered.source.contains "malloc" = false := by native_decide
+
+private abbrev Product : Ty :=
+  Ty.record [("flag", .bool), ("score", .i64)]
+
+private def productBody : Expr [.i64] Product :=
+  .record (.cons "flag" (.bool true) (.cons "score" (.var .zero) .nil))
+
+private def productKernel : CertifiedKernel :=
+  { sourceNode := "make_product"
+  , inputs := [.i64]
+  , output := Product
+  , body := productBody
+  , bounds :=
+      { stackBytes := 40
+      , staticBytes := 0
+      , outputBytes := 16
+      , checkpointBytes := 24
+      , maxSteps := 3
+      , checkpointWithinHostedCeiling := by decide
+      }
+  , regions :=
+      [ { name := "input.score", access := .read, capacity := 8, alignment := 8 }
+      , { name := "output.product", access := .write, capacity := 16, alignment := 8 }
+      ]
+  , regionsWellFormed := by simp [RegionsWellFormed]
+  , inputsWellFormed := by simp [WellFormedTy]
+  , outputWellFormed := by
+      simp [WellFormedTy, WellFormedFields, LabelsCanonical]
+      native_decide
+  , refinementBasis := by
+      simp [productBody, Product, RefinementExpr, RefinementRecord, RefinementTy]
+  , stepsSound := by native_decide
+  , outputSound := by native_decide
+  }
+
+private def productRegion : Region :=
+  { name := "make_product", inputLabels := ["score"], kernel := productKernel }
+
+private def productRenderedResult := render "native-pure-product-unit" productRegion
+
+example : productRenderedResult.toOption.isSome = true := by native_decide
+
+private def productRendered : Cortex.Wire.C11.RenderedArtifacts :=
+  productRenderedResult.toOption.get (by native_decide)
+
+example : productRendered.header.contains "padding_0[7u]" = true := by native_decide
+example : productRendered.source.contains "field_1 = input->field_0" = true := by native_decide
+
+private def sourceBody : Expr [] .i64 := .i64 one
+
+private def sourceKernel : CertifiedKernel :=
+  { sourceNode := "source"
+  , inputs := []
+  , output := .i64
+  , body := sourceBody
+  , bounds :=
+      { stackBytes := 16
+      , staticBytes := 0
+      , outputBytes := 8
+      , checkpointBytes := 8
+      , maxSteps := 1
+      , checkpointWithinHostedCeiling := by decide
+      }
+  , regions :=
+      [{ name := "output.value", access := .write, capacity := 8, alignment := 8 }]
+  , regionsWellFormed := by simp [RegionsWellFormed]
+  , inputsWellFormed := by simp
+  , outputWellFormed := by simp [WellFormedTy]
+  , refinementBasis := by simp [sourceBody, RefinementExpr]
+  , stepsSound := by native_decide
+  , outputSound := by native_decide
+  }
+
+private def sourceRegion : Region :=
+  { name := "source", inputLabels := [], kernel := sourceKernel }
+
+private def sourceRenderedResult := render "native-pure-source-unit" sourceRegion
+
+example : sourceRenderedResult.toOption.isSome = true := by native_decide
+
+private def sourceRendered : Cortex.Wire.C11.RenderedArtifacts :=
+  sourceRenderedResult.toOption.get (by native_decide)
+
+example : sourceRendered.header.contains "source_effect_frame" = true := by native_decide
+example : sourceRendered.header.contains "source_input input" = false := by native_decide
+example : sourceRendered.manifest.contains "\"size\":8" = true := by native_decide
+
+private def undersizedCheckpointKernel : CertifiedKernel :=
+  { kernel with
+    bounds :=
+      { kernel.bounds with
+        checkpointBytes := 8
+        checkpointWithinHostedCeiling := by decide
+      }
+  }
+
+private def undersizedCheckpointRegion : Region :=
+  { name := "undersized", inputLabels := ["score"], kernel := undersizedCheckpointKernel }
+
+example :
+    (translationUnit
+      "native-pure-bounds-unit" undersizedCheckpointRegion).toOption.isNone = true := by
+  native_decide
+
+end Cortex.Wire.NativePure.C.Unit

--- a/theory/Cortex/Wire/NativePure/Type.lean
+++ b/theory/Cortex/Wire/NativePure/Type.lean
@@ -26,7 +26,7 @@ inductive Ty where
   | vector (capacity : Nat) (element : Ty)
   | record (fields : List (Name × Ty))
   | sum (variants : List (Name × Ty))
-  deriving Repr
+  deriving BEq, Repr
 
 /-- A label/type pair occurs in a fixed record or sum description. -/
 inductive Member : Name → Ty → List (Name × Ty) → Type where

--- a/theory/CortexNativePureCFixture.lean
+++ b/theory/CortexNativePureCFixture.lean
@@ -1,0 +1,23 @@
+import Cortex.Wire.NativePure.C.Unit
+
+/-! Test-only artifact writer used by target and compiler gates. -/
+
+open Cortex.Wire.NativePure.C.Unit
+
+private def writeArtifacts
+    (directory stem : String) (artifacts : Cortex.Wire.C11.RenderedArtifacts) : IO Unit := do
+  IO.FS.writeFile (directory ++ "/" ++ stem ++ ".c") artifacts.source
+  IO.FS.writeFile (directory ++ "/" ++ stem ++ ".h") artifacts.header
+  IO.FS.writeFile (directory ++ "/" ++ stem ++ ".exports.txt") artifacts.exports
+  IO.FS.writeFile (directory ++ "/" ++ stem ++ ".manifest.json") artifacts.manifest
+
+def main (args : List String) : IO UInt32 := do
+  match args with
+  | [directory] =>
+      IO.FS.createDirAll directory
+      writeArtifacts directory "increment" rendered
+      writeArtifacts directory "classify" classifyRendered
+      pure 0
+  | [] | _ :: _ :: _ =>
+      IO.eprintln "usage: cortex-native-pure-c-fixture OUTPUT_DIRECTORY"
+      pure 2

--- a/theory/lakefile.lean
+++ b/theory/lakefile.lean
@@ -49,6 +49,8 @@ lean_lib «Cortex» where
     `Cortex.Wire.StaticCEmitter.Layout,
     `Cortex.Wire.StaticCEmitter.Unit,
     `Cortex.Wire.NativePure,
+    `Cortex.Wire.NativePure.C,
+    `Cortex.Wire.NativePure.C.Unit,
     `Cortex.Wire.Registry,
     `Cortex.Wire.Rewrite,
     `Cortex.Wire.Admission,
@@ -158,6 +160,11 @@ lean_exe «cortex-kernel-spike» where
 -- Host-side static Wire validator and freestanding C emitter (ADR 0091).
 lean_exe «cortex-wire-c» where
   root := `CortexWireC
+
+-- Test-only concrete NativePure C artifact writer. Production plan ingestion
+-- remains owned by the versioned compiler boundary rather than this fixture.
+lean_exe «cortex-native-pure-c-fixture» where
+  root := `CortexNativePureCFixture
 
 -- Lean reference interpreter for the ADR 0091 three-way differential suite.
 -- Replays the shared scenario corpus through the restricted target semantics


### PR DESCRIPTION
## Epic slice

PR 11 of the NativePure epic. Targets `codex/epic-native-pure-c`; it does not target or change `main`.

Closes the concrete region-lowering slice of #382.

## What this adds

- lowers each `CertifiedKernel.target` from the shared typed SemanticC IR into the validated structured C11 AST
- defines fixed input, output, and checkpoint/effect frames with explicit padding, layouts, `sizeof`/`_Alignof`/`offsetof` assertions, and certified output/checkpoint bound gates
- represents exclusive sums as a `uint32_t` tag plus a typed max-payload C union
- returns a closed NativePure status code and propagates checked i64 add/sub/mul overflow without undefined signed arithmetic
- keeps region functions synchronous, heap-free, and authority-free: the ABI exposes only typed input/output frame pointers and has no host context, worker, or authority parameter
- derives C source, header, export inventory, layout/resource manifest, and assertions from one validated translation unit
- adds executable Lean construction checks for scalar, record, sum, zero-input, overflow, and undersized-checkpoint cases
- adds strict host C11 runtime harnesses for checked scalar arithmetic and tagged exclusive-sum results

## Deliberate boundaries

- this consumes the already-certified SemanticC target; it does not create a second lowering path from CorePure
- scheduler integration, checkpoint ordering, select persistence, and v2 runtime interfaces remain PR 12
- hermetic host/bare-aarch64 target matrices, symbol/section gates, three-way differential corpora, sanitizers, and f64 validation remain PR 13
- authored Wire grammar and executor ABI compatibility work remain PRs 14 and 15
- no v1 schema, ABI, lifecycle, or StaticC golden changes

## Verification

- `just ci-check`: green, including formatting, Haskell lint/build/tests, Lean lint, docs/Wire checks, TLA+, full flake checks, docs build, hosted smoke, and existing StaticC differential/assurance suites
- hermetic Lean theory: 914 jobs, green
- generated increment/classify fixtures compile under strict C11 warnings and `-pedantic`
- runtime harnesses verify `41 + 1 = 42`, checked `INT64_MAX + 1` overflow, and both tagged classifier variants
- freestanding `-fno-builtin` objects have no undefined symbols
- commit `90bd194afb472c7299a08d2795e0666b4438e3a6` is signed and signed-off

Epic: #383
Tracker: #382
Research provenance: #370
Historical NativePure slice: #381
Decomposition donor: #378