### PR TITLE
ci(policy): enforce uniform branch naming, block AI tool names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,20 @@ jobs:
 
           scripts/check-commit-provenance "$RANGE"
 
+      - name: Check branch name
+        if: github.event_name == 'pull_request'
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          # Unlike commit provenance, branch naming is a lint, not a trust
+          # boundary: run the PR head's own copy of the checker so a PR that
+          # introduces or edits scripts/check-branch-name validates itself.
+          git show refs/remotes/pr/head:scripts/check-branch-name >/tmp/check-branch-name
+          chmod +x /tmp/check-branch-name
+          /tmp/check-branch-name "$PR_HEAD_REF"
+
   repository-merge-policy:
     name: Repository Merge Policy
     runs-on: ubuntu-24.04

--- a/justfile
+++ b/justfile
@@ -247,6 +247,10 @@ ci-check:
 check-commit-provenance RANGE="origin/main..HEAD":
     scripts/check-commit-provenance "{{ RANGE }}"
 
+# Check a branch name against the naming policy (default: current branch)
+check-branch-name BRANCH="":
+    scripts/check-branch-name "{{ BRANCH }}"
+
 # Check that GitHub merge settings cannot manufacture squash/merge commits
 check-github-merge-policy:
     nix develop -c scripts/check-github-merge-policy

--- a/scripts/check-branch-name
+++ b/scripts/check-branch-name
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check-branch-name [<branch-name>]
+
+Checks a Cortex branch name against the naming policy.
+
+Default branch: current branch (git rev-parse --abbrev-ref HEAD)
+
+Policy:
+  - lowercase kebab-case segments: [a-z0-9]+(-[a-z0-9]+)*
+  - at most one namespace level: "segment" or "segment/segment"
+  - no segment may name an AI coding tool/vendor (branch names are public
+    and are not a copyright/authorship record; tool names do not belong there)
+  - "main" is always allowed
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+branch="${1:-}"
+if [[ -z "$branch" ]]; then
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+fi
+
+if [[ "$branch" == "main" || "$branch" == "HEAD" ]]; then
+  echo "Branch name OK: $branch"
+  exit 0
+fi
+
+segment_re='[a-z0-9]+(-[a-z0-9]+)*'
+shape_re="^${segment_re}(/${segment_re})?\$"
+
+# AI coding tool / vendor identifiers that must not appear as a branch
+# namespace or segment. Extend this list as new tools show up in the wild
+# rather than loosening the shape check above.
+blocked_tokens=(
+  codex
+  claude
+  anthropic
+  copilot
+  chatgpt
+  gpt
+  cursor
+  aider
+  devin
+  opencode
+  windsurf
+  cline
+  gemini
+  bard
+  cody
+  tabnine
+  amazonq
+  jules
+  replit
+  warp
+)
+
+failed=0
+
+fail() {
+  printf 'branch name violation: %s\n' "$1" >&2
+  failed=1
+}
+
+if [[ ! "$branch" =~ $shape_re ]]; then
+  fail "'$branch' does not match required shape (lowercase kebab-case, at most one 'namespace/slug' level)"
+fi
+
+IFS='/' read -ra segments <<<"$branch"
+for segment in "${segments[@]}"; do
+  for token in "${blocked_tokens[@]}"; do
+    if [[ "$segment" == "$token" || "$segment" == "$token"-* || "$segment" == *-"$token" || "$segment" == *-"$token"-* ]]; then
+      fail "'$branch' names AI tool/vendor '$token' in segment '$segment'"
+    fi
+  done
+done
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "Branch name OK: $branch"

--- a/scripts/integrate-pr
+++ b/scripts/integrate-pr
@@ -46,6 +46,7 @@ git fetch "$remote" \
   "${base_branch}:${base_ref}" \
   "${target_branch}:${target_ref}"
 
+scripts/check-branch-name "$target_branch"
 scripts/check-commit-provenance "${base_ref}..${target_ref}"
 
 git switch "$base_branch"


### PR DESCRIPTION
## Summary
- Add `scripts/check-branch-name`: requires lowercase kebab-case with at most one `namespace/slug` level, and rejects known AI coding tool/vendor names (`codex`, `claude`, `copilot`, `cursor`, `opencode`, etc.) as a branch segment. Branch names are public but are not an authorship/copyright record, and `codex/...`-style branches read as if they were.
- Wire the check into `just check-branch-name`, `scripts/integrate-pr` (blocks fast-forwarding a badly-named branch into `main`), and the CI `commit-provenance` job (new step, `pull_request` events).
- Self-tested clean against all current branches except the pre-existing `codex/*` branches and `chore/opencode-provider-link`, which this PR does not touch — cleanup of those is a separate step.

## Test plan
- [x] `scripts/check-branch-name` passes on `ci/branch-naming-check` and on a sample of existing conforming branch names
- [x] `scripts/check-branch-name` fails on `codex/*`-style and `chore/opencode-provider-link`-style names
- [x] `just check-commit-provenance origin/main..HEAD` passes
- [x] pre-commit hooks (docs-lint, treefmt, wire-style, lean-lint) pass
- [ ] CI green on this PR (new "Check branch name" step included)