### PR TITLE
feat(wire): add NativePure v2 scheduler policy

### DIFF
--- a/cortex.cabal
+++ b/cortex.cabal
@@ -200,6 +200,7 @@ library
         Cortex.Wire.LeanFixture
         Cortex.Wire.NativePure.Admission
         Cortex.Wire.NativePure.Artifact
+        Cortex.Wire.NativePure.Scheduler
         Cortex.Wire.NativePure.Shape
         Cortex.Wire.Parser
         Cortex.Wire.Pure
@@ -468,6 +469,7 @@ test-suite cortex-test
         Cortex.Wire.ImportSpec
         Cortex.Wire.NativeShapeSpec
         Cortex.Wire.NativePureAdmissionSpec
+        Cortex.Wire.NativePureSchedulerSpec
         Cortex.Wire.ParserSpec
         Cortex.Wire.PureSpec
         Cortex.Wire.RuntimeSpec

--- a/docs/ADRs/0091-lean-hosted-freestanding-wire-c-backend.md
+++ b/docs/ADRs/0091-lean-hosted-freestanding-wire-c-backend.md
@@ -37,6 +37,14 @@ whitespace-only compatibility layout preserves the published v1 artifact bytes e
 inject, remove, or replace C tokens. The existing schemas, symbols, lifecycle behavior, target
 outputs, and four pinned artifact hashes remain unchanged.
 
+**2026-07-19 NativePure amendment.** NativePure adds a separately versioned executable scheduler
+policy under `static-program/v2`, `engine/v2`, `engine-state/v2`, `host-process/v2`, and
+`x86_64-linux-v2`. It specializes a witnessed realization quotient and executes pure units inside
+the engine without host authority. This addition does not replace, alias, or reinterpret any v1
+schema, symbol, state transition, artifact byte, or target. The v2 policy reuses the established
+`Cortex.Wire.Circuit.HostProtocol` worker/cancellation/terminal-authority rules; those rules and the
+TLA+ model are unchanged because this slice adds no new host-worker behavior.
+
 ## Context
 
 The earlier extraction direction treated the computable Track 2 Pulse kernel as an object library to

--- a/docs/ADRs/0096-certified-native-pure-region-compilation.md
+++ b/docs/ADRs/0096-certified-native-pure-region-compilation.md
@@ -47,8 +47,13 @@ tagged-sum payload unions, propagates checked-i64 overflow through a status resu
 headers, exports, layouts, resource manifests, and static assertions from the validated C11 unit.
 Executable construction checks cover scalar and exclusive-sum kernels, and strict local host
 compilation confirms the emitted functions have no unresolved host, heap, worker, or Lean-runtime
-symbols. This is not yet the NativePure execution profile: normalized-plan decoding in Lean, v2
-scheduling, the hermetic target matrix, and three-way differential closure remain later epic slices.
+symbols. The additive Haskell v2 scheduler policy now specializes witnessed quotient units, gates
+every effect behind the preceding checkpoint acknowledgement, executes pure regions synchronously,
+persists `select(...)` tags and skipped latent branches, rejoins the chosen branch, and restores the
+tag/value state without creating host work for pure units. Pure and effect failures become durable
+failed checkpoints. This is not yet the generally available NativePure execution profile:
+normalized-plan decoding in Lean, generated-engine integration, the hermetic target matrix, and
+three-way differential closure remain later epic slices.
 
 ## Context
 
@@ -165,9 +170,12 @@ worker registration, cancellation, deadline, and terminal-authority invariants r
   (additive contract projection and manifest decoding), and
   `src/Cortex/Wire/NativePure/Admission.hs` (strict candidate admission, typed expression checks,
   storage regions, and resource bounds), and `src/Cortex/Wire/NativePure/Artifact.hs` (normalized
-  input, maximal fusion, typed ANF/SSA, witnessed quotient, validation, and stable digests)
+  input, maximal fusion, typed ANF/SSA, witnessed quotient, validation, and stable digests), and
+  `src/Cortex/Wire/NativePure/Scheduler.hs` (additive v2 specialization, checkpoint acknowledgement,
+  synchronous pure execution, persisted selection/rejoin state, restore, cancellation, and bounded
+  hosted messages)
 - Tests: `test/Cortex/Wire/NativeShapeSpec.hs`, `test/Cortex/Wire/PackageSpec.hs`,
-  `test/Cortex/Wire/NativePureAdmissionSpec.hs`
+  `test/Cortex/Wire/NativePureAdmissionSpec.hs`, `test/Cortex/Wire/NativePureSchedulerSpec.hs`
 - Theory/proof: `theory/Cortex/Wire/NativePure/Type.lean` owns the shared bounded value algebra;
   `theory/Cortex/Wire/SemanticC.lean` defines the shared typed expression/statement/function IR,
   storage model, bounded control flow, calls, failures, and executable semantics;
@@ -187,11 +195,13 @@ worker registration, cancellation, deadline, and terminal-authority invariants r
 
 - Feature key: `wire.native_pure_compilation` (partial; bounded contract shapes, fixed layouts,
   admission, normalized realization artifacts, maximal fusion, and the Haskell plan validator are
-  implemented)
+  implemented, together with the additive executable v2 scheduler policy)
 - Current executable evidence: `test/Cortex/Wire/NativeShapeSpec.hs`, the `native_shape` manifest
   cases in `test/Cortex/Wire/PackageSpec.hs`, `test/Cortex/Wire/NativePureAdmissionSpec.hs`, the
-  Lean construction checks in `Cortex.Wire.NativePure.C.Unit`, and strict host compilation of the
-  emitted increment and tagged-classifier fixtures
+  effect/pure/effect, n-way selection, checkpoint recovery, failure, and protocol-bound tests in
+  `test/Cortex/Wire/NativePureSchedulerSpec.hs`, the Lean construction checks in
+  `Cortex.Wire.NativePure.C.Unit`, and strict host compilation of the emitted increment and
+  tagged-classifier fixtures
 - Planned public surface: normalized-plan decoding in Lean, hermetic host/bare-target and
-  differential gates, and additive v2 runtime/target interfaces
+  differential gates, and generated-engine integration for the additive v2 runtime/target interfaces
 - Implementation tracker: GitHub issue #382 and the NativePure epic PR

--- a/src/Cortex/Wire.hs
+++ b/src/Cortex/Wire.hs
@@ -19,6 +19,7 @@ module Cortex.Wire
   , module Cortex.Wire.Include
   , module Cortex.Wire.Format
   , module Cortex.Wire.NativePure.Artifact
+  , module Cortex.Wire.NativePure.Scheduler
   , module Cortex.Wire.NativePure.Shape
   , module Cortex.Wire.Pure
   , module Cortex.Wire.Std
@@ -119,6 +120,7 @@ import Cortex.Wire.Executor
 import Cortex.Wire.Format
 import Cortex.Wire.Include
 import Cortex.Wire.NativePure.Artifact
+import Cortex.Wire.NativePure.Scheduler
 import Cortex.Wire.NativePure.Shape
 import Cortex.Wire.Parser
   ( ParseError

--- a/src/Cortex/Wire/NativePure/Scheduler.hs
+++ b/src/Cortex/Wire/NativePure/Scheduler.hs
@@ -1,0 +1,1216 @@
+{- |
+Module      : Cortex.Wire.NativePure.Scheduler
+Description : Additive NativePure v2 quotient scheduler and hosted protocol model.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+This module is the executable policy model for the additive NativePure v2
+profile. It specializes the witnessed realization quotient into dense runtime
+units, executes pure units synchronously without host authority, and makes
+checkpoint acknowledgement a hard gate before any later effect request.
+
+The existing v1 program, engine, state, hosted protocol, and target remain
+separate and unchanged.
+-}
+module Cortex.Wire.NativePure.Scheduler
+  ( NativePureProgramV2 (..)
+  , NativePureProgramV2Unit (..)
+  , NativePureProgramV2UnitKind (..)
+  , NativePureProgramV2Edge (..)
+  , NativePureSelectV2 (..)
+  , NativePureSelectPlanV2 (..)
+  , NativePureProgramV2Error (..)
+  , NativePureEngineStateV2 (..)
+  , NativePureV2Status (..)
+  , NativePureV2Result (..)
+  , NativePureV2EffectCompletion (..)
+  , NativePureV2Action (..)
+  , NativePureV2Transition (..)
+  , NativePureV2HostCommand (..)
+  , NativePureV2EngineEvent (..)
+  , nativePureStaticProgramV2Schema
+  , nativePureEngineV2Abi
+  , nativePureEngineStateV2Schema
+  , nativePureHostProcessV2Protocol
+  , nativePureHostedLinuxV2Target
+  , nativePureHostedMessageCeiling
+  , specializeNativePureProgramV2
+  , validateNativePureProgramV2
+  , initialNativePureEngineStateV2
+  , validateNativePureEngineStateV2
+  , restoreNativePureEngineStateV2
+  , driveNativePureV2
+  , acknowledgeNativePureCheckpointV2
+  , completeNativePureEffectV2
+  , cancelNativePureV2
+  , encodeNativePureV2HostCommand
+  , decodeNativePureV2HostCommand
+  , encodeNativePureV2EngineEvent
+  , decodeNativePureV2EngineEvent
+  , renderNativePureProgramV2Error
+  )
+where
+
+import Control.Monad (foldM, join, unless, when)
+import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.:?), (.=))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Types qualified as AesonTypes
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
+import Data.List qualified as List
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, listToMaybe)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Word (Word32, Word64)
+import GHC.Generics (Generic)
+
+import Cortex.Wire.Circuit.Engine
+  ( EngineTerminalState (..)
+  , parseEngineTerminalState
+  , renderEngineTerminalState
+  )
+import Cortex.Wire.Circuit.IR (CircuitNodeRef (..))
+import Cortex.Wire.NativePure.Artifact
+  ( NativePurePlan (..)
+  , RealizationArtifact (..)
+  , RealizationRuntimeKind (..)
+  , RealizationRuntimeUnit (..)
+  )
+
+nativePureStaticProgramV2Schema :: Text
+nativePureStaticProgramV2Schema = "cortex.wire.static-program/v2"
+
+nativePureEngineV2Abi :: Text
+nativePureEngineV2Abi = "cortex.wire.engine/v2"
+
+nativePureEngineStateV2Schema :: Text
+nativePureEngineStateV2Schema = "cortex.wire.engine-state/v2"
+
+nativePureHostProcessV2Protocol :: Text
+nativePureHostProcessV2Protocol = "cortex.wire.host-process/v2"
+
+nativePureHostedLinuxV2Target :: Text
+nativePureHostedLinuxV2Target = "cortex.wire.target/x86_64-linux-v2"
+
+nativePureHostedMessageCeiling :: Int
+nativePureHostedMessageCeiling = 2 * 1024 * 1024
+
+data NativePureProgramV2UnitKind
+  = NativePureV2Effect
+  | NativePureV2PureRegion
+  | NativePureV2SelectGuard
+  | NativePureV2Rejoin
+  deriving stock (Eq, Ord, Show, Generic)
+
+data NativePureProgramV2Unit = NativePureProgramV2Unit
+  { nativePureProgramV2UnitId :: !Word32
+  , nativePureProgramV2UnitRef :: !Text
+  , nativePureProgramV2UnitKind :: !NativePureProgramV2UnitKind
+  , nativePureProgramV2UnitSources :: ![CircuitNodeRef]
+  }
+  deriving stock (Eq, Show, Generic)
+
+data NativePureProgramV2Edge = NativePureProgramV2Edge
+  { nativePureProgramV2EdgeFrom :: !Word32
+  , nativePureProgramV2EdgeTo :: !Word32
+  }
+  deriving stock (Eq, Ord, Show, Generic)
+
+{- | Authored select structure expressed over witnessed runtime-unit refs.
+Empty variant lists are identity arms. The guard and rejoin themselves are
+preserved quotient units; branch members may be pure regions or effects.
+-}
+data NativePureSelectV2 = NativePureSelectV2
+  { nativePureSelectV2GuardRef :: !Text
+  , nativePureSelectV2Variants :: !(Map Text [Text])
+  , nativePureSelectV2RejoinRef :: !Text
+  }
+  deriving stock (Eq, Show, Generic)
+
+data NativePureSelectPlanV2 = NativePureSelectPlanV2
+  { nativePureSelectPlanV2Guard :: !Word32
+  , nativePureSelectPlanV2Variants :: !(Map Text [Word32])
+  , nativePureSelectPlanV2Rejoin :: !Word32
+  }
+  deriving stock (Eq, Show, Generic)
+
+data NativePureProgramV2 = NativePureProgramV2
+  { nativePureProgramV2Id :: !Text
+  , nativePureProgramV2Identity :: !Text
+  , nativePureProgramV2PlanDigest :: !Text
+  , nativePureProgramV2Units :: ![NativePureProgramV2Unit]
+  , nativePureProgramV2Edges :: ![NativePureProgramV2Edge]
+  , nativePureProgramV2Selects :: ![NativePureSelectPlanV2]
+  }
+  deriving stock (Eq, Show, Generic)
+
+data NativePureProgramV2Error
+  = NativePureProgramV2UnitCountOverflow !Integer
+  | NativePureProgramV2MissingRuntimeRef !Text
+  | NativePureProgramV2InvalidSelect !Text
+  | NativePureProgramV2State !Text
+  | NativePureProgramV2Stuck
+  | NativePureProgramV2PureFailure !Word32 !Text
+  | NativePureProgramV2Protocol !Text
+  | NativePureProgramV2MessageTooLarge !Int
+  deriving stock (Eq, Show)
+
+renderNativePureProgramV2Error :: NativePureProgramV2Error -> Text
+renderNativePureProgramV2Error = \case
+  NativePureProgramV2UnitCountOverflow count ->
+    "NativePure v2 runtime-unit count exceeds uint32_t: " <> T.pack (show count)
+  NativePureProgramV2MissingRuntimeRef runtimeRef ->
+    "NativePure v2 select refers to unknown runtime unit " <> runtimeRef
+  NativePureProgramV2InvalidSelect reason -> "invalid NativePure v2 select: " <> reason
+  NativePureProgramV2State reason -> "invalid NativePure v2 engine state: " <> reason
+  NativePureProgramV2Stuck -> "NativePure v2 scheduler has unsettled units but no ready transition"
+  NativePureProgramV2PureFailure unitId reason ->
+    "NativePure v2 pure unit " <> T.pack (show unitId) <> " failed: " <> reason
+  NativePureProgramV2Protocol reason -> "NativePure v2 protocol error: " <> reason
+  NativePureProgramV2MessageTooLarge bytes ->
+    "NativePure v2 hosted message is " <> T.pack (show bytes) <> " bytes; maximum is 2097152"
+
+specializeNativePureProgramV2
+  :: NativePurePlan
+  -> [NativePureSelectV2]
+  -> Either NativePureProgramV2Error NativePureProgramV2
+specializeNativePureProgramV2 plan selectSpecs = do
+  let artifact = plan.nativePurePlanRealization
+      runtimeRows = Map.toAscList artifact.realizationArtifactRuntimeUnits
+      count = toInteger (length runtimeRows)
+  when (count > toInteger (maxBound :: Word32)) $
+    Left (NativePureProgramV2UnitCountOverflow count)
+  let refs = Map.fromAscList (zip (fmap fst runtimeRows) [0 ..])
+      baseUnits =
+        [ NativePureProgramV2Unit
+            { nativePureProgramV2UnitId = unitId
+            , nativePureProgramV2UnitRef = runtimeRef
+            , nativePureProgramV2UnitKind = runtimeKind unit.realizationRuntimeUnitKind
+            , nativePureProgramV2UnitSources = unit.realizationRuntimeUnitSources
+            }
+        | ((runtimeRef, unit), unitId) <- zip runtimeRows [0 ..]
+        ]
+  edges <-
+    traverse
+      (\(source, target) -> NativePureProgramV2Edge <$> lookupRef refs source <*> lookupRef refs target)
+      (Set.toAscList artifact.realizationArtifactRuntimeEdges)
+  (selects, selectKinds) <- foldM (lowerSelect refs) ([], Map.empty) selectSpecs
+  let units =
+        [ unit
+            { nativePureProgramV2UnitKind =
+                Map.findWithDefault unit.nativePureProgramV2UnitKind unit.nativePureProgramV2UnitId selectKinds
+            }
+        | unit <- baseUnits
+        ]
+  let program =
+        NativePureProgramV2
+          { nativePureProgramV2Id = plan.nativePurePlanProgramId
+          , nativePureProgramV2Identity = plan.nativePurePlanProgramIdentity
+          , nativePureProgramV2PlanDigest = plan.nativePurePlanDigest
+          , nativePureProgramV2Units = units
+          , nativePureProgramV2Edges = edges
+          , nativePureProgramV2Selects = selects
+          }
+  validateNativePureProgramV2 program
+  pure program
+  where
+    runtimeKind = \case
+      RealizationPureRegion -> NativePureV2PureRegion
+      RealizationPreservedNode -> NativePureV2Effect
+
+    lowerSelect refs (plans, assignedKinds) authored = do
+      guardId <- lookupRef refs authored.nativePureSelectV2GuardRef
+      rejoinId <- lookupRef refs authored.nativePureSelectV2RejoinRef
+      when (guardId == rejoinId) $
+        Left (NativePureProgramV2InvalidSelect "guard and rejoin must be distinct")
+      when (Map.size authored.nativePureSelectV2Variants < 2) $
+        Left (NativePureProgramV2InvalidSelect "at least two variants are required")
+      when (any (T.null . T.strip) (Map.keys authored.nativePureSelectV2Variants)) $
+        Left (NativePureProgramV2InvalidSelect "variant labels must be nonblank")
+      loweredVariants <- traverse (traverse (lookupRef refs)) authored.nativePureSelectV2Variants
+      let branchMembers = concat (Map.elems loweredVariants)
+      when (length branchMembers /= Set.size (Set.fromList branchMembers)) $
+        Left (NativePureProgramV2InvalidSelect "variant branch units must be pairwise disjoint")
+      when (guardId `elem` branchMembers || rejoinId `elem` branchMembers) $
+        Left (NativePureProgramV2InvalidSelect "guard or rejoin occurs inside a branch")
+      when (Map.member guardId assignedKinds || Map.member rejoinId assignedKinds) $
+        Left (NativePureProgramV2InvalidSelect "guard or rejoin is owned by multiple selects")
+      pure
+        ( plans
+            <> [ NativePureSelectPlanV2
+                   { nativePureSelectPlanV2Guard = guardId
+                   , nativePureSelectPlanV2Variants = loweredVariants
+                   , nativePureSelectPlanV2Rejoin = rejoinId
+                   }
+               ]
+        , Map.insert rejoinId NativePureV2Rejoin (Map.insert guardId NativePureV2SelectGuard assignedKinds)
+        )
+
+lookupRef :: Map Text Word32 -> Text -> Either NativePureProgramV2Error Word32
+lookupRef refs runtimeRef =
+  maybe (Left (NativePureProgramV2MissingRuntimeRef runtimeRef)) Right (Map.lookup runtimeRef refs)
+
+validateNativePureProgramV2 :: NativePureProgramV2 -> Either NativePureProgramV2Error ()
+validateNativePureProgramV2 program = do
+  when (T.null (T.strip program.nativePureProgramV2Id)) $
+    invalidState "program identifier must be nonblank"
+  when (T.null (T.strip program.nativePureProgramV2Identity)) $
+    invalidState "program identity must be nonblank"
+  when (T.null (T.strip program.nativePureProgramV2PlanDigest)) $
+    invalidState "plan digest must be nonblank"
+  let units = program.nativePureProgramV2Units
+      unitIds = fmap (.nativePureProgramV2UnitId) units
+      expectedIds = fmap fromIntegral [0 .. length units - 1]
+      unitRefs = fmap (.nativePureProgramV2UnitRef) units
+  unless (unitIds == expectedIds) $
+    invalidState "runtime unit identifiers must be dense, ascending, and zero-based"
+  when (any (T.null . T.strip) unitRefs) $
+    invalidState "runtime unit references must be nonblank"
+  unless (length unitRefs == Set.size (Set.fromList unitRefs)) $
+    invalidState "runtime unit references must be unique"
+  unless (length edgePairs == Set.size (Set.fromList edgePairs)) $
+    invalidState "runtime edges must be unique"
+  mapM_ validateEdge edgePairs
+  when (hasCycle unitIds edgePairs) $
+    invalidState "runtime quotient must be acyclic"
+  _owned <- foldM validateSelect Set.empty program.nativePureProgramV2Selects
+  pure ()
+  where
+    knownUnit unitId = isJust (unitById program unitId)
+
+    validateEdge (source, target) = do
+      unless (knownUnit source && knownUnit target) $
+        invalidState "runtime edge endpoint is outside the specialized program"
+      when (source == target) $
+        invalidState "runtime quotient contains a self-edge"
+
+    validateSelect owned selection = do
+      let guardId = selection.nativePureSelectPlanV2Guard
+          rejoinId = selection.nativePureSelectPlanV2Rejoin
+          variants = selection.nativePureSelectPlanV2Variants
+          branchMembers = concat (Map.elems variants)
+          selectionMembers = Set.fromList (guardId : rejoinId : branchMembers)
+      when (guardId == rejoinId) $
+        invalidSelect "guard and rejoin must be distinct"
+      unless (unitKindIs guardId NativePureV2SelectGuard) $
+        invalidSelect "select guard does not name a guard unit"
+      unless (unitKindIs rejoinId NativePureV2Rejoin) $
+        invalidSelect "select rejoin does not name a rejoin unit"
+      when (Map.size variants < 2 || any (T.null . T.strip) (Map.keys variants)) $
+        invalidSelect "select requires at least two nonblank variant labels"
+      unless (all knownUnit branchMembers) $
+        invalidSelect "select branch contains an unknown runtime unit"
+      unless (length branchMembers == Set.size (Set.fromList branchMembers)) $
+        invalidSelect "select branch units must be pairwise disjoint"
+      unless (Set.null (Set.intersection owned selectionMembers)) $
+        invalidSelect "runtime units cannot be owned by multiple select plans"
+      mapM_ (validateBranch guardId rejoinId) (Map.toAscList variants)
+      pure (Set.union owned selectionMembers)
+
+    validateBranch guardId rejoinId (_label, []) =
+      unless ((guardId, rejoinId) `elem` edgePairs) $
+        invalidSelect "an identity select arm requires a direct guard-to-rejoin edge"
+    validateBranch guardId rejoinId (_label, members) = do
+      let memberSet = Set.fromList members
+          forward = reachableWithin memberSet (successors program) [guardId]
+          backward = reachableWithin memberSet (predecessors program) [rejoinId]
+      unless (memberSet `Set.isSubsetOf` forward) $
+        invalidSelect "every branch unit must be reachable from its guard within that branch"
+      unless (memberSet `Set.isSubsetOf` backward) $
+        invalidSelect "every branch unit must reach its declared rejoin within that branch"
+
+    unitKindIs unitId kind =
+      maybe False ((== kind) . (.nativePureProgramV2UnitKind)) (unitById program unitId)
+
+    edgePairs =
+      fmap
+        (\edge -> (edge.nativePureProgramV2EdgeFrom, edge.nativePureProgramV2EdgeTo))
+        program.nativePureProgramV2Edges
+
+    invalidState = Left . NativePureProgramV2State
+    invalidSelect = Left . NativePureProgramV2InvalidSelect
+
+hasCycle :: [Word32] -> [(Word32, Word32)] -> Bool
+hasCycle unitIds edgePairs = visit Set.empty Set.empty unitIds
+  where
+    visit _visited _active [] = False
+    visit visited active (unitId : rest)
+      | Set.member unitId visited = visit visited active rest
+      | otherwise = case descend visited active unitId of
+          Nothing -> True
+          Just visited' -> visit visited' active rest
+
+    descend visited active unitId
+      | Set.member unitId active = Nothing
+      | Set.member unitId visited = Just visited
+      | otherwise = do
+          visited' <-
+            foldM
+              (\seen successor -> descend seen (Set.insert unitId active) successor)
+              visited
+              [target | (source, target) <- edgePairs, source == unitId]
+          pure (Set.insert unitId visited')
+
+reachableWithin
+  :: Set.Set Word32
+  -> (Word32 -> [Word32])
+  -> [Word32]
+  -> Set.Set Word32
+reachableWithin allowed adjacent = go Set.empty
+  where
+    go visited [] = visited
+    go visited (current : rest) =
+      let next = filter (`Set.member` allowed) (adjacent current)
+          unseen = filter (`Set.notMember` visited) next
+       in go (Set.union visited (Set.fromList unseen)) (rest <> unseen)
+
+data NativePureV2Status
+  = NativePureV2Pending
+  | NativePureV2RunningEffect
+  | NativePureV2Completed
+  | NativePureV2Failed
+  | NativePureV2Skipped
+  deriving stock (Eq, Ord, Show, Generic)
+
+data NativePureEngineStateV2 = NativePureEngineStateV2
+  { nativePureEngineStateV2ProgramIdentity :: !Text
+  , nativePureEngineStateV2CheckpointSequence :: !Word64
+  , nativePureEngineStateV2NextEffectSequence :: !Word64
+  , nativePureEngineStateV2AwaitingCheckpoint :: !Bool
+  , nativePureEngineStateV2Terminal :: !EngineTerminalState
+  , nativePureEngineStateV2Statuses :: ![NativePureV2Status]
+  , nativePureEngineStateV2Values :: ![Maybe Aeson.Value]
+  , nativePureEngineStateV2EffectSequences :: ![Maybe Word64]
+  , nativePureEngineStateV2SelectedTags :: !(Map Word32 Text)
+  , nativePureEngineStateV2Failure :: !(Maybe Text)
+  }
+  deriving stock (Eq, Show, Generic)
+
+data NativePureV2Result = NativePureV2Result
+  { nativePureV2ResultValue :: !Aeson.Value
+  , nativePureV2ResultSelectedTag :: !(Maybe Text)
+  }
+  deriving stock (Eq, Show, Generic)
+
+data NativePureV2EffectCompletion
+  = NativePureV2EffectSucceeded !Aeson.Value
+  | NativePureV2EffectSkipped
+  | NativePureV2EffectFailed !Text
+  deriving stock (Eq, Show, Generic)
+
+data NativePureV2Action
+  = NativePureV2CheckpointRequired !NativePureEngineStateV2
+  | NativePureV2EffectRequested !Word64 !Word32 !Text !(Map Text Aeson.Value)
+  | NativePureV2AwaitingEffects
+  | NativePureV2Terminal !EngineTerminalState
+  deriving stock (Eq, Show, Generic)
+
+data NativePureV2Transition = NativePureV2Transition
+  { nativePureV2TransitionState :: !NativePureEngineStateV2
+  , nativePureV2TransitionAction :: !NativePureV2Action
+  }
+  deriving stock (Eq, Show, Generic)
+
+initialNativePureEngineStateV2 :: NativePureProgramV2 -> NativePureEngineStateV2
+initialNativePureEngineStateV2 program =
+  NativePureEngineStateV2
+    { nativePureEngineStateV2ProgramIdentity = program.nativePureProgramV2Identity
+    , nativePureEngineStateV2CheckpointSequence = 1
+    , nativePureEngineStateV2NextEffectSequence = 1
+    , nativePureEngineStateV2AwaitingCheckpoint = True
+    , nativePureEngineStateV2Terminal = EngineActive
+    , nativePureEngineStateV2Statuses = replicate count NativePureV2Pending
+    , nativePureEngineStateV2Values = replicate count Nothing
+    , nativePureEngineStateV2EffectSequences = replicate count Nothing
+    , nativePureEngineStateV2SelectedTags = Map.empty
+    , nativePureEngineStateV2Failure = Nothing
+    }
+  where
+    count = length program.nativePureProgramV2Units
+
+validateNativePureEngineStateV2
+  :: NativePureProgramV2
+  -> NativePureEngineStateV2
+  -> Either NativePureProgramV2Error ()
+validateNativePureEngineStateV2 program state = do
+  validateNativePureProgramV2 program
+  unless (state.nativePureEngineStateV2ProgramIdentity == program.nativePureProgramV2Identity) $
+    stateError "program identity mismatch"
+  when (state.nativePureEngineStateV2CheckpointSequence == 0) $
+    stateError "checkpoint sequence must be positive"
+  when (state.nativePureEngineStateV2NextEffectSequence == 0) $
+    stateError "next effect sequence must be positive"
+  let count = length program.nativePureProgramV2Units
+  unless
+    ( length state.nativePureEngineStateV2Statuses == count
+        && length state.nativePureEngineStateV2Values == count
+        && length state.nativePureEngineStateV2EffectSequences == count
+    )
+    (stateError "unit-state arrays do not match the specialized program")
+  sequence_
+    [ validateSlot index status value effectSequence
+    | (index, (status, value, effectSequence)) <-
+        zip [0 :: Int ..] $
+          zip3
+            state.nativePureEngineStateV2Statuses
+            state.nativePureEngineStateV2Values
+            state.nativePureEngineStateV2EffectSequences
+    ]
+  sequence_
+    [ validateSelectedTag guardId label
+    | (guardId, label) <- Map.toAscList state.nativePureEngineStateV2SelectedTags
+    ]
+  validateTerminal
+  let encodedSize = fromIntegral (BSL.length (Aeson.encode state))
+  when (encodedSize > nativePureHostedMessageCeiling) $
+    Left (NativePureProgramV2MessageTooLarge encodedSize)
+  where
+    stateError = Left . NativePureProgramV2State
+
+    validateSlot index status value effectSequence = case status of
+      NativePureV2Pending -> absent index value effectSequence
+      NativePureV2RunningEffect -> do
+        when (isJust value) (stateError (slotReason index "running effect has a value"))
+        unless (isJust effectSequence) (stateError (slotReason index "running effect has no sequence"))
+        case program.nativePureProgramV2Units List.!? index of
+          Just unit
+            | unit.nativePureProgramV2UnitKind == NativePureV2Effect -> pure ()
+          _ -> stateError (slotReason index "non-effect unit is marked running")
+      NativePureV2Completed -> do
+        unless (isJust value) (stateError (slotReason index "completed unit has no value"))
+        when
+          (isJust effectSequence)
+          (stateError (slotReason index "completed unit keeps an effect sequence"))
+      NativePureV2Failed -> absent index value effectSequence
+      NativePureV2Skipped -> absent index value effectSequence
+
+    absent index value effectSequence =
+      unless (isNothing value && isNothing effectSequence) $
+        stateError (slotReason index "non-completed unit carries value or effect sequence")
+
+    validateSelectedTag guardId label =
+      case List.find ((== guardId) . (.nativePureSelectPlanV2Guard)) program.nativePureProgramV2Selects of
+        Nothing -> stateError "selected tag refers to a non-guard unit"
+        Just selection ->
+          unless (Map.member label selection.nativePureSelectPlanV2Variants) $
+            stateError "selected tag is not declared by its guard"
+
+    validateTerminal = case state.nativePureEngineStateV2Terminal of
+      EngineActive -> requireNoFailure
+      EngineSucceeded -> do
+        requireNoFailure
+        unless (all settled state.nativePureEngineStateV2Statuses) $
+          stateError "successful terminal contains an unsettled or failed unit"
+      EngineTerminalFailed -> do
+        unless (isJust state.nativePureEngineStateV2Failure) $
+          stateError "failed terminal contains no failure reason"
+        unless (NativePureV2Failed `elem` state.nativePureEngineStateV2Statuses) $
+          stateError "failed terminal contains no failed unit"
+      EngineCancelled -> do
+        requireNoFailure
+        when (NativePureV2RunningEffect `elem` state.nativePureEngineStateV2Statuses) $
+          stateError "cancelled terminal contains a running effect"
+
+    requireNoFailure =
+      when (isJust state.nativePureEngineStateV2Failure) $
+        stateError "non-failed terminal carries a failure reason"
+
+    slotReason index reason = "unit " <> T.pack (show index) <> " " <> reason
+
+restoreNativePureEngineStateV2
+  :: NativePureProgramV2
+  -> NativePureEngineStateV2
+  -> Either NativePureProgramV2Error NativePureEngineStateV2
+restoreNativePureEngineStateV2 program state = do
+  validateNativePureEngineStateV2 program state
+  let statuses = fmap restoreStatus state.nativePureEngineStateV2Statuses
+      restored =
+        state
+          { nativePureEngineStateV2AwaitingCheckpoint = True
+          , nativePureEngineStateV2Statuses = statuses
+          , nativePureEngineStateV2EffectSequences = replicate (length statuses) Nothing
+          }
+  validateNativePureEngineStateV2 program restored
+  pure restored
+  where
+    restoreStatus NativePureV2RunningEffect = NativePureV2Pending
+    restoreStatus status = status
+
+driveNativePureV2
+  :: (NativePureProgramV2Unit -> Map Text Aeson.Value -> Either Text NativePureV2Result)
+  -> NativePureProgramV2
+  -> NativePureEngineStateV2
+  -> Either NativePureProgramV2Error NativePureV2Transition
+driveNativePureV2 runPure program state = do
+  validateNativePureEngineStateV2 program state
+  if state.nativePureEngineStateV2AwaitingCheckpoint
+    then transition state (NativePureV2CheckpointRequired state)
+    else case state.nativePureEngineStateV2Terminal of
+      terminal | terminal /= EngineActive -> transition state (NativePureV2Terminal terminal)
+      _ ->
+        case List.find (unitReady program state) program.nativePureProgramV2Units of
+          Just unit -> runUnit runPure program state unit
+          Nothing
+            | NativePureV2RunningEffect `elem` state.nativePureEngineStateV2Statuses ->
+                transition state NativePureV2AwaitingEffects
+            | all settled state.nativePureEngineStateV2Statuses ->
+                checkpointTransition state {nativePureEngineStateV2Terminal = EngineSucceeded}
+            | otherwise -> Left NativePureProgramV2Stuck
+
+acknowledgeNativePureCheckpointV2
+  :: NativePureProgramV2
+  -> Word64
+  -> NativePureEngineStateV2
+  -> Either NativePureProgramV2Error NativePureEngineStateV2
+acknowledgeNativePureCheckpointV2 program sequenceNumber state = do
+  validateNativePureEngineStateV2 program state
+  unless state.nativePureEngineStateV2AwaitingCheckpoint $
+    Left (NativePureProgramV2Protocol "no checkpoint is awaiting acknowledgement")
+  unless (sequenceNumber == state.nativePureEngineStateV2CheckpointSequence) $
+    Left (NativePureProgramV2Protocol "checkpoint acknowledgement sequence mismatch")
+  pure state {nativePureEngineStateV2AwaitingCheckpoint = False}
+
+completeNativePureEffectV2
+  :: NativePureProgramV2
+  -> Word64
+  -> Word32
+  -> NativePureV2EffectCompletion
+  -> NativePureEngineStateV2
+  -> Either NativePureProgramV2Error NativePureEngineStateV2
+completeNativePureEffectV2 program sequenceNumber unitId completion state = do
+  validateNativePureEngineStateV2 program state
+  when state.nativePureEngineStateV2AwaitingCheckpoint $
+    Left (NativePureProgramV2Protocol "effect completion arrived before checkpoint acknowledgement")
+  index <- unitIndex program unitId
+  unless (state.nativePureEngineStateV2Statuses List.!? index == Just NativePureV2RunningEffect) $
+    Left (NativePureProgramV2Protocol "effect completion targets a unit that is not running")
+  unless (state.nativePureEngineStateV2EffectSequences List.!? index == Just (Just sequenceNumber)) $
+    Left (NativePureProgramV2Protocol "effect completion sequence mismatch")
+  let cleared = setAt index Nothing state.nativePureEngineStateV2EffectSequences
+      base = state {nativePureEngineStateV2EffectSequences = cleared}
+      completed = case completion of
+        NativePureV2EffectSucceeded value ->
+          base
+            { nativePureEngineStateV2Statuses =
+                setAt index NativePureV2Completed base.nativePureEngineStateV2Statuses
+            , nativePureEngineStateV2Values =
+                setAt index (Just value) base.nativePureEngineStateV2Values
+            }
+        NativePureV2EffectSkipped ->
+          base
+            { nativePureEngineStateV2Statuses =
+                setAt index NativePureV2Skipped base.nativePureEngineStateV2Statuses
+            }
+        NativePureV2EffectFailed reason ->
+          base
+            { nativePureEngineStateV2Statuses =
+                setAt index NativePureV2Failed base.nativePureEngineStateV2Statuses
+            , nativePureEngineStateV2Terminal = EngineTerminalFailed
+            , nativePureEngineStateV2Failure = Just reason
+            }
+  pure (checkpointState completed)
+
+cancelNativePureV2
+  :: NativePureProgramV2
+  -> NativePureEngineStateV2
+  -> Either NativePureProgramV2Error NativePureEngineStateV2
+cancelNativePureV2 program state = do
+  validateNativePureEngineStateV2 program state
+  unless (state.nativePureEngineStateV2Terminal == EngineActive) $
+    Left (NativePureProgramV2Protocol "cannot cancel a terminal engine")
+  let cancelStatus = \case
+        NativePureV2Pending -> NativePureV2Skipped
+        NativePureV2RunningEffect -> NativePureV2Skipped
+        status -> status
+      cancelled =
+        state
+          { nativePureEngineStateV2Statuses = fmap cancelStatus state.nativePureEngineStateV2Statuses
+          , nativePureEngineStateV2EffectSequences =
+              replicate (length state.nativePureEngineStateV2Statuses) Nothing
+          , nativePureEngineStateV2Terminal = EngineCancelled
+          }
+  pure (checkpointState cancelled)
+
+runUnit
+  :: (NativePureProgramV2Unit -> Map Text Aeson.Value -> Either Text NativePureV2Result)
+  -> NativePureProgramV2
+  -> NativePureEngineStateV2
+  -> NativePureProgramV2Unit
+  -> Either NativePureProgramV2Error NativePureV2Transition
+runUnit runPure program state unit = do
+  index <- unitIndex program unit.nativePureProgramV2UnitId
+  let inputs = unitInputValues program state unit.nativePureProgramV2UnitId
+  case unit.nativePureProgramV2UnitKind of
+    NativePureV2Effect -> do
+      let sequenceNumber = state.nativePureEngineStateV2NextEffectSequence
+          requested =
+            state
+              { nativePureEngineStateV2NextEffectSequence = sequenceNumber + 1
+              , nativePureEngineStateV2Statuses =
+                  setAt index NativePureV2RunningEffect state.nativePureEngineStateV2Statuses
+              , nativePureEngineStateV2EffectSequences =
+                  setAt index (Just sequenceNumber) state.nativePureEngineStateV2EffectSequences
+              }
+      transition
+        requested
+        ( NativePureV2EffectRequested
+            sequenceNumber
+            unit.nativePureProgramV2UnitId
+            unit.nativePureProgramV2UnitRef
+            inputs
+        )
+    NativePureV2PureRegion -> do
+      case runPure unit inputs of
+        Left reason -> failUnitTransition index reason state
+        Right result
+          | isJust result.nativePureV2ResultSelectedTag ->
+              failUnitTransition index "non-guard returned a selected tag" state
+          | otherwise -> checkpointTransition (completeUnit index result.nativePureV2ResultValue state)
+    NativePureV2SelectGuard -> do
+      selection <-
+        maybe
+          (Left (NativePureProgramV2InvalidSelect "guard has no select plan"))
+          Right
+          ( List.find
+              ((== unit.nativePureProgramV2UnitId) . (.nativePureSelectPlanV2Guard))
+              program.nativePureProgramV2Selects
+          )
+      case runPure unit inputs of
+        Left reason -> failUnitTransition index reason state
+        Right result -> case result.nativePureV2ResultSelectedTag of
+          Nothing -> failUnitTransition index "guard returned no selected tag" state
+          Just label
+            | not (Map.member label selection.nativePureSelectPlanV2Variants) ->
+                failUnitTransition index "guard returned an undeclared tag" state
+            | otherwise -> do
+                let selected =
+                      completeUnit
+                        index
+                        result.nativePureV2ResultValue
+                        state
+                          { nativePureEngineStateV2SelectedTags =
+                              Map.insert unit.nativePureProgramV2UnitId label state.nativePureEngineStateV2SelectedTags
+                          }
+                    skipped = skipUnselected selection label selected
+                checkpointTransition skipped
+    NativePureV2Rejoin -> do
+      selection <-
+        maybe
+          (Left (NativePureProgramV2InvalidSelect "rejoin has no select plan"))
+          Right
+          ( List.find
+              ((== unit.nativePureProgramV2UnitId) . (.nativePureSelectPlanV2Rejoin))
+              program.nativePureProgramV2Selects
+          )
+      label <-
+        maybe
+          (Left (NativePureProgramV2InvalidSelect "rejoin has no persisted selected tag"))
+          Right
+          (Map.lookup selection.nativePureSelectPlanV2Guard state.nativePureEngineStateV2SelectedTags)
+      branch <-
+        maybe
+          (Left (NativePureProgramV2InvalidSelect "persisted selected tag is undeclared"))
+          Right
+          (Map.lookup label selection.nativePureSelectPlanV2Variants)
+      let value =
+            fromMaybe Aeson.Null $
+              lastJust (fmap (valueAt state) (reverse branch))
+                <|> valueAt state selection.nativePureSelectPlanV2Guard
+      checkpointTransition (completeUnit index value state)
+
+failUnitTransition
+  :: Int
+  -> Text
+  -> NativePureEngineStateV2
+  -> Either NativePureProgramV2Error NativePureV2Transition
+failUnitTransition index reason state =
+  checkpointTransition
+    state
+      { nativePureEngineStateV2Statuses =
+          setAt index NativePureV2Failed state.nativePureEngineStateV2Statuses
+      , nativePureEngineStateV2Terminal = EngineTerminalFailed
+      , nativePureEngineStateV2Failure = Just reason
+      }
+
+unitReady :: NativePureProgramV2 -> NativePureEngineStateV2 -> NativePureProgramV2Unit -> Bool
+unitReady program state unit =
+  statusAt state unit.nativePureProgramV2UnitId == Just NativePureV2Pending
+    && branchEnabled program state unit.nativePureProgramV2UnitId
+    && all (maybe False settled . statusAt state) (predecessors program unit.nativePureProgramV2UnitId)
+
+branchEnabled :: NativePureProgramV2 -> NativePureEngineStateV2 -> Word32 -> Bool
+branchEnabled program state unitId =
+  all enabledBy program.nativePureProgramV2Selects
+  where
+    enabledBy selection =
+      case [ label
+           | (label, members) <- Map.toAscList selection.nativePureSelectPlanV2Variants
+           , unitId `elem` members
+           ] of
+        [] -> True
+        labels ->
+          case Map.lookup selection.nativePureSelectPlanV2Guard state.nativePureEngineStateV2SelectedTags of
+            Nothing -> False
+            Just selectedLabel -> selectedLabel `elem` labels
+
+predecessors :: NativePureProgramV2 -> Word32 -> [Word32]
+predecessors program unitId =
+  [ edge.nativePureProgramV2EdgeFrom
+  | edge <- program.nativePureProgramV2Edges
+  , edge.nativePureProgramV2EdgeTo == unitId
+  ]
+
+successors :: NativePureProgramV2 -> Word32 -> [Word32]
+successors program unitId =
+  [ edge.nativePureProgramV2EdgeTo
+  | edge <- program.nativePureProgramV2Edges
+  , edge.nativePureProgramV2EdgeFrom == unitId
+  ]
+
+unitInputValues
+  :: NativePureProgramV2
+  -> NativePureEngineStateV2
+  -> Word32
+  -> Map Text Aeson.Value
+unitInputValues program state unitId =
+  Map.fromList $
+    catMaybes
+      [ do
+          unit <- unitById program predecessor
+          value <- valueAt state predecessor
+          pure (unit.nativePureProgramV2UnitRef, value)
+      | predecessor <- predecessors program unitId
+      ]
+
+skipUnselected
+  :: NativePureSelectPlanV2
+  -> Text
+  -> NativePureEngineStateV2
+  -> NativePureEngineStateV2
+skipUnselected selection selectedLabel state =
+  foldl skip state unselected
+  where
+    unselected =
+      concat
+        [ members
+        | (label, members) <- Map.toAscList selection.nativePureSelectPlanV2Variants
+        , label /= selectedLabel
+        ]
+    skip current unitId = case word32Index unitId of
+      Nothing -> current
+      Just index ->
+        current
+          { nativePureEngineStateV2Statuses =
+              setAt index NativePureV2Skipped current.nativePureEngineStateV2Statuses
+          , nativePureEngineStateV2Values =
+              setAt index Nothing current.nativePureEngineStateV2Values
+          , nativePureEngineStateV2EffectSequences =
+              setAt index Nothing current.nativePureEngineStateV2EffectSequences
+          }
+
+completeUnit :: Int -> Aeson.Value -> NativePureEngineStateV2 -> NativePureEngineStateV2
+completeUnit index value state =
+  state
+    { nativePureEngineStateV2Statuses =
+        setAt index NativePureV2Completed state.nativePureEngineStateV2Statuses
+    , nativePureEngineStateV2Values =
+        setAt index (Just value) state.nativePureEngineStateV2Values
+    }
+
+checkpointTransition
+  :: NativePureEngineStateV2
+  -> Either NativePureProgramV2Error NativePureV2Transition
+checkpointTransition state =
+  let checkpointed = checkpointState state
+   in transition checkpointed (NativePureV2CheckpointRequired checkpointed)
+
+checkpointState :: NativePureEngineStateV2 -> NativePureEngineStateV2
+checkpointState state =
+  state
+    { nativePureEngineStateV2CheckpointSequence = state.nativePureEngineStateV2CheckpointSequence + 1
+    , nativePureEngineStateV2AwaitingCheckpoint = True
+    }
+
+transition
+  :: NativePureEngineStateV2
+  -> NativePureV2Action
+  -> Either NativePureProgramV2Error NativePureV2Transition
+transition state action = Right (NativePureV2Transition state action)
+
+settled :: NativePureV2Status -> Bool
+settled NativePureV2Completed = True
+settled NativePureV2Skipped = True
+settled _ = False
+
+statusAt :: NativePureEngineStateV2 -> Word32 -> Maybe NativePureV2Status
+statusAt state unitId = word32Index unitId >>= (state.nativePureEngineStateV2Statuses List.!?)
+
+valueAt :: NativePureEngineStateV2 -> Word32 -> Maybe Aeson.Value
+valueAt state unitId = join (word32Index unitId >>= (state.nativePureEngineStateV2Values List.!?))
+
+unitById :: NativePureProgramV2 -> Word32 -> Maybe NativePureProgramV2Unit
+unitById program unitId = List.find ((== unitId) . (.nativePureProgramV2UnitId)) program.nativePureProgramV2Units
+
+unitIndex :: NativePureProgramV2 -> Word32 -> Either NativePureProgramV2Error Int
+unitIndex program unitId =
+  case List.findIndex ((== unitId) . (.nativePureProgramV2UnitId)) program.nativePureProgramV2Units of
+    Nothing -> Left (NativePureProgramV2State "unit identifier is outside the specialized program")
+    Just index -> Right index
+
+word32Index :: Word32 -> Maybe Int
+word32Index value
+  | toInteger value <= toInteger (maxBound :: Int) = Just (fromIntegral value)
+  | otherwise = Nothing
+
+setAt :: Int -> value -> [value] -> [value]
+setAt index value values =
+  let (prefix, suffix) = splitAt index values
+   in case suffix of
+        [] -> values
+        _old : rest -> prefix <> (value : rest)
+
+lastJust :: [Maybe value] -> Maybe value
+lastJust = listToMaybe . catMaybes
+
+infixr 3 <|>
+(<|>) :: Maybe value -> Maybe value -> Maybe value
+Nothing <|> right = right
+left <|> _right = left
+
+-- JSON surfaces -------------------------------------------------------------
+
+instance ToJSON NativePureProgramV2UnitKind where
+  toJSON = Aeson.String . renderUnitKind
+
+instance FromJSON NativePureProgramV2UnitKind where
+  parseJSON = Aeson.withText "NativePureProgramV2UnitKind" $ \value ->
+    maybe (fail ("invalid NativePure v2 unit kind: " <> T.unpack value)) pure (parseUnitKind value)
+
+renderUnitKind :: NativePureProgramV2UnitKind -> Text
+renderUnitKind = \case
+  NativePureV2Effect -> "effect"
+  NativePureV2PureRegion -> "pure_region"
+  NativePureV2SelectGuard -> "select_guard"
+  NativePureV2Rejoin -> "rejoin"
+
+parseUnitKind :: Text -> Maybe NativePureProgramV2UnitKind
+parseUnitKind = \case
+  "effect" -> Just NativePureV2Effect
+  "pure_region" -> Just NativePureV2PureRegion
+  "select_guard" -> Just NativePureV2SelectGuard
+  "rejoin" -> Just NativePureV2Rejoin
+  _ -> Nothing
+
+instance ToJSON NativePureProgramV2Unit where
+  toJSON unit =
+    Aeson.object
+      [ "id" .= unit.nativePureProgramV2UnitId
+      , "ref" .= unit.nativePureProgramV2UnitRef
+      , "kind" .= unit.nativePureProgramV2UnitKind
+      , "sources" .= fmap (.unCircuitNodeRef) unit.nativePureProgramV2UnitSources
+      ]
+
+instance FromJSON NativePureProgramV2Unit where
+  parseJSON = Aeson.withObject "NativePureProgramV2Unit" $ \objectValue ->
+    NativePureProgramV2Unit
+      <$> objectValue .: "id"
+      <*> objectValue .: "ref"
+      <*> objectValue .: "kind"
+      <*> (fmap CircuitNodeRef <$> objectValue .: "sources")
+
+instance ToJSON NativePureProgramV2Edge where
+  toJSON edge = Aeson.object ["from" .= edge.nativePureProgramV2EdgeFrom, "to" .= edge.nativePureProgramV2EdgeTo]
+
+instance FromJSON NativePureProgramV2Edge where
+  parseJSON = Aeson.withObject "NativePureProgramV2Edge" $ \objectValue ->
+    NativePureProgramV2Edge <$> objectValue .: "from" <*> objectValue .: "to"
+
+instance ToJSON NativePureSelectPlanV2 where
+  toJSON selection =
+    Aeson.object
+      [ "guard" .= selection.nativePureSelectPlanV2Guard
+      , "variants" .= selection.nativePureSelectPlanV2Variants
+      , "rejoin" .= selection.nativePureSelectPlanV2Rejoin
+      ]
+
+instance FromJSON NativePureSelectPlanV2 where
+  parseJSON = Aeson.withObject "NativePureSelectPlanV2" $ \objectValue ->
+    NativePureSelectPlanV2
+      <$> objectValue .: "guard"
+      <*> objectValue .: "variants"
+      <*> objectValue .: "rejoin"
+
+instance ToJSON NativePureProgramV2 where
+  toJSON program =
+    Aeson.object
+      [ "schema" .= nativePureStaticProgramV2Schema
+      , "program_id" .= program.nativePureProgramV2Id
+      , "program_identity" .= program.nativePureProgramV2Identity
+      , "native_pure_plan_digest" .= program.nativePureProgramV2PlanDigest
+      , "units" .= program.nativePureProgramV2Units
+      , "edges" .= program.nativePureProgramV2Edges
+      , "selects" .= program.nativePureProgramV2Selects
+      ]
+
+instance FromJSON NativePureProgramV2 where
+  parseJSON = Aeson.withObject "NativePureProgramV2" $ \objectValue -> do
+    schema <- objectValue .: "schema"
+    unless (schema == nativePureStaticProgramV2Schema) $
+      fail ("unsupported NativePure static program schema: " <> T.unpack schema)
+    NativePureProgramV2
+      <$> objectValue .: "program_id"
+      <*> objectValue .: "program_identity"
+      <*> objectValue .: "native_pure_plan_digest"
+      <*> objectValue .: "units"
+      <*> objectValue .: "edges"
+      <*> objectValue .: "selects"
+
+instance ToJSON NativePureV2Status where
+  toJSON = Aeson.String . renderV2Status
+
+instance FromJSON NativePureV2Status where
+  parseJSON = Aeson.withText "NativePureV2Status" $ \value ->
+    maybe (fail ("invalid NativePure v2 status: " <> T.unpack value)) pure (parseV2Status value)
+
+renderV2Status :: NativePureV2Status -> Text
+renderV2Status = \case
+  NativePureV2Pending -> "pending"
+  NativePureV2RunningEffect -> "running_effect"
+  NativePureV2Completed -> "completed"
+  NativePureV2Failed -> "failed"
+  NativePureV2Skipped -> "skipped"
+
+parseV2Status :: Text -> Maybe NativePureV2Status
+parseV2Status = \case
+  "pending" -> Just NativePureV2Pending
+  "running_effect" -> Just NativePureV2RunningEffect
+  "completed" -> Just NativePureV2Completed
+  "failed" -> Just NativePureV2Failed
+  "skipped" -> Just NativePureV2Skipped
+  _ -> Nothing
+
+instance ToJSON NativePureEngineStateV2 where
+  toJSON state =
+    Aeson.object
+      [ "schema" .= nativePureEngineStateV2Schema
+      , "program_identity" .= state.nativePureEngineStateV2ProgramIdentity
+      , "checkpoint_sequence" .= state.nativePureEngineStateV2CheckpointSequence
+      , "next_effect_sequence" .= state.nativePureEngineStateV2NextEffectSequence
+      , "awaiting_checkpoint" .= state.nativePureEngineStateV2AwaitingCheckpoint
+      , "terminal" .= renderEngineTerminalState state.nativePureEngineStateV2Terminal
+      , "statuses" .= state.nativePureEngineStateV2Statuses
+      , "values" .= state.nativePureEngineStateV2Values
+      , "effect_sequences" .= state.nativePureEngineStateV2EffectSequences
+      , "selected_tags"
+          .= [ Aeson.object ["guard" .= guardId, "tag" .= label]
+             | (guardId, label) <- Map.toAscList state.nativePureEngineStateV2SelectedTags
+             ]
+      , "failure" .= state.nativePureEngineStateV2Failure
+      ]
+
+instance FromJSON NativePureEngineStateV2 where
+  parseJSON = Aeson.withObject "NativePureEngineStateV2" $ \objectValue -> do
+    schema <- objectValue .: "schema"
+    unless (schema == nativePureEngineStateV2Schema) $
+      fail ("unsupported NativePure engine-state schema: " <> T.unpack schema)
+    terminalText <- objectValue .: "terminal"
+    terminal <- either (fail . T.unpack) pure (parseEngineTerminalState terminalText)
+    selectedRows <- objectValue .: "selected_tags"
+    selectedTags <- Map.fromList <$> traverse parseSelectedTag selectedRows
+    NativePureEngineStateV2
+      <$> objectValue .: "program_identity"
+      <*> objectValue .: "checkpoint_sequence"
+      <*> objectValue .: "next_effect_sequence"
+      <*> objectValue .: "awaiting_checkpoint"
+      <*> pure terminal
+      <*> objectValue .: "statuses"
+      <*> objectValue .: "values"
+      <*> objectValue .: "effect_sequences"
+      <*> pure selectedTags
+      <*> objectValue .:? "failure"
+    where
+      parseSelectedTag = Aeson.withObject "NativePureSelectedTag" $ \row ->
+        (,) <$> row .: "guard" <*> row .: "tag"
+
+data NativePureV2HostCommand
+  = NativePureV2HostStart !Text
+  | NativePureV2HostRestore !Text !NativePureEngineStateV2
+  | NativePureV2HostEffectCompleted !Text !Word64 !Word32 !NativePureV2EffectCompletion
+  | NativePureV2HostCheckpointCommitted !Text !Word64
+  | NativePureV2HostCancel !Text !Text
+  | NativePureV2HostShutdown !Text
+  deriving stock (Eq, Show, Generic)
+
+data NativePureV2EngineEvent
+  = NativePureV2EngineHello !Text !Text
+  | NativePureV2EngineCheckpoint !Text !NativePureEngineStateV2
+  | NativePureV2EngineEffectRequested !Text !Word64 !Word32 !Text !(Map Text Aeson.Value)
+  | NativePureV2EngineTerminal !Text !EngineTerminalState
+  | NativePureV2EngineProtocolError !(Maybe Text) !Text
+  deriving stock (Eq, Show, Generic)
+
+instance ToJSON NativePureV2HostCommand where
+  toJSON = \case
+    NativePureV2HostStart runId -> v2Envelope "start" runId []
+    NativePureV2HostRestore runId state -> v2Envelope "restore" runId ["state" .= state]
+    NativePureV2HostEffectCompleted runId sequenceNumber unitId completion ->
+      let (outcome, value, message) = case completion of
+            NativePureV2EffectSucceeded result -> ("success" :: Text, Just result, Nothing)
+            NativePureV2EffectSkipped -> ("skipped", Nothing, Nothing)
+            NativePureV2EffectFailed reason -> ("failure", Nothing, Just reason)
+       in v2Envelope
+            "effect_completed"
+            runId
+            [ "sequence" .= sequenceNumber
+            , "unit_id" .= unitId
+            , "outcome" .= outcome
+            , "value" .= value
+            , "message" .= message
+            ]
+    NativePureV2HostCheckpointCommitted runId sequenceNumber ->
+      v2Envelope "checkpoint_committed" runId ["sequence" .= sequenceNumber]
+    NativePureV2HostCancel runId reason -> v2Envelope "cancel" runId ["reason" .= reason]
+    NativePureV2HostShutdown runId -> v2Envelope "shutdown" runId []
+
+instance FromJSON NativePureV2HostCommand where
+  parseJSON = Aeson.withObject "NativePureV2HostCommand" $ \objectValue -> do
+    requireV2Protocol objectValue
+    commandType <- objectValue .: "type"
+    runId <- objectValue .: "run_id"
+    case commandType :: Text of
+      "start" -> pure (NativePureV2HostStart runId)
+      "restore" -> NativePureV2HostRestore runId <$> objectValue .: "state"
+      "effect_completed" -> do
+        sequenceNumber <- objectValue .: "sequence"
+        unitId <- objectValue .: "unit_id"
+        outcome <- objectValue .: "outcome"
+        value <- objectValue .:? "value"
+        message <- objectValue .:? "message"
+        completion <- parseV2Completion outcome value message
+        pure (NativePureV2HostEffectCompleted runId sequenceNumber unitId completion)
+      "checkpoint_committed" ->
+        NativePureV2HostCheckpointCommitted runId <$> objectValue .: "sequence"
+      "cancel" -> NativePureV2HostCancel runId <$> objectValue .: "reason"
+      "shutdown" -> pure (NativePureV2HostShutdown runId)
+      _ -> fail ("unknown NativePure v2 host command: " <> T.unpack commandType)
+
+instance ToJSON NativePureV2EngineEvent where
+  toJSON = \case
+    NativePureV2EngineHello identity abi ->
+      Aeson.object
+        [ "type" .= ("hello" :: Text)
+        , "protocol" .= nativePureHostProcessV2Protocol
+        , "program_identity" .= identity
+        , "engine_abi" .= abi
+        ]
+    NativePureV2EngineCheckpoint runId state -> v2Envelope "checkpoint" runId ["state" .= state]
+    NativePureV2EngineEffectRequested runId sequenceNumber unitId unitRef inputs ->
+      v2Envelope
+        "effect_requested"
+        runId
+        [ "sequence" .= sequenceNumber
+        , "unit_id" .= unitId
+        , "unit_ref" .= unitRef
+        , "inputs" .= inputs
+        ]
+    NativePureV2EngineTerminal runId terminal ->
+      v2Envelope "terminal" runId ["terminal" .= renderEngineTerminalState terminal]
+    NativePureV2EngineProtocolError runId message ->
+      Aeson.object
+        [ "type" .= ("protocol_error" :: Text)
+        , "protocol" .= nativePureHostProcessV2Protocol
+        , "run_id" .= runId
+        , "message" .= message
+        ]
+
+instance FromJSON NativePureV2EngineEvent where
+  parseJSON = Aeson.withObject "NativePureV2EngineEvent" $ \objectValue -> do
+    requireV2Protocol objectValue
+    eventType <- objectValue .: "type"
+    case eventType :: Text of
+      "hello" ->
+        NativePureV2EngineHello <$> objectValue .: "program_identity" <*> objectValue .: "engine_abi"
+      "checkpoint" ->
+        NativePureV2EngineCheckpoint <$> objectValue .: "run_id" <*> objectValue .: "state"
+      "effect_requested" ->
+        NativePureV2EngineEffectRequested
+          <$> objectValue .: "run_id"
+          <*> objectValue .: "sequence"
+          <*> objectValue .: "unit_id"
+          <*> objectValue .: "unit_ref"
+          <*> objectValue .: "inputs"
+      "terminal" -> do
+        runId <- objectValue .: "run_id"
+        terminalText <- objectValue .: "terminal"
+        terminal <- either (fail . T.unpack) pure (parseEngineTerminalState terminalText)
+        pure (NativePureV2EngineTerminal runId terminal)
+      "protocol_error" ->
+        NativePureV2EngineProtocolError <$> objectValue .:? "run_id" <*> objectValue .: "message"
+      _ -> fail ("unknown NativePure v2 engine event: " <> T.unpack eventType)
+
+encodeNativePureV2HostCommand
+  :: NativePureV2HostCommand -> Either NativePureProgramV2Error BS.ByteString
+encodeNativePureV2HostCommand = encodeBounded
+
+decodeNativePureV2HostCommand
+  :: BS.ByteString -> Either NativePureProgramV2Error NativePureV2HostCommand
+decodeNativePureV2HostCommand = decodeBounded
+
+encodeNativePureV2EngineEvent
+  :: NativePureV2EngineEvent -> Either NativePureProgramV2Error BS.ByteString
+encodeNativePureV2EngineEvent = encodeBounded
+
+decodeNativePureV2EngineEvent
+  :: BS.ByteString -> Either NativePureProgramV2Error NativePureV2EngineEvent
+decodeNativePureV2EngineEvent = decodeBounded
+
+encodeBounded :: ToJSON value => value -> Either NativePureProgramV2Error BS.ByteString
+encodeBounded value =
+  let bytes = BSL.toStrict (BSL.snoc (Aeson.encode value) 10)
+   in if BS.length bytes <= nativePureHostedMessageCeiling
+        then Right bytes
+        else Left (NativePureProgramV2MessageTooLarge (BS.length bytes))
+
+decodeBounded :: FromJSON value => BS.ByteString -> Either NativePureProgramV2Error value
+decodeBounded bytes
+  | BS.length bytes > nativePureHostedMessageCeiling =
+      Left (NativePureProgramV2MessageTooLarge (BS.length bytes))
+  | otherwise =
+      case Aeson.eitherDecodeStrict' bytes of
+        Left reason -> Left (NativePureProgramV2Protocol (T.pack reason))
+        Right value -> Right value
+
+v2Envelope :: Text -> Text -> [AesonTypes.Pair] -> Aeson.Value
+v2Envelope messageType runId fields =
+  Aeson.object
+    (["type" .= messageType, "protocol" .= nativePureHostProcessV2Protocol, "run_id" .= runId] <> fields)
+
+requireV2Protocol :: Aeson.Object -> AesonTypes.Parser ()
+requireV2Protocol objectValue = do
+  protocol <- objectValue .: "protocol"
+  unless (protocol == nativePureHostProcessV2Protocol) $
+    fail ("unsupported NativePure hosted protocol: " <> T.unpack protocol)
+
+parseV2Completion
+  :: Text
+  -> Maybe Aeson.Value
+  -> Maybe Text
+  -> AesonTypes.Parser NativePureV2EffectCompletion
+parseV2Completion outcome value message = case outcome of
+  "success" ->
+    maybe
+      (fail "successful NativePure v2 effect completion requires a value")
+      (pure . NativePureV2EffectSucceeded)
+      value
+  "skipped"
+    | isJust value -> fail "skipped NativePure v2 effect completion must not carry a value"
+    | otherwise -> pure NativePureV2EffectSkipped
+  "failure"
+    | isJust value -> fail "failed NativePure v2 effect completion must not carry a value"
+    | otherwise -> pure (NativePureV2EffectFailed (fromMaybe "effect failed" message))
+  _ -> fail ("unknown NativePure v2 effect outcome: " <> T.unpack outcome)

--- a/test/Cortex/Wire/NativePureSchedulerSpec.hs
+++ b/test/Cortex/Wire/NativePureSchedulerSpec.hs
@@ -1,0 +1,377 @@
+{- |
+Module      : Cortex.Wire.NativePureSchedulerSpec
+Description : NativePure v2 scheduler, checkpoint, and select policy tests.
+Copyright   : (c) 2026 Digimuoto Oy
+License     : Apache-2.0
+Maintainer  : julius.koskela@digimuoto.com
+Stability   : experimental
+
+These specs pin the additive v2 profile without changing any v1 scheduler or
+host-process interface. In particular, every pure transition is synchronous
+and checkpointed; only effect units can produce host work.
+-}
+module Cortex.Wire.NativePureSchedulerSpec (spec) where
+
+import Data.Aeson qualified as Aeson
+import Data.List qualified as List
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text qualified as T
+import Data.Word (Word32, Word64)
+import Test.Hspec
+
+import Cortex.Wire
+  ( CircuitNodeRef (..)
+  , EngineTerminalState (..)
+  , NativePureEngineStateV2 (..)
+  , NativePurePlan (..)
+  , NativePureProgramV2 (..)
+  , NativePureProgramV2Edge (..)
+  , NativePureProgramV2Error (..)
+  , NativePureProgramV2Unit (..)
+  , NativePureProgramV2UnitKind (..)
+  , NativePureSelectPlanV2 (..)
+  , NativePureSelectV2 (..)
+  , NativePureV2Action (..)
+  , NativePureV2EffectCompletion (..)
+  , NativePureV2EngineEvent (..)
+  , NativePureV2HostCommand (..)
+  , NativePureV2Result (..)
+  , NativePureV2Status (..)
+  , NativePureV2Transition (..)
+  , RealizationArtifact (..)
+  , RealizationRuntimeKind (..)
+  , RealizationRuntimeUnit (..)
+  , acknowledgeNativePureCheckpointV2
+  , completeNativePureEffectV2
+  , decodeNativePureV2EngineEvent
+  , decodeNativePureV2HostCommand
+  , driveNativePureV2
+  , encodeNativePureV2EngineEvent
+  , encodeNativePureV2HostCommand
+  , initialNativePureEngineStateV2
+  , nativePureEngineStateV2Schema
+  , nativePureEngineV2Abi
+  , nativePureHostProcessV2Protocol
+  , nativePureHostedLinuxV2Target
+  , nativePureHostedMessageCeiling
+  , nativePureStaticProgramV2Schema
+  , restoreNativePureEngineStateV2
+  , specializeNativePureProgramV2
+  , validateNativePureProgramV2
+  )
+
+spec :: Spec
+spec = describe "NativePure v2 scheduler" $ do
+  it "specializes witnessed quotient units and select structure without changing the plan" $ do
+    program <- requireRight (specializeNativePureProgramV2 quotientPlan [authoredSelect])
+    fmap (.nativePureProgramV2UnitKind) program.nativePureProgramV2Units
+      `shouldBe` [NativePureV2SelectGuard, NativePureV2Effect, NativePureV2PureRegion, NativePureV2Rejoin]
+    program.nativePureProgramV2Edges
+      `shouldBe` [ NativePureProgramV2Edge 0 1
+                 , NativePureProgramV2Edge 0 2
+                 , NativePureProgramV2Edge 1 3
+                 , NativePureProgramV2Edge 2 3
+                 ]
+    program.nativePureProgramV2Selects
+      `shouldBe` [NativePureSelectPlanV2 0 (Map.fromList [("accepted", [1]), ("rejected", [2])]) 3]
+    quotientPlan.nativePurePlanRealization.realizationArtifactSourceToRuntime
+      `shouldBe` Map.fromList
+        [ (CircuitNodeRef "classify", "00-guard")
+        , (CircuitNodeRef "accepted-effect", "01-accepted")
+        , (CircuitNodeRef "rejected-pure", "02-rejected")
+        , (CircuitNodeRef "join", "03-rejoin")
+        ]
+
+  it "checkpoints effect to pure to effect and never requests host work for pure units" $ do
+    let program = effectPureEffectProgram
+        initial = initialNativePureEngineStateV2 program
+    initial.nativePureEngineStateV2CheckpointSequence `shouldBe` 1
+    driveNativePureV2 pureRunner program initial
+      `shouldSatisfy` hasCheckpoint 1
+
+    admitted <- requireRight (acknowledgeNativePureCheckpointV2 program 1 initial)
+    firstEffect <- requireRight (driveNativePureV2 pureRunner program admitted)
+    firstEffect.nativePureV2TransitionAction
+      `shouldBe` NativePureV2EffectRequested 1 0 "source" Map.empty
+
+    effectCheckpoint <-
+      requireRight
+        ( completeNativePureEffectV2
+            program
+            1
+            0
+            (NativePureV2EffectSucceeded (Aeson.Number 7))
+            firstEffect.nativePureV2TransitionState
+        )
+    driveNativePureV2 pureRunner program effectCheckpoint
+      `shouldSatisfy` hasCheckpoint 2
+
+    afterEffect <- requireRight (acknowledgeNativePureCheckpointV2 program 2 effectCheckpoint)
+    pureCheckpoint <- requireRight (driveNativePureV2 pureRunner program afterEffect)
+    pureCheckpoint.nativePureV2TransitionAction `shouldSatisfy` \case
+      NativePureV2CheckpointRequired state ->
+        state.nativePureEngineStateV2CheckpointSequence == 3
+          && state.nativePureEngineStateV2Statuses
+            == [NativePureV2Completed, NativePureV2Completed, NativePureV2Pending]
+      _ -> False
+    driveNativePureV2 pureRunner program pureCheckpoint.nativePureV2TransitionState
+      `shouldSatisfy` hasCheckpoint 3
+
+    afterPure <-
+      requireRight
+        ( acknowledgeNativePureCheckpointV2
+            program
+            3
+            pureCheckpoint.nativePureV2TransitionState
+        )
+    secondEffect <- requireRight (driveNativePureV2 pureRunner program afterPure)
+    secondEffect.nativePureV2TransitionAction
+      `shouldBe` NativePureV2EffectRequested 2 2 "sink" (Map.singleton "pure" (Aeson.String "pure-result"))
+
+  it "persists an n-way selection, skips latent work, rejoins, and restores the tag" $ do
+    let program = selectProgram
+        initial = initialNativePureEngineStateV2 program
+    admitted <- requireRight (acknowledgeNativePureCheckpointV2 program 1 initial)
+    selected <- requireRight (driveNativePureV2 selectRunner program admitted)
+    let selectedState = selected.nativePureV2TransitionState
+    selected.nativePureV2TransitionAction `shouldSatisfy` \case
+      NativePureV2CheckpointRequired _ -> True
+      _ -> False
+    selectedState.nativePureEngineStateV2SelectedTags `shouldBe` Map.singleton 0 "rejected"
+    selectedState.nativePureEngineStateV2Statuses
+      `shouldBe` [ NativePureV2Completed
+                 , NativePureV2Skipped
+                 , NativePureV2Skipped
+                 , NativePureV2Pending
+                 , NativePureV2Pending
+                 , NativePureV2Pending
+                 ]
+
+    afterGuard <- requireRight (acknowledgeNativePureCheckpointV2 program 2 selectedState)
+    branchPure <- requireRight (driveNativePureV2 selectRunner program afterGuard)
+    branchPure.nativePureV2TransitionAction `shouldSatisfy` isCheckpoint
+    afterBranch <-
+      requireRight
+        ( acknowledgeNativePureCheckpointV2
+            program
+            3
+            branchPure.nativePureV2TransitionState
+        )
+    rejoined <- requireRight (driveNativePureV2 selectRunner program afterBranch)
+    rejoined.nativePureV2TransitionAction `shouldSatisfy` isCheckpoint
+
+    restored <-
+      requireRight (restoreNativePureEngineStateV2 program rejoined.nativePureV2TransitionState)
+    restored.nativePureEngineStateV2SelectedTags `shouldBe` Map.singleton 0 "rejected"
+    restored.nativePureEngineStateV2Statuses List.!? 1 `shouldBe` Just NativePureV2Skipped
+    restored.nativePureEngineStateV2Values List.!? 4
+      `shouldBe` Just (Just (Aeson.String "rejected-value"))
+    afterRestore <- requireRight (acknowledgeNativePureCheckpointV2 program 4 restored)
+    downstream <- requireRight (driveNativePureV2 selectRunner program afterRestore)
+    downstream.nativePureV2TransitionAction
+      `shouldBe` NativePureV2EffectRequested
+        1
+        5
+        "downstream"
+        (Map.singleton "rejoin" (Aeson.String "rejected-value"))
+
+  it "checkpoints deterministic pure and select failures" $ do
+    let program = selectProgram
+        initial = initialNativePureEngineStateV2 program
+    admitted <- requireRight (acknowledgeNativePureCheckpointV2 program 1 initial)
+    failed <-
+      requireRight
+        ( driveNativePureV2
+            (\_unit _inputs -> Right (NativePureV2Result Aeson.Null (Just "unknown")))
+            program
+            admitted
+        )
+    let failedState = failed.nativePureV2TransitionState
+    failed.nativePureV2TransitionAction `shouldSatisfy` \case
+      NativePureV2CheckpointRequired checkpoint ->
+        checkpoint.nativePureEngineStateV2CheckpointSequence == 2
+      _ -> False
+    failedState.nativePureEngineStateV2Terminal `shouldBe` EngineTerminalFailed
+    failedState.nativePureEngineStateV2Failure `shouldBe` Just "guard returned an undeclared tag"
+    failedState.nativePureEngineStateV2Statuses List.!? 0 `shouldBe` Just NativePureV2Failed
+
+  it "rejects malformed quotient and select topology before execution" $ do
+    let cyclic =
+          effectPureEffectProgram
+            { nativePureProgramV2Edges =
+                NativePureProgramV2Edge 1 0
+                  : effectPureEffectProgram.nativePureProgramV2Edges
+            }
+        disconnected =
+          selectProgram
+            { nativePureProgramV2Edges =
+                filter
+                  (/= NativePureProgramV2Edge 3 4)
+                  selectProgram.nativePureProgramV2Edges
+            }
+    validateNativePureProgramV2 cyclic `shouldSatisfy` \case
+      Left NativePureProgramV2State {} -> True
+      _ -> False
+    validateNativePureProgramV2 disconnected `shouldSatisfy` \case
+      Left NativePureProgramV2InvalidSelect {} -> True
+      _ -> False
+
+  it "round-trips v2 hosted messages and enforces the 2 MiB ceiling" $ do
+    nativePureStaticProgramV2Schema `shouldBe` "cortex.wire.static-program/v2"
+    nativePureEngineV2Abi `shouldBe` "cortex.wire.engine/v2"
+    nativePureEngineStateV2Schema `shouldBe` "cortex.wire.engine-state/v2"
+    nativePureHostProcessV2Protocol `shouldBe` "cortex.wire.host-process/v2"
+    nativePureHostedLinuxV2Target `shouldBe` "cortex.wire.target/x86_64-linux-v2"
+    let command = NativePureV2HostCheckpointCommitted "run-1" 17
+        event = NativePureV2EngineCheckpoint "run-1" (initialNativePureEngineStateV2 effectPureEffectProgram)
+    (encodeNativePureV2HostCommand command >>= decodeNativePureV2HostCommand) `shouldBe` Right command
+    (encodeNativePureV2EngineEvent event >>= decodeNativePureV2EngineEvent) `shouldBe` Right event
+    let oversized =
+          NativePureV2EngineProtocolError
+            Nothing
+            (T.replicate (nativePureHostedMessageCeiling + 1) "x")
+    encodeNativePureV2EngineEvent oversized `shouldSatisfy` \case
+      Left NativePureProgramV2MessageTooLarge {} -> True
+      _ -> False
+
+effectPureEffectProgram :: NativePureProgramV2
+effectPureEffectProgram =
+  mkProgram
+    [ unit 0 "source" NativePureV2Effect
+    , unit 1 "pure" NativePureV2PureRegion
+    , unit 2 "sink" NativePureV2Effect
+    ]
+    [NativePureProgramV2Edge 0 1, NativePureProgramV2Edge 1 2]
+    []
+
+selectProgram :: NativePureProgramV2
+selectProgram =
+  mkProgram
+    [ unit 0 "guard" NativePureV2SelectGuard
+    , unit 1 "accepted-effect" NativePureV2Effect
+    , unit 2 "unused-third-arm" NativePureV2PureRegion
+    , unit 3 "rejected-pure" NativePureV2PureRegion
+    , unit 4 "rejoin" NativePureV2Rejoin
+    , unit 5 "downstream" NativePureV2Effect
+    ]
+    [ NativePureProgramV2Edge 0 1
+    , NativePureProgramV2Edge 0 2
+    , NativePureProgramV2Edge 0 3
+    , NativePureProgramV2Edge 1 4
+    , NativePureProgramV2Edge 2 4
+    , NativePureProgramV2Edge 3 4
+    , NativePureProgramV2Edge 4 5
+    ]
+    [ NativePureSelectPlanV2
+        0
+        (Map.fromList [("accepted", [1]), ("deferred", [2]), ("rejected", [3])])
+        4
+    ]
+
+mkProgram
+  :: [NativePureProgramV2Unit]
+  -> [NativePureProgramV2Edge]
+  -> [NativePureSelectPlanV2]
+  -> NativePureProgramV2
+mkProgram units edges selects =
+  NativePureProgramV2
+    { nativePureProgramV2Id = "program"
+    , nativePureProgramV2Identity = "identity"
+    , nativePureProgramV2PlanDigest = "plan-digest"
+    , nativePureProgramV2Units = units
+    , nativePureProgramV2Edges = edges
+    , nativePureProgramV2Selects = selects
+    }
+
+unit :: Word32 -> T.Text -> NativePureProgramV2UnitKind -> NativePureProgramV2Unit
+unit unitId unitRef kind =
+  NativePureProgramV2Unit unitId unitRef kind [CircuitNodeRef unitRef]
+
+pureRunner :: NativePureProgramV2Unit -> Map T.Text Aeson.Value -> Either T.Text NativePureV2Result
+pureRunner unitValue inputs = case unitValue.nativePureProgramV2UnitRef of
+  "pure" ->
+    if Map.lookup "source" inputs == Just (Aeson.Number 7)
+      then Right (NativePureV2Result (Aeson.String "pure-result") Nothing)
+      else Left "pure input was not restored from its predecessor"
+  ref -> Left ("unexpected pure runner call for " <> ref)
+
+selectRunner
+  :: NativePureProgramV2Unit -> Map T.Text Aeson.Value -> Either T.Text NativePureV2Result
+selectRunner unitValue _inputs = case unitValue.nativePureProgramV2UnitRef of
+  "guard" -> Right (NativePureV2Result (Aeson.String "decision") (Just "rejected"))
+  "rejected-pure" -> Right (NativePureV2Result (Aeson.String "rejected-value") Nothing)
+  ref -> Left ("unexpected pure runner call for " <> ref)
+
+hasCheckpoint :: Word64 -> Either NativePureProgramV2Error NativePureV2Transition -> Bool
+hasCheckpoint sequenceNumber = \case
+  Right transitionValue -> case transitionValue.nativePureV2TransitionAction of
+    NativePureV2CheckpointRequired state ->
+      state.nativePureEngineStateV2CheckpointSequence == sequenceNumber
+    _ -> False
+  Left _ -> False
+
+isCheckpoint :: NativePureV2Action -> Bool
+isCheckpoint = \case
+  NativePureV2CheckpointRequired _ -> True
+  _ -> False
+
+requireRight :: (HasCallStack, Show error) => Either error value -> IO value
+requireRight = \case
+  Left err -> do
+    expectationFailure ("expected Right, got " <> show err)
+    fail "unreachable after expectationFailure"
+  Right value -> pure value
+
+quotientPlan :: NativePurePlan
+quotientPlan =
+  NativePurePlan
+    { nativePurePlanProgramId = "select-program"
+    , nativePurePlanProgramIdentity = "identity"
+    , nativePurePlanInputDigest = "input-digest"
+    , nativePurePlanRealization =
+        RealizationArtifact
+          { realizationArtifactReferentIdentity = "identity"
+          , realizationArtifactInputDigest = "input-digest"
+          , realizationArtifactSourceToRuntime =
+              Map.fromList
+                [ (CircuitNodeRef "classify", "00-guard")
+                , (CircuitNodeRef "accepted-effect", "01-accepted")
+                , (CircuitNodeRef "rejected-pure", "02-rejected")
+                , (CircuitNodeRef "join", "03-rejoin")
+                ]
+          , realizationArtifactRuntimeUnits =
+              Map.fromList
+                [ runtimeUnit "00-guard" RealizationPureRegion "classify"
+                , runtimeUnit "01-accepted" RealizationPreservedNode "accepted-effect"
+                , runtimeUnit "02-rejected" RealizationPureRegion "rejected-pure"
+                , runtimeUnit "03-rejoin" RealizationPreservedNode "join"
+                ]
+          , realizationArtifactRuntimeEdges =
+              Set.fromList
+                [ ("00-guard", "01-accepted")
+                , ("00-guard", "02-rejected")
+                , ("01-accepted", "03-rejoin")
+                , ("02-rejected", "03-rejoin")
+                ]
+          , realizationArtifactDigest = "artifact-digest"
+          }
+    , nativePurePlanRegions = []
+    , nativePurePlanDigest = "plan-digest"
+    }
+
+runtimeUnit :: T.Text -> RealizationRuntimeKind -> T.Text -> (T.Text, RealizationRuntimeUnit)
+runtimeUnit runtimeRef kind source =
+  ( runtimeRef
+  , RealizationRuntimeUnit runtimeRef kind [CircuitNodeRef source]
+  )
+
+authoredSelect :: NativePureSelectV2
+authoredSelect =
+  NativePureSelectV2
+    { nativePureSelectV2GuardRef = "00-guard"
+    , nativePureSelectV2Variants =
+        Map.fromList [("accepted", ["01-accepted"]), ("rejected", ["02-rejected"])]
+    , nativePureSelectV2RejoinRef = "03-rejoin"
+    }


### PR DESCRIPTION
## NativePure epic slice 12/15

Targets `codex/epic-native-pure-c`; this PR is additive and does not change any v1 schema, ABI, target, lifecycle behavior, generated artifact, or authored Wire syntax.

### What lands

- versioned `static-program/v2`, `engine/v2`, `engine-state/v2`, `host-process/v2`, and `x86_64-linux-v2` identifiers
- specialization of the witnessed `NativePurePlan` quotient into dense runtime units
- strict validation of dense IDs, unique refs/edges, acyclicity, select ownership, and guard-to-rejoin branch topology
- synchronous in-engine execution for pure regions and select guards; pure units cannot emit host effect requests
- hard checkpoint acknowledgement gates before pure execution and before downstream effect requests
- atomic pure/effect/failure checkpoints, bounded persisted values, selected tags, skipped latent arms, rejoin values, cancellation, and restore
- bounded canonical JSON host commands/events with the existing 2 MiB ceiling
- ADR 0091/0096 amendments documenting the separate v2 profile and unchanged v1/HostProtocol/TLA+ policy

### Verification

- `just ci-check` — green
  - formatting, Fourmolu, HLint, language pragmas, Haddock/module boundary checks
  - Lean lint/theory (124 files)
  - docs lint/build and 119 Wire documentation examples
  - TLA+ positive and documented negative models
  - flake checks, packages, hosted runtime smoke, StaticC differential (42 topologies / 995 scenarios)
- `just test` — 1263 examples, 0 failures, 164 DB-dependent pending
- focused `NativePure v2 scheduler` corpus — 6 examples, 0 failures
- commit signature/signoff/provenance verified

### Deliberate boundaries

- no generated C scheduler integration yet
- no new NativePure differential/target corpus yet (epic PR 13)
- no v1 modifications
- no HostProtocol or TLA+ transition changes: pure units never register workers, so existing worker/cancellation/deadline/terminal-authority policy is reused unchanged
- no Wire authoring compatibility surface or breaking removal (epic PRs 14 and 15)

Part of #382 and epic #383. Supersedes the corresponding scheduler/checkpoint/select slice from donor #378.